### PR TITLE
Remove obsolete declaration of acl_user_owns_name

### DIFF
--- a/src/manage_acl.h
+++ b/src/manage_acl.h
@@ -127,9 +127,6 @@ int
 acl_user_is_observer (const char *);
 
 int
-acl_user_owns_name (const char *, const char *);
-
-int
 acl_user_owns (const char *, resource_t, int);
 
 int


### PR DESCRIPTION
This commit removes the obsolete declaration of the
`acl_user_owns_name` function. The corresponding implementation in
`manage_acl.c` was removed in commit 6afba0f.