### PR TITLE
Fix modify_credential certificate and type checks

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -41311,7 +41311,7 @@ modify_credential (const char *credential_id,
       // Truncate certificate which also validates it.
       gchar *certificate_truncated;
       certificate_truncated = truncate_certificate (certificate);
-      if (certificate_truncated == NULL)
+      if (certificate_truncated)
         {
           set_credential_certificate (credential, certificate_truncated);
           g_free (certificate_truncated);
@@ -41438,11 +41438,18 @@ modify_credential (const char *credential_id,
                   : credential_iterator_privacy_password (&iterator));
             }
         }
+      else if (strcmp (type, "pgp") == 0
+               || strcmp (type, "smime") == 0)
+        {
+          set_credential_data (credential, "secret", "");
+        }
       else
         {
           g_warning ("%s: Unknown credential type: %s", __FUNCTION__, type);
           sql_rollback ();
           cleanup_iterator (&iterator);
+          g_free (key_private_truncated);
+          return -1;
         }
 
       g_free (key_private_truncated);


### PR DESCRIPTION
This fixes several smaller bugs in the modify_credential function:
* The truncated certificate check was reversed, rejecting valid
 certificates and accpting invalid ones
* The newer types "pgp" and "smime" were not recognized
* The function did not return for unknown credential types,
 causing cleanup_iterator to be called twice.