### PR TITLE
Exclude trash resources from count in GET_TAGS

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -66513,7 +66513,9 @@ modify_tag (const char *tag_id, const char *name, const char *comment,
    { "resource_type", NULL, KEYWORD_TYPE_STRING },                           \
    { "active", NULL, KEYWORD_TYPE_INTEGER },                                 \
    { "value", NULL, KEYWORD_TYPE_STRING },                                   \
-   { "(SELECT count(*) FROM tag_resources WHERE tag = tags.id)",             \
+   { "(SELECT count(*) FROM tag_resources"                                   \
+     " WHERE tag = tags.id"                                                  \
+     " AND resource_location = " G_STRINGIFY (LOCATION_TABLE) ")",           \
      "resources", KEYWORD_TYPE_INTEGER },                                    \
    { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                                      \
  }


### PR DESCRIPTION
In GET_TAGS/RESOURCES/COUNT for regular tags, don't count trashcan resources,
because trashcan resources are not relevant for regular tags.  If the
tag is in the trashcan, then include all resources.