### PR TITLE
Fix privacy_algorithm check in modify_credential (7.0)

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -42335,8 +42335,9 @@ modify_credential (const char *credential_id,
 
   if (privacy_algorithm && ret == 0)
     {
-      if (strcmp (auth_algorithm, "aes")
-          && strcmp (auth_algorithm, "des"))
+      if (strcmp (privacy_algorithm, "aes")
+          && strcmp (privacy_algorithm, "des")
+          && strcmp (privacy_algorithm, ""))
         ret = 7;
       else
         set_credential_privacy_algorithm (credential, privacy_algorithm);

--- a/src/omp.c
+++ b/src/omp.c
@@ -22504,13 +22504,6 @@ omp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                                     "Selected type requires an"
                                     " auth_algorithm"));
                 break;
-              case 13:
-                SEND_TO_CLIENT_OR_FAIL
-                 (XML_ERROR_SYNTAX ("create_credential",
-                                    "Selected type requires a"
-                                    " password in the privacy element"
-                                    " if an algorithm is given"));
-                break;
               case 14:
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("create_credential",
@@ -26475,8 +26468,8 @@ omp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
               case 10:
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("modify_credential",
-                                    "Privacy algorithm and password"
-                                    " must be both empty or non-empty"));
+                                    "Privacy password must also be empty"
+                                    " if privacy algorithm is empty"));
                 log_event_fail ("credential", "Credential",
                                 modify_credential_data->credential_id,
                                 "modified");

--- a/src/omp.c
+++ b/src/omp.c
@@ -22508,13 +22508,15 @@ omp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("create_credential",
                                     "Selected type requires a"
-                                    " password in a privacy element"));
+                                    " password in the privacy element"
+                                    " if an algorithm is given"));
                 break;
               case 14:
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("create_credential",
                                     "Selected type requires an"
-                                    " algorithm in a privacy element"));
+                                    " algorithm in the privacy element"
+                                    " if a password is given"));
                 break;
               case 15:
                 SEND_TO_CLIENT_OR_FAIL
@@ -22524,8 +22526,8 @@ omp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
               case 16:
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("create_credential",
-                                    "privacy algorithm must be 'aes'"
-                                    " or 'des'"));
+                                    "privacy algorithm must be 'aes', 'des'"
+                                    " or empty"));
                 break;
               case 17:
                 SEND_TO_CLIENT_OR_FAIL
@@ -26466,6 +26468,15 @@ omp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("modify_credential",
                                     "Invalid or empty private key"));
+                log_event_fail ("credential", "Credential",
+                                modify_credential_data->credential_id,
+                                "modified");
+                break;
+              case 10:
+                SEND_TO_CLIENT_OR_FAIL
+                 (XML_ERROR_SYNTAX ("modify_credential",
+                                    "Privacy algorithm and password"
+                                    " must be both empty or non-empty"));
                 log_event_fail ("credential", "Credential",
                                 modify_credential_data->credential_id,
                                 "modified");

--- a/src/omp.c
+++ b/src/omp.c
@@ -22497,30 +22497,36 @@ omp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                  (XML_ERROR_SYNTAX ("create_credential",
                                     "Selected type requires a community and/or"
                                     " username + password"));
+                break;
               case 12:
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("create_credential",
                                     "Selected type requires an"
                                     " auth_algorithm"));
+                break;
               case 13:
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("create_credential",
                                     "Selected type requires a"
                                     " password in a privacy element"));
+                break;
               case 14:
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("create_credential",
                                     "Selected type requires an"
                                     " algorithm in a privacy element"));
+                break;
               case 15:
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("create_credential",
                                     "auth algorithm must be 'md5' or 'sha1'"));
+                break;
               case 16:
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("create_credential",
                                     "privacy algorithm must be 'aes'"
                                     " or 'des'"));
+                break;
               case 17:
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("create_credential",


### PR DESCRIPTION
This makes it possible to set the privacy_algorithm to a "aes", "des" or
an empty string when modifying an SNMP credential.