### PR TITLE
Fix rsync errors due to IP blocking

### DIFF
--- a/tools/greenbone-certdata-sync.in
+++ b/tools/greenbone-certdata-sync.in
@@ -366,6 +366,8 @@ do_sync_community_feed () {
 }
 
 sync_certdata(){
+  # Sleep for ten seconds to prevent IP blocking.
+  sleep 10
   if [ -e $ACCESSKEY ]
   then
     log_notice "Found Greenbone Security Feed subscription file, trying to synchronize with Greenbone CERT data Repository ..."
@@ -413,7 +415,7 @@ sync_certdata(){
     log_notice "Synchronization with the Greenbone CERT data Repository successful."
     echo
   else
-    log_notice "No Greenbone Security Feed accees key found, falling back to Greenbone Community Feed"
+    log_notice "No Greenbone Security Feed access key found, falling back to Greenbone Community Feed"
     do_sync_community_feed
   fi
 

--- a/tools/greenbone-scapdata-sync.in
+++ b/tools/greenbone-scapdata-sync.in
@@ -385,6 +385,8 @@ do_sync_community_feed () {
 }
 
 sync_scapdata(){
+  # Sleep for ten seconds to prevent IP blocking.
+  sleep 10
   if [ -e $ACCESSKEY ]
   then
     log_notice "Found Greenbone Security Feed subscription file, trying to synchronize with Greenbone SCAP data Repository ..."
@@ -432,7 +434,7 @@ sync_scapdata(){
     done
     log_notice "Synchronization with the Greenbone SCAP data Repository successful."
   else
-    log_notice "No Greenbone Security Feed accees key found, falling back to Greenbone Community Feed"
+    log_notice "No Greenbone Security Feed access key found, falling back to Greenbone Community Feed"
     do_sync_community_feed
   fi
 


### PR DESCRIPTION
The synchronization scripts do two rsyncs in quick succession, this leads to frequent IP blocking by the rsync server.

Fixed by adding a short sleep before the second (synchronization) rsync.

Also fixed a small typo.