### PR TITLE
Remove 'textual' qualifier in protocol specification

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -163,7 +163,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <name>threat</name>
     <summary>A threat level</summary>
     <description>
-      Threat levels are a textual classification of severity scores only
+      Threat levels are a classification of severity scores only
       supported for importing reports from OpenVAS-6 and older.
       The use of these elements is deprecated as they are otherwise replaced by
       severity elements, which should be used instead.
@@ -697,7 +697,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </ele>
     <ele>
       <name>hosts</name>
-      <summary>A textual list of hosts</summary>
+      <summary>A comma-separated list of hosts</summary>
       <pattern>
         text
       </pattern>
@@ -1061,7 +1061,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </ele>
     <ele>
       <name>hosts</name>
-      <summary>A textual list of hosts</summary>
+      <summary>A comma-separated list of hosts</summary>
       <pattern>
         text
       </pattern>
@@ -4228,7 +4228,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </ele>
     <ele>
       <name>hosts</name>
-      <summary>A textual list of hosts</summary>
+      <summary>A comma-separated list of hosts</summary>
       <pattern>
         text
       </pattern>
@@ -4368,7 +4368,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </ele>
     <ele>
       <name>hosts</name>
-      <summary>A textual list of hosts</summary>
+      <summary>A comma-separated list of hosts</summary>
       <pattern>
         text
       </pattern>
@@ -5473,7 +5473,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </ele>
     <ele>
       <name>hosts</name>
-      <summary>A textual list of hosts, which may be empty</summary>
+      <summary>A comma-separated list of hosts, which may be empty</summary>
       <pattern>
         text
       </pattern>
@@ -5862,7 +5862,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </ele>
     <ele>
       <name>hosts</name>
-      <summary>User access rules: a textual list of hosts</summary>
+      <summary>User access rules: a comma-separated list of hosts</summary>
       <pattern>
         <attrib>
           <name>allow</name>
@@ -5874,7 +5874,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </ele>
     <ele>
       <name>ifaces</name>
-      <summary>User access rules: a textual list of ifaces</summary>
+      <summary>User access rules: a comma-separated list of ifaces</summary>
       <pattern>
         <attrib>
           <name>allow</name>
@@ -23548,7 +23548,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </ele>
     <ele>
       <name>hosts</name>
-      <summary>A textual list of hosts</summary>
+      <summary>A comma-separated list of hosts</summary>
       <pattern>
         text
       </pattern>
@@ -23681,7 +23681,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </ele>
     <ele>
       <name>hosts</name>
-      <summary>A textual list of hosts</summary>
+      <summary>A comma-separated list of hosts</summary>
       <pattern>
         text
       </pattern>
@@ -24925,7 +24925,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </ele>
     <ele>
       <name>hosts</name>
-      <summary>User access rules: a textual list of hosts</summary>
+      <summary>User access rules: a comma-separated list of hosts</summary>
       <description>
         User is allowed to access any host if this element is missing.
       </description>
@@ -24940,7 +24940,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </ele>
     <ele>
       <name>ifaces</name>
-      <summary>User access rules: a textual list of ifaces</summary>
+      <summary>User access rules: a comma-separated list of ifaces</summary>
       <pattern>
         <attrib>
           <name>allow</name>


### PR DESCRIPTION
This commit removes the vague *textual* qualifier from the GMP protocol
specification and makes it clearer that a comma-separated list of items
is expected where appropriate.