### PR TITLE
Add new "Report Composer Defaults" setting

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -63055,6 +63055,10 @@ modify_setting (const gchar *uuid, const gchar *name,
       else if (strcmp (uuid, "956d13bd-3baa-4404-a138-5e7eb8f9630e") == 0)
         setting_name = g_strdup ("Overrides Filter");
 
+      /* Content composer defaults */
+      else if (strcmp (uuid, "b6b449ee-5d90-4ff0-af20-7e838c389d39") == 0)
+        setting_name = g_strdup ("Report Composer Defaults");
+
       /* Default resource selections */
       else if (strcmp (uuid, "f9f5a546-8018-48d0-bef5-5ad4926ea899") == 0)
         setting_name = g_strdup ("Default Alert");


### PR DESCRIPTION
This setting is to be used by the report composer in greenbone/gsa#1073.