### PR TITLE
Use 0 for targets of container tasks, instead of a mix of 0 and NULL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 198)
+set (GVMD_DATABASE_VERSION 199)
 
 set (GVMD_SCAP_DATABASE_VERSION 15)
 

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -14901,6 +14901,39 @@ migrate_197_to_198 ()
   return 0;
 }
 
+/**
+ * @brief Migrate the database from version 198 to version 199.
+ *
+ * @return 0 success, -1 error.
+ */
+int
+migrate_198_to_199 ()
+{
+  sql_begin_immediate ();
+
+  /* Ensure that the database is currently version 198. */
+
+  if (manage_db_version () != 198)
+    {
+      sql_rollback ();
+      return -1;
+    }
+
+  /* Update the database. */
+
+  /* Container target are now only 0, and never NULL. */
+
+  sql ("UPDATE tasks SET target = 0 WHERE target IS NULL;");
+
+  /* Set the database version to 199. */
+
+  set_db_version (199);
+
+  sql_commit ();
+
+  return 0;
+}
+
 #undef UPDATE_CHART_SETTINGS
 #undef UPDATE_DASHBOARD_SETTINGS
 
@@ -15118,6 +15151,7 @@ static migrator_t database_migrators[]
     {196, migrate_195_to_196},
     {197, migrate_196_to_197},
     {198, migrate_197_to_198},
+    {199, migrate_198_to_199},
     /* End marker. */
     {-1, NULL}};
 

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -1544,7 +1544,7 @@ manage_create_sql_functions ()
              " RETURNS double precision AS $$"
              /* Calculate the severity of a task. */
              "  SELECT CASE"
-             "         WHEN (SELECT target IS NULL OR target = 0"
+             "         WHEN (SELECT target = 0"
              "               FROM tasks WHERE id = $1)"
              "         THEN CAST (NULL AS double precision)"
              "         ELSE"

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -31945,11 +31945,11 @@ make_task (char* name, char* comment, int in_assets, int event)
   quoted_comment = comment ? sql_quote ((gchar*) comment) : NULL;
   sql ("INSERT into tasks"
        " (owner, uuid, name, hidden, comment, schedule,"
-       "  schedule_next_time, config_location, target_location,"
+       "  schedule_next_time, config_location, target, target_location,"
        "  scanner_location, schedule_location, alterable,"
        "  creation_time, modification_time)"
        " VALUES ((SELECT id FROM users WHERE users.uuid = '%s'),"
-       "         '%s', '%s', 0, '%s', 0, 0, 0, 0, 0, 0, 0, m_now (),"
+       "         '%s', '%s', 0, '%s', 0, 0, 0, 0, 0, 0, 0, 0, m_now (),"
        "         m_now ());",
        current_credentials.uuid,
        uuid,


### PR DESCRIPTION
Tasks created by CREATE_TASKS were using 0, whereas tasks created by CREATE_REPORT were using NULL.  Both now use 0.

This includes migration of existing tasks.