### PR TITLE
Drop optimization remove-open-port-results

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -281,12 +281,6 @@ supported values for `<name>` are:
   database must be up to date (if Manager and Scanner are both running, then
   this should happen automatically).
 
-- `remove-open-port-results`
-
-  This option removes results which were used in older versions of GVM to
-  indicate an open port. Since open ports are now part of the host details
-  these results are now obsolete in most cases.
-
 - `cleanup-port-names`
 
   This cleans up the ports of results as stored in the database by removing

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1797,7 +1797,7 @@ main (int argc, char** argv)
           G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE,
           &decrypt_all_credentials, NULL, NULL },
         { "new-password", '\0', 0, G_OPTION_ARG_STRING, &new_password, "Modify user's password and exit.", "<password>" },
-        { "optimize", '\0', 0, G_OPTION_ARG_STRING, &optimize, "Run an optimization: vacuum, analyze, cleanup-config-prefs, remove-open-port-results, cleanup-port-names, cleanup-result-severities, cleanup-schedule-times, rebuild-report-cache or update-report-cache.", "<name>" },
+        { "optimize", '\0', 0, G_OPTION_ARG_STRING, &optimize, "Run an optimization: vacuum, analyze, cleanup-config-prefs, cleanup-port-names, cleanup-result-severities, cleanup-schedule-times, rebuild-report-cache or update-report-cache.", "<name>" },
         { "password", '\0', 0, G_OPTION_ARG_STRING, &password, "Password, for --create-user.", "<password>" },
         { "port", 'p', 0, G_OPTION_ARG_STRING, &manager_port_string, "Use port number <number>.", "<number>" },
         { "port2", '\0', 0, G_OPTION_ARG_STRING, &manager_port_string_2, "Use port number <number> for address 2.", "<number>" },

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -68989,16 +68989,6 @@ manage_optimize (GSList *log_config, const gchar *database, const gchar *name)
                                       " %d. Corrected preference values: %d",
                                       removed, fixed_values);
     }
-  else if (strcasecmp (name, "remove-open-port-results") == 0)
-    {
-      int changes;
-      sql ("DELETE FROM results WHERE nvt='0';");
-      changes = sql_changes();
-      success_text = g_strdup_printf ("Optimized: remove-open-port-results."
-                                      " Superfluous open port results removed:"
-                                      " %d.",
-                                      changes);
-    }
   else if (strcasecmp (name, "cleanup-port-names") == 0)
     {
       int changes_iana, changes_old_format;


### PR DESCRIPTION
It has been a long time since we've had these type of results, and when tickets
are introduced there will be a slight chance of problems with tickets that
refer to the results.

If someone still wants to do this they can easily run the SQL by hand, it is only
1 statement.