### PR TITLE
Make asset type mandatory in create_asset

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@ gvmd 8.0+beta3 (work in progress)
 
 Main changes compared to gvm 8.0+beta2:
 * The new alert method "Alemba vFire" has been added.
+* GMP CREATE_ASSET, its GMP doc and usage by GSA are now more consistent.
 
 
 gvmd 8.0+beta2 (2018-12-05)

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -22536,11 +22536,12 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
           resource_t asset;
 
           if (create_asset_data->report_id == NULL
-              && create_asset_data->name == NULL)
+              && (create_asset_data->name == NULL
+                  || create_asset_data->type == NULL))
             SEND_TO_CLIENT_OR_FAIL
              (XML_ERROR_SYNTAX ("create_asset",
-                                "CREATE_ASSET requires a report ID or host"
-                                " name"));
+                                "CREATE_ASSET requires a report ID or an"
+                                " ASSET with TYPE and NAME"));
           else if (create_asset_data->report_id)
             switch (create_asset_report (create_asset_data->report_id,
                                          create_asset_data->filter_term))
@@ -22576,46 +22577,57 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                   log_event_fail ("asset", "Asset", NULL, "created");
                   break;
               }
-          else switch (create_asset_host (create_asset_data->name,
-                                          create_asset_data->comment,
-                                          &asset))
+          else if (strcasecmp (create_asset_data->type, "host") == 0)
             {
-              case 0:
+              switch (create_asset_host (create_asset_data->name,
+                                         create_asset_data->comment,
+                                         &asset))
                 {
-                  char *uuid;
-                  uuid = host_uuid (asset);
-                  SENDF_TO_CLIENT_OR_FAIL (XML_OK_CREATED_ID ("create_asset"),
-                                           uuid);
-                  log_event ("asset", "Asset", uuid, "created");
-                  g_free (uuid);
-                  break;
+                  case 0:
+                    {
+                      char *uuid;
+                      uuid = host_uuid (asset);
+                      SENDF_TO_CLIENT_OR_FAIL
+                        (XML_OK_CREATED_ID ("create_asset"), uuid);
+                      log_event ("asset", "Asset", uuid, "created");
+                      g_free (uuid);
+                      break;
+                    }
+                  case 1:
+                    SEND_TO_CLIENT_OR_FAIL
+                       (XML_ERROR_SYNTAX ("create_asset",
+                                          "Asset exists already"));
+                    log_event_fail ("asset", "Asset", NULL, "created");
+                    break;
+                  case 2:
+                    SEND_TO_CLIENT_OR_FAIL
+                       (XML_ERROR_SYNTAX ("create_asset",
+                                          "Name may only contain alphanumeric"
+                                          " characters"));
+                    log_event_fail ("asset", "Asset", NULL, "created");
+                    break;
+                  case 99:
+                    SEND_TO_CLIENT_OR_FAIL
+                       (XML_ERROR_SYNTAX ("create_asset",
+                                          "Permission denied"));
+                    log_event_fail ("asset", "Asset", NULL, "created");
+                    break;
+                  default:
+                    assert (0);
+                  case -1:
+                    SEND_TO_CLIENT_OR_FAIL
+                       (XML_INTERNAL_ERROR ("create_asset"));
+                    log_event_fail ("asset", "Asset", NULL, "created");
+                    break;
                 }
-              case 1:
-                SEND_TO_CLIENT_OR_FAIL
+            }
+          else
+            {
+              SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("create_asset",
-                                    "Asset exists already"));
-                log_event_fail ("asset", "Asset", NULL, "created");
-                break;
-              case 2:
-                SEND_TO_CLIENT_OR_FAIL
-                 (XML_ERROR_SYNTAX ("create_asset",
-                                    "Name may only contain alphanumeric"
-                                    " characters"));
-                log_event_fail ("asset", "Asset", NULL, "created");
-                break;
-              case 99:
-                SEND_TO_CLIENT_OR_FAIL
-                 (XML_ERROR_SYNTAX ("create_asset",
-                                    "Permission denied"));
-                log_event_fail ("asset", "Asset", NULL, "created");
-                break;
-              default:
-                assert (0);
-              case -1:
-                SEND_TO_CLIENT_OR_FAIL
-                 (XML_INTERNAL_ERROR ("create_asset"));
-                log_event_fail ("asset", "Asset", NULL, "created");
-                break;
+                                    "ASSET TYPE must be 'host'"));
+              log_event_fail ("asset", "Asset", NULL, "created");
+              break;
             }
           create_asset_data_reset (create_asset_data);
           set_client_state (CLIENT_AUTHENTIC);

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -3679,7 +3679,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       <name>asset</name>
       <pattern>
         <e>name</e>
-        <e>comment</e>
+        <o><e>comment</e></o>
+        <e>type</e>
       </pattern>
       <ele>
         <name>name</name>
@@ -3691,6 +3692,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       <ele>
         <name>comment</name>
         <summary>A comment on the asset</summary>
+        <pattern>
+          text
+        </pattern>
+      </ele>
+      <ele>
+        <name>type</name>
+        <summary>The type of asset to create. Must be 'host'</summary>
         <pattern>
           text
         </pattern>
@@ -25684,6 +25692,17 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 
   <!-- Compatibility changes between versions. -->
 
+  <change>
+    <command>CREATE_ASSET</command>
+    <summary>ASSET TYPE now mandatory</summary>
+    <description>
+      <p>
+        The TYPE subelement of the ASSET is now mandatory and must be
+        a type supported by the command.
+      </p>
+    </description>
+    <version>8.0</version>
+  </change>
   <change>
     <command>GET_NVTS</command>
     <summary>Remove COPYRIGHT</summary>


### PR DESCRIPTION
The TYPE subelement of the ASSET is now mandatory and must be a type
supported by the command (currently only 'host').