### PR TITLE
Fix syntax errors in SMB alert script

### DIFF
--- a/src/alert_methods/SMB/alert
+++ b/src/alert_methods/SMB/alert
@@ -81,8 +81,8 @@ def smb_dir_exists(auth_path, share, check_dir):
 
     if rc == 0:
         return True
-    elif stdout.endswith("NT_STATUS_OBJECT_NAME_NOT_FOUND\n")
-            or stdout.endswith("NT_STATUS_OBJECT_PATH_NOT_FOUND\n"):
+    elif (stdout.endswith("NT_STATUS_OBJECT_NAME_NOT_FOUND\n")
+          or stdout.endswith("NT_STATUS_OBJECT_PATH_NOT_FOUND\n")):
         return False
     else:
         smb_error_print("Error checking directory %s" % check_dir,

--- a/src/alert_methods/SMB/alert
+++ b/src/alert_methods/SMB/alert
@@ -117,10 +117,10 @@ def smb_put(auth_path, share, report_path, dest_path):
         sys.exit(1)
 
 def main():
-  if len(sys.argv) != 5:
-    print("usage: %s <share> <dest_path> <auth_path> <report_path>" \
-          % sys.argv[0], file=sys.stderr)
-    sys.exit(1);
+    if len(sys.argv) != 5:
+        print("usage: %s <share> <dest_path> <auth_path> <report_path>" \
+              % sys.argv[0], file=sys.stderr)
+        sys.exit(1);
 
     share = sys.argv[1]
     dest_path = sys.argv[2]


### PR DESCRIPTION
This fixes a few errors introduced by updating the indentation and overall code style in #275.