### PR TITLE
Remove stray ret check

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -3248,15 +3248,11 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
                 case 0:
                   break;
                 case 404:
-                  if (ret == 404)
-                    {
-                      /* Resource Missing. */
-                      set_task_interrupted (task,
-                                            "Failed to find task on slave."
-                                            "  Interrupting scan.");
-                      goto giveup;
-                    }
-                  break;
+                  /* Resource Missing. */
+                  set_task_interrupted (task,
+                                        "Failed to find task on slave."
+                                        "  Interrupting scan.");
+                  goto giveup;
                 default:
                   goto fail_stop_task;
               }


### PR DESCRIPTION
Found by Clang.  Introduced in the original commit
129bf2343cdd95fa893bb815e9e7806f321dbd67 in 2013.