### PR TITLE
Add CircleCI jobs to build with Clang

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,22 @@ jobs:
       - run:
           name: Configure and Compile (Release)
           command: mkdir build && cd build/ && cmake -DBACKEND=POSTGRESQL -DCMAKE_BUILD_TYPE=Release .. && make install
+  build_sqlite3_debug_clang:
+    docker:
+      - image: greenbone/build-env-gvm-master-debian-stretch-clang-sqlite
+    steps:
+      - checkout
+      - run:
+          name: Configure and Compile with Clang (Debug, SQLite3)
+          command: mkdir build && cd build/ && cmake -DCMAKE_C_COMPILER=clang -DCMAKE_C_FLAGS="-Wno-ignored-attributes" -DCMAKE_BUILD_TYPE=Debug .. && make install
+  build_postgresql_debug_clang:
+    docker:
+      - image: greenbone/build-env-gvm-master-debian-stretch-clang-postgresql
+    steps:
+      - checkout
+      - run:
+          name: Configure and Compile with Clang (Debug, PostgreSQL)
+          command: mkdir build && cd build/ && cmake -DCMAKE_C_COMPILER=clang -DCMAKE_C_FLAGS="-Wno-ignored-attributes" -DBACKEND=POSTGRESQL -DCMAKE_BUILD_TYPE=Debug .. && make install
   build_doc:
     docker:
       - image: greenbone/code-metrics-doxygen-debian-stretch
@@ -117,6 +133,8 @@ workflows:
       - build_postgresql_debug
       - build_sqlite_release
       - build_postgresql_release
+      - build_sqlite3_debug_clang
+      - build_postgresql_debug_clang
       - build_doc
       - gen_xml_doc
       - doc_coverage:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,14 @@ jobs:
     docker:
       - image: greenbone/build-env-gvm-master-debian-stretch-clang-sqlite
     steps:
+      - run:
+          working_directory: ~/gvm-libs
+          name: Checkout gvm-libs
+          command: git clone --depth 1 https://github.com/greenbone/gvm-libs.git
+      - run:
+          working_directory: ~/gvm-libs
+          name: Configure and compile gvm-libs (Release)
+          command: pushd gvm-libs && mkdir build && cd build/ && cmake -DCMAKE_BUILD_TYPE=Release .. && make install && popd
       - checkout
       - run:
           name: Configure and Compile with Clang (Debug, SQLite3)
@@ -76,6 +84,14 @@ jobs:
     docker:
       - image: greenbone/build-env-gvm-master-debian-stretch-clang-postgresql
     steps:
+      - run:
+          working_directory: ~/gvm-libs
+          name: Checkout gvm-libs
+          command: git clone --depth 1 https://github.com/greenbone/gvm-libs.git
+      - run:
+          working_directory: ~/gvm-libs
+          name: Configure and compile gvm-libs (Release)
+          command: pushd gvm-libs && mkdir build && cd build/ && cmake -DCMAKE_BUILD_TYPE=Release .. && make install && popd
       - checkout
       - run:
           name: Configure and Compile with Clang (Debug, PostgreSQL)


### PR DESCRIPTION
These are the Debug builds, so the job fails if there are any Clang
warnings.