### PR TITLE
Small fixes for Alemba vfire alert

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -10926,7 +10926,7 @@ buffer_vfire_call_input (gchar *key, gchar *value, GString *buffer)
  * @param[in]  description_template  Template for the description text.
  * @param[out] message        Error message.
  *
- * @return 0 success, -1 error
+ * @return 0 success, -1 error, -5 alert script failed.
  */
 static int
 send_to_vfire (const char *base_url, const char *client_id,
@@ -11059,7 +11059,7 @@ send_to_vfire (const char *base_url, const char *client_id,
                  __FUNCTION__, exit_status);
       g_message ("%s: stderr: %s",
                  __FUNCTION__, *message);
-      ret = -1;
+      ret = -5;
     }
 
   // Cleanup

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -12369,8 +12369,11 @@ escalate_to_vfire (alert_t alert, task_t task, report_t report, event_t event,
   // Cleanup
   gvm_file_remove_recurse (reports_dir);
 
-  get_data_reset (alert_filter_get);
-  g_free (alert_filter_get);
+  if (alert_filter_get)
+    {
+      get_data_reset (alert_filter_get);
+      g_free (alert_filter_get);
+    }
   free (base_url);
   free (session_type);
   free (client_id);


### PR DESCRIPTION
* In send_to_vfire, failures in the alert script will now be handled diffently from internal errors
* Some invalid free operations are fixed in the cleanup of escalate_to_vfire