### PR TITLE
Add CirclCI job to build docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,7 @@ workflows:
       - build_postgresql_debug
       - build_sqlite_release
       - build_postgresql_release
+      - build_doc
       - gen_xml_doc
       - doc_coverage:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
       - checkout
       - run:
           name: Build standard documentation, failing if there are warnings
-          command: mkdir build && cd build/ && cmake -DSKIP_SRC=1 .. && make doc 2>&1 1>/dev/null | ! grep --invert-match "CGI::Pretty"
+          command: mkdir build && cd build/ && cmake -DSKIP_SRC=1 .. && make doc 2>&1 1>/dev/null | { ! grep --invert-match "CGI::Pretty"; }
   gen_xml_doc:
     docker:
       - image: greenbone/code-metrics-doxygen-debian-stretch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,14 @@ jobs:
       - run:
           name: Configure and Compile
           command: mkdir build && cd build/ && cmake -DBACKEND=POSTGRESQL -DCMAKE_BUILD_TYPE=Debug .. && make install
+  build_doc:
+    docker:
+      - image: greenbone/code-metrics-doxygen-debian-stretch
+    steps:
+      - checkout
+      - run:
+          name: Build standard documentation, failing if there are warnings
+          command: mkdir build && cd build/ && cmake -DSKIP_SRC=1 .. && make doc 2>&1 1>/dev/null | ! grep --invert-match "CGI::Pretty"
   gen_xml_doc:
     docker:
       - image: greenbone/code-metrics-doxygen-debian-stretch


### PR DESCRIPTION
The job builds the standard Doxygen docs, and fails if there are
warnings.  The aim is to help us catch undocumented symbols before
accepting PRs.