### PR TITLE
Remove trailing newlines from log messages

### DIFF
--- a/src/comm.c
+++ b/src/comm.c
@@ -98,14 +98,14 @@ sendn_to_server (const void * msg, size_t n)
 {
   if (TO_SERVER_BUFFER_SIZE - to_server_end < n)
     {
-      g_debug ("   sendn_to_server: available space (%i) < n (%zu)\n",
+      g_debug ("   sendn_to_server: available space (%i) < n (%zu)",
                TO_SERVER_BUFFER_SIZE - to_server_end, n);
       return 1;
     }
 
   memmove (to_server + to_server_end, msg, n);
-  g_debug ("s> server  (string) %.*s\n", (int) n, to_server + to_server_end);
-  g_debug ("-> server  %zu bytes\n", n);
+  g_debug ("s> server  (string) %.*s", (int) n, to_server + to_server_end);
+  g_debug ("-> server  %zu bytes", n);
   to_server_end += n;
 
   return 0;

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -387,7 +387,7 @@ try_gpgme_import (const char *key_str, gpgme_data_type_t key_type,
 
   if (mkdtemp (gpg_temp_dir) == NULL)
     {
-      g_warning ("%s: mkdtemp failed\n", __FUNCTION__);
+      g_warning ("%s: mkdtemp failed", __FUNCTION__);
       return -1;
     }
 
@@ -5485,7 +5485,7 @@ static void
 set_client_state (client_state_t state)
 {
   client_state = state;
-  g_debug ("   client state set: %i\n", client_state);
+  g_debug ("   client state set: %i", client_state);
 }
 
 
@@ -5623,7 +5623,7 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
     = (int (*) (const char *, void*)) gmp_parser->client_writer;
   void* write_to_client_data = (void*) gmp_parser->client_writer_data;
 
-  g_debug ("   XML  start: %s (%i)\n", element_name, client_state);
+  g_debug ("   XML  start: %s (%i)", element_name, client_state);
 
   if (gmp_parser->read_over)
     gmp_parser->read_over++;
@@ -10251,14 +10251,14 @@ strdiff (const gchar *one, const gchar *two)
   old_lc_all = getenv ("LC_ALL") ? g_strdup (getenv ("LC_ALL")) : NULL;
   if (setenv ("LC_ALL", "C", 1) == -1)
     {
-      g_warning ("%s: failed to set LC_ALL\n", __FUNCTION__);
+      g_warning ("%s: failed to set LC_ALL", __FUNCTION__);
       return NULL;
     }
 
   old_language = getenv ("LANGUAGE") ? g_strdup (getenv ("LANGUAGE")) : NULL;
   if (setenv ("LANGUAGE", "C", 1) == -1)
     {
-      g_warning ("%s: failed to set LANGUAGE\n", __FUNCTION__);
+      g_warning ("%s: failed to set LANGUAGE", __FUNCTION__);
       return NULL;
     }
 
@@ -10269,7 +10269,7 @@ strdiff (const gchar *one, const gchar *two)
   cmd[2] = g_strdup ("Report 1");
   cmd[3] = g_strdup ("Report 2");
   cmd[4] = NULL;
-  g_debug ("%s: Spawning in %s: %s \"%s\" \"%s\"\n",
+  g_debug ("%s: Spawning in %s: %s \"%s\" \"%s\"",
            __FUNCTION__, dir,
            cmd[0], cmd[1], cmd[2]);
   if ((g_spawn_sync (dir,
@@ -10294,8 +10294,8 @@ strdiff (const gchar *one, const gchar *two)
                    exit_status,
                    WIFEXITED (exit_status),
                    WEXITSTATUS (exit_status));
-          g_debug ("%s: stdout: %s\n", __FUNCTION__, standard_out);
-          g_debug ("%s: stderr: %s\n", __FUNCTION__, standard_err);
+          g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
+          g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);
           ret = NULL;
           g_free (standard_out);
         }
@@ -10305,12 +10305,12 @@ strdiff (const gchar *one, const gchar *two)
 
   if (old_lc_all && (setenv ("LC_ALL", old_lc_all, 1) == -1))
     {
-      g_warning ("%s: failed to reset LC_ALL\n", __FUNCTION__);
+      g_warning ("%s: failed to reset LC_ALL", __FUNCTION__);
       ret = NULL;
     }
   else if (old_language && (setenv ("LANGUAGE", old_language, 1) == -1))
     {
-      g_warning ("%s: failed to reset LANGUAGE\n", __FUNCTION__);
+      g_warning ("%s: failed to reset LANGUAGE", __FUNCTION__);
       ret = NULL;
     }
 
@@ -13875,7 +13875,7 @@ get_feed_info_parse (entity_t entity, const gchar *config_path,
   child = entity_child (entity, "name");
   if (child == NULL)
     {
-      g_warning ("%s: Missing name in '%s'\n", __FUNCTION__, config_path);
+      g_warning ("%s: Missing name in '%s'", __FUNCTION__, config_path);
       return -1;
     }
   *name = entity_text (child);
@@ -13883,7 +13883,7 @@ get_feed_info_parse (entity_t entity, const gchar *config_path,
   child = entity_child (entity, "description");
   if (child == NULL)
     {
-      g_warning ("%s: Missing description in '%s'\n",
+      g_warning ("%s: Missing description in '%s'",
                  __FUNCTION__, config_path);
       return -1;
     }
@@ -13892,7 +13892,7 @@ get_feed_info_parse (entity_t entity, const gchar *config_path,
   child = entity_child (entity, "version");
   if (child == NULL)
     {
-      g_warning ("%s: Missing version in '%s'\n", __FUNCTION__, config_path);
+      g_warning ("%s: Missing version in '%s'", __FUNCTION__, config_path);
       return -1;
     }
   *version = entity_text (child);
@@ -13934,7 +13934,7 @@ get_feed_info (int feed_type, gchar **feed_name, gchar **feed_version,
   g_file_get_contents (config_path, &xml, &xml_len, &error);
   if (error)
     {
-      g_warning ("%s: Failed to read '%s': %s\n",
+      g_warning ("%s: Failed to read '%s': %s",
                   __FUNCTION__,
                  config_path,
                  error->message);
@@ -13947,7 +13947,7 @@ get_feed_info (int feed_type, gchar **feed_name, gchar **feed_version,
 
   if (parse_entity (xml, &entity))
     {
-      g_warning ("%s: Failed to parse '%s'\n", __FUNCTION__, config_path);
+      g_warning ("%s: Failed to parse '%s'", __FUNCTION__, config_path);
       g_free (config_path);
       return -1;
     }
@@ -20316,7 +20316,7 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
     = (int (*) (const char *, void*)) gmp_parser->client_writer;
   void* write_to_client_data = (void*) gmp_parser->client_writer_data;
 
-  g_debug ("   XML    end: %s\n", element_name);
+  g_debug ("   XML    end: %s", element_name);
 
   if (gmp_parser->read_over > 1)
     {
@@ -20586,7 +20586,7 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                   /** @todo Or some other error occurred. */
                   /** @todo Consider reverting parsing for retry. */
                   /** @todo process_gmp_client_input must return -2. */
-                  g_debug ("delete_task failed\n");
+                  g_debug ("delete_task failed");
                   abort ();
                   break;
                 case -5:
@@ -28013,7 +28013,7 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
               /* Forked task process: success. */
               forked = 1;
               current_error = 2;
-              g_debug ("   %s: move_task fork success\n", __FUNCTION__);
+              g_debug ("   %s: move_task fork success", __FUNCTION__);
               g_set_error (error,
                             G_MARKUP_ERROR,
                             G_MARKUP_ERROR_INVALID_CONTENT,
@@ -28284,7 +28284,7 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                     case 2:
                       /* Forked task process: success. */
                       current_error = 2;
-                      g_debug ("   %s: resume_task fork success\n", __FUNCTION__);
+                      g_debug ("   %s: resume_task fork success", __FUNCTION__);
                       g_set_error (error,
                                    G_MARKUP_ERROR,
                                    G_MARKUP_ERROR_INVALID_CONTENT,
@@ -28318,7 +28318,7 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                     case -10:
                       /* Forked task process: error. */
                       current_error = -10;
-                      g_debug ("   %s: resume_task fork error\n", __FUNCTION__);
+                      g_debug ("   %s: resume_task fork error", __FUNCTION__);
                       g_set_error (error,
                                    G_MARKUP_ERROR,
                                    G_MARKUP_ERROR_INVALID_CONTENT,
@@ -28455,7 +28455,7 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                   {
                     /* Process forked to run a task. */
                     current_error = 2;
-                    g_debug ("   %s: run_wizard fork success\n", __FUNCTION__);
+                    g_debug ("   %s: run_wizard fork success", __FUNCTION__);
                     g_set_error (error,
                                  G_MARKUP_ERROR,
                                  G_MARKUP_ERROR_INVALID_CONTENT,
@@ -28544,7 +28544,7 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                   {
                     /* Process forked to run a task.  Task start failed. */
                     current_error = -10;
-                    g_debug ("   %s: run_wizard fork error\n", __FUNCTION__);
+                    g_debug ("   %s: run_wizard fork error", __FUNCTION__);
                     g_set_error (error,
                                  G_MARKUP_ERROR,
                                  G_MARKUP_ERROR_INVALID_CONTENT,
@@ -28624,7 +28624,7 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                     case 2:
                       /* Forked task process: success. */
                       current_error = 2;
-                      g_debug ("   %s: start_task fork success\n", __FUNCTION__);
+                      g_debug ("   %s: start_task fork success", __FUNCTION__);
                       g_set_error (error,
                                    G_MARKUP_ERROR,
                                    G_MARKUP_ERROR_INVALID_CONTENT,
@@ -28697,7 +28697,7 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                     case -10:
                       /* Forked task process: error. */
                       current_error = -10;
-                      g_debug ("   %s: start_task fork error\n", __FUNCTION__);
+                      g_debug ("   %s: start_task fork error", __FUNCTION__);
                       g_set_error (error,
                                    G_MARKUP_ERROR,
                                    G_MARKUP_ERROR_INVALID_CONTENT,
@@ -28951,7 +28951,7 @@ gmp_xml_handle_text (/* unused */ GMarkupParseContext* context,
                      /* unused */ GError **error)
 {
   if (text_len == 0) return;
-  g_debug ("   XML   text: %s\n", text);
+  g_debug ("   XML   text: %s", text);
   switch (client_state)
     {
       case CLIENT_AUTHENTICATE_CREDENTIALS_USERNAME:
@@ -30086,7 +30086,7 @@ gmp_xml_handle_error (/* unused */ GMarkupParseContext* context,
                       GError *error,
                       /* unused */ gpointer user_data)
 {
-  g_debug ("   XML ERROR %s\n", error->message);
+  g_debug ("   XML ERROR %s", error->message);
 }
 
 
@@ -30225,7 +30225,7 @@ process_gmp_client_input ()
           if (g_error_matches (error,
                                G_MARKUP_ERROR,
                                G_MARKUP_ERROR_UNKNOWN_ELEMENT))
-            g_debug ("   client error: G_MARKUP_ERROR_UNKNOWN_ELEMENT\n");
+            g_debug ("   client error: G_MARKUP_ERROR_UNKNOWN_ELEMENT");
           else if (g_error_matches (error,
                                     G_MARKUP_ERROR,
                                     G_MARKUP_ERROR_INVALID_CONTENT))
@@ -30237,15 +30237,15 @@ process_gmp_client_input ()
                   g_error_free (error);
                   return current_error;
                 }
-              g_debug ("   client error: G_MARKUP_ERROR_INVALID_CONTENT\n");
+              g_debug ("   client error: G_MARKUP_ERROR_INVALID_CONTENT");
             }
           else if (g_error_matches (error,
                                     G_MARKUP_ERROR,
                                     G_MARKUP_ERROR_UNKNOWN_ATTRIBUTE))
-            g_debug ("   client error: G_MARKUP_ERROR_UNKNOWN_ATTRIBUTE\n");
+            g_debug ("   client error: G_MARKUP_ERROR_UNKNOWN_ATTRIBUTE");
           else
             err = -1;
-          g_info ("   Failed to parse client XML: %s\n", error->message);
+          g_info ("   Failed to parse client XML: %s", error->message);
           g_error_free (error);
         }
       else
@@ -30272,7 +30272,7 @@ process_gmp_client_input ()
 static int
 process_gmp_write (const char* msg, void* buffer)
 {
-  g_debug ("-> client internal: %s\n", msg);
+  g_debug ("-> client internal: %s", msg);
   g_string_append ((GString*) buffer, msg);
   return FALSE;
 }
@@ -30353,7 +30353,7 @@ process_gmp (gmp_parser_t *parser, const gchar *command, gchar **response)
           if (g_error_matches (error,
                                G_MARKUP_ERROR,
                                G_MARKUP_ERROR_UNKNOWN_ELEMENT))
-            g_debug ("   client error: G_MARKUP_ERROR_UNKNOWN_ELEMENT\n");
+            g_debug ("   client error: G_MARKUP_ERROR_UNKNOWN_ELEMENT");
           else if (g_error_matches (error,
                                     G_MARKUP_ERROR,
                                     G_MARKUP_ERROR_INVALID_CONTENT))
@@ -30365,15 +30365,15 @@ process_gmp (gmp_parser_t *parser, const gchar *command, gchar **response)
                   g_error_free (error);
                   return current_error;
                 }
-              g_debug ("   client error: G_MARKUP_ERROR_INVALID_CONTENT\n");
+              g_debug ("   client error: G_MARKUP_ERROR_INVALID_CONTENT");
             }
           else if (g_error_matches (error,
                                     G_MARKUP_ERROR,
                                     G_MARKUP_ERROR_UNKNOWN_ATTRIBUTE))
-            g_debug ("   client error: G_MARKUP_ERROR_UNKNOWN_ATTRIBUTE\n");
+            g_debug ("   client error: G_MARKUP_ERROR_UNKNOWN_ATTRIBUTE");
           else
             err = -1;
-          g_info ("   Failed to parse client XML: %s\n", error->message);
+          g_info ("   Failed to parse client XML: %s", error->message);
           g_error_free (error);
         }
       else

--- a/src/gmp_base.c
+++ b/src/gmp_base.c
@@ -205,7 +205,7 @@ send_find_error_to_client (const char* command, const char* type,
 void
 error_send_to_client (GError** error)
 {
-  g_debug ("   send_to_client out of space in to_client\n");
+  g_debug ("   send_to_client out of space in to_client");
   g_set_error (error, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
                "Manager out of space for reply to client.");
 }

--- a/src/gmpd.c
+++ b/src/gmpd.c
@@ -157,7 +157,7 @@ read_from_client_unix (int client_socket)
           if (errno == EINTR)
             /* Interrupted, try read again. */
             continue;
-          g_warning ("%s: failed to read from client: %s\n",
+          g_warning ("%s: failed to read from client: %s",
                      __FUNCTION__, strerror (errno));
           return -1;
         }
@@ -210,7 +210,7 @@ read_from_client_tls (gnutls_session_t* client_session)
           if (count == GNUTLS_E_REHANDSHAKE)
             {
               /** @todo Rehandshake. */
-              g_debug ("   should rehandshake\n");
+              g_debug ("   should rehandshake");
               continue;
             }
           if (gnutls_error_is_fatal ((int) count) == 0
@@ -219,10 +219,10 @@ read_from_client_tls (gnutls_session_t* client_session)
             {
               int alert = gnutls_alert_get (*client_session);
               const char* alert_name = gnutls_alert_get_name (alert);
-              g_warning ("%s: TLS Alert %d: %s\n",
+              g_warning ("%s: TLS Alert %d: %s",
                          __FUNCTION__, alert, alert_name);
             }
-          g_warning ("%s: failed to read from client: %s\n",
+          g_warning ("%s: failed to read from client: %s",
                      __FUNCTION__, gnutls_strerror ((int) count));
           return -1;
         }
@@ -291,15 +291,15 @@ write_to_client_tls (gnutls_session_t* client_session)
           if (count == GNUTLS_E_REHANDSHAKE)
             /** @todo Rehandshake. */
             continue;
-          g_warning ("%s: failed to write to client: %s\n",
+          g_warning ("%s: failed to write to client: %s",
                      __FUNCTION__,
                      gnutls_strerror ((int) count));
           return -1;
         }
       to_client_start += count;
-      g_debug ("=> client  %u bytes\n", (unsigned int) count);
+      g_debug ("=> client  %u bytes", (unsigned int) count);
     }
-  g_debug ("=> client  done\n");
+  g_debug ("=> client  done");
   to_client_start = to_client_end = 0;
 
   /* Wrote everything. */
@@ -330,15 +330,15 @@ write_to_client_unix (int client_socket)
           if (errno == EINTR)
             /* Interrupted, try write again. */
             continue;
-          g_warning ("%s: failed to write to client: %s\n",
+          g_warning ("%s: failed to write to client: %s",
                      __FUNCTION__,
                      strerror (errno));
           return -1;
         }
       to_client_start += count;
-      g_debug ("=> client  %u bytes\n", (unsigned int) count);
+      g_debug ("=> client  %u bytes", (unsigned int) count);
     }
-  g_debug ("=> client  done\n");
+  g_debug ("=> client  done");
   to_client_start = to_client_end = 0;
 
   /* Wrote everything. */
@@ -388,7 +388,7 @@ gmpd_send_to_client (const char* msg, void* write_to_client_data)
           case  0:      /* Wrote everything in to_client. */
             break;
           case -1:      /* Error. */
-            g_debug ("   %s full (%i < %zu); client write failed\n",
+            g_debug ("   %s full (%i < %zu); client write failed",
                     __FUNCTION__,
                     ((buffer_size_t) TO_CLIENT_BUFFER_SIZE) - to_client_end,
                     strlen (msg));
@@ -405,7 +405,7 @@ gmpd_send_to_client (const char* msg, void* write_to_client_data)
         break;
 
       memmove (to_client + to_client_end, msg, length);
-      g_debug ("-> client: %.*s\n", (int) length, msg);
+      g_debug ("-> client: %.*s", (int) length, msg);
       to_client_end += length;
       msg += length;
     }
@@ -415,7 +415,7 @@ gmpd_send_to_client (const char* msg, void* write_to_client_data)
       assert (strlen (msg)
               <= (((buffer_size_t) TO_CLIENT_BUFFER_SIZE) - to_client_end));
       memmove (to_client + to_client_end, msg, strlen (msg));
-      g_debug ("-> client: %s\n", msg);
+      g_debug ("-> client: %s", msg);
       to_client_end += strlen (msg);
     }
 
@@ -485,7 +485,7 @@ serve_gmp (gvm_connection_t *client_connection, const gchar *database,
     gmpd_nvt_cache_mode = client_connection->socket;
 
   if (gmpd_nvt_cache_mode == 0)
-    g_debug ("   Serving GMP.\n");
+    g_debug ("   Serving GMP");
 
   /* Initialise the XML parser and the manage library. */
   init_gmp_process (gmpd_nvt_cache_mode,
@@ -669,7 +669,7 @@ serve_gmp (gvm_connection_t *client_connection, const gchar *database,
         }
       else if (ret < 0)
         {
-          g_warning ("%s: child select failed: %s\n", __FUNCTION__,
+          g_warning ("%s: child select failed: %s", __FUNCTION__,
                      strerror (errno));
           rc = -1;
           goto client_free;
@@ -692,7 +692,7 @@ serve_gmp (gvm_connection_t *client_connection, const gchar *database,
                 /* There may be more to read. */
                 break;
               case -3:       /* End of file. */
-                g_debug ("   EOF reading from client.\n");
+                g_debug ("   EOF reading from client");
                 if (client_connection->socket > 0
                     && FD_ISSET (client_connection->socket, &writefds))
                   /* Write rest of to_client to client, so that the client gets
@@ -711,9 +711,9 @@ serve_gmp (gvm_connection_t *client_connection, const gchar *database,
               if (g_strstr_len (from_client + initial_start,
                                 from_client_end - initial_start,
                                 "<password>"))
-                g_debug ("<= client  Input may contain password, suppressed.\n");
+                g_debug ("<= client  Input may contain password, suppressed");
               else
-                g_debug ("<= client  \"%.*s\"\n",
+                g_debug ("<= client  \"%.*s\"",
                         from_client_end - initial_start,
                         from_client + initial_start);
             }
@@ -773,14 +773,14 @@ serve_gmp (gvm_connection_t *client_connection, const gchar *database,
           else if (ret == -2)
             {
               /* to_scanner buffer full. */
-              g_debug ("   client input stalled 1\n");
+              g_debug ("   client input stalled 1");
               client_input_stalled = 1;
               /* Carry on to write to_scanner. */
             }
           else if (ret == -3)
             {
               /* to_client buffer full. */
-              g_debug ("   client input stalled 2\n");
+              g_debug ("   client input stalled 2");
               client_input_stalled = 2;
               /* Carry on to write to_client. */
             }
@@ -925,13 +925,13 @@ serve_gmp (gvm_connection_t *client_connection, const gchar *database,
           else if (ret == -2)
             {
               /* to_scanner buffer full. */
-              g_debug ("   client input still stalled (1)\n");
+              g_debug ("   client input still stalled (1)");
               client_input_stalled = 1;
             }
           else if (ret == -3)
             {
               /* to_client buffer full. */
-              g_debug ("   client input still stalled (2)\n");
+              g_debug ("   client input still stalled (2)");
               client_input_stalled = 2;
             }
           else
@@ -989,7 +989,7 @@ serve_gmp (gvm_connection_t *client_connection, const gchar *database,
             }
           else if (ret == -3)
             /* to_scanner buffer still full. */
-            g_debug ("   scanner input stalled\n");
+            g_debug ("   scanner input stalled");
           else
             {
               /* Programming error. */

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -314,7 +314,7 @@ set_gnutls_priority (gnutls_session_t *session, const char *priority)
   const char *errp = NULL;
   if (gnutls_priority_set_direct (*session, priority, &errp)
       == GNUTLS_E_INVALID_REQUEST)
-    g_warning ("Invalid GnuTLS priority: %s\n", errp);
+    g_warning ("Invalid GnuTLS priority: %s", errp);
 }
 
 /**
@@ -331,13 +331,13 @@ option_lock (lockfile_t *lockfile_checking)
 
   if (lockfile_lock_shared_nb (&lockfile_helping, "gvm-helping"))
     {
-      g_critical ("%s: Error getting helping lock\n", __FUNCTION__);
+      g_critical ("%s: Error getting helping lock", __FUNCTION__);
       return -1;
     }
 
   if (lockfile_unlock (lockfile_checking))
     {
-      g_critical ("%s: Error releasing checking lock\n", __FUNCTION__);
+      g_critical ("%s: Error releasing checking lock", __FUNCTION__);
       return -1;
     }
 
@@ -463,7 +463,7 @@ serve_client (int server_socket, gvm_connection_t *client_connection)
                       SOL_SOCKET, SO_KEEPALIVE,
                       &optval, sizeof (int)))
         {
-          g_critical ("%s: failed to set SO_KEEPALIVE on scanner socket: %s\n",
+          g_critical ("%s: failed to set SO_KEEPALIVE on scanner socket: %s",
                       __FUNCTION__,
                       strerror (errno));
           exit (EXIT_FAILURE);
@@ -484,7 +484,7 @@ serve_client (int server_socket, gvm_connection_t *client_connection)
   if (client_connection->tls
       && gvm_server_attach (client_connection->socket, &client_session))
     {
-      g_debug ("%s: failed to attach client session to socket %i\n",
+      g_debug ("%s: failed to attach client session to socket %i",
                __FUNCTION__,
               client_connection->socket);
       goto fail;
@@ -494,7 +494,7 @@ serve_client (int server_socket, gvm_connection_t *client_connection)
    * error" removes the data between `select' and `read'. */
   if (fcntl (client_connection->socket, F_SETFL, O_NONBLOCK) == -1)
     {
-      g_warning ("%s: failed to set real client socket flag: %s\n",
+      g_warning ("%s: failed to set real client socket flag: %s",
                  __FUNCTION__,
                  strerror (errno));
       goto fail;
@@ -569,7 +569,7 @@ accept_and_maybe_fork (int server_socket, sigset_t *sigmask_current)
       if (errno == EAGAIN || errno == EWOULDBLOCK)
         /* The connection is gone, return to select. */
         return;
-      g_critical ("%s: failed to accept client connection: %s\n",
+      g_critical ("%s: failed to accept client connection: %s",
                   __FUNCTION__,
                   strerror (errno));
       exit (EXIT_FAILURE);
@@ -599,7 +599,7 @@ accept_and_maybe_fork (int server_socket, sigset_t *sigmask_current)
           action.sa_handler = SIG_DFL;
           if (sigaction (SIGCHLD, &action, NULL) == -1)
             {
-              g_critical ("%s: failed to set client SIGCHLD handler: %s\n",
+              g_critical ("%s: failed to set client SIGCHLD handler: %s",
                           __FUNCTION__,
                           strerror (errno));
               shutdown (client_socket, SHUT_RDWR);
@@ -612,7 +612,7 @@ accept_and_maybe_fork (int server_socket, sigset_t *sigmask_current)
            */
           if (fcntl (client_socket, F_SETFL, O_NONBLOCK) == -1)
             {
-              g_critical ("%s: failed to set client socket flag: %s\n",
+              g_critical ("%s: failed to set client socket flag: %s",
                           __FUNCTION__,
                           strerror (errno));
               shutdown (client_socket, SHUT_RDWR);
@@ -631,7 +631,7 @@ accept_and_maybe_fork (int server_socket, sigset_t *sigmask_current)
         }
       case -1:
         /* Parent when error, return to select. */
-        g_warning ("%s: failed to fork child: %s\n",
+        g_warning ("%s: failed to fork child: %s",
                    __FUNCTION__,
                    strerror (errno));
         close (client_socket);
@@ -675,7 +675,7 @@ fork_connection_internal (gvm_connection_t *client_connection, gchar* uuid,
 
       case -1:
         /* Parent when error. */
-        g_warning ("%s: fork: %s\n", __FUNCTION__, strerror (errno));
+        g_warning ("%s: fork: %s", __FUNCTION__, strerror (errno));
         return -1;
         break;
 
@@ -698,7 +698,7 @@ fork_connection_internal (gvm_connection_t *client_connection, gchar* uuid,
   /* Create a connected pair of sockets. */
   if (socketpair (AF_UNIX, SOCK_STREAM, 0, sockets))
     {
-      g_warning ("%s: socketpair: %s\n", __FUNCTION__, strerror (errno));
+      g_warning ("%s: socketpair: %s", __FUNCTION__, strerror (errno));
       exit (EXIT_FAILURE);
     }
 
@@ -722,7 +722,7 @@ fork_connection_internal (gvm_connection_t *client_connection, gchar* uuid,
         action.sa_handler = SIG_DFL;
         if (sigaction (SIGCHLD, &action, NULL) == -1)
           {
-            g_critical ("%s: failed to set client SIGCHLD handler: %s\n",
+            g_critical ("%s: failed to set client SIGCHLD handler: %s",
                         __FUNCTION__,
                         strerror (errno));
             shutdown (parent_client_socket, SHUT_RDWR);
@@ -735,7 +735,7 @@ fork_connection_internal (gvm_connection_t *client_connection, gchar* uuid,
          */
         if (fcntl (parent_client_socket, F_SETFL, O_NONBLOCK) == -1)
           {
-            g_critical ("%s: failed to set client socket flag: %s\n",
+            g_critical ("%s: failed to set client socket flag: %s",
                         __FUNCTION__,
                         strerror (errno));
             shutdown (parent_client_socket, SHUT_RDWR);
@@ -763,14 +763,14 @@ fork_connection_internal (gvm_connection_t *client_connection, gchar* uuid,
                                 &client_session,
                                 &client_credentials))
               {
-                g_critical ("%s: client server initialisation failed\n",
+                g_critical ("%s: client server initialisation failed",
                             __FUNCTION__);
                 exit (EXIT_FAILURE);
               }
             set_gnutls_priority (&client_session, priorities_option);
             if (dh_params_option
                 && set_gnutls_dhparams (client_credentials, dh_params_option))
-              g_warning ("Couldn't set DH parameters from %s\n", dh_params_option);
+              g_warning ("Couldn't set DH parameters from %s", dh_params_option);
           }
 
         /* Serve client. */
@@ -791,7 +791,7 @@ fork_connection_internal (gvm_connection_t *client_connection, gchar* uuid,
       case -1:
         /* Parent when error. */
 
-        g_warning ("%s: fork: %s\n", __FUNCTION__, strerror (errno));
+        g_warning ("%s: fork: %s", __FUNCTION__, strerror (errno));
         exit (EXIT_FAILURE);
         break;
 
@@ -888,7 +888,7 @@ log_config_free ()
 static void
 cleanup ()
 {
-  g_debug ("   Cleaning up.\n");
+  g_debug ("   Cleaning up");
   /** @todo These should happen via gmp, maybe with "cleanup_gmp ();". */
   cleanup_manage_process (TRUE);
   g_strfreev (disabled_commands);
@@ -898,12 +898,12 @@ cleanup ()
   if (log_stream != NULL)
     {
       if (fclose (log_stream))
-        g_critical ("%s: failed to close log stream: %s\n",
+        g_critical ("%s: failed to close log stream: %s",
                     __FUNCTION__,
                     strerror (errno));
     }
 #endif /* LOG */
-  g_debug ("   Exiting.\n");
+  g_debug ("   Exiting");
   if (log_config) log_config_free ();
 
   /* Tear down authentication system conf, if any. */
@@ -935,7 +935,7 @@ setup_signal_handler (int signal, void (*handler) (int), int block)
   action.sa_handler = handler;
   if (sigaction (signal, &action, NULL) == -1)
     {
-      g_critical ("%s: failed to register %s handler\n",
+      g_critical ("%s: failed to register %s handler",
                   __FUNCTION__, sys_siglist[signal]);
       exit (EXIT_FAILURE);
     }
@@ -966,7 +966,7 @@ setup_signal_handler_info (int signal,
   action.sa_sigaction = handler;
   if (sigaction (signal, &action, NULL) == -1)
     {
-      g_critical ("%s: failed to register %s handler\n",
+      g_critical ("%s: failed to register %s handler",
                   __FUNCTION__, sys_siglist[signal]);
       exit (EXIT_FAILURE);
     }
@@ -1010,7 +1010,7 @@ handle_sigabrt (int given_signal)
       frame_count = 0;
     }
   for (index = 0; index < frame_count; index++)
-    g_debug ("%s\n", frames_text[index]);
+    g_debug ("%s", frames_text[index]);
   free (frames_text);
 #endif
 
@@ -1114,13 +1114,13 @@ update_nvt_cache (int register_cleanup)
       case 0:
         break;
       case -2:
-        g_critical ("%s: database is wrong version\n", __FUNCTION__);
+        g_critical ("%s: database is wrong version", __FUNCTION__);
         log_config_free ();
         exit (EXIT_FAILURE);
         break;
       case -1:
       default:
-        g_critical ("%s: failed to initialise GMP daemon\n", __FUNCTION__);
+        g_critical ("%s: failed to initialise GMP daemon", __FUNCTION__);
         log_config_free ();
         exit (EXIT_FAILURE);
     }
@@ -1129,7 +1129,7 @@ update_nvt_cache (int register_cleanup)
 
   if (register_cleanup && atexit (&cleanup))
     {
-      g_critical ("%s: failed to register `atexit' cleanup function\n",
+      g_critical ("%s: failed to register `atexit' cleanup function",
                   __FUNCTION__);
       log_config_free ();
       exit (EXIT_FAILURE);
@@ -1159,7 +1159,7 @@ update_nvt_cache (int register_cleanup)
       case 1:
         return 2;
       case -2:
-        g_critical ("%s: scanner OpenVAS Default has no cert\n", __FUNCTION__);
+        g_critical ("%s: scanner OpenVAS Default has no cert", __FUNCTION__);
         return EXIT_FAILURE;
       default:
       case -1:
@@ -1230,12 +1230,12 @@ fork_update_nvt_cache ()
   /* Block SIGCHLD until parent records the value of the child PID. */
   if (sigemptyset (&sigmask_all))
     {
-      g_critical ("%s: Error emptying signal set\n", __FUNCTION__);
+      g_critical ("%s: Error emptying signal set", __FUNCTION__);
       return -1;
     }
   if (pthread_sigmask (SIG_BLOCK, &sigmask_all, &sigmask_current))
     {
-      g_critical ("%s: Error setting signal mask\n", __FUNCTION__);
+      g_critical ("%s: Error setting signal mask", __FUNCTION__);
       return -1;
     }
 
@@ -1269,10 +1269,10 @@ fork_update_nvt_cache ()
 
       case -1:
         /* Parent when error. */
-        g_warning ("%s: fork: %s\n", __FUNCTION__, strerror (errno));
+        g_warning ("%s: fork: %s", __FUNCTION__, strerror (errno));
         update_in_progress = 0;
         if (pthread_sigmask (SIG_SETMASK, &sigmask_current, NULL))
-          g_warning ("%s: Error resetting signal mask\n", __FUNCTION__);
+          g_warning ("%s: Error resetting signal mask", __FUNCTION__);
         return -1;
 
       default:
@@ -1280,7 +1280,7 @@ fork_update_nvt_cache ()
         g_debug ("%s: %i forked %i", __FUNCTION__, getpid (), pid);
         update_in_progress = pid;
         if (pthread_sigmask (SIG_SETMASK, &sigmask_current, NULL))
-          g_warning ("%s: Error resetting signal mask\n", __FUNCTION__);
+          g_warning ("%s: Error resetting signal mask", __FUNCTION__);
         return 0;
     }
 }
@@ -1305,12 +1305,12 @@ serve_and_schedule ()
 
   if (sigfillset (&sigmask_all))
     {
-      g_critical ("%s: Error filling signal set\n", __FUNCTION__);
+      g_critical ("%s: Error filling signal set", __FUNCTION__);
       exit (EXIT_FAILURE);
     }
   if (pthread_sigmask (SIG_BLOCK, &sigmask_all, &sigmask_current))
     {
-      g_critical ("%s: Error setting signal mask\n", __FUNCTION__);
+      g_critical ("%s: Error setting signal mask", __FUNCTION__);
       exit (EXIT_FAILURE);
     }
   sigmask_normal = &sigmask_current;
@@ -1335,7 +1335,7 @@ serve_and_schedule ()
 
       if (termination_signal)
         {
-          g_debug ("Received %s signal.\n",
+          g_debug ("Received %s signal",
                    sys_siglist[termination_signal]);
           cleanup ();
           /* Raise signal again, to exit with the correct return value. */
@@ -1376,7 +1376,7 @@ serve_and_schedule ()
           /* Error occurred while selecting socket. */
           if (errno == EINTR)
             continue;
-          g_critical ("%s: select failed: %s\n",
+          g_critical ("%s: select failed: %s",
                       __FUNCTION__,
                       strerror (errno));
           exit (EXIT_FAILURE);
@@ -1387,12 +1387,12 @@ serve_and_schedule ()
           /* Have an incoming connection. */
           if (FD_ISSET (manager_socket, &exceptfds))
             {
-              g_critical ("%s: exception in select\n", __FUNCTION__);
+              g_critical ("%s: exception in select", __FUNCTION__);
               exit (EXIT_FAILURE);
             }
           if ((manager_socket_2 > -1) && FD_ISSET (manager_socket_2, &exceptfds))
             {
-              g_critical ("%s: exception in select (2)\n", __FUNCTION__);
+              g_critical ("%s: exception in select (2)", __FUNCTION__);
               exit (EXIT_FAILURE);
             }
           if (FD_ISSET (manager_socket, &readfds))
@@ -1424,7 +1424,7 @@ serve_and_schedule ()
 
       if (termination_signal)
         {
-          g_debug ("Received %s signal.\n",
+          g_debug ("Received %s signal",
                    sys_siglist[termination_signal]);
           cleanup ();
           /* Raise signal again, to exit with the correct return value. */
@@ -1461,7 +1461,7 @@ manager_listen (const char *address_str_unix, const char *address_str_tls,
   memset (&address_tls, 0, sizeof (struct sockaddr_storage));
   memset (&address_unix, 0, sizeof (struct sockaddr_un));
 
-  g_debug ("%s: address_str_unix: %s\n", __FUNCTION__, address_str_unix);
+  g_debug ("%s: address_str_unix: %s", __FUNCTION__, address_str_unix);
   if (address_str_unix)
     {
       struct stat state;
@@ -1473,7 +1473,7 @@ manager_listen (const char *address_str_unix, const char *address_str_tls,
                address_str_unix,
                sizeof (address_unix.sun_path) - 1);
 
-      g_debug ("%s: address_unix.sun_path: %s\n",
+      g_debug ("%s: address_unix.sun_path: %s",
                __FUNCTION__,
                address_unix.sun_path);
 
@@ -1812,7 +1812,7 @@ main (int argc, char** argv)
   if (!g_option_context_parse (option_context, &argc, &argv, &error))
     {
       g_option_context_free (option_context);
-      g_critical ("%s: g_option_context_parse: %s\n\n", __FUNCTION__,
+      g_critical ("%s: g_option_context_parse: %s", __FUNCTION__,
                   error->message);
       exit (EXIT_FAILURE);
     }
@@ -1867,7 +1867,7 @@ main (int argc, char** argv)
       use_tls = 0;
       if (manager_address_string || manager_address_string_2)
         {
-          g_critical ("%s: --listen or --listen2 given with --unix-socket\n",
+          g_critical ("%s: --listen or --listen2 given with --unix-socket",
                       __FUNCTION__);
           return EXIT_FAILURE;
         }
@@ -1876,7 +1876,7 @@ main (int argc, char** argv)
   if (use_tls == 0
       && (manager_port_string || manager_port_string_2))
     {
-      g_critical ("%s: --port or --port2 given when listening on UNIX socket\n",
+      g_critical ("%s: --port or --port2 given when listening on UNIX socket",
                   __FUNCTION__);
       return EXIT_FAILURE;
     }
@@ -1894,10 +1894,10 @@ main (int argc, char** argv)
 
   if (migrate_database
       && manage_migrate_needs_timezone (log_config, database))
-    g_info ("%s: leaving TZ as is, for migrator\n", __FUNCTION__);
+    g_info ("%s: leaving TZ as is, for migrator", __FUNCTION__);
   else if (setenv ("TZ", "utc 0", 1) == -1)
     {
-      g_critical ("%s: failed to set timezone\n", __FUNCTION__);
+      g_critical ("%s: failed to set timezone", __FUNCTION__);
       exit (EXIT_FAILURE);
     }
   tzset ();
@@ -1926,12 +1926,12 @@ main (int argc, char** argv)
   }
 
 #ifdef GVMD_GIT_REVISION
-  g_message ("   Greenbone Vulnerability Manager version %s (GIT revision %s) (DB revision %i)\n",
+  g_message ("   Greenbone Vulnerability Manager version %s (GIT revision %s) (DB revision %i)",
              GVMD_VERSION,
              GVMD_GIT_REVISION,
              manage_db_supported_version ());
 #else
-  g_message ("   Greenbone Vulnerability Manager version %s (DB revision %i)\n",
+  g_message ("   Greenbone Vulnerability Manager version %s (DB revision %i)",
              GVMD_VERSION,
              manage_db_supported_version ());
 #endif
@@ -1962,7 +1962,7 @@ main (int argc, char** argv)
         return EXIT_FAILURE;
       case -1:
       default:
-        g_critical ("%s: Error trying to get checking lock\n", __FUNCTION__);
+        g_critical ("%s: Error trying to get checking lock", __FUNCTION__);
         return EXIT_FAILURE;
     }
 
@@ -2002,56 +2002,56 @@ main (int argc, char** argv)
             g_warning ("%s: A migrate is already running", __FUNCTION__);
             return EXIT_FAILURE;
           case -1:
-            g_critical ("%s: Error getting migrating lock\n", __FUNCTION__);
+            g_critical ("%s: Error getting migrating lock", __FUNCTION__);
             return EXIT_FAILURE;
         }
 
       if (lockfile_unlock (&lockfile_checking))
         {
-          g_critical ("%s: Error releasing checking lock\n", __FUNCTION__);
+          g_critical ("%s: Error releasing checking lock", __FUNCTION__);
           return EXIT_FAILURE;
         }
 
       proctitle_set ("gvmd: Migrating database");
 
-      g_info ("   Migrating database.\n");
+      g_info ("   Migrating database.");
 
       switch (manage_migrate (log_config, database))
         {
           case 0:
-            g_info ("   Migration succeeded.\n");
+            g_info ("   Migration succeeded.");
             return EXIT_SUCCESS;
           case 1:
-            g_warning ("%s: databases are already at the supported version\n",
+            g_warning ("%s: databases are already at the supported version",
                        __FUNCTION__);
             return EXIT_SUCCESS;
           case 2:
-            g_warning ("%s: database migration too hard\n",
+            g_warning ("%s: database migration too hard",
                        __FUNCTION__);
             return EXIT_FAILURE;
           case 11:
-            g_warning ("%s: cannot migrate SCAP database\n",
+            g_warning ("%s: cannot migrate SCAP database",
                        __FUNCTION__);
             return EXIT_FAILURE;
           case 12:
-            g_warning ("%s: cannot migrate CERT database\n",
+            g_warning ("%s: cannot migrate CERT database",
                        __FUNCTION__);
             return EXIT_FAILURE;
           case -1:
-            g_critical ("%s: database migration failed\n",
+            g_critical ("%s: database migration failed",
                         __FUNCTION__);
             return EXIT_FAILURE;
           case -11:
-            g_critical ("%s: SCAP database migration failed\n",
+            g_critical ("%s: SCAP database migration failed",
                         __FUNCTION__);
             return EXIT_FAILURE;
           case -12:
-            g_critical ("%s: CERT database migration failed\n",
+            g_critical ("%s: CERT database migration failed",
                         __FUNCTION__);
             return EXIT_FAILURE;
           default:
             assert (0);
-            g_critical ("%s: strange return from manage_migrate\n",
+            g_critical ("%s: strange return from manage_migrate",
                         __FUNCTION__);
             return EXIT_FAILURE;
         }
@@ -2077,22 +2077,22 @@ main (int argc, char** argv)
 
       proctitle_set ("gvmd: Backing up database");
 
-      g_info ("   Backing up database.\n");
+      g_info ("   Backing up database.");
 
       /* TODO Not sure about locking.  Not used by Postgres.  Perhaps remove. */
 
       switch (manage_backup_db (database))
         {
           case 0:
-            g_info ("   Backup succeeded.\n");
+            g_info ("   Backup succeeded.");
             return EXIT_SUCCESS;
           case -1:
-            g_critical ("%s: database backup failed\n",
+            g_critical ("%s: database backup failed",
                         __FUNCTION__);
             return EXIT_FAILURE;
           default:
             assert (0);
-            g_critical ("%s: strange return from manage_backup_db\n",
+            g_critical ("%s: strange return from manage_backup_db",
                         __FUNCTION__);
             return EXIT_FAILURE;
         }
@@ -2107,7 +2107,7 @@ main (int argc, char** argv)
                                           "pwpolicy.conf",
                                           NULL);
       if (g_file_test (password_policy, G_FILE_TEST_EXISTS) == FALSE)
-        g_warning ("%s: password policy missing: %s\n",
+        g_warning ("%s: password policy missing: %s",
                    __FUNCTION__,
                    password_policy);
       g_free (password_policy);
@@ -2196,7 +2196,7 @@ main (int argc, char** argv)
             type = SCANNER_TYPE_OSP;
           else
             {
-              g_warning ("Invalid scanner type value.\n");
+              g_warning ("Invalid scanner type value");
               return EXIT_FAILURE;
             }
 
@@ -2410,7 +2410,7 @@ main (int argc, char** argv)
         return EXIT_FAILURE;
       case -1:
       default:
-        g_critical ("%s: Error trying to get serving lock\n", __FUNCTION__);
+        g_critical ("%s: Error trying to get serving lock", __FUNCTION__);
         return EXIT_FAILURE;
     }
 
@@ -2425,7 +2425,7 @@ main (int argc, char** argv)
             break;
           case -1:
             /* Parent when error. */
-            g_critical ("%s: failed to fork into background: %s\n",
+            g_critical ("%s: failed to fork into background: %s",
                         __FUNCTION__,
                         strerror (errno));
             log_config_free ();
@@ -2449,13 +2449,13 @@ main (int argc, char** argv)
       case 0:
         break;
       case -2:
-        g_critical ("%s: database is wrong version\n", __FUNCTION__);
+        g_critical ("%s: database is wrong version", __FUNCTION__);
         log_config_free ();
         exit (EXIT_FAILURE);
         break;
       case -4:
         g_critical ("%s: --max-ips-per-target out of range"
-                    " (min=1, max=%i, requested=%i)\n",
+                    " (min=1, max=%i, requested=%i)",
                     __FUNCTION__,
                     MANAGE_ABSOLUTE_MAX_IPS_PER_TARGET,
                     max_ips_per_target);
@@ -2464,7 +2464,7 @@ main (int argc, char** argv)
         break;
       case -1:
       default:
-        g_critical ("%s: failed to initialise GMP daemon\n", __FUNCTION__);
+        g_critical ("%s: failed to initialise GMP daemon", __FUNCTION__);
         log_config_free ();
         exit (EXIT_FAILURE);
     }
@@ -2473,7 +2473,7 @@ main (int argc, char** argv)
 
   if (lockfile_unlock (&lockfile_checking))
     {
-      g_critical ("%s: Error releasing checking lock\n", __FUNCTION__);
+      g_critical ("%s: Error releasing checking lock", __FUNCTION__);
       return EXIT_FAILURE;
     }
 
@@ -2481,7 +2481,7 @@ main (int argc, char** argv)
 
   if (atexit (&cleanup))
     {
-      g_critical ("%s: failed to register `atexit' cleanup function\n",
+      g_critical ("%s: failed to register `atexit' cleanup function",
                   __FUNCTION__);
       log_config_free ();
       exit (EXIT_FAILURE);
@@ -2507,7 +2507,7 @@ main (int argc, char** argv)
                             0755) /* "rwxr-xr-x" */
       == -1)
     {
-      g_critical ("%s: failed to create log directory: %s\n",
+      g_critical ("%s: failed to create log directory: %s",
                   __FUNCTION__,
                   strerror (errno));
       exit (EXIT_FAILURE);
@@ -2516,7 +2516,7 @@ main (int argc, char** argv)
   log_stream = fopen (LOG_FILE, "w");
   if (log_stream == NULL)
     {
-      g_critical ("%s: failed to open log file: %s\n",
+      g_critical ("%s: failed to open log file: %s",
                   __FUNCTION__,
                   strerror (errno));
       exit (EXIT_FAILURE);
@@ -2544,7 +2544,7 @@ main (int argc, char** argv)
                           &client_session,
                           &client_credentials))
         {
-          g_critical ("%s: client server initialisation failed\n",
+          g_critical ("%s: client server initialisation failed",
                       __FUNCTION__);
           exit (EXIT_FAILURE);
         }
@@ -2552,7 +2552,7 @@ main (int argc, char** argv)
       set_gnutls_priority (&client_session, priorities);
       dh_params_option = dh_params;
       if (dh_params && set_gnutls_dhparams (client_credentials, dh_params))
-        g_warning ("Couldn't set DH parameters from %s\n", dh_params);
+        g_warning ("Couldn't set DH parameters from %s", dh_params);
     }
 
   if (disable_encrypted_credentials)

--- a/src/lsc_crypt.c
+++ b/src/lsc_crypt.c
@@ -269,7 +269,7 @@ find_the_key (lsc_crypt_ctx_t ctx, gboolean no_create)
       g_free (path);
       if (!ctx->encctx)
         {
-          g_critical ("%s: can't continue w/o a gpgme context\n", G_STRFUNC);
+          g_critical ("%s: can't continue w/o a gpgme context", G_STRFUNC);
           exit (EXIT_FAILURE);
         }
     }
@@ -489,7 +489,7 @@ lsc_crypt_new ()
   g_free (path);
   if (!ctx->encctx)
     {
-      g_critical ("%s: can't continue w/o a gpgme context\n", G_STRFUNC);
+      g_critical ("%s: can't continue w/o a gpgme context", G_STRFUNC);
       exit (EXIT_FAILURE);
     }
 

--- a/src/lsc_user.c
+++ b/src/lsc_user.c
@@ -107,13 +107,13 @@ create_ssh_key (const char *comment, const char *passphrase,
     {
       if (err)
         {
-          g_debug ("%s: failed to create private key: %s\n",
+          g_debug ("%s: failed to create private key: %s",
                    __FUNCTION__, err->message);
           g_error_free (err);
         }
       else
-        g_debug ("%s: failed to create private key\n", __FUNCTION__);
-      g_debug ("%s: key-gen failed with %d (WIF %i, WEX %i).\n",
+        g_debug ("%s: failed to create private key", __FUNCTION__);
+      g_debug ("%s: key-gen failed with %d (WIF %i, WEX %i)",
                __FUNCTION__, exit_status, WIFEXITED (exit_status),
                WEXITSTATUS (exit_status));
       g_debug ("%s: stdout: %s", __FUNCTION__, astdout);
@@ -204,11 +204,11 @@ lsc_user_rpm_create (const gchar *username,
   g_debug ("%s: create temporary directory", __FUNCTION__);
   if (mkdtemp (tmpdir) == NULL)
     return FALSE;
-  g_debug ("%s: temporary directory: %s\n", __FUNCTION__, tmpdir);
+  g_debug ("%s: temporary directory: %s", __FUNCTION__, tmpdir);
 
   /* Copy the public key into the temporary directory. */
 
-  g_debug ("%s: copy key to temporary directory\n", __FUNCTION__);
+  g_debug ("%s: copy key to temporary directory", __FUNCTION__);
   pubkey_basename = g_strdup_printf ("%s.pub", username);
   new_pubkey_filename = g_build_filename (tmpdir, pubkey_basename, NULL);
   if (gvm_file_copy (public_key_path, new_pubkey_filename)
@@ -224,7 +224,7 @@ lsc_user_rpm_create (const gchar *username,
   /* Execute create-rpm script with the temporary directory as the
    * target and the public key in the temporary directory as the key. */
 
-  g_debug ("%s: Attempting RPM build\n", __FUNCTION__);
+  g_debug ("%s: Attempting RPM build", __FUNCTION__);
   cmd = (gchar **) g_malloc (6 * sizeof (gchar *));
   cmd[0] = g_build_filename (GVM_DATA_DIR,
                              "gvm-lsc-rpm-creator.sh",
@@ -234,7 +234,7 @@ lsc_user_rpm_create (const gchar *username,
   cmd[3] = g_strdup (tmpdir);
   cmd[4] = g_strdup (to_filename);
   cmd[5] = NULL;
-  g_debug ("%s: Spawning in %s: %s %s %s %s %s\n",
+  g_debug ("%s: Spawning in %s: %s %s %s %s %s",
            __FUNCTION__, tmpdir, cmd[0], cmd[1], cmd[2], cmd[3], cmd[4]);
   if ((g_spawn_sync (tmpdir,
                      cmd,
@@ -255,8 +255,8 @@ lsc_user_rpm_create (const gchar *username,
                exit_status,
                WIFEXITED (exit_status),
                WEXITSTATUS (exit_status));
-      g_debug ("%s: stdout: %s\n", __FUNCTION__, standard_out);
-      g_debug ("%s: stderr: %s\n", __FUNCTION__, standard_err);
+      g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
+      g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);
       success = FALSE;
     }
 
@@ -391,11 +391,11 @@ lsc_user_deb_create (const gchar *username,
   g_debug ("%s: create temporary directory", __FUNCTION__);
   if (mkdtemp (tmpdir) == NULL)
     return FALSE;
-  g_debug ("%s: temporary directory: %s\n", __FUNCTION__, tmpdir);
+  g_debug ("%s: temporary directory: %s", __FUNCTION__, tmpdir);
 
   /* Copy the public key into the temporary directory. */
 
-  g_debug ("%s: copy key to temporary directory\n", __FUNCTION__);
+  g_debug ("%s: copy key to temporary directory", __FUNCTION__);
   pubkey_basename = g_strdup_printf ("%s.pub", username);
   new_pubkey_filename = g_build_filename (tmpdir, pubkey_basename, NULL);
   if (gvm_file_copy (public_key_path, new_pubkey_filename)
@@ -411,7 +411,7 @@ lsc_user_deb_create (const gchar *username,
   /* Execute create-deb script with the temporary directory as the
    * target and the public key in the temporary directory as the key. */
 
-  g_debug ("%s: Attempting DEB build\n", __FUNCTION__);
+  g_debug ("%s: Attempting DEB build", __FUNCTION__);
   cmd = (gchar **) g_malloc (7 * sizeof (gchar *));
   cmd[0] = g_build_filename (GVM_DATA_DIR,
                              "gvm-lsc-deb-creator.sh",
@@ -422,7 +422,7 @@ lsc_user_deb_create (const gchar *username,
   cmd[4] = g_strdup (to_filename);
   cmd[5] = g_strdup (maintainer);
   cmd[6] = NULL;
-  g_debug ("%s: Spawning in %s: %s %s %s %s %s %s\n",
+  g_debug ("%s: Spawning in %s: %s %s %s %s %s %s",
            __FUNCTION__, tmpdir,
            cmd[0], cmd[1], cmd[2], cmd[3], cmd[4], cmd[5]);
   if ((g_spawn_sync (tmpdir,
@@ -444,8 +444,8 @@ lsc_user_deb_create (const gchar *username,
                exit_status,
                WIFEXITED (exit_status),
                WEXITSTATUS (exit_status));
-      g_debug ("%s: stdout: %s\n", __FUNCTION__, standard_out);
-      g_debug ("%s: stderr: %s\n", __FUNCTION__, standard_err);
+      g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
+      g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);
       success = FALSE;
     }
 
@@ -683,8 +683,8 @@ execute_makensis (const gchar *nsis_script)
   cmd[0] = g_strdup ("makensis");
   cmd[1] = g_strdup (nsis_script);
   cmd[2] = NULL;
-  g_debug ("--- executing makensis.\n");
-  g_debug ("%s: Spawning in %s: %s %s\n",
+  g_debug ("--- executing makensis");
+  g_debug ("%s: Spawning in %s: %s %s",
            __FUNCTION__,
            dirname, cmd[0], cmd[1]);
   if ((g_spawn_sync (dirname,
@@ -705,8 +705,8 @@ execute_makensis (const gchar *nsis_script)
                exit_status,
                WIFEXITED (exit_status),
                WEXITSTATUS (exit_status));
-      g_debug ("%s: stdout: %s\n", __FUNCTION__, standard_out);
-      g_debug ("%s: stderr: %s\n", __FUNCTION__, standard_err);
+      g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
+      g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);
       ret = -1;
     }
 
@@ -740,14 +740,14 @@ lsc_user_exe_create (const gchar *user_name, const gchar *password,
 
   if (create_nsis_script (nsis_script, to_filename, user_name, password))
     {
-      g_warning ("%s: Failed to create NSIS script\n", __FUNCTION__);
+      g_warning ("%s: Failed to create NSIS script", __FUNCTION__);
       g_free (nsis_script);
       return -1;
     }
 
   if (execute_makensis (nsis_script))
     {
-      g_warning ("%s: Failed to execute makensis\n", __FUNCTION__);
+      g_warning ("%s: Failed to execute makensis", __FUNCTION__);
       g_free (nsis_script);
       return -1;
     }

--- a/src/manage.c
+++ b/src/manage.c
@@ -2307,7 +2307,7 @@ slave_connect (gvm_connection_t *connection)
                     SOL_SOCKET, SO_KEEPALIVE,
                     &optval, sizeof (int)))
       {
-        g_warning ("%s: failed to set SO_KEEPALIVE on slave socket: %s\n",
+        g_warning ("%s: failed to set SO_KEEPALIVE on slave socket: %s",
                    __FUNCTION__,
                    strerror (errno));
         gvm_connection_close (connection);
@@ -2315,7 +2315,7 @@ slave_connect (gvm_connection_t *connection)
       }
   }
 
-  g_debug ("   %s: connected\n", __FUNCTION__);
+  g_debug ("   %s: connected", __FUNCTION__);
 
   /* Authenticate using the slave login. */
 
@@ -2325,7 +2325,7 @@ slave_connect (gvm_connection_t *connection)
       return 1;
     }
 
-  g_debug ("   %s: authenticated\n", __FUNCTION__);
+  g_debug ("   %s: authenticated", __FUNCTION__);
 
   return 0;
 }
@@ -2347,18 +2347,18 @@ slave_sleep_connect (gvm_connection_t *connection, task_t task)
           || (task_run_status (task) == TASK_STATUS_STOP_REQUESTED))
         {
           if (task_run_status (task) == TASK_STATUS_STOP_REQUESTED_GIVEUP)
-            g_debug ("   %s: task stopped for giveup\n", __FUNCTION__);
+            g_debug ("   %s: task stopped for giveup", __FUNCTION__);
           else
-            g_debug ("   %s: task stopped\n", __FUNCTION__);
+            g_debug ("   %s: task stopped", __FUNCTION__);
           set_task_run_status (current_scanner_task, TASK_STATUS_STOPPED);
           return 3;
         }
-      g_debug ("   %s: sleeping for %i\n", __FUNCTION__,
+      g_debug ("   %s: sleeping for %i", __FUNCTION__,
               RUN_SLAVE_TASK_SLEEP_SECONDS);
       gvm_sleep (RUN_SLAVE_TASK_SLEEP_SECONDS);
     }
   while (slave_connect (connection));
-  g_debug ("   %s: connected\n", __FUNCTION__);
+  g_debug ("   %s: connected", __FUNCTION__);
   return 0;
 }
 
@@ -2652,7 +2652,7 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
    * status to Stopped, which will match the slave. */
   if (atexit (&cleanup_slave))
     {
-      g_critical ("%s: failed to register `atexit' slave_cleanup function\n",
+      g_critical ("%s: failed to register `atexit' slave_cleanup function",
                   __FUNCTION__);
       goto fail;
     }
@@ -2717,7 +2717,7 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
                   global_slave_report_uuid = get_tasks_last_report (get_tasks);
                   if (global_slave_report_uuid == NULL)
                     {
-                      g_warning ("%s: slave report %s missing UUID\n", __FUNCTION__,
+                      g_warning ("%s: slave report %s missing UUID", __FUNCTION__,
                                  global_slave_task_uuid);
                       goto fail;
                     }
@@ -3028,16 +3028,16 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
             }
         }
 
-      g_debug ("   %s: slave SSH credential uuid: %s\n", __FUNCTION__,
+      g_debug ("   %s: slave SSH credential uuid: %s", __FUNCTION__,
                global_slave_ssh_credential_uuid);
 
-      g_debug ("   %s: slave SMB credential uuid: %s\n", __FUNCTION__,
+      g_debug ("   %s: slave SMB credential uuid: %s", __FUNCTION__,
                global_slave_smb_credential_uuid);
 
-      g_debug ("   %s: slave ESXi credential uuid: %s\n", __FUNCTION__,
+      g_debug ("   %s: slave ESXi credential uuid: %s", __FUNCTION__,
                global_slave_esxi_credential_uuid);
 
-      g_debug ("   %s: slave SNMP credential uuid: %s\n", __FUNCTION__,
+      g_debug ("   %s: slave SNMP credential uuid: %s", __FUNCTION__,
                global_slave_snmp_credential_uuid);
 
       /* Create the target on the slave. */
@@ -3144,7 +3144,7 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
           goto fail_esxi_credential;
         }
 
-      g_debug ("   %s: slave target uuid: %s\n",
+      g_debug ("   %s: slave target uuid: %s",
                __FUNCTION__,
                global_slave_target_uuid);
 
@@ -3262,7 +3262,7 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
           goto fail_target;
       }
 
-      g_debug ("   %s: slave config uuid: %s\n",
+      g_debug ("   %s: slave config uuid: %s",
                __FUNCTION__,
                global_slave_config_uuid);
 
@@ -3382,7 +3382,7 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
                                    TASK_STATUS_STOP_WAITING);
             break;
           case TASK_STATUS_STOP_REQUESTED_GIVEUP:
-            g_debug ("   %s: task stopped for giveup\n", __FUNCTION__);
+            g_debug ("   %s: task stopped for giveup", __FUNCTION__);
             set_task_run_status (current_scanner_task, TASK_STATUS_STOPPED);
             goto giveup;
             break;
@@ -3602,7 +3602,7 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
   global_slave_ssh_credential_uuid = NULL;
   gvm_connection_close (connection);
   global_slave_connection = NULL;
-  g_debug ("   %s: succeed\n", __FUNCTION__);
+  g_debug ("   %s: succeed", __FUNCTION__);
   return 0;
 
  fail_stop_task:
@@ -3654,13 +3654,13 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
                                    del_opts);
   free (global_slave_ssh_credential_uuid);
  fail:
-  g_debug ("   %s: fail (%i)\n", __FUNCTION__, ret_fail);
+  g_debug ("   %s: fail (%i)", __FUNCTION__, ret_fail);
   gvm_connection_close (connection);
   global_slave_connection = NULL;
   return ret_fail;
 
  giveup:
-  g_debug ("   %s: giveup (%i)\n", __FUNCTION__, ret_giveup);
+  g_debug ("   %s: giveup (%i)", __FUNCTION__, ret_giveup);
   gvm_connection_close (connection);
   global_slave_connection = NULL;
   return ret_giveup;
@@ -3704,7 +3704,7 @@ handle_slave_task (task_t task, target_t target,
    * the master, and the open statement would prevent the slave from getting
    * a lock on the database and fulfilling the request. */
 
-  g_debug ("   Running slave task %llu\n", task);
+  g_debug ("   Running slave task %llu", task);
 
   // FIX permission checks  may the user still access the slave, target, port list etc?
 
@@ -3935,7 +3935,7 @@ delete_osp_scan (const char *report_id, const char *host, int port,
   connection = osp_connection_new (host, port, ca_pub, key_pub, key_priv);
   if (!connection)
     {
-      g_warning ("Couldn't connect to OSP scanner on %s:%d\n", host, port);
+      g_warning ("Couldn't connect to OSP scanner on %s:%d", host, port);
       return;
     }
   osp_delete_scan (connection, report_id);
@@ -3968,7 +3968,7 @@ get_osp_scan_report (const char *scan_id, const char *host, int port,
   connection = osp_connection_new (host, port, ca_pub, key_pub, key_priv);
   if (!connection)
     {
-      g_warning ("Couldn't connect to OSP scanner on %s:%d\n", host, port);
+      g_warning ("Couldn't connect to OSP scanner on %s:%d", host, port);
       return -1;
     }
   progress = osp_get_scan (connection, scan_id, report_xml, details, &error);
@@ -4174,7 +4174,7 @@ fork_osp_scan_handler (task_t task, target_t target)
 
   if (create_current_report (task, &report_id, TASK_STATUS_REQUESTED))
     {
-      g_debug ("   %s: failed to create report.\n", __FUNCTION__);
+      g_debug ("   %s: failed to create report", __FUNCTION__);
       return -1;
     }
 
@@ -4186,7 +4186,7 @@ fork_osp_scan_handler (task_t task, target_t target)
         break;
       case -1:
         /* Parent, failed to fork. */
-        g_warning ("%s: Failed to fork: %s\n",
+        g_warning ("%s: Failed to fork: %s",
                    __FUNCTION__,
                    strerror (errno));
         set_task_interrupted (task,
@@ -4282,7 +4282,7 @@ run_osp_task (task_t task)
 
   if (fork_osp_scan_handler (task, target))
     {
-      g_warning ("Couldn't fork OSP scan handler.\n");
+      g_warning ("Couldn't fork OSP scan handler");
       return -1;
     }
   return 0;
@@ -4317,7 +4317,7 @@ cve_scan_host (task_t task, gvm_host_t *gvm_host)
 
   if (host_nthlast_report_host (ip, &report_host, 1))
     {
-      g_warning ("%s: Failed to get nthlast report.\n", __FUNCTION__);
+      g_warning ("%s: Failed to get nthlast report", __FUNCTION__);
       g_free (ip);
       return 1;
     }
@@ -4444,7 +4444,7 @@ fork_cve_scan_handler (task_t task, target_t target)
 
   if (create_current_report (task, &report_id, TASK_STATUS_REQUESTED))
     {
-      g_debug ("   %s: failed to create report.\n", __FUNCTION__);
+      g_debug ("   %s: failed to create report", __FUNCTION__);
       return -1;
     }
 
@@ -4457,7 +4457,7 @@ fork_cve_scan_handler (task_t task, target_t target)
         break;
       case -1:
         /* Parent, failed to fork. */
-        g_warning ("%s: Failed to fork: %s\n",
+        g_warning ("%s: Failed to fork: %s",
                    __FUNCTION__,
                    strerror (errno));
         set_task_interrupted (task,
@@ -4560,7 +4560,7 @@ run_cve_task (task_t task)
 
   if (fork_cve_scan_handler (task, target))
     {
-      g_warning ("Couldn't fork CVE scan handler.\n");
+      g_warning ("Couldn't fork CVE scan handler");
       return -1;
     }
   return 0;
@@ -4726,7 +4726,7 @@ run_task_prepare_report (task_t task, char **report_id, int from,
     {
       if (task_last_resumable_report (task, last_stopped_report))
         {
-          g_debug ("   error getting last stopped report.\n");
+          g_debug ("   error getting last stopped report");
           return -1;
         }
 
@@ -4828,7 +4828,7 @@ run_slave_or_gmp_task (task_t task, int from, char **report_id,
 
   if (target_hosts (target) == NULL)
     {
-      g_debug ("   target hosts is NULL.\n");
+      g_debug ("   target hosts is NULL");
       set_task_run_status (task, run_status);
       return -4;
     }
@@ -4868,7 +4868,7 @@ run_slave_or_gmp_task (task_t task, int from, char **report_id,
         return -9;
         break;
       default:
-        g_debug ("%s: forked %i to run slave/gmp task\n",
+        g_debug ("%s: forked %i to run slave/gmp task",
                  __FUNCTION__,
                  pid);
         /* Parent.  Return, in order to respond to client. */
@@ -4955,7 +4955,7 @@ run_gmp_task (task_t task, scanner_t scanner, int from, char **report_id)
       return -1;
     }
 
-  g_debug ("   %s: connection.host: %s\n", __FUNCTION__,
+  g_debug ("   %s: connection.host: %s", __FUNCTION__,
            connection.host_string);
 
   connection.port = scanner_port (scanner);
@@ -5084,7 +5084,7 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
 
   if (target_hosts (target) == NULL)
     {
-      g_debug ("   target hosts is NULL.\n");
+      g_debug ("   target hosts is NULL");
       set_task_run_status (task, run_status);
       return -4;
     }
@@ -5116,7 +5116,7 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
         break;
       case -1:
         /* Parent when error. */
-        g_warning ("%s: Failed to fork task child: %s\n",
+        g_warning ("%s: Failed to fork task child: %s",
                    __FUNCTION__,
                    strerror (errno));
         set_task_interrupted (task,
@@ -6150,7 +6150,7 @@ get_slave_system_report_types (const char *required_type, gchar ***start,
   host = scanner_host (slave);
   if (host == NULL) return -1;
 
-  g_debug ("   %s: host: %s\n", __FUNCTION__, host);
+  g_debug ("   %s: host: %s", __FUNCTION__, host);
 
   port = scanner_port (slave);
   if (port == -1)
@@ -6163,7 +6163,7 @@ get_slave_system_report_types (const char *required_type, gchar ***start,
   free (host);
   if (socket == -1) return 4;
 
-  g_debug ("   %s: connected\n", __FUNCTION__);
+  g_debug ("   %s: connected", __FUNCTION__);
 
   /* Authenticate using the slave login. */
 
@@ -6173,7 +6173,7 @@ get_slave_system_report_types (const char *required_type, gchar ***start,
       goto fail;
     }
 
-  g_debug ("   %s: authenticated\n", __FUNCTION__);
+  g_debug ("   %s: authenticated", __FUNCTION__);
 
   if (gmp_get_system_reports (&session, required_type, 1, &get))
     {
@@ -6456,7 +6456,7 @@ slave_system_report (const char *name, const char *duration,
   host = scanner_host (slave);
   if (host == NULL) return -1;
 
-  g_debug ("   %s: host: %s\n", __FUNCTION__, host);
+  g_debug ("   %s: host: %s", __FUNCTION__, host);
 
   port = scanner_port (slave);
   if (port == -1)
@@ -6469,7 +6469,7 @@ slave_system_report (const char *name, const char *duration,
   free (host);
   if (socket == -1) return 4;
 
-  g_debug ("   %s: connected\n", __FUNCTION__);
+  g_debug ("   %s: connected", __FUNCTION__);
 
   /* Authenticate using the slave login. */
 
@@ -6479,7 +6479,7 @@ slave_system_report (const char *name, const char *duration,
       goto fail;
     }
 
-  g_debug ("   %s: authenticated\n", __FUNCTION__);
+  g_debug ("   %s: authenticated", __FUNCTION__);
 
   opts = gmp_get_system_reports_opts_defaults;
   opts.name = name;
@@ -6509,7 +6509,7 @@ slave_system_report (const char *name, const char *duration,
     }
 
   free_entity (get);
-  g_warning ("   %s: error getting entity\n", __FUNCTION__);
+  g_warning ("   %s: error getting entity", __FUNCTION__);
   return 6;
 
  fail:
@@ -6860,7 +6860,7 @@ scheduled_task_start (scheduled_task_t *scheduled_task,
 
       case -1:
         /* Parent on error. */
-        g_warning ("%s: fork failed\n", __FUNCTION__);
+        g_warning ("%s: fork failed", __FUNCTION__);
         return -1;
 
       default:
@@ -6880,7 +6880,7 @@ scheduled_task_start (scheduled_task_t *scheduled_task,
 
       case -1:
         /* Parent on error. */
-        g_warning ("%s: fork_connection failed\n", __FUNCTION__);
+        g_warning ("%s: fork_connection failed", __FUNCTION__);
         reschedule_task (scheduled_task->task_uuid);
         scheduled_task_free (scheduled_task);
         exit (EXIT_FAILURE);
@@ -6983,7 +6983,7 @@ scheduled_task_start (scheduled_task_t *scheduled_task,
 
           /* Child failed, reset task schedule time and exit. */
 
-          g_warning ("%s: child failed\n", __FUNCTION__);
+          g_warning ("%s: child failed", __FUNCTION__);
           reschedule_task (scheduled_task->task_uuid);
           scheduled_task_free (scheduled_task);
           exit (EXIT_FAILURE);
@@ -7059,7 +7059,7 @@ scheduled_task_stop (scheduled_task_t *scheduled_task,
 
       case -1:
         /* Parent on error. */
-        g_warning ("%s: stop fork failed\n", __FUNCTION__);
+        g_warning ("%s: stop fork failed", __FUNCTION__);
         return -1;
 
       default:
@@ -7437,7 +7437,7 @@ get_report_format_files (const char *dir_name, GPtrArray **start)
   setlocale (LC_ALL, locale);
   if (n < 0)
     {
-      g_warning ("%s: failed to open dir %s: %s\n",
+      g_warning ("%s: failed to open dir %s: %s",
                  __FUNCTION__,
                  dir_name,
                  strerror (errno));
@@ -7713,19 +7713,19 @@ delete_slave_task (const gchar *host, int port, const gchar *username,
 
   /* Connect to the slave. */
 
-  g_debug ("   %s: host: %s\n", __FUNCTION__, host);
+  g_debug ("   %s: host: %s", __FUNCTION__, host);
 
   socket = gvm_server_open (&session, host, port);
   if (socket == -1) return -1;
 
-  g_debug ("   %s: connected\n", __FUNCTION__);
+  g_debug ("   %s: connected", __FUNCTION__);
 
   /* Authenticate using the slave login. */
 
   if (gmp_authenticate (&session, username, password))
     return -1;
 
-  g_debug ("   %s: authenticated\n", __FUNCTION__);
+  g_debug ("   %s: authenticated", __FUNCTION__);
 
   /* Get the UUIDs of the slave resources. */
 
@@ -7960,7 +7960,7 @@ xsl_transform (gchar *stylesheet, gchar *xmlfile, gchar **param_names,
 
   /* DEBUG: display the final command line. */
   cmd_full = g_strjoinv (" ", cmd);
-  g_debug ("%s: Spawning in parent dir: %s\n",
+  g_debug ("%s: Spawning in parent dir: %s",
            __FUNCTION__, cmd_full);
   g_free (cmd_full);
   /* --- */
@@ -7984,8 +7984,8 @@ xsl_transform (gchar *stylesheet, gchar *xmlfile, gchar **param_names,
                exit_status,
                WIFEXITED (exit_status),
                WEXITSTATUS (exit_status));
-      g_debug ("%s: stderr: %s\n", __FUNCTION__, standard_err);
-      g_debug ("%s: stdout: %s\n", __FUNCTION__, standard_out);
+      g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);
+      g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
       success = FALSE;
     }
   else if (strlen (standard_out) == 0)
@@ -8886,7 +8886,7 @@ manage_run_wizard (const gchar *wizard_name,
   g_free (file);
   if (get_error)
     {
-      g_warning ("%s: Failed to read wizard: %s\n",
+      g_warning ("%s: Failed to read wizard: %s",
                  __FUNCTION__,
                  get_error->message);
       g_error_free (get_error);
@@ -8898,7 +8898,7 @@ manage_run_wizard (const gchar *wizard_name,
   entity = NULL;
   if (parse_entity (wizard, &entity))
     {
-      g_warning ("%s: Failed to parse wizard\n", __FUNCTION__);
+      g_warning ("%s: Failed to parse wizard", __FUNCTION__);
       g_free (wizard);
       return -1;
     }
@@ -8971,7 +8971,7 @@ manage_run_wizard (const gchar *wizard_name,
           if ((name_entity == NULL)
               || (strcmp (entity_text (name_entity), "") == 0))
             {
-              g_warning ("%s: Wizard PARAM missing NAME\n",
+              g_warning ("%s: Wizard PARAM missing NAME",
                          __FUNCTION__);
               free_entity (entity);
               return -1;
@@ -8983,7 +8983,7 @@ manage_run_wizard (const gchar *wizard_name,
           if ((regex_entity == NULL)
               || (strcmp (entity_text (regex_entity), "") == 0))
             {
-              g_warning ("%s: Wizard PARAM missing REGEX\n",
+              g_warning ("%s: Wizard PARAM missing REGEX",
                          __FUNCTION__);
               free_entity (entity);
               return -1;
@@ -9085,7 +9085,7 @@ manage_run_wizard (const gchar *wizard_name,
           command = entity_child (step, "command");
           if (command == NULL)
             {
-              g_warning ("%s: Wizard STEP missing COMMAND\n",
+              g_warning ("%s: Wizard STEP missing COMMAND",
                          __FUNCTION__);
               free_entity (entity);
               g_free (response);
@@ -9099,7 +9099,7 @@ manage_run_wizard (const gchar *wizard_name,
           xsl_fd = mkstemp (xsl_file_name);
           if (xsl_fd == -1)
             {
-              g_warning ("%s: Wizard XSL file create failed\n",
+              g_warning ("%s: Wizard XSL file create failed",
                          __FUNCTION__);
               free_entity (entity);
               g_free (response);
@@ -9111,7 +9111,7 @@ manage_run_wizard (const gchar *wizard_name,
           xsl_file = fdopen (xsl_fd, "w");
           if (xsl_file == NULL)
             {
-              g_warning ("%s: Wizard XSL file open failed\n",
+              g_warning ("%s: Wizard XSL file open failed",
                          __FUNCTION__);
               close (xsl_fd);
               free_entity (entity);
@@ -9129,7 +9129,7 @@ manage_run_wizard (const gchar *wizard_name,
           xml_fd = mkstemp (xml_file_name);
           if (xml_fd == -1)
             {
-              g_warning ("%s: Wizard XML file create failed\n",
+              g_warning ("%s: Wizard XML file create failed",
                          __FUNCTION__);
               fclose (xsl_file);
               unlink (xsl_file_name);
@@ -9143,7 +9143,7 @@ manage_run_wizard (const gchar *wizard_name,
           xml_file = fdopen (xml_fd, "w");
           if (xml_file == NULL)
             {
-              g_warning ("%s: Wizard XML file open failed\n",
+              g_warning ("%s: Wizard XML file open failed",
                          __FUNCTION__);
               fclose (xsl_file);
               unlink (xsl_file_name);
@@ -9173,7 +9173,7 @@ manage_run_wizard (const gchar *wizard_name,
               fclose (xml_file);
               unlink (xml_file_name);
               free_entity (entity);
-              g_warning ("%s: Wizard failed to write XML\n",
+              g_warning ("%s: Wizard failed to write XML",
                          __FUNCTION__);
               g_free (response);
               g_free (extra);
@@ -9193,7 +9193,7 @@ manage_run_wizard (const gchar *wizard_name,
           unlink (xml_file_name);
           if (gmp == NULL)
             {
-              g_warning ("%s: Wizard XSL transform failed\n",
+              g_warning ("%s: Wizard XSL transform failed",
                          __FUNCTION__);
               free_entity (entity);
               g_free (response);
@@ -9262,7 +9262,7 @@ manage_run_wizard (const gchar *wizard_name,
               response_entity = NULL;
               if (parse_entity (response, &response_entity))
                 {
-                  g_warning ("%s: Wizard failed to parse response\n",
+                  g_warning ("%s: Wizard failed to parse response",
                              __FUNCTION__);
                   free_entity (entity);
                   g_free (response);
@@ -9276,7 +9276,7 @@ manage_run_wizard (const gchar *wizard_name,
                   || (strlen (status) == 0)
                   || (status[0] != '2'))
                 {
-                  g_debug ("response was %s\n", response);
+                  g_debug ("response was %s", response);
                   if (command_error)
                     {
                       const char *text;
@@ -9309,7 +9309,7 @@ manage_run_wizard (const gchar *wizard_name,
               xsl_fd = mkstemp (extra_xsl_file_name);
               if (xsl_fd == -1)
                 {
-                  g_warning ("%s: Wizard extra_data XSL file create failed\n",
+                  g_warning ("%s: Wizard extra_data XSL file create failed",
                             __FUNCTION__);
                   free_entity (entity);
                   g_free (response);
@@ -9321,7 +9321,7 @@ manage_run_wizard (const gchar *wizard_name,
               xsl_file = fdopen (xsl_fd, "w");
               if (xsl_file == NULL)
                 {
-                  g_warning ("%s: Wizard extra_data XSL file open failed\n",
+                  g_warning ("%s: Wizard extra_data XSL file open failed",
                             __FUNCTION__);
                   close (xsl_fd);
                   free_entity (entity);
@@ -9339,7 +9339,7 @@ manage_run_wizard (const gchar *wizard_name,
               xml_fd = mkstemp (extra_xml_file_name);
               if (xml_fd == -1)
                 {
-                  g_warning ("%s: Wizard XML file create failed\n",
+                  g_warning ("%s: Wizard XML file create failed",
                             __FUNCTION__);
                   fclose (xsl_file);
                   unlink (xsl_file_name);
@@ -9353,7 +9353,7 @@ manage_run_wizard (const gchar *wizard_name,
               xml_file = fdopen (xml_fd, "w");
               if (xml_file == NULL)
                 {
-                  g_warning ("%s: Wizard XML file open failed\n",
+                  g_warning ("%s: Wizard XML file open failed",
                             __FUNCTION__);
                   fclose (xsl_file);
                   unlink (xsl_file_name);
@@ -9385,7 +9385,7 @@ manage_run_wizard (const gchar *wizard_name,
                   fclose (xml_file);
                   unlink (extra_xml_file_name);
                   free_entity (entity);
-                  g_warning ("%s: Wizard failed to write XML\n",
+                  g_warning ("%s: Wizard failed to write XML",
                             __FUNCTION__);
                   g_free (response);
                   g_free (extra);

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -1085,7 +1085,7 @@ migrate_5_to_6 ()
   else
     {
       g_warning ("%s: a predefined config has moved from the standard location,"
-                 " giving up\n",
+                 " giving up",
                  __FUNCTION__);
       sql_rollback ();
       return -1;
@@ -1999,7 +1999,7 @@ migrate_19_to_20 ()
 
       if (stmt == NULL)
         {
-          g_warning ("%s: sql_prepare failed\n", __FUNCTION__);
+          g_warning ("%s: sql_prepare failed", __FUNCTION__);
           cleanup_iterator (&rows);
           sql_rollback ();
           return -1;
@@ -2017,7 +2017,7 @@ migrate_19_to_20 ()
 
       if (sql_bind_text (stmt, 1, installer, installer_size))
         {
-          g_warning ("%s: sql_bind_text failed\n", __FUNCTION__);
+          g_warning ("%s: sql_bind_text failed", __FUNCTION__);
           cleanup_iterator (&rows);
           sql_rollback ();
           g_free (installer);
@@ -2030,7 +2030,7 @@ migrate_19_to_20 ()
       while ((ret = sql_exec (stmt)) > 0);
       if (ret < 0)
         {
-          g_warning ("%s: sql_exec failed\n", __FUNCTION__);
+          g_warning ("%s: sql_exec failed", __FUNCTION__);
           cleanup_iterator (&rows);
           sql_rollback ();
           return -1;
@@ -2257,7 +2257,7 @@ migrate_21_to_22 ()
                                    iterator_int64 (&rows, 2));
           if (owner_uuid == NULL)
             {
-              g_warning ("%s: owner missing from users table\n", __FUNCTION__);
+              g_warning ("%s: owner missing from users table", __FUNCTION__);
               cleanup_iterator (&rows);
               sql_rollback ();
               return -1;
@@ -2281,7 +2281,7 @@ migrate_21_to_22 ()
         {
           if (g_file_test (old_dir, G_FILE_TEST_EXISTS)
               && gvm_file_remove_recurse (old_dir))
-            g_warning ("%s: failed to remove %s\n",
+            g_warning ("%s: failed to remove %s",
                        __FUNCTION__,
                        old_dir);
         }
@@ -2291,7 +2291,7 @@ migrate_21_to_22 ()
                 || user_format)
                && rename (old_dir, new_dir))
         {
-          g_warning ("%s: renaming %s to %s failed: %s\n",
+          g_warning ("%s: renaming %s to %s failed: %s",
                      __FUNCTION__,
                      old_dir,
                      new_dir,
@@ -3143,7 +3143,7 @@ migrate_37_to_38 ()
     cmd[1] = old_dir;
     cmd[2] = new_dir;
     cmd[3] = NULL;
-    g_debug ("%s: Spawning in .: %s %s %s\n",
+    g_debug ("%s: Spawning in .: %s %s %s",
              __FUNCTION__, cmd[0], cmd[1], cmd[2]);
     if ((g_spawn_sync (".",
                        cmd,
@@ -3164,8 +3164,8 @@ migrate_37_to_38 ()
                    exit_status,
                    WIFEXITED (exit_status),
                  WEXITSTATUS (exit_status));
-        g_debug ("%s: stdout: %s\n", __FUNCTION__, standard_out);
-        g_debug ("%s: stderr: %s\n", __FUNCTION__, standard_err);
+        g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
+        g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);
         g_free (old_dir);
         g_free (new_dir);
         g_free (cmd[0]);
@@ -6419,7 +6419,7 @@ migrate_79_to_80 ()
   count = scandir (GVM_STATE_DIR "/users", &names, NULL, alphasort);
   if (count < 0)
     {
-      g_warning ("%s: failed to open dir %s/users: %s\n",
+      g_warning ("%s: failed to open dir %s/users: %s",
                  __FUNCTION__,
                  GVM_STATE_DIR,
                  strerror (errno));
@@ -6471,10 +6471,10 @@ migrate_79_to_80 ()
                                            "methods",
                                            "ldap_connect",
                                            NULL);
-      g_debug ("          user: %s\n", names[index]->d_name);
-      g_debug ("    remote dir: %s\n", remote_dir);
-      g_debug ("   classic dir: %s\n", classic_dir);
-      g_debug ("     flag file: %s\n", remote_flag_file);
+      g_debug ("          user: %s", names[index]->d_name);
+      g_debug ("    remote dir: %s", remote_dir);
+      g_debug ("   classic dir: %s", classic_dir);
+      g_debug ("     flag file: %s", remote_flag_file);
       if (g_file_test (remote_dir, G_FILE_TEST_IS_DIR)
           && g_file_test (remote_flag_file, G_FILE_TEST_EXISTS))
         method = AUTHENTICATION_METHOD_LDAP_CONNECT;
@@ -6503,7 +6503,7 @@ migrate_79_to_80 ()
                            &error);
       if (error)
         {
-          g_warning ("%s: Failed to read %s: %s\n",
+          g_warning ("%s: Failed to read %s: %s",
                      __FUNCTION__,
                      uuid_file,
                      error->message);
@@ -6520,7 +6520,7 @@ migrate_79_to_80 ()
 
       if (uuid == NULL || strlen (g_strchomp (uuid)) != 36)
         {
-          g_warning ("%s: Error in UUID: %s\n",
+          g_warning ("%s: Error in UUID: %s",
                      __FUNCTION__,
                      uuid);
           g_free (classic_dir);
@@ -6529,7 +6529,7 @@ migrate_79_to_80 ()
           sql_rollback ();
           return -1;
         }
-      g_debug ("          uuid: %s\n", uuid);
+      g_debug ("          uuid: %s", uuid);
 
       /* Get role. */
 
@@ -6569,7 +6569,7 @@ migrate_79_to_80 ()
           default:       /* Programming error. */
             assert (0);
           case -1:
-            g_warning ("%s: Error finding user %s\n",
+            g_warning ("%s: Error finding user %s",
                        __FUNCTION__,
                        uuid);
             g_free (uuid);
@@ -6593,7 +6593,7 @@ migrate_79_to_80 ()
                                &error);
           if (error)
             {
-              g_warning ("%s: Failed to read %s: %s\n",
+              g_warning ("%s: Failed to read %s: %s",
                          __FUNCTION__,
                          file,
                          error->message);
@@ -6618,7 +6618,7 @@ migrate_79_to_80 ()
       hosts_allow = 2;
       if (migrate_79_to_80_user_access (classic_dir, &hosts, &hosts_allow))
         {
-          g_warning ("%s: Failed to get user rules from %s\n",
+          g_warning ("%s: Failed to get user rules from %s",
                      __FUNCTION__,
                      classic_dir);
           g_free (classic_dir);
@@ -6690,7 +6690,7 @@ migrate_79_to_80 ()
   if (g_lstat (dir, &state))
     {
       if (errno != ENOENT)
-        g_warning ("%s: g_lstat (%s) failed: %s\n",
+        g_warning ("%s: g_lstat (%s) failed: %s",
                    __FUNCTION__, dir, g_strerror (errno));
     }
   else
@@ -9218,20 +9218,20 @@ migrate_129_to_130 ()
   /* Fetch default certificates content. */
   if (!g_file_get_contents (CACERT, &ca_pub, NULL, &error))
     {
-      g_warning ("%s: %s\n", __FUNCTION__, error->message);
+      g_warning ("%s: %s", __FUNCTION__, error->message);
       g_error_free (error);
       return -1;
     }
   if (!g_file_get_contents (CLIENTCERT, &key_pub, NULL, &error))
     {
-      g_warning ("%s: %s\n", __FUNCTION__, error->message);
+      g_warning ("%s: %s", __FUNCTION__, error->message);
       g_error_free (error);
       g_free (ca_pub);
       return -1;
     }
   if (!g_file_get_contents (CLIENTKEY, &key_priv, NULL, &error))
     {
-      g_warning ("%s: %s\n", __FUNCTION__, error->message);
+      g_warning ("%s: %s", __FUNCTION__, error->message);
       g_error_free (error);
       g_free (ca_pub);
       g_free (key_pub);
@@ -12785,12 +12785,12 @@ migrate_170_to_171 ()
        * directory. */
 
       if (errno != ENOENT)
-        g_warning ("%s: g_lstat (%s) failed: %s\n",
+        g_warning ("%s: g_lstat (%s) failed: %s",
                    __FUNCTION__, old_dir, g_strerror (errno));
       else
-        g_warning ("%s: trash report formats directory missing (%s)\n",
+        g_warning ("%s: trash report formats directory missing (%s)",
                    __FUNCTION__, old_dir);
-      g_warning ("%s: any trash report formats will be removed on startup\n",
+      g_warning ("%s: any trash report formats will be removed on startup",
                  __FUNCTION__);
     }
   else
@@ -12809,7 +12809,7 @@ migrate_170_to_171 ()
       cmd[1] = old_dir;
       cmd[2] = new_dir;
       cmd[3] = NULL;
-      g_debug ("%s: Spawning in .: %s %s %s\n",
+      g_debug ("%s: Spawning in .: %s %s %s",
                __FUNCTION__, cmd[0], cmd[1], cmd[2]);
       if ((g_spawn_sync (".",
                          cmd,
@@ -12830,8 +12830,8 @@ migrate_170_to_171 ()
                      exit_status,
                      WIFEXITED (exit_status),
                    WEXITSTATUS (exit_status));
-          g_debug ("%s: stdout: %s\n", __FUNCTION__, standard_out);
-          g_debug ("%s: stderr: %s\n", __FUNCTION__, standard_err);
+          g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
+          g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);
           g_free (old_dir);
           g_free (new_dir);
           g_free (cmd[0]);
@@ -12905,10 +12905,10 @@ migrate_171_to_172 ()
        * to move anyway, and the Manager install should have put the actual
        * files in the right place. */
       if (errno != ENOENT)
-        g_warning ("%s: g_lstat (%s) failed: %s\n",
+        g_warning ("%s: g_lstat (%s) failed: %s",
                    __FUNCTION__, old_dir_path, g_strerror (errno));
       else
-        g_info ("%s: old global report formats directory missing (%s)\n",
+        g_info ("%s: old global report formats directory missing (%s)",
                 __FUNCTION__, old_dir_path);
     }
   else
@@ -12961,7 +12961,7 @@ migrate_171_to_172 ()
               cmd[1] = old_subdir_path;
               cmd[2] = new_subdir_path;
               cmd[3] = NULL;
-              g_debug ("%s: Spawning in .: %s %s %s\n",
+              g_debug ("%s: Spawning in .: %s %s %s",
                       __FUNCTION__, cmd[0], cmd[1], cmd[2]);
               if ((g_spawn_sync (".",
                                 cmd,
@@ -12982,8 +12982,8 @@ migrate_171_to_172 ()
                             exit_status,
                             WIFEXITED (exit_status),
                           WEXITSTATUS (exit_status));
-                  g_debug ("%s: stdout: %s\n", __FUNCTION__, standard_out);
-                  g_debug ("%s: stderr: %s\n", __FUNCTION__, standard_err);
+                  g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
+                  g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);
                   move_failed = 1;
                 }
               g_free (cmd[0]);
@@ -13226,7 +13226,7 @@ migrate_174_to_175 ()
           cmd[1] = old_subdir_path;
           cmd[2] = new_subdir_path;
           cmd[3] = NULL;
-          g_debug ("%s: Spawning in .: %s %s %s\n",
+          g_debug ("%s: Spawning in .: %s %s %s",
                   __FUNCTION__, cmd[0], cmd[1], cmd[2]);
           if ((g_spawn_sync (".",
                             cmd,
@@ -13247,8 +13247,8 @@ migrate_174_to_175 ()
                         exit_status,
                         WIFEXITED (exit_status),
                       WEXITSTATUS (exit_status));
-              g_debug ("%s: stdout: %s\n", __FUNCTION__, standard_out);
-              g_debug ("%s: stderr: %s\n", __FUNCTION__, standard_err);
+              g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
+              g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);
               move_failed = 1;
             }
           g_free (cmd[0]);
@@ -13755,7 +13755,7 @@ migrate_181_to_182_move (const char *dest)
       cmd[1] = old_asc_path;
       cmd[2] = new_asc_path;
       cmd[3] = NULL;
-      g_debug ("%s: Spawning in .: %s %s %s\n",
+      g_debug ("%s: Spawning in .: %s %s %s",
               __FUNCTION__, cmd[0], cmd[1], cmd[2]);
       if ((g_spawn_sync (".",
                         cmd,
@@ -13776,8 +13776,8 @@ migrate_181_to_182_move (const char *dest)
                     exit_status,
                     WIFEXITED (exit_status),
                   WEXITSTATUS (exit_status));
-          g_debug ("%s: stdout: %s\n", __FUNCTION__, standard_out);
-          g_debug ("%s: stderr: %s\n", __FUNCTION__, standard_err);
+          g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
+          g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);
           move_failed = 1;
         }
       g_free (cmd[0]);
@@ -15264,7 +15264,7 @@ manage_migrate (GSList *log_config, const gchar *database)
 
   if (old_version == -2)
     {
-      g_warning ("%s: no task tables yet, so no need to migrate them\n",
+      g_warning ("%s: no task tables yet, so no need to migrate them",
                  __FUNCTION__);
       version_current = 1;
     }

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -99,11 +99,11 @@ __cyg_profile_func_enter (void *func, void *caller)
   Dl_info info;
 
   if (dladdr (func, &info))
-      g_debug ("TTT: enter %p %s\n",
+      g_debug ("TTT: enter %p %s",
                (int*) func,
                info.dli_sname ? info.dli_sname : "?");
   else
-      g_debug ("TTT: enter %p\n", (int*) func);
+      g_debug ("TTT: enter %p", (int*) func);
 }
 
 void __cyg_profile_func_exit (void *, void *)
@@ -115,11 +115,11 @@ __cyg_profile_func_exit (void *func, void *caller)
   Dl_info info;
 
   if (dladdr (func, &info))
-      g_debug ("TTT: exit  %p %s\n",
+      g_debug ("TTT: exit  %p %s",
                (int*) func,
                info.dli_sname ? info.dli_sname : "?");
   else
-      g_debug ("TTT: exit  %p\n", (int*) func);
+      g_debug ("TTT: exit  %p", (int*) func);
 }
 #endif
 
@@ -6505,7 +6505,7 @@ manage_encrypt_all_credentials (GSList *log_config, const gchar *database)
 {
   int ret;
 
-  g_info ("   (Re-)encrypting all credentials.\n");
+  g_info ("   (Re-)encrypting all credentials.");
 
   ret = manage_option_setup (log_config, database);
   if (ret)
@@ -6537,7 +6537,7 @@ manage_decrypt_all_credentials (GSList *log_config, const gchar *database)
 {
   int ret;
 
-  g_info ("   Decrypting all credentials.\n");
+  g_info ("   Decrypting all credentials.");
 
   ret = manage_option_setup (log_config, database);
   if (ret)
@@ -6811,7 +6811,7 @@ manage_check_alerts (GSList *log_config, const gchar *database)
 {
   int ret;
 
-  g_info ("   Checking alerts.\n");
+  g_info ("   Checking alerts.");
 
   ret = manage_option_setup (log_config, database);
   if (ret)
@@ -9204,7 +9204,7 @@ email (const char *to_address, const char *from_address, const char *subject,
   content_fd = mkstemp (content_file_name);
   if (content_fd == -1)
     {
-      g_warning ("%s: mkstemp: %s\n", __FUNCTION__, strerror (errno));
+      g_warning ("%s: mkstemp: %s", __FUNCTION__, strerror (errno));
       return -1;
     }
 
@@ -9239,7 +9239,7 @@ email (const char *to_address, const char *from_address, const char *subject,
           plain_fd = mkstemp (plain_file_name);
           if (plain_fd == -1)
             {
-              g_warning ("%s: mkstemp for plain text file: %s\n",
+              g_warning ("%s: mkstemp for plain text file: %s",
                          __FUNCTION__, strerror (errno));
               fclose (content_file);
               unlink (content_file_name);
@@ -9343,7 +9343,7 @@ email (const char *to_address, const char *from_address, const char *subject,
   to_fd = mkstemp (to_file_name);
   if (to_fd == -1)
     {
-      g_warning ("%s: mkstemp: %s\n", __FUNCTION__, strerror (errno));
+      g_warning ("%s: mkstemp: %s", __FUNCTION__, strerror (errno));
       fclose (content_file);
       return -1;
     }
@@ -9364,12 +9364,12 @@ email (const char *to_address, const char *from_address, const char *subject,
                              to_file_name,
                              content_file_name);
 
-  g_debug ("   command: %s\n", command);
+  g_debug ("   command: %s", command);
 
   ret = system (command);
   if ((ret == -1) || WEXITSTATUS (ret))
     {
-      g_warning ("%s: system failed with ret %i, %i, %s\n",
+      g_warning ("%s: system failed with ret %i, %i, %s",
                  __FUNCTION__,
                  ret,
                  WEXITSTATUS (ret),
@@ -9413,7 +9413,7 @@ http_get (const char *url)
   cmd[2] = g_strdup ("-");
   cmd[3] = g_strdup (url);
   cmd[4] = NULL;
-  g_debug ("%s: Spawning in /tmp/: %s %s %s %s\n",
+  g_debug ("%s: Spawning in /tmp/: %s %s %s %s",
            __FUNCTION__, cmd[0], cmd[1], cmd[2], cmd[3]);
   if ((g_spawn_sync ("/tmp/",
                      cmd,
@@ -9434,8 +9434,8 @@ http_get (const char *url)
                exit_status,
                WIFEXITED (exit_status),
                WEXITSTATUS (exit_status));
-      g_debug ("%s: stdout: %s\n", __FUNCTION__, standard_out);
-      g_debug ("%s: stderr: %s\n", __FUNCTION__, standard_err);
+      g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
+      g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);
       ret = -1;
     }
   else
@@ -9489,7 +9489,7 @@ alert_script_init (const char *report_filename, const char* report,
 
   if (mkdtemp (report_dir) == NULL)
     {
-      g_warning ("%s: mkdtemp failed\n", __FUNCTION__);
+      g_warning ("%s: mkdtemp failed", __FUNCTION__);
       return -1;
     }
 
@@ -9518,7 +9518,7 @@ alert_script_init (const char *report_filename, const char* report,
 
   if (mkstemp (*error_path) == -1)
     {
-      g_warning ("%s: mkstemp for error output failed\n", __FUNCTION__);
+      g_warning ("%s: mkstemp for error output failed", __FUNCTION__);
       gvm_file_remove_recurse (report_dir);
       g_free (*report_path);
       g_free (*error_path);
@@ -9532,7 +9532,7 @@ alert_script_init (const char *report_filename, const char* report,
       *extra_path = g_strdup_printf ("%s/extra_XXXXXX", report_dir);
       if (mkstemp (*extra_path) == -1)
         {
-          g_warning ("%s: mkstemp for extra data failed\n", __FUNCTION__);
+          g_warning ("%s: mkstemp for extra data failed", __FUNCTION__);
           gvm_file_remove_recurse (report_dir);
           g_free (*report_path);
           g_free (*error_path);
@@ -9591,7 +9591,7 @@ alert_script_exec (const char *alert_id, const char *command_args,
 
   if (!g_file_test (script, G_FILE_TEST_EXISTS))
     {
-      g_warning ("%s: Failed to find alert script: %s\n",
+      g_warning ("%s: Failed to find alert script: %s",
            __FUNCTION__,
            script);
       g_free (script);
@@ -9610,7 +9610,7 @@ alert_script_exec (const char *alert_id, const char *command_args,
     previous_dir = getcwd (NULL, 0);
     if (previous_dir == NULL)
       {
-        g_warning ("%s: Failed to getcwd: %s\n",
+        g_warning ("%s: Failed to getcwd: %s",
                    __FUNCTION__,
                    strerror (errno));
         g_free (previous_dir);
@@ -9621,7 +9621,7 @@ alert_script_exec (const char *alert_id, const char *command_args,
 
     if (chdir (script_dir))
       {
-        g_warning ("%s: Failed to chdir: %s\n",
+        g_warning ("%s: Failed to chdir: %s",
                    __FUNCTION__,
                    strerror (errno));
         g_free (previous_dir);
@@ -9650,7 +9650,7 @@ alert_script_exec (const char *alert_id, const char *command_args,
                                  error_path);
     g_free (script);
 
-    g_debug ("   command: %s\n", command);
+    g_debug ("   command: %s", command);
 
     if (geteuid () == 0)
       {
@@ -9667,7 +9667,7 @@ alert_script_exec (const char *alert_id, const char *command_args,
             || (extra_path && chown (extra_path, nobody->pw_uid,
                                      nobody->pw_gid)))
           {
-            g_warning ("%s: Failed to set permissions for user nobody: %s\n",
+            g_warning ("%s: Failed to set permissions for user nobody: %s",
                        __FUNCTION__,
                        strerror (errno));
             g_free (previous_dir);
@@ -9688,20 +9688,20 @@ alert_script_exec (const char *alert_id, const char *command_args,
 
                 if (setgroups (0,NULL))
                   {
-                    g_warning ("%s (child): setgroups: %s\n",
+                    g_warning ("%s (child): setgroups: %s",
                                __FUNCTION__, strerror (errno));
                     exit (EXIT_FAILURE);
                   }
                 if (setgid (nobody->pw_gid))
                   {
-                    g_warning ("%s (child): setgid: %s\n",
+                    g_warning ("%s (child): setgid: %s",
                                __FUNCTION__,
                                strerror (errno));
                     exit (EXIT_FAILURE);
                   }
                 if (setuid (nobody->pw_uid))
                   {
-                    g_warning ("%s (child): setuid: %s\n",
+                    g_warning ("%s (child): setuid: %s",
                                __FUNCTION__,
                                strerror (errno));
                     exit (EXIT_FAILURE);
@@ -9714,7 +9714,7 @@ alert_script_exec (const char *alert_id, const char *command_args,
                 if (ret == -1)
                   {
                     g_warning ("%s (child):"
-                               " system failed with ret %i, %i, %s\n",
+                               " system failed with ret %i, %i, %s",
                                __FUNCTION__,
                                ret,
                                WEXITSTATUS (ret),
@@ -9768,11 +9768,11 @@ alert_script_exec (const char *alert_id, const char *command_args,
             case -1:
               /* Parent when error. */
 
-              g_warning ("%s: Failed to fork: %s\n",
+              g_warning ("%s: Failed to fork: %s",
                          __FUNCTION__,
                          strerror (errno));
               if (chdir (previous_dir))
-                g_warning ("%s: and chdir failed\n",
+                g_warning ("%s: and chdir failed",
                            __FUNCTION__);
               g_free (previous_dir);
               g_free (command);
@@ -9792,7 +9792,7 @@ alert_script_exec (const char *alert_id, const char *command_args,
                         g_warning ("%s: Failed to get child exit status",
                                    __FUNCTION__);
                         if (chdir (previous_dir))
-                          g_warning ("%s: and chdir failed\n",
+                          g_warning ("%s: and chdir failed",
                                      __FUNCTION__);
                         g_free (previous_dir);
                         return -1;
@@ -9803,7 +9803,7 @@ alert_script_exec (const char *alert_id, const char *command_args,
                                __FUNCTION__,
                                strerror (errno));
                     if (chdir (previous_dir))
-                      g_warning ("%s: and chdir failed\n",
+                      g_warning ("%s: and chdir failed",
                                  __FUNCTION__);
                     g_free (previous_dir);
                     return -1;
@@ -9832,27 +9832,27 @@ alert_script_exec (const char *alert_id, const char *command_args,
                             }
                         }
                       if (chdir (previous_dir))
-                        g_warning ("%s: chdir failed\n",
+                        g_warning ("%s: chdir failed",
                                    __FUNCTION__);
                       return -5;
                     case EXIT_FAILURE:
                     default:
-                      g_warning ("%s: child failed, %s\n",
+                      g_warning ("%s: child failed, %s",
                                  __FUNCTION__,
                                  command);
                       if (chdir (previous_dir))
-                        g_warning ("%s: and chdir failed\n",
+                        g_warning ("%s: and chdir failed",
                                    __FUNCTION__);
                       g_free (previous_dir);
                       return -1;
                     }
                 else
                   {
-                    g_warning ("%s: child failed, %s\n",
+                    g_warning ("%s: child failed, %s",
                                __FUNCTION__,
                                command);
                     if (chdir (previous_dir))
-                      g_warning ("%s: and chdir failed\n",
+                      g_warning ("%s: and chdir failed",
                                  __FUNCTION__);
                     g_free (previous_dir);
                     return -1;
@@ -9873,13 +9873,13 @@ alert_script_exec (const char *alert_id, const char *command_args,
          * specified what it must be in the past. */
         if (ret == -1)
           {
-            g_warning ("%s: system failed with ret %i, %i, %s\n",
+            g_warning ("%s: system failed with ret %i, %i, %s",
                        __FUNCTION__,
                        ret,
                        WEXITSTATUS (ret),
                        command);
             if (chdir (previous_dir))
-              g_warning ("%s: and chdir failed\n",
+              g_warning ("%s: and chdir failed",
                          __FUNCTION__);
             g_free (previous_dir);
             g_free (command);
@@ -9923,7 +9923,7 @@ alert_script_exec (const char *alert_id, const char *command_args,
 
     if (chdir (previous_dir))
       {
-        g_warning ("%s: Failed to chdir back: %s\n",
+        g_warning ("%s: Failed to chdir back: %s",
                    __FUNCTION__,
                    strerror (errno));
         g_free (previous_dir);
@@ -10221,7 +10221,7 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
 
   if (mkdtemp (report_dir) == NULL)
     {
-      g_warning ("%s: mkdtemp failed\n", __FUNCTION__);
+      g_warning ("%s: mkdtemp failed", __FUNCTION__);
       return -1;
     }
 
@@ -10286,7 +10286,7 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
     previous_dir = getcwd (NULL, 0);
     if (previous_dir == NULL)
       {
-        g_warning ("%s: Failed to getcwd: %s\n",
+        g_warning ("%s: Failed to getcwd: %s",
                    __FUNCTION__,
                    strerror (errno));
         g_free (report_file);
@@ -10299,7 +10299,7 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
 
     if (chdir (script_dir))
       {
-        g_warning ("%s: Failed to chdir: %s\n",
+        g_warning ("%s: Failed to chdir: %s",
                    __FUNCTION__,
                    strerror (errno));
         g_free (report_file);
@@ -10327,7 +10327,7 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
     g_free (clean_ip);
     g_free (clean_port);
 
-    g_debug ("   command: %s\n", command);
+    g_debug ("   command: %s", command);
 
     if (geteuid () == 0)
       {
@@ -10342,7 +10342,7 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
             || chown (report_file, nobody->pw_uid, nobody->pw_gid)
             || chown (pkcs12_file, nobody->pw_uid, nobody->pw_gid))
           {
-            g_warning ("%s: Failed to set permissions for user nobody: %s\n",
+            g_warning ("%s: Failed to set permissions for user nobody: %s",
                        __FUNCTION__,
                        strerror (errno));
             g_free (report_file);
@@ -10365,20 +10365,20 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
 
                 if (setgroups (0,NULL))
                   {
-                    g_warning ("%s (child): setgroups: %s\n",
+                    g_warning ("%s (child): setgroups: %s",
                                __FUNCTION__, strerror (errno));
                     exit (EXIT_FAILURE);
                   }
                 if (setgid (nobody->pw_gid))
                   {
-                    g_warning ("%s (child): setgid: %s\n",
+                    g_warning ("%s (child): setgid: %s",
                                __FUNCTION__,
                                strerror (errno));
                     exit (EXIT_FAILURE);
                   }
                 if (setuid (nobody->pw_uid))
                   {
-                    g_warning ("%s (child): setuid: %s\n",
+                    g_warning ("%s (child): setuid: %s",
                                __FUNCTION__,
                                strerror (errno));
                     exit (EXIT_FAILURE);
@@ -10390,7 +10390,7 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
                 if (ret == -1)
                   {
                     g_warning ("%s (child):"
-                               " system failed with ret %i, %i, %s\n",
+                               " system failed with ret %i, %i, %s",
                                __FUNCTION__,
                                ret,
                                WEXITSTATUS (ret),
@@ -10404,11 +10404,11 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
           case -1:
             /* Parent when error. */
 
-            g_warning ("%s: Failed to fork: %s\n",
+            g_warning ("%s: Failed to fork: %s",
                        __FUNCTION__,
                        strerror (errno));
             if (chdir (previous_dir))
-              g_warning ("%s: and chdir failed\n",
+              g_warning ("%s: and chdir failed",
                          __FUNCTION__);
             g_free (previous_dir);
             g_free (command);
@@ -10430,7 +10430,7 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
                         g_warning ("%s: Failed to get child exit status",
                                    __FUNCTION__);
                         if (chdir (previous_dir))
-                          g_warning ("%s: and chdir failed\n",
+                          g_warning ("%s: and chdir failed",
                                      __FUNCTION__);
                         g_free (previous_dir);
                         return -1;
@@ -10441,7 +10441,7 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
                                __FUNCTION__,
                                strerror (errno));
                     if (chdir (previous_dir))
-                      g_warning ("%s: and chdir failed\n",
+                      g_warning ("%s: and chdir failed",
                                  __FUNCTION__);
                     g_free (previous_dir);
                     return -1;
@@ -10453,22 +10453,22 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
                       break;
                     case EXIT_FAILURE:
                     default:
-                      g_warning ("%s: child failed, %s\n",
+                      g_warning ("%s: child failed, %s",
                                  __FUNCTION__,
                                  command);
                       if (chdir (previous_dir))
-                        g_warning ("%s: and chdir failed\n",
+                        g_warning ("%s: and chdir failed",
                                    __FUNCTION__);
                       g_free (previous_dir);
                       return -1;
                     }
                 else
                   {
-                    g_warning ("%s: child failed, %s\n",
+                    g_warning ("%s: child failed, %s",
                                __FUNCTION__,
                                command);
                     if (chdir (previous_dir))
-                      g_warning ("%s: and chdir failed\n",
+                      g_warning ("%s: and chdir failed",
                                  __FUNCTION__);
                     g_free (previous_dir);
                     return -1;
@@ -10491,13 +10491,13 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
          * specified what it must be in the past. */
         if (ret == -1)
           {
-            g_warning ("%s: system failed with ret %i, %i, %s\n",
+            g_warning ("%s: system failed with ret %i, %i, %s",
                        __FUNCTION__,
                        ret,
                        WEXITSTATUS (ret),
                        command);
             if (chdir (previous_dir))
-              g_warning ("%s: and chdir failed\n",
+              g_warning ("%s: and chdir failed",
                          __FUNCTION__);
             g_free (previous_dir);
             g_free (command);
@@ -10511,7 +10511,7 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
 
     if (chdir (previous_dir))
       {
-        g_warning ("%s: Failed to chdir back: %s\n",
+        g_warning ("%s: Failed to chdir back: %s",
                    __FUNCTION__,
                    strerror (errno));
         g_free (previous_dir);
@@ -10558,7 +10558,7 @@ send_to_verinice (const char *url, const char *username, const char *password,
 
   if (mkdtemp (archive_dir) == NULL)
     {
-      g_warning ("%s: mkdtemp failed\n", __FUNCTION__);
+      g_warning ("%s: mkdtemp failed", __FUNCTION__);
       return -1;
     }
 
@@ -10584,7 +10584,7 @@ send_to_verinice (const char *url, const char *username, const char *password,
 
   if (!g_file_test (script, G_FILE_TEST_EXISTS))
     {
-      g_warning ("%s: Failed to find alert script: %s\n",
+      g_warning ("%s: Failed to find alert script: %s",
            __FUNCTION__,
            script);
       g_free (archive_file);
@@ -10604,7 +10604,7 @@ send_to_verinice (const char *url, const char *username, const char *password,
     previous_dir = getcwd (NULL, 0);
     if (previous_dir == NULL)
       {
-        g_warning ("%s: Failed to getcwd: %s\n",
+        g_warning ("%s: Failed to getcwd: %s",
                    __FUNCTION__,
                    strerror (errno));
         g_free (archive_file);
@@ -10616,7 +10616,7 @@ send_to_verinice (const char *url, const char *username, const char *password,
 
     if (chdir (script_dir))
       {
-        g_warning ("%s: Failed to chdir: %s\n",
+        g_warning ("%s: Failed to chdir: %s",
                    __FUNCTION__,
                    strerror (errno));
         g_free (archive_file);
@@ -10651,7 +10651,7 @@ send_to_verinice (const char *url, const char *username, const char *password,
     g_free (clean_username);
     g_free (clean_password);
 
-    g_debug ("   command: %s\n", log_command);
+    g_debug ("   command: %s", log_command);
 
     if (geteuid () == 0)
       {
@@ -10665,7 +10665,7 @@ send_to_verinice (const char *url, const char *username, const char *password,
             || chown (archive_dir, nobody->pw_uid, nobody->pw_gid)
             || chown (archive_file, nobody->pw_uid, nobody->pw_gid))
           {
-            g_warning ("%s: Failed to set permissions for user nobody: %s\n",
+            g_warning ("%s: Failed to set permissions for user nobody: %s",
                        __FUNCTION__,
                        strerror (errno));
             g_free (previous_dir);
@@ -10689,20 +10689,20 @@ send_to_verinice (const char *url, const char *username, const char *password,
 
                 if (setgroups (0,NULL))
                   {
-                    g_warning ("%s (child): setgroups: %s\n",
+                    g_warning ("%s (child): setgroups: %s",
                                __FUNCTION__, strerror (errno));
                     exit (EXIT_FAILURE);
                   }
                 if (setgid (nobody->pw_gid))
                   {
-                    g_warning ("%s (child): setgid: %s\n",
+                    g_warning ("%s (child): setgid: %s",
                                __FUNCTION__,
                                strerror (errno));
                     exit (EXIT_FAILURE);
                   }
                 if (setuid (nobody->pw_uid))
                   {
-                    g_warning ("%s (child): setuid: %s\n",
+                    g_warning ("%s (child): setuid: %s",
                                __FUNCTION__,
                                strerror (errno));
                     exit (EXIT_FAILURE);
@@ -10714,7 +10714,7 @@ send_to_verinice (const char *url, const char *username, const char *password,
                 if (ret == -1)
                   {
                     g_warning ("%s (child):"
-                               " system failed with ret %i, %i, %s\n",
+                               " system failed with ret %i, %i, %s",
                                __FUNCTION__,
                                ret,
                                WEXITSTATUS (ret),
@@ -10728,11 +10728,11 @@ send_to_verinice (const char *url, const char *username, const char *password,
           case -1:
             /* Parent when error. */
 
-            g_warning ("%s: Failed to fork: %s\n",
+            g_warning ("%s: Failed to fork: %s",
                        __FUNCTION__,
                        strerror (errno));
             if (chdir (previous_dir))
-              g_warning ("%s: and chdir failed\n",
+              g_warning ("%s: and chdir failed",
                          __FUNCTION__);
             g_free (previous_dir);
             g_free (command);
@@ -10753,7 +10753,7 @@ send_to_verinice (const char *url, const char *username, const char *password,
                         g_warning ("%s: Failed to get child exit status",
                                    __FUNCTION__);
                         if (chdir (previous_dir))
-                          g_warning ("%s: and chdir failed\n",
+                          g_warning ("%s: and chdir failed",
                                      __FUNCTION__);
                         g_free (previous_dir);
                         return -1;
@@ -10764,7 +10764,7 @@ send_to_verinice (const char *url, const char *username, const char *password,
                                __FUNCTION__,
                                strerror (errno));
                     if (chdir (previous_dir))
-                      g_warning ("%s: and chdir failed\n",
+                      g_warning ("%s: and chdir failed",
                                  __FUNCTION__);
                     g_free (previous_dir);
                     return -1;
@@ -10776,22 +10776,22 @@ send_to_verinice (const char *url, const char *username, const char *password,
                       break;
                     case EXIT_FAILURE:
                     default:
-                      g_warning ("%s: child failed, %s\n",
+                      g_warning ("%s: child failed, %s",
                                  __FUNCTION__,
                                  log_command);
                       if (chdir (previous_dir))
-                        g_warning ("%s: and chdir failed\n",
+                        g_warning ("%s: and chdir failed",
                                    __FUNCTION__);
                       g_free (previous_dir);
                       return -1;
                     }
                 else
                   {
-                    g_warning ("%s: child failed, %s\n",
+                    g_warning ("%s: child failed, %s",
                                __FUNCTION__,
                                log_command);
                     if (chdir (previous_dir))
-                      g_warning ("%s: and chdir failed\n",
+                      g_warning ("%s: and chdir failed",
                                  __FUNCTION__);
                     g_free (previous_dir);
                     return -1;
@@ -10813,13 +10813,13 @@ send_to_verinice (const char *url, const char *username, const char *password,
          * specified what it must be in the past. */
         if (ret == -1)
           {
-            g_warning ("%s: system failed with ret %i, %i, %s\n",
+            g_warning ("%s: system failed with ret %i, %i, %s",
                        __FUNCTION__,
                        ret,
                        WEXITSTATUS (ret),
                        log_command);
             if (chdir (previous_dir))
-              g_warning ("%s: and chdir failed\n",
+              g_warning ("%s: and chdir failed",
                          __FUNCTION__);
             g_free (previous_dir);
             g_free (command);
@@ -10835,7 +10835,7 @@ send_to_verinice (const char *url, const char *username, const char *password,
 
     if (chdir (previous_dir))
       {
-        g_warning ("%s: Failed to chdir back: %s\n",
+        g_warning ("%s: Failed to chdir back: %s",
                    __FUNCTION__,
                    strerror (errno));
         g_free (previous_dir);
@@ -11112,7 +11112,7 @@ send_to_tippingpoint (const char *report, size_t report_size,
       if ((nobody == NULL)
           || chown (cert_path, nobody->pw_uid, nobody->pw_gid))
         {
-          g_warning ("%s: Failed to set permissions for user nobody: %s\n",
+          g_warning ("%s: Failed to set permissions for user nobody: %s",
                       __FUNCTION__,
                       strerror (errno));
           g_free (cert_path);
@@ -12230,7 +12230,7 @@ escalate_to_vfire (alert_t alert, task_t task, report_t report, event_t event,
   // Generate reports
   if (mkdtemp (reports_dir) == NULL)
     {
-      g_warning ("%s: mkdtemp failed\n", __FUNCTION__);
+      g_warning ("%s: mkdtemp failed", __FUNCTION__);
       get_data_reset (alert_filter_get);
       g_free (alert_filter_get);
       return -1;
@@ -13486,7 +13486,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
 
           if (manage_fork_connection == NULL)
             {
-              g_warning ("%s: no connection fork available\n", __FUNCTION__);
+              g_warning ("%s: no connection fork available", __FUNCTION__);
               return -1;
             }
 
@@ -13501,7 +13501,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
               case -1:
                 /* Parent on error. */
                 g_free (task_id);
-                g_warning ("%s: fork failed\n", __FUNCTION__);
+                g_warning ("%s: fork failed", __FUNCTION__);
                 return -1;
                 break;
 
@@ -13916,7 +13916,7 @@ condition_met (task_t task, report_t report, alert_t alert,
             {
               last_report = 0;
               if (task_last_report (task, &last_report))
-                g_warning ("%s: failed to get last report\n", __FUNCTION__);
+                g_warning ("%s: failed to get last report", __FUNCTION__);
             }
 
           g_debug ("%s: last_report: %llu", __FUNCTION__, last_report);
@@ -13973,7 +13973,7 @@ condition_met (task_t task, report_t report, alert_t alert,
             {
               last_report = 0;
               if (task_last_report (task, &last_report))
-                g_warning ("%s: failed to get last report\n", __FUNCTION__);
+                g_warning ("%s: failed to get last report", __FUNCTION__);
             }
 
           if (last_report)
@@ -13992,7 +13992,7 @@ condition_met (task_t task, report_t report, alert_t alert,
 
               second_last_report = 0;
               if (task_second_last_report (task, &second_last_report))
-                g_warning ("%s: failed to get second last report\n", __FUNCTION__);
+                g_warning ("%s: failed to get second last report", __FUNCTION__);
 
               if (second_last_report)
                 {
@@ -14005,10 +14005,10 @@ condition_met (task_t task, report_t report, alert_t alert,
                                       + false_positives;
 
                   cmp = last_count - second_last_count;
-                  g_debug ("cmp: %i (vs %i)\n", cmp, count);
-                  g_debug ("direction: %s\n", direction);
-                  g_debug ("last_count: %i\n", last_count);
-                  g_debug ("second_last_count: %i\n", second_last_count);
+                  g_debug ("cmp: %i (vs %i)", cmp, count);
+                  g_debug ("direction: %s", direction);
+                  g_debug ("last_count: %i", last_count);
+                  g_debug ("second_last_count: %i", second_last_count);
                   if (count < 0)
                     {
                       count = -count;
@@ -14044,9 +14044,9 @@ condition_met (task_t task, report_t report, alert_t alert,
                 }
               else
                 {
-                  g_debug ("direction: %s\n", direction);
-                  g_debug ("last_count: %i\n", last_count);
-                  g_debug ("second_last_count NULL\n");
+                  g_debug ("direction: %s", direction);
+                  g_debug ("last_count: %i", last_count);
+                  g_debug ("second_last_count NULL");
                   if (((strcasecmp (direction, "changed") == 0)
                        || (strcasecmp (direction, "increased") == 0))
                       && (last_count > 0))
@@ -14107,10 +14107,10 @@ condition_met (task_t task, report_t report, alert_t alert,
               && second_last_severity > SEVERITY_MISSING)
             {
               double cmp = last_severity - second_last_severity;
-              g_debug ("cmp: %f\n", cmp);
-              g_debug ("direction: %s\n", direction);
-              g_debug ("last_level: %1.1f\n", last_severity);
-              g_debug ("second_last_level: %1.1f\n", second_last_severity);
+              g_debug ("cmp: %f", cmp);
+              g_debug ("direction: %s", direction);
+              g_debug ("last_level: %1.1f", last_severity);
+              g_debug ("second_last_level: %1.1f", second_last_severity);
               if (((strcasecmp (direction, "changed") == 0) && cmp)
                   || ((strcasecmp (direction, "increased") == 0) && (cmp > 0))
                   || ((strcasecmp (direction, "decreased") == 0) && (cmp < 0)))
@@ -14122,9 +14122,9 @@ condition_met (task_t task, report_t report, alert_t alert,
           else if (direction
                    && last_severity > SEVERITY_MISSING)
             {
-              g_debug ("direction: %s\n", direction);
-              g_debug ("last_level: %1.1f\n", last_severity);
-              g_debug ("second_last_level NULL\n");
+              g_debug ("direction: %s", direction);
+              g_debug ("last_level: %1.1f", last_severity);
+              g_debug ("second_last_level NULL");
               if ((strcasecmp (direction, "changed") == 0)
                   || (strcasecmp (direction, "increased") == 0))
                 {
@@ -14934,7 +14934,7 @@ init_manage_process (int update_nvt_cache, const gchar *database)
   /* Open the database. */
   if (sql_open (database))
     {
-      g_warning ("%s: sql_open failed\n", __FUNCTION__);
+      g_warning ("%s: sql_open failed", __FUNCTION__);
       abort ();
     }
 
@@ -16244,10 +16244,10 @@ check_db_versions (int nvt_cache_mode)
           && strcmp (database_version,
                      G_STRINGIFY (GVMD_DATABASE_VERSION)))
         {
-          g_message ("%s: database version of database: %s\n",
+          g_message ("%s: database version of database: %s",
                      __FUNCTION__,
                      database_version);
-          g_message ("%s: database version supported by manager: %s\n",
+          g_message ("%s: database version supported by manager: %s",
                      __FUNCTION__,
                      G_STRINGIFY (GVMD_DATABASE_VERSION));
           g_free (database_version);
@@ -16267,10 +16267,10 @@ check_db_versions (int nvt_cache_mode)
           if (strcmp (database_version,
                       G_STRINGIFY (GVMD_DATABASE_VERSION)))
             {
-              g_message ("%s: database version of database: %s\n",
+              g_message ("%s: database version of database: %s",
                          __FUNCTION__,
                          database_version);
-              g_message ("%s: database version supported by manager: %s\n",
+              g_message ("%s: database version supported by manager: %s",
                          __FUNCTION__,
                          G_STRINGIFY (GVMD_DATABASE_VERSION));
               g_free (database_version);
@@ -16304,10 +16304,10 @@ check_db_versions (int nvt_cache_mode)
     g_message ("No SCAP database found");
   else if (scap_db_version != manage_scap_db_supported_version ())
     {
-      g_message ("%s: database version of SCAP database: %i\n",
+      g_message ("%s: database version of SCAP database: %i",
                  __FUNCTION__,
                  scap_db_version);
-      g_message ("%s: SCAP database version supported by manager: %s\n",
+      g_message ("%s: SCAP database version supported by manager: %s",
                  __FUNCTION__,
                  G_STRINGIFY (GVMD_SCAP_DATABASE_VERSION));
       return -2;
@@ -16320,10 +16320,10 @@ check_db_versions (int nvt_cache_mode)
     g_message ("No CERT database found");
   else if (cert_db_version != manage_cert_db_supported_version ())
     {
-      g_message ("%s: database version of CERT database: %i\n",
+      g_message ("%s: database version of CERT database: %i",
                  __FUNCTION__,
                  cert_db_version);
-      g_message ("%s: CERT database version supported by manager: %s\n",
+      g_message ("%s: CERT database version supported by manager: %s",
                  __FUNCTION__,
                  G_STRINGIFY (GVMD_CERT_DATABASE_VERSION));
       return -2;
@@ -16705,7 +16705,7 @@ make_report_format_uuids_unique ()
           command = g_strdup_printf ("cp -a %s %s > /dev/null 2>&1",
                                      dir,
                                      new_dir);
-          g_debug ("   command: %s\n", command);
+          g_debug ("   command: %s", command);
           ret = system (command);
           g_free (command);
 
@@ -16776,7 +16776,7 @@ check_db_trash_report_formats ()
 
       if (errno != ENOENT)
         {
-          g_warning ("%s: g_lstat (%s) failed: %s\n",
+          g_warning ("%s: g_lstat (%s) failed: %s",
                      __FUNCTION__, dir, g_strerror (errno));
           g_free (dir);
           return -1;
@@ -16981,7 +16981,7 @@ check_db_report_formats_trash ()
       assert (error);
       if (!g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
         {
-          g_warning ("g_dir_open (%s) failed - %s\n", dir, error->message);
+          g_warning ("g_dir_open (%s) failed - %s", dir, error->message);
           g_error_free (error);
           g_free (dir);
           return -1;
@@ -17465,7 +17465,7 @@ check_generate_scripts ()
                                    NULL);
 
           if (chmod (path, 0755 /* rwxr-xr-x */))
-            g_warning ("%s: chmod %s failed: %s\n",
+            g_warning ("%s: chmod %s failed: %s",
                        __FUNCTION__,
                        path,
                        strerror (errno));
@@ -17877,7 +17877,7 @@ cleanup_manage_process (gboolean cleanup)
 void
 manage_cleanup_process_error (int signal)
 {
-  g_debug ("Received %s signal.\n", sys_siglist[signal]);
+  g_debug ("Received %s signal", sys_siglist[signal]);
   if (sql_is_open ())
     {
       if (current_scanner_task)
@@ -18117,7 +18117,7 @@ manage_scanner_set (const char *uuid)
   if (find_scanner_with_permission (uuid, &scanner, "get_scanners")
       || scanner == 0)
     {
-      g_warning ("Failed to find scanner %s\n", uuid);
+      g_warning ("Failed to find scanner %s", uuid);
       return -1;
     }
   if (!strcmp (current_credentials.uuid, ""))
@@ -18126,7 +18126,7 @@ manage_scanner_set (const char *uuid)
   type = scanner_type (scanner);
   if (type != SCANNER_TYPE_OPENVAS)
     {
-      g_warning ("Scanner %s not an OpenVAS Scanner\n", uuid);
+      g_warning ("Scanner %s not an OpenVAS Scanner", uuid);
       return -1;
     }
   host = scanner_host (scanner);
@@ -18143,7 +18143,7 @@ manage_scanner_set (const char *uuid)
       port = scanner_port (scanner);
       if (openvas_scanner_set_address (host, port))
         {
-          g_warning ("Failed to set %s:%d as scanner\n", host, port);
+          g_warning ("Failed to set %s:%d as scanner", host, port);
           g_free (host);
           return -1;
         }
@@ -20235,7 +20235,7 @@ auto_delete_reports ()
             }
           if (ret)
             {
-              g_warning ("%s: failed to delete %llu (%i)\n",
+              g_warning ("%s: failed to delete %llu (%i)",
                          __FUNCTION__, report, ret);
               sql_rollback ();
             }
@@ -20279,7 +20279,7 @@ reschedule_task (const gchar *task_id)
                      task_id))
     {
       case 0:
-        g_warning ("%s: rescheduling task '%s'\n", __FUNCTION__, task_id);
+        g_warning ("%s: rescheduling task '%s'", __FUNCTION__, task_id);
         set_task_schedule_next_time (task, time (NULL) - 1);
         break;
       case 1:        /* Too few rows in result of query. */
@@ -20709,7 +20709,7 @@ make_result (task_t task, const char* host, const char *hostname,
 
   if (nvt && strcmp (nvt, "") && (find_nvt (nvt, &nvt_id) || nvt_id <= 0))
     {
-      g_warning ("NVT '%s' not found. Result not created.\n", nvt);
+      g_warning ("NVT '%s' not found. Result not created", nvt);
       return 0;
     }
   else if (nvt && strcmp (nvt, ""))
@@ -21014,7 +21014,7 @@ init_prognosis_iterator (iterator_t *iterator, const char *cpe)
     {
       if (sql_reset (prognosis_stmt))
         {
-          g_warning ("%s: sql_reset failed\n", __FUNCTION__);
+          g_warning ("%s: sql_reset failed", __FUNCTION__);
           abort ();
         }
     }
@@ -21027,7 +21027,7 @@ init_prognosis_iterator (iterator_t *iterator, const char *cpe)
   /* Bind iterator. */
   if (sql_bind_text (prognosis_stmt, 1, cpe, -1))
     {
-      g_warning ("%s: sql_bind_text failed\n", __FUNCTION__);
+      g_warning ("%s: sql_bind_text failed", __FUNCTION__);
       abort ();
     }
 }
@@ -21973,7 +21973,7 @@ create_report (array_t *results, const char *task_id, const char *task_name,
                 break;
               case -1:
                 /* Grandchild's parent when error. */
-                g_warning ("%s: fork: %s\n", __FUNCTION__, strerror (errno));
+                g_warning ("%s: fork: %s", __FUNCTION__, strerror (errno));
                 exit (EXIT_FAILURE);
                 break;
               default:
@@ -21986,7 +21986,7 @@ create_report (array_t *results, const char *task_id, const char *task_name,
         break;
       case -1:
         /* Parent when error. */
-        g_warning ("%s: fork: %s\n", __FUNCTION__, strerror (errno));
+        g_warning ("%s: fork: %s", __FUNCTION__, strerror (errno));
         global_current_report = report;
         set_task_interrupted (task,
                               "Failed to fork child to import report."
@@ -22028,7 +22028,7 @@ create_report (array_t *results, const char *task_id, const char *task_name,
                  "SELECT owner FROM tasks WHERE tasks.id = %llu",
                  task))
     {
-      g_warning ("%s: failed to get owner of task\n", __FUNCTION__);
+      g_warning ("%s: failed to get owner of task", __FUNCTION__);
       return -1;
     }
 
@@ -28541,10 +28541,10 @@ report_progress_active (report_t report, long maximum_hosts, gchar **hosts_xml)
                    ? (total / (maximum_hosts - dead_hosts)) : 0;
 
 #if 1
-  g_debug ("   total: %li\n", total);
-  g_debug ("   num_hosts: %li\n", num_hosts);
-  g_debug ("   maximum_hosts: %li\n", maximum_hosts);
-  g_debug ("   total_progress: %i\n", total_progress);
+  g_debug ("   total: %li", total);
+  g_debug ("   num_hosts: %li", num_hosts);
+  g_debug ("   maximum_hosts: %li", maximum_hosts);
+  g_debug ("   total_progress: %i", total_progress);
 #endif
 
   if (total_progress == 0) total_progress = 1;
@@ -29171,7 +29171,7 @@ print_report_delta_xml (FILE *out, iterator_t *results,
                                           &would_use);
       if (state == COMPARE_RESULTS_ERROR)
         {
-          g_warning ("%s: compare_and_buffer_results failed\n",
+          g_warning ("%s: compare_and_buffer_results failed",
                      __FUNCTION__);
           return -1;
         }
@@ -29466,7 +29466,7 @@ print_report_delta_xml (FILE *out, iterator_t *results,
                                           &would_use);
       if (state == COMPARE_RESULTS_ERROR)
         {
-          g_warning ("%s: compare_and_buffer_results failed\n",
+          g_warning ("%s: compare_and_buffer_results failed",
                      __FUNCTION__);
           return -1;
         }
@@ -29719,7 +29719,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
 
   if (out == NULL)
     {
-      g_warning ("%s: fopen failed: %s\n",
+      g_warning ("%s: fopen failed: %s",
                  __FUNCTION__,
                  strerror (errno));
       return -1;
@@ -30291,7 +30291,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
 
       if (fclose (out))
         {
-          g_warning ("%s: fclose failed: %s\n",
+          g_warning ("%s: fclose failed: %s",
                      __FUNCTION__,
                      strerror (errno));
           return -1;
@@ -30820,7 +30820,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
 
   if (fclose (out))
     {
-      g_warning ("%s: fclose failed: %s\n",
+      g_warning ("%s: fclose failed: %s",
                  __FUNCTION__,
                  strerror (errno));
       return -1;
@@ -30854,7 +30854,7 @@ print_report_xml_end (gchar *xml_start, gchar *xml_full,
   out = fopen (xml_full, "a");
   if (out == NULL)
     {
-      g_warning ("%s: fopen failed: %s\n",
+      g_warning ("%s: fopen failed: %s",
                  __FUNCTION__,
                  strerror (errno));
       return -1;
@@ -30875,7 +30875,7 @@ print_report_xml_end (gchar *xml_start, gchar *xml_full,
 
   if (fclose (out))
     {
-      g_warning ("%s: fclose failed: %s\n",
+      g_warning ("%s: fclose failed: %s",
                  __FUNCTION__,
                  strerror (errno));
       return -1;
@@ -30938,7 +30938,7 @@ manage_report (report_t report, report_t delta_report, const get_data_t *get,
 
   if (mkdtemp (xml_dir) == NULL)
     {
-      g_warning ("%s: mkdtemp failed\n", __FUNCTION__);
+      g_warning ("%s: mkdtemp failed", __FUNCTION__);
       return NULL;
     }
 
@@ -30988,7 +30988,7 @@ manage_report (report_t report, report_t delta_report, const get_data_t *get,
   if (get_error)
     {
       g_free (report_format_id);
-      g_warning ("%s: Failed to get output: %s\n",
+      g_warning ("%s: Failed to get output: %s",
                   __FUNCTION__,
                   get_error->message);
       g_error_free (get_error);
@@ -31127,7 +31127,7 @@ run_report_format_script (gchar *report_format_id,
   previous_dir = getcwd (NULL, 0);
   if (previous_dir == NULL)
     {
-      g_warning ("%s: Failed to getcwd: %s\n",
+      g_warning ("%s: Failed to getcwd: %s",
                   __FUNCTION__,
                   strerror (errno));
       g_free (previous_dir);
@@ -31138,7 +31138,7 @@ run_report_format_script (gchar *report_format_id,
 
   if (chdir (script_dir))
     {
-      g_warning ("%s: Failed to chdir: %s\n",
+      g_warning ("%s: Failed to chdir: %s",
                   __FUNCTION__,
                   strerror (errno));
       g_free (previous_dir);
@@ -31158,7 +31158,7 @@ run_report_format_script (gchar *report_format_id,
                              output_file);
   g_free (script);
 
-  g_debug ("   command: %s\n", command);
+  g_debug ("   command: %s", command);
 
   if (geteuid () == 0)
     {
@@ -31173,7 +31173,7 @@ run_report_format_script (gchar *report_format_id,
           || chown (xml_file, nobody->pw_uid, nobody->pw_gid)
           || chown (output_file, nobody->pw_uid, nobody->pw_gid))
         {
-          g_warning ("%s: Failed to set dir permissions: %s\n",
+          g_warning ("%s: Failed to set dir permissions: %s",
                       __FUNCTION__,
                       strerror (errno));
           g_free (previous_dir);
@@ -31193,20 +31193,20 @@ run_report_format_script (gchar *report_format_id,
 
               if (setgroups (0,NULL))
                 {
-                  g_warning ("%s (child): setgroups: %s\n",
+                  g_warning ("%s (child): setgroups: %s",
                               __FUNCTION__, strerror (errno));
                   exit (EXIT_FAILURE);
                 }
               if (setgid (nobody->pw_gid))
                 {
-                  g_warning ("%s (child): setgid: %s\n",
+                  g_warning ("%s (child): setgid: %s",
                               __FUNCTION__,
                               strerror (errno));
                   exit (EXIT_FAILURE);
                 }
               if (setuid (nobody->pw_uid))
                 {
-                  g_warning ("%s (child): setuid: %s\n",
+                  g_warning ("%s (child): setuid: %s",
                               __FUNCTION__,
                               strerror (errno));
                   exit (EXIT_FAILURE);
@@ -31218,7 +31218,7 @@ run_report_format_script (gchar *report_format_id,
               if (ret == -1)
                 {
                   g_warning ("%s (child):"
-                              " system failed with ret %i, %i, %s\n",
+                              " system failed with ret %i, %i, %s",
                               __FUNCTION__,
                               ret,
                               WEXITSTATUS (ret),
@@ -31232,11 +31232,11 @@ run_report_format_script (gchar *report_format_id,
           case -1:
             /* Parent when error. */
 
-            g_warning ("%s: Failed to fork: %s\n",
+            g_warning ("%s: Failed to fork: %s",
                         __FUNCTION__,
                         strerror (errno));
             if (chdir (previous_dir))
-              g_warning ("%s: and chdir failed\n",
+              g_warning ("%s: and chdir failed",
                           __FUNCTION__);
             g_free (previous_dir);
             g_free (command);
@@ -31258,7 +31258,7 @@ run_report_format_script (gchar *report_format_id,
                       g_warning ("%s: Failed to get child exit status",
                                   __FUNCTION__);
                       if (chdir (previous_dir))
-                        g_warning ("%s: and chdir failed\n",
+                        g_warning ("%s: and chdir failed",
                                     __FUNCTION__);
                       g_free (previous_dir);
                       return -1;
@@ -31269,7 +31269,7 @@ run_report_format_script (gchar *report_format_id,
                               __FUNCTION__,
                               strerror (errno));
                   if (chdir (previous_dir))
-                    g_warning ("%s: and chdir failed\n",
+                    g_warning ("%s: and chdir failed",
                                 __FUNCTION__);
                   g_free (previous_dir);
                   return -1;
@@ -31281,22 +31281,22 @@ run_report_format_script (gchar *report_format_id,
                       break;
                     case EXIT_FAILURE:
                     default:
-                      g_warning ("%s: child failed, %s\n",
+                      g_warning ("%s: child failed, %s",
                                   __FUNCTION__,
                                   command);
                       if (chdir (previous_dir))
-                        g_warning ("%s: and chdir failed\n",
+                        g_warning ("%s: and chdir failed",
                                     __FUNCTION__);
                       g_free (previous_dir);
                       return -1;
                   }
               else
                 {
-                  g_warning ("%s: child failed, %s\n",
+                  g_warning ("%s: child failed, %s",
                               __FUNCTION__,
                               command);
                   if (chdir (previous_dir))
-                    g_warning ("%s: and chdir failed\n",
+                    g_warning ("%s: and chdir failed",
                                 __FUNCTION__);
                   g_free (previous_dir);
                   return -1;
@@ -31317,13 +31317,13 @@ run_report_format_script (gchar *report_format_id,
         * specified what it must be in the past. */
       if (ret == -1)
         {
-          g_warning ("%s: system failed with ret %i, %i, %s\n",
+          g_warning ("%s: system failed with ret %i, %i, %s",
                       __FUNCTION__,
                       ret,
                       WEXITSTATUS (ret),
                       command);
           if (chdir (previous_dir))
-            g_warning ("%s: and chdir failed\n",
+            g_warning ("%s: and chdir failed",
                         __FUNCTION__);
           g_free (previous_dir);
           g_free (command);
@@ -31337,7 +31337,7 @@ run_report_format_script (gchar *report_format_id,
 
   if (chdir (previous_dir))
     {
-      g_warning ("%s: Failed to chdir back: %s\n",
+      g_warning ("%s: Failed to chdir back: %s",
                   __FUNCTION__,
                   strerror (errno));
       g_free (previous_dir);
@@ -31442,7 +31442,7 @@ apply_report_format (gchar *report_format_id,
 
           if (mkdtemp (subreport_dir) == NULL)
             {
-              g_warning ("%s: mkdtemp failed\n", __FUNCTION__);
+              g_warning ("%s: mkdtemp failed", __FUNCTION__);
               g_free (subreport_dir);
               break;
             }
@@ -31697,7 +31697,7 @@ manage_send_report (report_t report, report_t delta_report,
 
   if (mkdtemp (xml_dir) == NULL)
     {
-      g_warning ("%s: mkdtemp failed\n", __FUNCTION__);
+      g_warning ("%s: mkdtemp failed", __FUNCTION__);
       return -1;
     }
 
@@ -31739,7 +31739,7 @@ manage_send_report (report_t report, report_t delta_report,
   g_free (output_file);
   if (stream == NULL)
     {
-      g_warning ("%s: %s\n",
+      g_warning ("%s: %s",
                   __FUNCTION__,
                   strerror (errno));
       gvm_file_remove_recurse (xml_dir);
@@ -31749,7 +31749,7 @@ manage_send_report (report_t report, report_t delta_report,
   if (prefix && send (prefix, send_data_1, send_data_2))
     {
       fclose (stream);
-      g_warning ("%s: send prefix error\n", __FUNCTION__);
+      g_warning ("%s: send prefix error", __FUNCTION__);
       gvm_file_remove_recurse (xml_dir);
       return -1;
     }
@@ -31769,7 +31769,7 @@ manage_send_report (report_t report, report_t delta_report,
           if (ferror (stream))
             {
               fclose (stream);
-              g_warning ("%s: error after fread\n", __FUNCTION__);
+              g_warning ("%s: error after fread", __FUNCTION__);
               gvm_file_remove_recurse (xml_dir);
               return -1;
             }
@@ -31795,7 +31795,7 @@ manage_send_report (report_t report, report_t delta_report,
                 {
                   g_free (chunk64);
                   fclose (stream);
-                  g_warning ("%s: send error\n", __FUNCTION__);
+                  g_warning ("%s: send error", __FUNCTION__);
                   gvm_file_remove_recurse (xml_dir);
                   return -1;
                 }
@@ -31807,7 +31807,7 @@ manage_send_report (report_t report, report_t delta_report,
               if (send (chunk, send_data_1, send_data_2))
                 {
                   fclose (stream);
-                  g_warning ("%s: send error\n", __FUNCTION__);
+                  g_warning ("%s: send error", __FUNCTION__);
                   gvm_file_remove_recurse (xml_dir);
                   return -1;
                 }
@@ -31901,7 +31901,7 @@ parse_osp_report (task_t task, report_t report, const char *report_xml)
 
   if (parse_entity (report_xml, &entity))
     {
-      g_warning ("Couldn't parse %s OSP scan report\n", report_xml);
+      g_warning ("Couldn't parse %s OSP scan report", report_xml);
       return;
     }
 
@@ -32445,7 +32445,7 @@ request_delete_task (task_t* task_pointer)
   task_t task = *task_pointer;
   int hidden;
 
-  g_debug ("   request delete task %llu\n", task);
+  g_debug ("   request delete task %llu", task);
 
   hidden = sql_int ("SELECT hidden from tasks WHERE id = %llu;",
                     *task_pointer);
@@ -32504,7 +32504,7 @@ request_delete_task_uuid (const char *task_id, int ultimate)
    * should all work because there is already handling of the hidden flag
    * everywhere else. */
 
-  g_debug ("   request delete task %s\n", task_id);
+  g_debug ("   request delete task %s", task_id);
 
   if (sql_is_sqlite3 ())
     sql_begin_exclusive ();
@@ -32634,7 +32634,7 @@ request_delete_task_uuid (const char *task_id, int ultimate)
 int
 delete_task (task_t task, int ultimate)
 {
-  g_debug ("   delete task %llu\n", task);
+  g_debug ("   delete task %llu", task);
 
   assert (current_credentials.uuid);
 
@@ -32735,7 +32735,7 @@ delete_task_lock (task_t task, int ultimate)
 {
   int ret;
 
-  g_debug ("   delete task %llu\n", task);
+  g_debug ("   delete task %llu", task);
 
   if (sql_is_sqlite3 ())
     sql_begin_exclusive ();
@@ -34038,7 +34038,7 @@ create_target (const char* name, const char* asset_hosts_filter,
       chosen_hosts = g_string_free (buffer, FALSE);
       quoted_exclude_hosts = g_strdup ("");
 
-      g_debug ("asset chosen_hosts: %s\n", chosen_hosts);
+      g_debug ("asset chosen_hosts: %s", chosen_hosts);
     }
   else
     {
@@ -34046,7 +34046,7 @@ create_target (const char* name, const char* asset_hosts_filter,
       quoted_exclude_hosts = exclude_hosts ? sql_quote (exclude_hosts)
                                            : g_strdup ("");
 
-      g_debug ("manual chosen_hosts: %s\n", chosen_hosts);
+      g_debug ("manual chosen_hosts: %s", chosen_hosts);
     }
 
   max = manage_count_hosts (chosen_hosts, quoted_exclude_hosts);
@@ -42706,7 +42706,7 @@ credential_iterator_rpm (iterator_t *iterator)
     }
   else if (lsc_user_rpm_recreate (login, public_key, &rpm, &rpm_size))
     {
-      g_warning ("%s: Failed to create RPM\n", __FUNCTION__);
+      g_warning ("%s: Failed to create RPM", __FUNCTION__);
       g_free (public_key);
       return NULL;
     }
@@ -42755,7 +42755,7 @@ credential_iterator_deb (iterator_t *iterator)
                                   maintainer ? maintainer : "",
                                   &deb, &deb_size))
     {
-      g_warning ("%s: Failed to create DEB\n", __FUNCTION__);
+      g_warning ("%s: Failed to create DEB", __FUNCTION__);
       g_free (public_key);
       free (maintainer);
       return NULL;
@@ -42794,7 +42794,7 @@ credential_iterator_exe (iterator_t *iterator)
     return NULL;
   else if (lsc_user_exe_recreate (login, password, &exe, &exe_size))
     {
-      g_warning ("%s: Failed to create EXE\n", __FUNCTION__);
+      g_warning ("%s: Failed to create EXE", __FUNCTION__);
       return NULL;
     }
   exe64 = (exe && exe_size)
@@ -43192,7 +43192,7 @@ find_signature (const gchar *location, const gchar *installer_filename,
                                              location,
                                              signature_basename,
                                              NULL);
-      g_debug ("signature_filename: %s\n", signature_filename);
+      g_debug ("signature_filename: %s", signature_filename);
 
       g_file_get_contents (signature_filename, signature, signature_size,
                            &error);
@@ -43214,7 +43214,7 @@ find_signature (const gchar *location, const gchar *installer_filename,
                                                      location,
                                                      signature_basename,
                                                      NULL);
-              g_debug ("signature_filename (private): %s\n", signature_filename);
+              g_debug ("signature_filename (private): %s", signature_filename);
               g_free (signature_basename);
               g_file_get_contents (signature_filename, signature, signature_size,
                                    &error);
@@ -43227,7 +43227,7 @@ find_signature (const gchar *location, const gchar *installer_filename,
 
               real = realpath (signature_filename, NULL);
               g_free (signature_filename);
-              g_debug ("real pathname: %s\n", real);
+              g_debug ("real pathname: %s", real);
               if (real == NULL)
                 return -1;
               real_basename = g_path_get_basename (real);
@@ -43236,7 +43236,7 @@ find_signature (const gchar *location, const gchar *installer_filename,
                 *uuid = g_strdup (*split);
               else
                 *uuid = g_strdup (real_basename);
-              g_debug ("*uuid: %s\n", *uuid);
+              g_debug ("*uuid: %s", *uuid);
               g_free (real_basename);
               g_strfreev (split);
               free (real);
@@ -43244,7 +43244,7 @@ find_signature (const gchar *location, const gchar *installer_filename,
             }
           else
             {
-              g_debug ("%s: failed to read %s: %s\n", __FUNCTION__,
+              g_debug ("%s: failed to read %s: %s", __FUNCTION__,
                        signature_filename, error->message);
               g_free (signature_filename);
             }
@@ -43374,7 +43374,7 @@ verify_signature (const gchar *installer, gsize installer_size,
   cmd[7] = g_strdup (signature_file);
   cmd[8] = g_strdup (installer_file);
   cmd[9] = NULL;
-  g_debug ("%s: Spawning in /tmp/: %s %s %s %s %s %s %s %s %s\n",
+  g_debug ("%s: Spawning in /tmp/: %s %s %s %s %s %s %s %s %s",
            __FUNCTION__,
            cmd[0], cmd[1], cmd[2], cmd[3], cmd[4], cmd[5],
            cmd[6], cmd[7], cmd[8]);
@@ -43401,8 +43401,8 @@ verify_signature (const gchar *installer, gsize installer_size,
                    exit_status,
                    WIFEXITED (exit_status),
                    WEXITSTATUS (exit_status));
-          g_debug ("%s: stdout: %s\n", __FUNCTION__, standard_out);
-          g_debug ("%s: stderr: %s\n", __FUNCTION__, standard_err);
+          g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
+          g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);
           ret = -1;
 #endif
           /* This can be caused by the contents of the signature file, so
@@ -43567,7 +43567,7 @@ create_agent (const char* name, const char* comment, const char* installer_64,
         g_free (quoted_filename);
         if (stmt == NULL)
           {
-            g_warning ("%s: sql_prepare failed\n", __FUNCTION__);
+            g_warning ("%s: sql_prepare failed", __FUNCTION__);
             g_free (installer);
             g_free (installer_signature);
             sql_rollback ();
@@ -43578,7 +43578,7 @@ create_agent (const char* name, const char* comment, const char* installer_64,
 
         if (sql_bind_text (stmt, 1, installer, installer_size))
           {
-            g_warning ("%s: sql_bind_text failed\n", __FUNCTION__);
+            g_warning ("%s: sql_bind_text failed", __FUNCTION__);
             sql_rollback ();
             g_free (installer);
             g_free (installer_signature);
@@ -43588,7 +43588,7 @@ create_agent (const char* name, const char* comment, const char* installer_64,
 
         if (sql_bind_text (stmt, 2, installer_64, strlen (installer_64)))
           {
-            g_warning ("%s: sql_bind_text failed\n", __FUNCTION__);
+            g_warning ("%s: sql_bind_text failed", __FUNCTION__);
             sql_rollback ();
             g_free (installer_signature);
             return -1;
@@ -43598,21 +43598,21 @@ create_agent (const char* name, const char* comment, const char* installer_64,
         if (sql_bind_text (stmt, 3, installer_signature_64,
                            strlen (installer_signature_64)))
           {
-            g_warning ("%s: sql_bind_text failed\n", __FUNCTION__);
+            g_warning ("%s: sql_bind_text failed", __FUNCTION__);
             sql_rollback ();
             return -1;
           }
 
         if (sql_bind_text (stmt, 4, howto_install, strlen (howto_install)))
           {
-            g_warning ("%s: sql_bind_text failed\n", __FUNCTION__);
+            g_warning ("%s: sql_bind_text failed", __FUNCTION__);
             sql_rollback ();
             return -1;
           }
 
         if (sql_bind_blob (stmt, 5, howto_use, strlen (howto_use)))
           {
-            g_warning ("%s: sql_bind_blob failed\n", __FUNCTION__);
+            g_warning ("%s: sql_bind_blob failed", __FUNCTION__);
             sql_rollback ();
             return -1;
           }
@@ -43628,7 +43628,7 @@ create_agent (const char* name, const char* comment, const char* installer_64,
           }
         if (ret < 0)
           {
-            g_warning ("%s: sql_exec failed\n", __FUNCTION__);
+            g_warning ("%s: sql_exec failed", __FUNCTION__);
             sql_rollback ();
             return -1;
           }
@@ -44251,7 +44251,7 @@ verify_agent (const char *agent_id)
 
       signature_64 = agent_iterator_installer_signature_64 (&agents);
 
-      g_debug ("%s: finding signature\n", __FUNCTION__);
+      g_debug ("%s: finding signature", __FUNCTION__);
 
       find_signature ("agents",
                       agent_iterator_installer_filename (&agents),
@@ -44275,7 +44275,7 @@ verify_agent (const char *agent_id)
 
               /* Try the signature from the database. */
 
-              g_debug ("%s: trying database signature\n", __FUNCTION__);
+              g_debug ("%s: trying database signature", __FUNCTION__);
 
               signature = (gchar*) g_base64_decode (signature_64,
                                                     &signature_length);
@@ -44283,7 +44283,7 @@ verify_agent (const char *agent_id)
               if (verify_signature (installer, installer_size, signature,
                                     signature_length, &agent_trust))
                 {
-                  g_warning ("%s: verify_signature error\n", __FUNCTION__);
+                  g_warning ("%s: verify_signature error", __FUNCTION__);
                   cleanup_iterator (&agents);
                   g_free (agent_signature);
                   sql_rollback ();
@@ -44298,12 +44298,12 @@ verify_agent (const char *agent_id)
                || (agent_trust == TRUST_UNKNOWN))
               && agent_signature)
             {
-              g_debug ("%s: trying feed signature\n", __FUNCTION__);
+              g_debug ("%s: trying feed signature", __FUNCTION__);
 
               if (verify_signature (installer, installer_size, agent_signature,
                                     strlen (agent_signature), &agent_trust))
                 {
-                  g_warning ("%s: verify_signature error\n", __FUNCTION__);
+                  g_warning ("%s: verify_signature error", __FUNCTION__);
                   cleanup_iterator (&agents);
                   g_free (agent_signature);
                   sql_rollback ();
@@ -44331,7 +44331,7 @@ verify_agent (const char *agent_id)
     }
   else
     {
-      g_warning ("%s: agent iterator empty\n", __FUNCTION__);
+      g_warning ("%s: agent iterator empty", __FUNCTION__);
       cleanup_iterator (&agents);
       sql_rollback ();
       return -1;
@@ -46730,7 +46730,7 @@ manage_create_scanner (GSList *log_config, const gchar *database,
   gchar *name_for_credential;
   scanner_t scanner;
 
-  g_info ("   Creating scanner.\n");
+  g_info ("   Creating scanner.");
 
   ret = manage_option_setup (log_config, database);
   if (ret)
@@ -46882,7 +46882,7 @@ manage_delete_scanner (GSList *log_config, const gchar *database,
 
   assert (uuid);
 
-  g_info ("   Deleting scanner.\n");
+  g_info ("   Deleting scanner.");
 
   if (!strcmp (uuid, SCANNER_UUID_CVE))
     {
@@ -46960,7 +46960,7 @@ manage_modify_scanner (GSList *log_config, const gchar *database,
   gchar *credential_id;
   gchar *name_for_credential;
 
-  g_info ("   Modifying scanner.\n");
+  g_info ("   Modifying scanner.");
 
   ret = manage_option_setup (log_config, database);
   if (ret)
@@ -47154,7 +47154,7 @@ manage_verify_scanner (GSList *log_config, const gchar *database,
 
   assert (uuid);
 
-  g_info ("   Verifying scanner.\n");
+  g_info ("   Verifying scanner.");
 
   ret = manage_option_setup (log_config, database);
   if (ret)
@@ -48692,7 +48692,7 @@ manage_get_scanners (GSList *log_config, const gchar *database)
   iterator_t scanners;
   int ret;
 
-  g_info ("   Getting scanners.\n");
+  g_info ("   Getting scanners.");
 
   ret = manage_option_setup (log_config, database);
   if (ret)
@@ -50414,7 +50414,7 @@ create_report_format (const char *uuid, const char *name,
               g_free (old);
               old = g_build_filename (GVM_NVT_DIR, "report_formats", base,
                                       NULL);
-              g_debug ("using standard old: %s\n", old);
+              g_debug ("using standard old: %s", old);
             }
           else
             {
@@ -50436,7 +50436,7 @@ create_report_format (const char *uuid, const char *name,
               real_old[state.st_size] = '\0';
               g_free (old);
               old = real_old;
-              g_debug ("using linked old: %s\n", old);
+              g_debug ("using linked old: %s", old);
             }
         }
       g_free (base);
@@ -50534,7 +50534,7 @@ create_report_format (const char *uuid, const char *name,
 
       if (chmod (report_dir, 0755 /* rwxr-xr-x */))
         {
-          g_warning ("%s: chmod failed: %s\n",
+          g_warning ("%s: chmod failed: %s",
                      __FUNCTION__,
                      strerror (errno));
           g_free (dir);
@@ -50551,7 +50551,7 @@ create_report_format (const char *uuid, const char *name,
   /* glib seems to apply the mode to the first dir only. */
   if (chmod (dir, 0755 /* rwxr-xr-x */))
     {
-      g_warning ("%s: chmod failed: %s\n",
+      g_warning ("%s: chmod failed: %s",
                  __FUNCTION__,
                  strerror (errno));
       g_free (dir);
@@ -50612,7 +50612,7 @@ create_report_format (const char *uuid, const char *name,
         ret = chmod (full_file_name, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
       if (ret)
         {
-          g_warning ("%s: chmod failed: %s\n",
+          g_warning ("%s: chmod failed: %s",
                      __FUNCTION__,
                      strerror (errno));
           gvm_file_remove_recurse (dir);
@@ -50966,7 +50966,7 @@ copy_report_format (const char* name, const char* source_uuid,
 
   if (chmod (tmp_dir, 0755 /* rwxr-xr-x */))
     {
-      g_warning ("%s: chmod %s failed: %s\n",
+      g_warning ("%s: chmod %s failed: %s",
                  __FUNCTION__,
                  tmp_dir,
                  strerror (errno));
@@ -50987,7 +50987,7 @@ copy_report_format (const char* name, const char* source_uuid,
 
   if (chmod (tmp_dir, 0755 /* rwxr-xr-x */))
     {
-      g_warning ("%s: chmod %s failed: %s\n",
+      g_warning ("%s: chmod %s failed: %s",
                  __FUNCTION__,
                  tmp_dir,
                  strerror (errno));
@@ -51012,7 +51012,7 @@ copy_report_format (const char* name, const char* source_uuid,
       {
         if (error)
           {
-            g_warning ("g_dir_open(%s) failed - %s\n",
+            g_warning ("g_dir_open(%s) failed - %s",
                        source_dir, error->message);
             g_error_free (error);
           }
@@ -51034,7 +51034,7 @@ copy_report_format (const char* name, const char* source_uuid,
 
             if (gvm_file_copy (source_file, copy_file) == FALSE)
               {
-                g_warning ("%s: copy of %s to %s failed.\n",
+                g_warning ("%s: copy of %s to %s failed",
                            __FUNCTION__, source_file, copy_file);
                 g_free (source_file);
                 g_free (copy_file);
@@ -51186,7 +51186,7 @@ move_report_format_dir (const char *dir, const char *new_dir)
 
               if (directory == NULL)
                 {
-                  g_warning ("%s: failed to g_dir_open %s: %s\n",
+                  g_warning ("%s: failed to g_dir_open %s: %s",
                              __FUNCTION__, dir, error->message);
                   g_error_free (error);
                   return -1;
@@ -51217,7 +51217,7 @@ move_report_format_dir (const char *dir, const char *new_dir)
             }
           else
             {
-              g_warning ("%s: rename %s to %s: %s\n",
+              g_warning ("%s: rename %s to %s: %s",
                          __FUNCTION__, dir, new_dir, strerror (errno));
               return -1;
             }
@@ -51225,7 +51225,7 @@ move_report_format_dir (const char *dir, const char *new_dir)
     }
   else
     {
-      g_warning ("%s: report dir missing: %s\n",
+      g_warning ("%s: report dir missing: %s",
                  __FUNCTION__, dir);
       return -1;
     }
@@ -52594,7 +52594,7 @@ check_report_format_create (const gchar *quoted_uuid, const gchar *name,
         assert (0);
       case 1:        /* Too few rows in result of query. */
       case -1:
-        g_warning ("%s: Report format missing: %s\n",
+        g_warning ("%s: Report format missing: %s",
                    __FUNCTION__, quoted_uuid);
         return -1;
     }
@@ -52640,7 +52640,7 @@ check_report_format_add_params (const gchar *quoted_uuid, const gchar *config_pa
           child = entity_child (param, "name");
           if (child == NULL)
             {
-              g_warning ("%s: Param missing name in '%s'\n",
+              g_warning ("%s: Param missing name in '%s'",
                          __FUNCTION__, config_path);
               return -1;
             }
@@ -52649,7 +52649,7 @@ check_report_format_add_params (const gchar *quoted_uuid, const gchar *config_pa
           child = entity_child (param, "default");
           if (child == NULL)
             {
-              g_warning ("%s: Param missing default in '%s'\n",
+              g_warning ("%s: Param missing default in '%s'",
                          __FUNCTION__, config_path);
               return -1;
             }
@@ -52658,7 +52658,7 @@ check_report_format_add_params (const gchar *quoted_uuid, const gchar *config_pa
           child = entity_child (param, "type");
           if (child == NULL)
             {
-              g_warning ("%s: Param missing type in '%s'\n",
+              g_warning ("%s: Param missing type in '%s'",
                          __FUNCTION__, config_path);
               return -1;
             }
@@ -52666,7 +52666,7 @@ check_report_format_add_params (const gchar *quoted_uuid, const gchar *config_pa
           if (report_format_param_type_from_name (type)
               == REPORT_FORMAT_PARAM_TYPE_ERROR)
             {
-              g_warning ("%s: Error in param type in '%s'\n",
+              g_warning ("%s: Error in param type in '%s'",
                          __FUNCTION__, config_path);
               return -1;
             }
@@ -52687,7 +52687,7 @@ check_report_format_add_params (const gchar *quoted_uuid, const gchar *config_pa
                       || number == LLONG_MAX
                       || number == LLONG_MIN)
                     {
-                      g_warning ("%s: Failed to parse min in '%s'\n",
+                      g_warning ("%s: Failed to parse min in '%s'",
                                  __FUNCTION__, config_path);
                       g_free (type);
                       return -1;
@@ -52706,7 +52706,7 @@ check_report_format_add_params (const gchar *quoted_uuid, const gchar *config_pa
                       || number == LLONG_MAX
                       || number == LLONG_MIN)
                     {
-                      g_warning ("%s: Failed to parse max in '%s'\n",
+                      g_warning ("%s: Failed to parse max in '%s'",
                                  __FUNCTION__, config_path);
                       g_free (type);
                       return -1;
@@ -52721,7 +52721,7 @@ check_report_format_add_params (const gchar *quoted_uuid, const gchar *config_pa
                   options = entity_child (child, "options");
                   if (options == NULL)
                     {
-                      g_warning ("%s: Selection missing options in '%s'\n",
+                      g_warning ("%s: Selection missing options in '%s'",
                                  __FUNCTION__, config_path);
                       g_free (type);
                       return -1;
@@ -52739,7 +52739,7 @@ check_report_format_add_params (const gchar *quoted_uuid, const gchar *config_pa
               child = entity_child (param, "value");
               if (child == NULL)
                 {
-                  g_warning ("%s: Param missing value in '%s'\n",
+                  g_warning ("%s: Param missing value in '%s'",
                              __FUNCTION__, config_path);
                   g_free (type);
                   return -1;
@@ -52754,7 +52754,7 @@ check_report_format_add_params (const gchar *quoted_uuid, const gchar *config_pa
               child = entity_child (param, "value");
               if (child == NULL)
                 {
-                  g_warning ("%s: Param missing value in '%s'\n",
+                  g_warning ("%s: Param missing value in '%s'",
                              __FUNCTION__, config_path);
                   g_free (type);
                   return -1;
@@ -52763,7 +52763,7 @@ check_report_format_add_params (const gchar *quoted_uuid, const gchar *config_pa
               report_format = entity_child (child, "report_format");
               if (report_format == NULL)
                 {
-                  g_warning ("%s: Param missing report format in '%s'\n",
+                  g_warning ("%s: Param missing report format in '%s'",
                              __FUNCTION__, config_path);
                   g_free (type);
                   return -1;
@@ -52772,7 +52772,7 @@ check_report_format_add_params (const gchar *quoted_uuid, const gchar *config_pa
               value = entity_attribute (report_format, "id");
               if (value == NULL)
                 {
-                  g_warning ("%s: Report format missing id in '%s'\n",
+                  g_warning ("%s: Report format missing id in '%s'",
                              __FUNCTION__, config_path);
                   g_free (type);
                   return -1;
@@ -52946,7 +52946,7 @@ check_report_format_parse (entity_t entity, const char *config_path,
   child = entity_child (entity, "name");
   if (child == NULL)
     {
-      g_warning ("%s: Missing name in '%s'\n", __FUNCTION__, config_path);
+      g_warning ("%s: Missing name in '%s'", __FUNCTION__, config_path);
       return -1;
     }
   *name = entity_text (child);
@@ -52954,7 +52954,7 @@ check_report_format_parse (entity_t entity, const char *config_path,
   child = entity_child (entity, "summary");
   if (child == NULL)
     {
-      g_warning ("%s: Missing summary in '%s'\n", __FUNCTION__, config_path);
+      g_warning ("%s: Missing summary in '%s'", __FUNCTION__, config_path);
       return -1;
     }
   *summary = entity_text (child);
@@ -52962,7 +52962,7 @@ check_report_format_parse (entity_t entity, const char *config_path,
   child = entity_child (entity, "description");
   if (child == NULL)
     {
-      g_warning ("%s: Missing description in '%s'\n",
+      g_warning ("%s: Missing description in '%s'",
                  __FUNCTION__, config_path);
       return -1;
     }
@@ -52971,7 +52971,7 @@ check_report_format_parse (entity_t entity, const char *config_path,
   child = entity_child (entity, "extension");
   if (child == NULL)
     {
-      g_warning ("%s: Missing extension in '%s'\n", __FUNCTION__, config_path);
+      g_warning ("%s: Missing extension in '%s'", __FUNCTION__, config_path);
       return -1;
     }
   *extension = entity_text (child);
@@ -52979,7 +52979,7 @@ check_report_format_parse (entity_t entity, const char *config_path,
   child = entity_child (entity, "content_type");
   if (child == NULL)
     {
-      g_warning ("%s: Missing content_type in '%s'\n",
+      g_warning ("%s: Missing content_type in '%s'",
                  __FUNCTION__, config_path);
       return -1;
     }
@@ -53020,7 +53020,7 @@ check_report_format (const gchar *uuid)
   g_file_get_contents (config_path, &xml, &xml_len, &error);
   if (error)
     {
-      g_warning ("%s: Failed to read '%s': %s\n",
+      g_warning ("%s: Failed to read '%s': %s",
                   __FUNCTION__,
                  config_path,
                  error->message);
@@ -53033,7 +53033,7 @@ check_report_format (const gchar *uuid)
 
   if (parse_entity (xml, &entity))
     {
-      g_warning ("%s: Failed to parse '%s'\n", __FUNCTION__, config_path);
+      g_warning ("%s: Failed to parse '%s'", __FUNCTION__, config_path);
       g_free (config_path);
       return -1;
     }
@@ -58900,7 +58900,7 @@ manage_schema (gchar *format, gchar **output_return, gsize *output_length,
 
     if (mkdtemp (output_dir) == NULL)
       {
-        g_warning ("%s: mkdtemp failed\n", __FUNCTION__);
+        g_warning ("%s: mkdtemp failed", __FUNCTION__);
         return -1;
       }
 
@@ -58967,7 +58967,7 @@ manage_schema (gchar *format, gchar **output_return, gsize *output_length,
       previous_dir = getcwd (NULL, 0);
       if (previous_dir == NULL)
         {
-          g_warning ("%s: Failed to getcwd: %s\n",
+          g_warning ("%s: Failed to getcwd: %s",
                      __FUNCTION__,
                      strerror (errno));
           g_free (previous_dir);
@@ -58980,7 +58980,7 @@ manage_schema (gchar *format, gchar **output_return, gsize *output_length,
 
       if (chdir (script_dir))
         {
-          g_warning ("%s: Failed to chdir: %s\n",
+          g_warning ("%s: Failed to chdir: %s",
                      __FUNCTION__,
                      strerror (errno));
           g_free (previous_dir);
@@ -59005,20 +59005,20 @@ manage_schema (gchar *format, gchar **output_return, gsize *output_length,
                                  output_file);
       g_free (script);
 
-      g_debug ("   command: %s\n", command);
+      g_debug ("   command: %s", command);
 
       ret = system (command);
       if ((ret == -1)
           /* The schema "generate" script must exit with 0. */
           || WEXITSTATUS (ret))
         {
-          g_warning ("%s: system failed with ret %i, %i, %s\n",
+          g_warning ("%s: system failed with ret %i, %i, %s",
                      __FUNCTION__,
                      ret,
                      WEXITSTATUS (ret),
                      command);
           if (chdir (previous_dir))
-            g_warning ("%s: and chdir failed\n",
+            g_warning ("%s: and chdir failed",
                        __FUNCTION__);
           g_free (previous_dir);
           g_free (command);
@@ -59039,7 +59039,7 @@ manage_schema (gchar *format, gchar **output_return, gsize *output_length,
 
         if (chdir (previous_dir))
           {
-            g_warning ("%s: Failed to chdir back: %s\n",
+            g_warning ("%s: Failed to chdir back: %s",
                        __FUNCTION__,
                        strerror (errno));
             g_free (previous_dir);
@@ -59059,7 +59059,7 @@ manage_schema (gchar *format, gchar **output_return, gsize *output_length,
         g_free (output_file);
         if (get_error)
           {
-            g_warning ("%s: Failed to get output: %s\n",
+            g_warning ("%s: Failed to get output: %s",
                        __FUNCTION__,
                        get_error->message);
             g_error_free (get_error);
@@ -63690,7 +63690,7 @@ manage_modify_setting (GSList *log_config, const gchar *database,
   int ret;
   gchar *quoted_name, *quoted_description, *quoted_value, *normalised;
 
-  g_info ("   Modifying setting.\n");
+  g_info ("   Modifying setting.");
 
   if (strcmp (uuid, SETTING_UUID_DEFAULT_CA_CERT)
       && strcmp (uuid, SETTING_UUID_MAX_ROWS_PER_PAGE)
@@ -63832,7 +63832,7 @@ manage_create_user (GSList *log_config, const gchar *database,
   int ret;
   gchar *rejection_msg;
 
-  g_info ("   Creating user.\n");
+  g_info ("   Creating user.");
 
   ret = manage_option_setup (log_config, database);
   if (ret)
@@ -63922,7 +63922,7 @@ manage_delete_user (GSList *log_config, const gchar *database,
 {
   int ret;
 
-  g_info ("   Deleting user.\n");
+  g_info ("   Deleting user.");
 
   ret = manage_option_setup (log_config, database);
   if (ret)
@@ -63983,7 +63983,7 @@ manage_get_users (GSList *log_config, const gchar *database,
   iterator_t users;
   int ret;
 
-  g_info ("   Getting users.\n");
+  g_info ("   Getting users.");
 
   ret = manage_option_setup (log_config, database);
   if (ret)
@@ -64077,7 +64077,7 @@ manage_set_password (GSList *log_config, const gchar *database,
   int ret;
   gchar *rejection_msg;
 
-  g_info ("   Modifying user password.\n");
+  g_info ("   Modifying user password.");
 
   if (name == NULL)
     {
@@ -66617,7 +66617,7 @@ tag_add_resource (tag_t tag, const char *type, const char *uuid,
 
   if (already_added == 0)
     {
-      g_debug ("%s - adding %s %s\n", __FUNCTION__, type, uuid);
+      g_debug ("%s - adding %s %s", __FUNCTION__, type, uuid);
       sql ("INSERT INTO tag_resources"
            " (tag, resource_type, resource, resource_uuid, resource_location)"
            " VALUES (%llu, '%s', %llu, %s, %d)",
@@ -66625,7 +66625,7 @@ tag_add_resource (tag_t tag, const char *type, const char *uuid,
     }
   else
     {
-      g_debug ("%s - skipping %s %s\n", __FUNCTION__, type, uuid);
+      g_debug ("%s - skipping %s %s", __FUNCTION__, type, uuid);
     }
 
   g_free (quoted_resource_uuid);
@@ -68521,7 +68521,7 @@ manage_optimize (GSList *log_config, const gchar *database, const gchar *name)
   gchar *success_text;
   int ret;
 
-  g_info ("   Optimizing: %s.\n", name);
+  g_info ("   Optimizing: %s.", name);
 
   if (name == NULL)
     {

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -1405,7 +1405,7 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
 
   if (g_stat (full_path, &state))
     {
-      g_warning ("%s: Failed to stat CERT file: %s\n",
+      g_warning ("%s: Failed to stat CERT file: %s",
                  __FUNCTION__,
                  strerror (errno));
       return -1;
@@ -1425,7 +1425,7 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
   g_file_get_contents (full_path, &xml, &xml_len, &error);
   if (error)
     {
-      g_warning ("%s: Failed to get contents: %s\n",
+      g_warning ("%s: Failed to get contents: %s",
                  __FUNCTION__,
                  error->message);
       g_error_free (error);
@@ -1436,7 +1436,7 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
   if (parse_entity (xml, &entity))
     {
       g_free (xml);
-      g_warning ("%s: Failed to parse entity\n", __FUNCTION__);
+      g_warning ("%s: Failed to parse entity", __FUNCTION__);
       g_free (full_path);
       return -1;
     }
@@ -1453,7 +1453,7 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
           updated = entity_child (child, "updated");
           if (updated == NULL)
             {
-              g_warning ("%s: UPDATED missing\n", __FUNCTION__);
+              g_warning ("%s: UPDATED missing", __FUNCTION__);
               free_entity (entity);
               goto fail;
             }
@@ -1471,9 +1471,9 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
                   GString *string;
 
                   string = g_string_new ("");
-                  g_warning ("%s: REFNUM missing\n", __FUNCTION__);
+                  g_warning ("%s: REFNUM missing", __FUNCTION__);
                   print_entity_to_string (child, string);
-                  g_debug ("child:\n%s\n", string->str);
+                  g_debug ("child:%s", string->str);
                   g_string_free (string, TRUE);
                   free_entity (entity);
                   goto fail;
@@ -1482,7 +1482,7 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
               published = entity_child (child, "published");
               if (published == NULL)
                 {
-                  g_warning ("%s: PUBLISHED missing\n", __FUNCTION__);
+                  g_warning ("%s: PUBLISHED missing", __FUNCTION__);
                   free_entity (entity);
                   goto fail;
                 }
@@ -1490,7 +1490,7 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
               title = entity_child (child, "title");
               if (title == NULL)
                 {
-                  g_warning ("%s: TITLE missing\n", __FUNCTION__);
+                  g_warning ("%s: TITLE missing", __FUNCTION__);
                   free_entity (entity);
                   goto fail;
                 }
@@ -1498,7 +1498,7 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
               summary = entity_child (child, "summary");
               if (summary == NULL)
                 {
-                  g_warning ("%s: SUMMARY missing\n", __FUNCTION__);
+                  g_warning ("%s: SUMMARY missing", __FUNCTION__);
                   free_entity (entity);
                   goto fail;
                 }
@@ -1680,7 +1680,7 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
 
   if (g_stat (full_path, &state))
     {
-      g_warning ("%s: Failed to stat CERT file: %s\n",
+      g_warning ("%s: Failed to stat CERT file: %s",
                  __FUNCTION__,
                  strerror (errno));
       return -1;
@@ -1700,7 +1700,7 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
   g_file_get_contents (full_path, &xml, &xml_len, &error);
   if (error)
     {
-      g_warning ("%s: Failed to get contents: %s\n",
+      g_warning ("%s: Failed to get contents: %s",
                  __FUNCTION__,
                  error->message);
       g_error_free (error);
@@ -1711,7 +1711,7 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
   if (parse_entity (xml, &entity))
     {
       g_free (xml);
-      g_warning ("%s: Failed to parse entity\n", __FUNCTION__);
+      g_warning ("%s: Failed to parse entity", __FUNCTION__);
       g_free (full_path);
       return -1;
     }
@@ -1728,7 +1728,7 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
           date = entity_child (child, "Date");
           if (date == NULL)
             {
-              g_warning ("%s: Date missing\n", __FUNCTION__);
+              g_warning ("%s: Date missing", __FUNCTION__);
               free_entity (entity);
               goto fail;
             }
@@ -1746,9 +1746,9 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
                   GString *string;
 
                   string = g_string_new ("");
-                  g_warning ("%s: Ref_Num missing\n", __FUNCTION__);
+                  g_warning ("%s: Ref_Num missing", __FUNCTION__);
                   print_entity_to_string (child, string);
-                  g_debug ("child:\n%s\n", string->str);
+                  g_debug ("child:%s", string->str);
                   g_string_free (string, TRUE);
                   free_entity (entity);
                   goto fail;
@@ -1757,7 +1757,7 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
               title = entity_child (child, "Title");
               if (title == NULL)
                 {
-                  g_warning ("%s: Title missing\n", __FUNCTION__);
+                  g_warning ("%s: Title missing", __FUNCTION__);
                   free_entity (entity);
                   goto fail;
                 }
@@ -1948,7 +1948,7 @@ update_scap_cpes (int last_scap_update)
 
   if (g_stat (full_path, &state))
     {
-      g_warning ("%s: No CPE dictionary found at %s\n",
+      g_warning ("%s: No CPE dictionary found at %s",
                  __FUNCTION__,
                  strerror (errno));
       return -1;
@@ -1975,7 +1975,7 @@ update_scap_cpes (int last_scap_update)
   g_free (full_path);
   if (error)
     {
-      g_warning ("%s: Failed to get contents: %s\n",
+      g_warning ("%s: Failed to get contents: %s",
                  __FUNCTION__,
                  error->message);
       g_error_free (error);
@@ -1985,7 +1985,7 @@ update_scap_cpes (int last_scap_update)
   if (parse_entity (xml, &entity))
     {
       g_free (xml);
-      g_warning ("%s: Failed to parse entity\n", __FUNCTION__);
+      g_warning ("%s: Failed to parse entity", __FUNCTION__);
       return -1;
     }
   g_free (xml);
@@ -1994,7 +1994,7 @@ update_scap_cpes (int last_scap_update)
   if (strcmp (entity_name (cpe_list), "cpe-list"))
     {
       free_entity (entity);
-      g_warning ("%s: CPE dictionary missing CPE-LIST\n", __FUNCTION__);
+      g_warning ("%s: CPE dictionary missing CPE-LIST", __FUNCTION__);
       return -1;
     }
 
@@ -2011,7 +2011,7 @@ update_scap_cpes (int last_scap_update)
           item_metadata = entity_child (cpe_item, "meta:item-metadata");
           if (item_metadata == NULL)
             {
-              g_warning ("%s: item-metadata missing\n", __FUNCTION__);
+              g_warning ("%s: item-metadata missing", __FUNCTION__);
 
               free_entity (entity);
               goto fail;
@@ -2021,7 +2021,7 @@ update_scap_cpes (int last_scap_update)
                                                 "modification-date");
           if (modification_date == NULL)
             {
-              g_warning ("%s: modification-date missing\n", __FUNCTION__);
+              g_warning ("%s: modification-date missing", __FUNCTION__);
               free_entity (entity);
               goto fail;
             }
@@ -2037,7 +2037,7 @@ update_scap_cpes (int last_scap_update)
               name = entity_attribute (cpe_item, "name");
               if (name == NULL)
                 {
-                  g_warning ("%s: name missing\n", __FUNCTION__);
+                  g_warning ("%s: name missing", __FUNCTION__);
                   free_entity (entity);
                   goto fail;
                 }
@@ -2045,7 +2045,7 @@ update_scap_cpes (int last_scap_update)
               status = entity_attribute (item_metadata, "status");
               if (status == NULL)
                 {
-                  g_warning ("%s: status missing\n", __FUNCTION__);
+                  g_warning ("%s: status missing", __FUNCTION__);
                   free_entity (entity);
                   goto fail;
                 }
@@ -2066,7 +2066,7 @@ update_scap_cpes (int last_scap_update)
               nvd_id = entity_attribute (item_metadata, "nvd-id");
               if (nvd_id == NULL)
                 {
-                  g_warning ("%s: nvd_id missing\n", __FUNCTION__);
+                  g_warning ("%s: nvd_id missing", __FUNCTION__);
                   free_entity (entity);
                   goto fail;
                 }
@@ -2155,7 +2155,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
 
   if (g_stat (full_path, &state))
     {
-      g_warning ("%s: Failed to stat SCAP file: %s\n",
+      g_warning ("%s: Failed to stat SCAP file: %s",
                  __FUNCTION__,
                  strerror (errno));
       return -1;
@@ -2176,7 +2176,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
   g_file_get_contents (full_path, &xml, &xml_len, &error);
   if (error)
     {
-      g_warning ("%s: Failed to get contents: %s\n",
+      g_warning ("%s: Failed to get contents: %s",
                  __FUNCTION__,
                  error->message);
       g_error_free (error);
@@ -2187,7 +2187,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
   if (parse_entity (xml, &entity))
     {
       g_free (xml);
-      g_warning ("%s: Failed to parse entity\n", __FUNCTION__);
+      g_warning ("%s: Failed to parse entity", __FUNCTION__);
       g_free (full_path);
       return -1;
     }
@@ -2204,7 +2204,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
           last_modified = entity_child (entry, "vuln:last-modified-datetime");
           if (last_modified == NULL)
             {
-              g_warning ("%s: vuln:last-modified-datetime missing\n",
+              g_warning ("%s: vuln:last-modified-datetime missing",
                          __FUNCTION__);
               free_entity (entity);
               goto fail;
@@ -2229,7 +2229,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
               id = entity_attribute (entry, "id");
               if (id == NULL)
                 {
-                  g_warning ("%s: id missing\n",
+                  g_warning ("%s: id missing",
                              __FUNCTION__);
                   free_entity (entity);
                   goto fail;
@@ -2238,7 +2238,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
               published = entity_child (entry, "vuln:published-datetime");
               if (published == NULL)
                 {
-                  g_warning ("%s: vuln:published-datetime missing\n",
+                  g_warning ("%s: vuln:published-datetime missing",
                              __FUNCTION__);
                   free_entity (entity);
                   goto fail;
@@ -2264,7 +2264,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                   score = entity_child (base_metrics, "cvss:score");
                   if (score == NULL)
                     {
-                      g_warning ("%s: cvss:score missing\n", __FUNCTION__);
+                      g_warning ("%s: cvss:score missing", __FUNCTION__);
                       free_entity (entity);
                       goto fail;
                     }
@@ -2272,7 +2272,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                   access_vector = entity_child (base_metrics, "cvss:access-vector");
                   if (access_vector == NULL)
                     {
-                      g_warning ("%s: cvss:access-vector missing\n", __FUNCTION__);
+                      g_warning ("%s: cvss:access-vector missing", __FUNCTION__);
                       free_entity (entity);
                       goto fail;
                     }
@@ -2281,7 +2281,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                                                     "cvss:access-complexity");
                   if (access_complexity == NULL)
                     {
-                      g_warning ("%s: cvss:access-complexity missing\n",
+                      g_warning ("%s: cvss:access-complexity missing",
                                  __FUNCTION__);
                       free_entity (entity);
                       goto fail;
@@ -2291,7 +2291,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                                                  "cvss:authentication");
                   if (authentication == NULL)
                     {
-                      g_warning ("%s: cvss:authentication missing\n",
+                      g_warning ("%s: cvss:authentication missing",
                                  __FUNCTION__);
                       free_entity (entity);
                       goto fail;
@@ -2302,7 +2302,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                                              "cvss:confidentiality-impact");
                   if (confidentiality_impact == NULL)
                     {
-                      g_warning ("%s: cvss:confidentiality-impact missing\n",
+                      g_warning ("%s: cvss:confidentiality-impact missing",
                                  __FUNCTION__);
                       free_entity (entity);
                       goto fail;
@@ -2313,7 +2313,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                                        "cvss:integrity-impact");
                   if (integrity_impact == NULL)
                     {
-                      g_warning ("%s: cvss:integrity-impact missing\n",
+                      g_warning ("%s: cvss:integrity-impact missing",
                                  __FUNCTION__);
                       free_entity (entity);
                       goto fail;
@@ -2324,7 +2324,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                                           "cvss:availability-impact");
                   if (availability_impact == NULL)
                     {
-                      g_warning ("%s: cvss:availability-impact missing\n",
+                      g_warning ("%s: cvss:availability-impact missing",
                                  __FUNCTION__);
                       free_entity (entity);
                       goto fail;
@@ -2334,7 +2334,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
               summary = entity_child (entry, "vuln:summary");
               if (summary == NULL)
                 {
-                  g_warning ("%s: vuln:summary missing\n", __FUNCTION__);
+                  g_warning ("%s: vuln:summary missing", __FUNCTION__);
                   free_entity (entity);
                   goto fail;
                 }
@@ -2571,7 +2571,7 @@ oval_definition_dates (entity_t definition, int *definition_date_newest,
   metadata = entity_child (definition, "metadata");
   if (metadata == NULL)
     {
-      g_warning ("%s: metadata missing\n",
+      g_warning ("%s: metadata missing",
                  __FUNCTION__);
       return;
     }
@@ -2579,7 +2579,7 @@ oval_definition_dates (entity_t definition, int *definition_date_newest,
   oval_repository = entity_child (metadata, "oval_repository");
   if (oval_repository == NULL)
     {
-      g_warning ("%s: oval_repository missing\n",
+      g_warning ("%s: oval_repository missing",
                  __FUNCTION__);
       return;
     }
@@ -2587,7 +2587,7 @@ oval_definition_dates (entity_t definition, int *definition_date_newest,
   dates = entity_child (oval_repository, "dates");
   if (dates == NULL)
     {
-      g_warning ("%s: dates missing\n",
+      g_warning ("%s: dates missing",
                  __FUNCTION__);
       return;
     }
@@ -2636,7 +2636,7 @@ oval_oval_definitions_date (entity_t entity, int *file_timestamp)
   generator = entity_child (entity, "generator");
   if (generator == NULL)
     {
-      g_warning ("%s: generator missing\n",
+      g_warning ("%s: generator missing",
                  __FUNCTION__);
       return;
     }
@@ -2644,7 +2644,7 @@ oval_oval_definitions_date (entity_t entity, int *file_timestamp)
   timestamp = entity_child (generator, "oval:timestamp");
   if (timestamp == NULL)
     {
-      g_warning ("%s: oval:timestamp missing\n",
+      g_warning ("%s: oval:timestamp missing",
                  __FUNCTION__);
       return;
     }
@@ -2671,7 +2671,7 @@ verify_oval_file (const gchar *full_path)
   g_file_get_contents (full_path, &xml, &xml_len, &error);
   if (error)
     {
-      g_warning ("%s: Failed to get contents: %s\n",
+      g_warning ("%s: Failed to get contents: %s",
                  __FUNCTION__,
                  error->message);
       g_error_free (error);
@@ -2681,7 +2681,7 @@ verify_oval_file (const gchar *full_path)
   if (parse_entity (xml, &entity))
     {
       g_free (xml);
-      g_warning ("%s: Failed to parse entity\n", __FUNCTION__);
+      g_warning ("%s: Failed to parse entity", __FUNCTION__);
       return -1;
     }
   g_free (xml);
@@ -2717,7 +2717,7 @@ verify_oval_file (const gchar *full_path)
       free_entity (entity);
       if (definition_count == 0)
         {
-          g_warning ("%s: No OVAL definitions found\n", __FUNCTION__);
+          g_warning ("%s: No OVAL definitions found", __FUNCTION__);
           return -1;
         }
       else
@@ -2755,7 +2755,7 @@ verify_oval_file (const gchar *full_path)
       free_entity (entity);
       if (variable_count == 0)
         {
-          g_warning ("%s: No OVAL variables found\n", __FUNCTION__);
+          g_warning ("%s: No OVAL variables found", __FUNCTION__);
           return -1;
         }
       else
@@ -2764,19 +2764,19 @@ verify_oval_file (const gchar *full_path)
 
   if (strcmp (entity_name (entity), "oval_system_characteristics") == 0)
     {
-      g_warning ("%s: File is an OVAL System Characteristics file\n",
+      g_warning ("%s: File is an OVAL System Characteristics file",
                  __FUNCTION__);
       return -1;
     }
 
   if (strcmp (entity_name (entity), "oval_results") == 0)
     {
-      g_warning ("%s: File is an OVAL Results one\n",
+      g_warning ("%s: File is an OVAL Results one",
                  __FUNCTION__);
       return -1;
     }
 
-  g_warning ("%s: Root tag neither oval_definitions nor oval_variables\n",
+  g_warning ("%s: Root tag neither oval_definitions nor oval_variables",
              __FUNCTION__);
   free_entity (entity);
   return -1;
@@ -2811,14 +2811,14 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
   xml_path = file_and_date[0];
   assert (xml_path);
 
-  g_debug ("%s: xml_path: %s\n", __FUNCTION__, xml_path);
+  g_debug ("%s: xml_path: %s", __FUNCTION__, xml_path);
 
   /* The timestamp from the OVAL XML. */
   oval_timestamp = file_and_date[1];
 
   if (g_stat (xml_path, &state))
     {
-      g_warning ("%s: Failed to stat OVAL file %s: %s\n",
+      g_warning ("%s: Failed to stat OVAL file %s: %s",
                  __FUNCTION__,
                  xml_path,
                  strerror (errno));
@@ -2836,7 +2836,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
   xml_basename = strstr (xml_path, GVM_SCAP_DATA_DIR);
   if (xml_basename == NULL)
     {
-      g_warning ("%s: xml_path missing GVM_SCAP_DATA_DIR: %s\n",
+      g_warning ("%s: xml_path missing GVM_SCAP_DATA_DIR: %s",
                  __FUNCTION__,
                  xml_path);
       return -1;
@@ -2882,7 +2882,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
   g_file_get_contents (xml_path, &xml, &xml_len, &error);
   if (error)
     {
-      g_warning ("%s: Failed to get contents: %s\n",
+      g_warning ("%s: Failed to get contents: %s",
                  __FUNCTION__,
                  error->message);
       g_error_free (error);
@@ -2893,7 +2893,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
   if (parse_entity (xml, &entity))
     {
       g_free (xml);
-      g_warning ("%s: Failed to parse entity\n", __FUNCTION__);
+      g_warning ("%s: Failed to parse entity", __FUNCTION__);
       g_free (quoted_xml_basename);
       return -1;
     }
@@ -2974,7 +2974,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                   metadata = entity_child (definition, "metadata");
                   if (metadata == NULL)
                     {
-                      g_warning ("%s: metadata missing\n",
+                      g_warning ("%s: metadata missing",
                                  __FUNCTION__);
                       free_entity (entity);
                       goto fail;
@@ -2983,7 +2983,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                   title = entity_child (metadata, "title");
                   if (title == NULL)
                     {
-                      g_warning ("%s: title missing\n",
+                      g_warning ("%s: title missing",
                                  __FUNCTION__);
                       free_entity (entity);
                       goto fail;
@@ -2992,7 +2992,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                   description = entity_child (metadata, "description");
                   if (description == NULL)
                     {
-                      g_warning ("%s: description missing\n",
+                      g_warning ("%s: description missing",
                                  __FUNCTION__);
                       free_entity (entity);
                       goto fail;
@@ -3001,7 +3001,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                   repository = entity_child (metadata, "oval_repository");
                   if (repository == NULL)
                     {
-                      g_warning ("%s: oval_repository missing\n",
+                      g_warning ("%s: oval_repository missing",
                                  __FUNCTION__);
                       free_entity (entity);
                       goto fail;
@@ -3173,7 +3173,7 @@ oval_timestamp (const gchar *xml)
 
   if (parse_entity (xml, &entity))
     {
-      g_warning ("%s: Failed to parse entity: %s\n", __FUNCTION__, xml);
+      g_warning ("%s: Failed to parse entity: %s", __FUNCTION__, xml);
       return NULL;
     }
 
@@ -3214,7 +3214,7 @@ oval_timestamp (const gchar *xml)
         }
     }
 
-  g_warning ("%s: No timestamp: %s\n", __FUNCTION__, xml);
+  g_warning ("%s: No timestamp: %s", __FUNCTION__, xml);
   return NULL;
 }
 
@@ -3249,13 +3249,13 @@ oval_files_add (const char *path, const struct stat *stat, int flag,
   if ((dot == NULL) || strcasecmp (dot, ".xml"))
     return 0;
 
-  g_debug ("%s: path: %s\n", __FUNCTION__, path);
+  g_debug ("%s: path: %s", __FUNCTION__, path);
 
   error = NULL;
   g_file_get_contents (path, &oval_xml, &len, &error);
   if (error)
     {
-      g_warning ("%s: Failed get contents of %s: %s\n",
+      g_warning ("%s: Failed get contents of %s: %s",
                  __FUNCTION__,
                  path,
                  error->message);
@@ -3459,7 +3459,7 @@ update_scap_ovaldefs (int last_scap_update, int private)
             }
           else
             {
-              g_warning ("g_dir_open (%s) failed - %s\n", oval_dir,
+              g_warning ("g_dir_open (%s) failed - %s", oval_dir,
                          error->message);
               g_free (oval_dir);
               g_error_free (error);
@@ -3535,7 +3535,7 @@ update_scap_ovaldefs (int last_scap_update, int private)
           suffix = strstr (pair[0], GVM_SCAP_DATA_DIR);
           if (suffix == NULL)
             {
-              g_warning ("%s: pair[0] missing GVM_SCAP_DATA_DIR: %s\n",
+              g_warning ("%s: pair[0] missing GVM_SCAP_DATA_DIR: %s",
                          __FUNCTION__,
                          pair[0]);
               g_free (oval_dir);
@@ -3608,7 +3608,7 @@ write_sync_start (int lockfile)
           if (errno == EAGAIN || errno == EINTR)
             /* Interrupted, try write again. */
             continue;
-          g_warning ("%s: failed to write to lockfile: %s\n",
+          g_warning ("%s: failed to write to lockfile: %s",
                      __FUNCTION__,
                      strerror (errno));
           break;
@@ -3704,7 +3704,7 @@ sync_secinfo (sigset_t *sigmask_current, int (*update) (int),
 
       case -1:
         /* Parent on error.  Reschedule and continue to next task. */
-        g_warning ("%s: fork failed\n", __FUNCTION__);
+        g_warning ("%s: fork failed", __FUNCTION__);
         return;
 
       default:
@@ -3763,7 +3763,7 @@ manage_feed_timestamp (const gchar *name)
         stamp = 0;
       else
         {
-          g_warning ("%s: Failed to get timestamp: %s\n",
+          g_warning ("%s: Failed to get timestamp: %s",
                      __FUNCTION__,
                      error->message);
           return -1;
@@ -3773,7 +3773,7 @@ manage_feed_timestamp (const gchar *name)
     {
       if (strlen (timestamp) < 8)
         {
-          g_warning ("%s: Feed timestamp too short: %s\n",
+          g_warning ("%s: Feed timestamp too short: %s",
                      __FUNCTION__,
                      timestamp);
           g_free (timestamp);
@@ -3838,7 +3838,7 @@ update_cert_timestamp ()
         stamp = 0;
       else
         {
-          g_warning ("%s: Failed to get timestamp: %s\n",
+          g_warning ("%s: Failed to get timestamp: %s",
                      __FUNCTION__,
                      error->message);
           return -1;
@@ -3848,7 +3848,7 @@ update_cert_timestamp ()
     {
       if (strlen (timestamp) < 8)
         {
-          g_warning ("%s: Feed timestamp too short: %s\n",
+          g_warning ("%s: Feed timestamp too short: %s",
                      __FUNCTION__,
                      timestamp);
           g_free (timestamp);
@@ -3896,10 +3896,10 @@ update_cvss_dfn_cert (int updated_dfn_cert, int last_cert_update,
            "                     WHERE adv_id = dfn_cert_advs.id)"
            "                 AND cvss != 0.0);");
 
-      g_info ("Updating DFN-CERT CVSS max succeeded.\n");
+      g_info ("Updating DFN-CERT CVSS max succeeded.");
     }
   else
-    g_info ("Updating DFN-CERT CVSS max succeeded (nothing to do).\n");
+    g_info ("Updating DFN-CERT CVSS max succeeded (nothing to do).");
 }
 
 /**
@@ -3928,10 +3928,10 @@ update_cvss_cert_bund (int updated_cert_bund, int last_cert_update,
            "                           WHERE adv_id = cert_bund_advs.id)"
            "                 AND cvss != 0.0);");
 
-      g_info ("Updating CERT-Bund CVSS max succeeded.\n");
+      g_info ("Updating CERT-Bund CVSS max succeeded.");
     }
   else
-    g_info ("Updating CERT-Bund CVSS max succeeded (nothing to do).\n");
+    g_info ("Updating CERT-Bund CVSS max succeeded (nothing to do).");
 }
 
 /**
@@ -4055,7 +4055,7 @@ sync_cert (int lockfile)
   /* Clear date from lock file. */
 
   if (ftruncate (lockfile, 0))
-    g_warning ("%s: failed to ftruncate lockfile: %s\n",
+    g_warning ("%s: failed to ftruncate lockfile: %s",
                __FUNCTION__,
                strerror (errno));
 
@@ -4065,7 +4065,7 @@ sync_cert (int lockfile)
   /* Clear date from lock file. */
 
   if (ftruncate (lockfile, 0))
-    g_warning ("%s: failed to ftruncate lockfile: %s\n",
+    g_warning ("%s: failed to ftruncate lockfile: %s",
                __FUNCTION__,
                strerror (errno));
 
@@ -4144,7 +4144,7 @@ update_scap_timestamp ()
         stamp = 0;
       else
         {
-          g_warning ("%s: Failed to get timestamp: %s\n",
+          g_warning ("%s: Failed to get timestamp: %s",
                      __FUNCTION__,
                      error->message);
           return -1;
@@ -4154,7 +4154,7 @@ update_scap_timestamp ()
     {
       if (strlen (timestamp) < 8)
         {
-          g_warning ("%s: Feed timestamp too short: %s\n",
+          g_warning ("%s: Feed timestamp too short: %s",
                      __FUNCTION__,
                      timestamp);
           g_free (timestamp);
@@ -4391,7 +4391,7 @@ sync_scap (int lockfile)
   /* Clear date from lock file. */
 
   if (ftruncate (lockfile, 0))
-    g_warning ("%s: failed to ftruncate lockfile: %s\n",
+    g_warning ("%s: failed to ftruncate lockfile: %s",
                __FUNCTION__,
                strerror (errno));
 
@@ -4401,7 +4401,7 @@ sync_scap (int lockfile)
   /* Clear date from lock file. */
 
   if (ftruncate (lockfile, 0))
-    g_warning ("%s: failed to ftruncate lockfile: %s\n",
+    g_warning ("%s: failed to ftruncate lockfile: %s",
                __FUNCTION__,
                strerror (errno));
 

--- a/src/manage_sqlite3.c
+++ b/src/manage_sqlite3.c
@@ -1514,7 +1514,7 @@ sql_common_cve (sqlite3_context *context, int argc, sqlite3_value** argv)
 
   assert (argc == 2);
 
-  g_debug ("   %s: top\n", __FUNCTION__);
+  g_debug ("   %s: top", __FUNCTION__);
 
   cve1 = sqlite3_value_text (argv[0]);
   if (cve1 == NULL)
@@ -1538,7 +1538,7 @@ sql_common_cve (sqlite3_context *context, int argc, sqlite3_value** argv)
     {
       while (*point_2)
         {
-          g_debug ("   %s: %s vs %s\n", __FUNCTION__, g_strstrip (*point_1), g_strstrip (*point_2));
+          g_debug ("   %s: %s vs %s", __FUNCTION__, g_strstrip (*point_1), g_strstrip (*point_2));
           if (strcmp (g_strstrip (*point_1), g_strstrip (*point_2)) == 0)
             {
               g_strfreev (split_1);
@@ -1723,7 +1723,7 @@ clear_cache (void *cache_arg)
   sql_severity_t *cache;
 
   cache = (sql_severity_t*) cache_arg;
-  g_debug ("   %s: %llu, %llu\n", __FUNCTION__, cache->task, cache->overrides_task);
+  g_debug ("   %s: %llu, %llu", __FUNCTION__, cache->task, cache->overrides_task);
   cache->task = 0;
   cache->overrides_task = 0;
   free (cache->severity);
@@ -1844,7 +1844,7 @@ sql_task_threat_level (sqlite3_context *context, int argc, sqlite3_value** argv)
   else
     threat = severity_to_level (severity_dbl, 0);
 
-  g_debug ("   %s: %llu: %s\n", __FUNCTION__, task, threat);
+  g_debug ("   %s: %llu: %s", __FUNCTION__, task, threat);
   if (threat)
     {
       sqlite3_result_text (context, threat, -1, SQLITE_TRANSIENT);
@@ -2134,7 +2134,7 @@ sql_task_severity (sqlite3_context *context, int argc, sqlite3_value** argv)
 
   severity = cached_task_severity (context, task, overrides, min_qod);
   severity_double = severity ? g_strtod (severity, 0) : 0.0;
-  g_debug ("   %s: %llu: %s\n", __FUNCTION__, task, severity);
+  g_debug ("   %s: %llu: %s", __FUNCTION__, task, severity);
   if (severity)
     {
       sqlite3_result_double (context, severity_double);
@@ -4071,7 +4071,7 @@ manage_attach_databases ()
         case ENOENT:
           break;
         default:
-          g_warning ("%s: failed to stat SCAP database: %s\n",
+          g_warning ("%s: failed to stat SCAP database: %s",
                      __FUNCTION__,
                      strerror (errno));
           break;
@@ -4088,7 +4088,7 @@ manage_attach_databases ()
         case ENOENT:
           break;
         default:
-          g_warning ("%s: failed to stat CERT database: %s\n",
+          g_warning ("%s: failed to stat CERT database: %s",
                      __FUNCTION__,
                      strerror (errno));
           break;
@@ -4131,7 +4131,7 @@ manage_db_init (const gchar *name)
       if (access (CERT_DB_FILE, R_OK)
           && errno != ENOENT)
         {
-          g_warning ("%s: failed to stat CERT database: %s\n",
+          g_warning ("%s: failed to stat CERT database: %s",
                      __FUNCTION__,
                      strerror (errno));
           return -1;
@@ -4143,7 +4143,7 @@ manage_db_init (const gchar *name)
           if (g_mkdir_with_parents (CERT_DB_DIR, 0755 /* "rwxr-xr-x" */)
               == -1)
             {
-              g_warning ("%s: failed to create CERT directory: %s\n",
+              g_warning ("%s: failed to create CERT directory: %s",
                          __FUNCTION__,
                          strerror (errno));
               abort ();
@@ -4240,7 +4240,7 @@ manage_db_init (const gchar *name)
       if (access (SCAP_DB_FILE, R_OK)
           && errno != ENOENT)
         {
-          g_warning ("%s: failed to stat SCAP database: %s\n",
+          g_warning ("%s: failed to stat SCAP database: %s",
                      __FUNCTION__,
                      strerror (errno));
           return -1;
@@ -4252,7 +4252,7 @@ manage_db_init (const gchar *name)
           if (g_mkdir_with_parents (SCAP_DB_DIR, 0755 /* "rwxr-xr-x" */)
               == -1)
             {
-              g_warning ("%s: failed to create SCAP directory: %s\n",
+              g_warning ("%s: failed to create SCAP directory: %s",
                          __FUNCTION__,
                          strerror (errno));
               abort ();
@@ -4451,7 +4451,7 @@ manage_db_check (const gchar *name)
           if (errno == ENOENT)
             return 0;
 
-          g_warning ("%s: failed to stat CERT database: %s\n",
+          g_warning ("%s: failed to stat CERT database: %s",
                      __FUNCTION__,
                      strerror (errno));
           return -1;
@@ -4474,7 +4474,7 @@ manage_db_check (const gchar *name)
           if (errno == ENOENT)
             return 0;
 
-          g_warning ("%s: failed to stat SCAP database: %s\n",
+          g_warning ("%s: failed to stat SCAP database: %s",
                      __FUNCTION__,
                      strerror (errno));
           return -1;
@@ -4510,7 +4510,7 @@ manage_cert_loaded ()
           return 0;
           break;
         default:
-          g_warning ("%s: failed to stat CERT database: %s\n",
+          g_warning ("%s: failed to stat CERT database: %s",
                      __FUNCTION__,
                      strerror (errno));
           return 0;
@@ -4546,7 +4546,7 @@ manage_scap_loaded ()
           return 0;
           break;
         default:
-          g_warning ("%s: failed to stat SCAP database: %s\n",
+          g_warning ("%s: failed to stat SCAP database: %s",
                      __FUNCTION__,
                      strerror (errno));
           return 0;
@@ -4577,7 +4577,7 @@ manage_cert_db_exists ()
           return 0;
           break;
         default:
-          g_warning ("%s: failed to stat CERT database: %s\n",
+          g_warning ("%s: failed to stat CERT database: %s",
                      __FUNCTION__,
                      strerror (errno));
           return 1;
@@ -4600,7 +4600,7 @@ manage_scap_db_exists ()
           return 0;
           break;
         default:
-          g_warning ("%s: failed to stat SCAP database: %s\n",
+          g_warning ("%s: failed to stat SCAP database: %s",
                      __FUNCTION__,
                      strerror (errno));
           return 1;
@@ -4846,7 +4846,7 @@ backup_db (const gchar *database, gchar **backup_file_arg)
 
   if (sqlite3_open (backup_file, &backup_db) != SQLITE_OK)
     {
-      g_warning ("%s: sqlite3_open failed: %s\n",
+      g_warning ("%s: sqlite3_open failed: %s",
                  __FUNCTION__,
                  sqlite3_errmsg (gvmd_db));
       goto fail;
@@ -4861,7 +4861,7 @@ backup_db (const gchar *database, gchar **backup_file_arg)
   backup = sqlite3_backup_init (backup_db, "main", gvmd_db, "main");
   if (backup == NULL)
     {
-      g_warning ("%s: sqlite3_backup_init failed: %s\n",
+      g_warning ("%s: sqlite3_backup_init failed: %s",
                  __FUNCTION__,
                  sqlite3_errmsg (backup_db));
       goto fail;
@@ -4881,7 +4881,7 @@ backup_db (const gchar *database, gchar **backup_file_arg)
           sqlite3_sleep (250);
           continue;
         }
-      g_warning ("%s: sqlite3_backup_step failed: %s\n",
+      g_warning ("%s: sqlite3_backup_step failed: %s",
                  __FUNCTION__,
                  sqlite3_errmsg (backup_db));
       sqlite3_backup_finish (backup);

--- a/src/otp.c
+++ b/src/otp.c
@@ -285,7 +285,7 @@ append_log_message (task_t task, message_t* message)
       if (manage_report_host_detail (global_current_report,
                                      message->host,
                                      message->description))
-        g_warning ("%s: Failed to add report detail for host '%s': %s\n",
+        g_warning ("%s: Failed to add report detail for host '%s': %s",
                    __FUNCTION__,
                    message->host,
                    message->description);
@@ -395,7 +395,7 @@ static void
 set_scanner_state (scanner_state_t state)
 {
   scanner_state = state;
-  g_debug ("   scanner state set: %i\n", scanner_state);
+  g_debug ("   scanner state set: %i", scanner_state);
 }
 
 /**
@@ -427,7 +427,7 @@ void
 set_scanner_init_state (scanner_init_state_t state)
 {
   scanner_init_state = state;
-  g_debug ("   scanner init state set: %i\n", scanner_init_state);
+  g_debug ("   scanner init state set: %i", scanner_init_state);
 }
 
 /**
@@ -465,7 +465,7 @@ sync_buffer ()
   if (from_scanner_start > 0 && from_scanner_start == from_scanner_end)
     {
       from_scanner_start = from_scanner_end = 0;
-      g_debug ("   scanner start caught end\n");
+      g_debug ("   scanner start caught end");
     }
   else if (from_scanner_start == 0)
     {
@@ -485,9 +485,9 @@ sync_buffer ()
       memmove (from_scanner, start, from_scanner_end);
       from_scanner_start = 0;
       from_scanner[from_scanner_end] = '\0';
-      g_debug ("   new from_scanner_start: %" BUFFER_SIZE_T_FORMAT "\n",
+      g_debug ("   new from_scanner_start: %" BUFFER_SIZE_T_FORMAT,
                from_scanner_start);
-      g_debug ("   new from_scanner_end: %" BUFFER_SIZE_T_FORMAT "\n",
+      g_debug ("   new from_scanner_end: %" BUFFER_SIZE_T_FORMAT,
                from_scanner_end);
     }
   return 0;
@@ -512,7 +512,7 @@ parse_scanner_done (char** messages)
     return -2;
   if (strncasecmp ("SERVER", *messages, 6))
     {
-      g_debug ("   scanner fail: expected final \"SERVER\"\n");
+      g_debug ("   scanner fail: expected final \"SERVER\"");
       return -1;
     }
   set_scanner_state (SCANNER_TOP);
@@ -542,7 +542,7 @@ parse_scanner_bad_login (char** messages)
       /** @todo Are there 19 characters available? */
       if (strncasecmp ("Bad login attempt !", *messages, 19) == 0)
         {
-          g_debug ("match bad login\n");
+          g_debug ("match bad login");
           from_scanner_start += match + 1 - *messages;
           *messages = match + 1;
           set_scanner_init_state (SCANNER_INIT_TOP);
@@ -816,11 +816,11 @@ process_otp_scanner_input ()
             parse_scanner_loading (messages);
             if (scanner_current_loading && scanner_total_loading)
               g_log (G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE,
-                     "Waiting for scanner to load NVTs: %d / %d.\n",
+                     "Waiting for scanner to load NVTs: %d / %d",
                      scanner_current_loading, scanner_total_loading);
             else
               g_log (G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE,
-                     "Waiting for scanner to load: No information provided. (Message: %s)\n", messages);
+                     "Waiting for scanner to load: No information provided. (Message: %s)", messages);
             return 3;
           }
         /* If message is empty we assume the scanner is still loading. */
@@ -837,7 +837,7 @@ process_otp_scanner_input ()
         if (strncasecmp (ver_str, messages, ver_len))
           {
             g_debug ("   scanner fail: expected \"%s\""
-                     "   got \"%.12s\"\n\n", ver_str, messages);
+                     "   got \"%.12s\"", ver_str, messages);
             return -1;
           }
         from_scanner_start += ver_len;
@@ -947,8 +947,8 @@ process_otp_scanner_input ()
           field = gvm_strip_space (message, match);
           blank_control_chars (field);
 
-          g_debug ("   scanner old state %i\n", scanner_state);
-          g_debug ("   scanner field: %s\n", field);
+          g_debug ("   scanner old state %i", scanner_state);
+          g_debug ("   scanner field: %s", field);
           switch (scanner_state)
             {
               case SCANNER_BYE:
@@ -1012,7 +1012,7 @@ process_otp_scanner_input ()
                       number = atoi (field);
                       protocol[0] = '\0';
                     }
-                  g_debug ("   scanner got debug port, number: %i, protocol: %s\n",
+                  g_debug ("   scanner got debug port, number: %i, protocol: %s",
                            number, protocol);
 
                   set_message_port_number (current_message, number);
@@ -1091,7 +1091,7 @@ process_otp_scanner_input ()
                       number = atoi (field);
                       protocol[0] = '\0';
                     }
-                  g_debug ("   scanner got alarm port, number: %i, protocol: %s\n",
+                  g_debug ("   scanner got alarm port, number: %i, protocol: %s",
                            number, protocol);
 
                   set_message_port_number (current_message, number);
@@ -1170,7 +1170,7 @@ process_otp_scanner_input ()
                       number = atoi (field);
                       protocol[0] = '\0';
                     }
-                  g_debug ("   scanner got log port, number: %i, protocol: %s\n",
+                  g_debug ("   scanner got log port, number: %i, protocol: %s",
                            number, protocol);
 
                   set_message_port_number (current_message, number);
@@ -1288,7 +1288,7 @@ process_otp_scanner_input ()
                   char *feed_version, *db_feed_version;
 
                   feed_version = g_strdup (field);
-                  g_debug ("   scanner got nvti_info: %s\n", feed_version);
+                  g_debug ("   scanner got nvti_info: %s", feed_version);
                   if (plugins_feed_version)
                     g_free (plugins_feed_version);
                   plugins_feed_version = feed_version;
@@ -1297,7 +1297,7 @@ process_otp_scanner_input ()
                       && (strcmp (plugins_feed_version, db_feed_version) == 0))
                     /* NVTs are at this version already. */
                     return 4;
-                  g_info ("   Updating NVT cache.\n");
+                  g_info ("   Updating NVT cache");
                   set_scanner_state (SCANNER_DONE);
                   switch (parse_scanner_done (&messages))
                     {
@@ -1414,7 +1414,7 @@ process_otp_scanner_input ()
                   }
                 else
                   {
-                    g_debug ("New scanner command to implement: %s\n",
+                    g_debug ("New scanner command to implement: %s",
                              field);
                     goto return_error;
                   }
@@ -1433,7 +1433,7 @@ process_otp_scanner_input ()
                   if (global_current_report && current_host)
                     {
                       unsigned int current, max;
-                      g_debug ("   scanner got ports: %s\n", field);
+                      g_debug ("   scanner got ports: %s", field);
                       if (sscanf (field, "%u/%u", &current, &max) == 2)
                         set_scan_ports (global_current_report,
                                         current_host,
@@ -1639,8 +1639,8 @@ process_otp_scanner_input ()
                 }
               case SCANNER_TOP:
               default:
-                g_debug ("   switch t\n");
-                g_debug ("   cmp %i\n", strcasecmp ("SERVER", field));
+                g_debug ("   switch t");
+                g_debug ("   cmp %i", strcasecmp ("SERVER", field));
                 if (strcasecmp ("SERVER", field))
                   goto return_error;
                 set_scanner_state (SCANNER_SERVER);
@@ -1659,7 +1659,7 @@ process_otp_scanner_input ()
                 break;
             }
 
-          g_debug ("   scanner new state: %i\n", scanner_state);
+          g_debug ("   scanner new state: %i", scanner_state);
 
           continue;
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -151,7 +151,7 @@ write_string_to_server (char* const string)
                 continue;
               else
                 {
-                  g_warning ("%s: Failed to write to scanner: %s\n", __FUNCTION__,
+                  g_warning ("%s: Failed to write to scanner: %s", __FUNCTION__,
                              strerror (errno));
                   return -1;
                 }
@@ -172,17 +172,17 @@ write_string_to_server (char* const string)
               if (count == GNUTLS_E_REHANDSHAKE)
                 /** @todo Rehandshake. */
                 continue;
-              g_warning ("%s: failed to write to server: %s\n",
+              g_warning ("%s: failed to write to server: %s",
                          __FUNCTION__,
                          gnutls_strerror ((int) count));
               return -1;
             }
         }
-      g_debug ("s> server  (string) %.*s\n", (int) count, point);
+      g_debug ("s> server  (string) %.*s", (int) count, point);
       point += count;
-      g_debug ("=> server  (string) %zi bytes\n", count);
+      g_debug ("=> server  (string) %zi bytes", count);
     }
-  g_debug ("=> server  (string) done\n");
+  g_debug ("=> server  (string) done");
   /* Wrote everything. */
   return 0;
 }
@@ -212,7 +212,7 @@ write_to_server_buffer ()
                 return -3;
               else
                 {
-                  g_warning ("%s: Failed to write to scanner: %s\n", __FUNCTION__,
+                  g_warning ("%s: Failed to write to scanner: %s", __FUNCTION__,
                              strerror (errno));
                   return -1;
                 }
@@ -234,17 +234,17 @@ write_to_server_buffer ()
               if (count == GNUTLS_E_REHANDSHAKE)
                 /** @todo Rehandshake. */
                 continue;
-              g_warning ("%s: failed to write to server: %s\n",
+              g_warning ("%s: failed to write to server: %s",
                          __FUNCTION__,
                          gnutls_strerror ((int) count));
               return -1;
             }
         }
-      g_debug ("s> server  %.*s\n", (int) count, to_server + to_server_start);
+      g_debug ("s> server  %.*s", (int) count, to_server + to_server_start);
       to_server_start += count;
-      g_debug ("=> server  %zi bytes\n", count);
+      g_debug ("=> server  %zi bytes", count);
     }
-  g_debug ("=> server  done\n");
+  g_debug ("=> server  done");
   to_server_start = to_server_end = 0;
   /* Wrote everything. */
   return 0;
@@ -279,7 +279,7 @@ openvas_scanner_read ()
                 return 0;
               else
                 {
-                  g_warning ("%s: Failed to read from scanner: %s\n", __FUNCTION__,
+                  g_warning ("%s: Failed to read from scanner: %s", __FUNCTION__,
                              strerror (errno));
                   return -1;
                 }
@@ -301,7 +301,7 @@ openvas_scanner_read ()
               if (count == GNUTLS_E_REHANDSHAKE)
                 {
                   /** @todo Rehandshake. */
-                  g_debug ("   should rehandshake\n");
+                  g_debug ("   should rehandshake");
                   continue;
                 }
               if (gnutls_error_is_fatal (count) == 0
@@ -310,10 +310,10 @@ openvas_scanner_read ()
                 {
                   int alert = gnutls_alert_get (openvas_scanner_session);
                   const char* alert_name = gnutls_alert_get_name (alert);
-                  g_warning ("%s: TLS Alert %d: %s\n", __FUNCTION__, alert,
+                  g_warning ("%s: TLS Alert %d: %s", __FUNCTION__, alert,
                              alert_name);
                 }
-              g_warning ("%s: failed to read from server: %s\n", __FUNCTION__,
+              g_warning ("%s: failed to read from server: %s", __FUNCTION__,
                          gnutls_strerror (count));
               return -1;
             }
@@ -381,7 +381,7 @@ openvas_scanner_write (int nvt_cache_mode)
              * error" removes the data between `select' and `read'. */
             if (fcntl (openvas_scanner_socket, F_SETFL, O_NONBLOCK) == -1)
               {
-                g_warning ("%s: failed to set scanner socket flag: %s\n",
+                g_warning ("%s: failed to set scanner socket flag: %s",
                            __FUNCTION__, strerror (errno));
                 return -1;
               }
@@ -503,7 +503,7 @@ openvas_scanner_wait ()
         {
           if (errno == EINTR)
             continue;
-          g_warning ("%s: select failed (connect): %s\n", __FUNCTION__,
+          g_warning ("%s: select failed (connect): %s", __FUNCTION__,
                      strerror (errno));
           return -1;
         }
@@ -532,7 +532,7 @@ load_cas (gnutls_certificate_credentials_t *scanner_credentials)
     {
       if (errno != ENOENT)
         {
-          g_warning ("%s: failed to open " CA_DIR ": %s\n", __FUNCTION__,
+          g_warning ("%s: failed to open " CA_DIR ": %s", __FUNCTION__,
                      strerror (errno));
           return -1;
         }
@@ -551,7 +551,7 @@ load_cas (gnutls_certificate_credentials_t *scanner_credentials)
           && (gnutls_certificate_set_x509_trust_file
                (*scanner_credentials, name, GNUTLS_X509_FMT_PEM) < 0))
         {
-          g_warning ("%s: gnutls_certificate_set_x509_trust_file failed: %s\n",
+          g_warning ("%s: gnutls_certificate_set_x509_trust_file failed: %s",
                      __FUNCTION__, name);
           g_free (name);
           closedir (dir);
@@ -620,7 +620,7 @@ openvas_scanner_connect_unix ()
   openvas_scanner_socket = socket (AF_UNIX, SOCK_STREAM, 0);
   if (openvas_scanner_socket == -1)
     {
-      g_warning ("%s: failed to create scanner socket: %s\n", __FUNCTION__,
+      g_warning ("%s: failed to create scanner socket: %s", __FUNCTION__,
                  strerror (errno));
       return -1;
     }
@@ -630,7 +630,7 @@ openvas_scanner_connect_unix ()
   len = strlen (addr.sun_path) + sizeof (addr.sun_family);
   if (connect (openvas_scanner_socket, (struct sockaddr *) &addr, len) == -1)
     {
-      g_warning ("%s: Failed to connect to scanner (%s): %s\n", __FUNCTION__,
+      g_warning ("%s: Failed to connect to scanner (%s): %s", __FUNCTION__,
                  openvas_scanner_unix_path, strerror (errno));
       return -1;
     }
@@ -653,7 +653,7 @@ openvas_scanner_connect ()
   openvas_scanner_socket = socket (PF_INET, SOCK_STREAM, 0);
   if (openvas_scanner_socket == -1)
     {
-      g_warning ("%s: failed to create scanner socket: %s\n", __FUNCTION__,
+      g_warning ("%s: failed to create scanner socket: %s", __FUNCTION__,
                  strerror (errno));
       return -1;
     }

--- a/src/sql.c
+++ b/src/sql.c
@@ -172,7 +172,7 @@ sqlv (int retry, char* sql, va_list args)
       ret = sql_prepare_internal (retry, 1, sql, args_copy, &stmt);
       va_end (args_copy);
       if (ret == -1)
-        g_warning ("%s: sql_prepare_internal failed\n", __FUNCTION__);
+        g_warning ("%s: sql_prepare_internal failed", __FUNCTION__);
       if (ret)
         return ret;
 
@@ -180,7 +180,7 @@ sqlv (int retry, char* sql, va_list args)
 
       while ((ret = sql_exec_internal (retry, stmt)) == 1);
       if ((ret == -1) && log_errors)
-        g_warning ("%s: sql_exec_internal failed\n", __FUNCTION__);
+        g_warning ("%s: sql_exec_internal failed", __FUNCTION__);
       sql_finalize (stmt);
       if (ret == 2)
         continue;
@@ -298,7 +298,7 @@ sql_x_internal (int log, char* sql, va_list args, sql_stmt_t** stmt_return)
 
       if (ret)
         {
-          g_warning ("%s: sql_prepare failed\n", __FUNCTION__);
+          g_warning ("%s: sql_prepare failed", __FUNCTION__);
           return -1;
         }
 
@@ -308,7 +308,7 @@ sql_x_internal (int log, char* sql, va_list args, sql_stmt_t** stmt_return)
       if (ret == -1)
         {
           if (log_errors)
-            g_warning ("%s: sql_exec_internal failed\n", __FUNCTION__);
+            g_warning ("%s: sql_exec_internal failed", __FUNCTION__);
           return -1;
         }
       if (ret == 0)
@@ -324,7 +324,7 @@ sql_x_internal (int log, char* sql, va_list args, sql_stmt_t** stmt_return)
     }
   assert (ret == 1);
   if (log)
-    g_debug ("   sql_x end (%s)\n", sql);
+    g_debug ("   sql_x end (%s)", sql);
   return 0;
 }
 
@@ -522,7 +522,7 @@ init_prepared_iterator (iterator_t* iterator, sql_stmt_t* stmt)
   iterator->stmt = stmt;
   iterator->prepared = 1;
   iterator->crypt_ctx = NULL;
-  g_debug ("   sql: init prepared %p\n", stmt);
+  g_debug ("   sql: init prepared %p", stmt);
 }
 
 /**
@@ -547,7 +547,7 @@ init_iterator (iterator_t* iterator, const char* sql, ...)
   va_end (args);
   if (ret)
     {
-      g_warning ("%s: sql_prepare failed\n", __FUNCTION__);
+      g_warning ("%s: sql_prepare failed", __FUNCTION__);
       abort ();
     }
   iterator->stmt = stmt;
@@ -623,7 +623,7 @@ cleanup_iterator (iterator_t* iterator)
 {
   if (iterator == NULL)
     {
-      g_warning ("%s: null iterator pointer.\n", __FUNCTION__);
+      g_warning ("%s: null iterator pointer", __FUNCTION__);
       return;
     }
 
@@ -663,7 +663,7 @@ next (iterator_t* iterator)
       if (ret == -1)
         {
           if (log_errors)
-            g_warning ("%s: sql_exec_internal failed\n", __FUNCTION__);
+            g_warning ("%s: sql_exec_internal failed", __FUNCTION__);
           abort ();
         }
       if (ret == -3 || ret == -2)
@@ -672,7 +672,7 @@ next (iterator_t* iterator)
            * we used to do in sql_exec_internal.  We're not supposed to do this
            * for SQLite, but it would mean quite a bit of reworking in the
            * callers to be able to handle this case. */
-          g_warning ("%s: stepping after reset\n", __FUNCTION__);
+          g_warning ("%s: stepping after reset", __FUNCTION__);
           continue;
         }
       if (ret == 2)
@@ -688,7 +688,7 @@ next (iterator_t* iterator)
                      "  This is possibly due to running VACUUM while Manager\n"
                      "  is running.  Restart Manager.  In future use\n"
                      "  --optimize=vacuum instead of running VACUUM"
-                     "  directly.\n",
+                     "  directly.",
                      __FUNCTION__);
           abort ();
         }

--- a/src/sql_pg.c
+++ b/src/sql_pg.c
@@ -135,7 +135,7 @@ sql_select_limit (int max)
     return "ALL";
   if (snprintf (string, 19, "%i", max) < 0)
     {
-      g_warning ("%s: snprintf failed\n", __FUNCTION__);
+      g_warning ("%s: snprintf failed", __FUNCTION__);
       abort ();
     }
   string[19] = '\0';
@@ -277,13 +277,13 @@ sql_open (const char *database)
   g_free (conn_info);
   if (conn == NULL)
     {
-      g_warning ("%s: PQconnectStart failed to allocate conn\n",
+      g_warning ("%s: PQconnectStart failed to allocate conn",
                  __FUNCTION__);
       return -1;
     }
   if (PQstatus (conn) == CONNECTION_BAD)
     {
-      g_warning ("%s: PQconnectStart to '%s' failed: %s\n",
+      g_warning ("%s: PQconnectStart to '%s' failed: %s",
                  __FUNCTION__,
                  database ? database : sql_default_database (),
                  PQerrorMessage (conn));
@@ -293,13 +293,13 @@ sql_open (const char *database)
   socket = PQsocket (conn);
   if (socket == 0)
     {
-      g_warning ("%s: PQsocket 0\n", __FUNCTION__);
+      g_warning ("%s: PQsocket 0", __FUNCTION__);
       goto fail;
     }
 
   poll_status = PGRES_POLLING_WRITING;
 
-  g_debug ("%s: polling\n", __FUNCTION__);
+  g_debug ("%s: polling", __FUNCTION__);
 
   while (1)
     {
@@ -316,7 +316,7 @@ sql_open (const char *database)
             continue;
           if (ret < 0)
             {
-              g_warning ("%s: write select failed: %s\n",
+              g_warning ("%s: write select failed: %s",
                          __FUNCTION__, strerror (errno));
               goto fail;
             }
@@ -335,7 +335,7 @@ sql_open (const char *database)
             continue;
           if (ret < 0)
             {
-              g_warning ("%s: read select failed: %s\n",
+              g_warning ("%s: read select failed: %s",
                          __FUNCTION__, strerror (errno));
               goto fail;
             }
@@ -343,7 +343,7 @@ sql_open (const char *database)
         }
       else if (poll_status == PGRES_POLLING_FAILED)
         {
-          g_warning ("%s: PQconnectPoll failed\n",
+          g_warning ("%s: PQconnectPoll failed",
                      __FUNCTION__);
           g_warning ("%s: PQerrorMessage (conn): %s", __FUNCTION__,
                      PQerrorMessage (conn));
@@ -358,12 +358,12 @@ sql_open (const char *database)
 
   PQsetNoticeProcessor (conn, log_notice, NULL);
 
-  g_debug ("%s:   db: %s\n", __FUNCTION__, PQdb (conn));
-  g_debug ("%s: user: %s\n", __FUNCTION__, PQuser (conn));
-  g_debug ("%s: host: %s\n", __FUNCTION__, PQhost (conn));
-  g_debug ("%s: port: %s\n", __FUNCTION__, PQport (conn));
-  g_debug ("%s: socket: %i\n", __FUNCTION__, PQsocket (conn));
-  g_debug ("%s: postgres version: %i\n", __FUNCTION__, PQserverVersion (conn));
+  g_debug ("%s:   db: %s", __FUNCTION__, PQdb (conn));
+  g_debug ("%s: user: %s", __FUNCTION__, PQuser (conn));
+  g_debug ("%s: host: %s", __FUNCTION__, PQhost (conn));
+  g_debug ("%s: port: %s", __FUNCTION__, PQport (conn));
+  g_debug ("%s: socket: %i", __FUNCTION__, PQsocket (conn));
+  g_debug ("%s: postgres version: %i", __FUNCTION__, PQserverVersion (conn));
 
   return 0;
 
@@ -484,7 +484,7 @@ sql_prepare_internal (int retry, int log, const char* sql, va_list args,
   (*stmt)->sql = g_strdup_vprintf (sql, args);
 
   if (log)
-    g_debug ("   sql: %s\n", (*stmt)->sql);
+    g_debug ("   sql: %s", (*stmt)->sql);
 
   return 0;
 }
@@ -523,11 +523,11 @@ sql_exec_internal (int retry, sql_stmt_t *stmt)
           char *sqlstate;
 
           sqlstate = PQresultErrorField (result, PG_DIAG_SQLSTATE);
-          g_debug ("%s: sqlstate: %s\n", __FUNCTION__, sqlstate);
+          g_debug ("%s: sqlstate: %s", __FUNCTION__, sqlstate);
           if (sqlstate && (strcmp (sqlstate, "57014") == 0)) /* query_canceled */
             {
               log_errors = 0;
-              g_debug ("%s: canceled SQL: %s\n", __FUNCTION__, stmt->sql);
+              g_debug ("%s: canceled SQL: %s", __FUNCTION__, stmt->sql);
             }
           else if (sqlstate && (strcmp (sqlstate, "55P03") == 0))
             {
@@ -539,11 +539,11 @@ sql_exec_internal (int retry, sql_stmt_t *stmt)
 
           if (log_errors)
             {
-              g_warning ("%s: PQexec failed: %s (%i)\n",
+              g_warning ("%s: PQexec failed: %s (%i)",
                          __FUNCTION__,
                          PQresultErrorMessage (result),
                          PQresultStatus (result));
-              g_warning ("%s: SQL: %s\n", __FUNCTION__, stmt->sql);
+              g_warning ("%s: SQL: %s", __FUNCTION__, stmt->sql);
             }
 #if 0
           // FIX ?

--- a/src/sql_sqlite3.c
+++ b/src/sql_sqlite3.c
@@ -127,7 +127,7 @@ sql_select_limit (int max)
     return "-1";
   if (snprintf (string, 19, "%i", max) < 0)
     {
-      g_warning ("%s: snprintf failed\n", __FUNCTION__);
+      g_warning ("%s: snprintf failed", __FUNCTION__);
       abort ();
     }
   string[19] = '\0';
@@ -218,7 +218,7 @@ sql_open (const char *database)
   ret = g_mkdir_with_parents (GVMD_STATE_DIR, 0755 /* "rwxr-xr-x" */);
   if (ret == -1)
     {
-      g_warning ("%s: failed to create database directory %s: %s\n",
+      g_warning ("%s: failed to create database directory %s: %s",
                  __FUNCTION__,
                  GVMD_STATE_DIR,
                  strerror (errno));
@@ -233,19 +233,19 @@ sql_open (const char *database)
         case ENOENT:
           break;
         default:
-          g_warning ("%s: failed to stat database: %s\n",
+          g_warning ("%s: failed to stat database: %s",
                      __FUNCTION__,
                      strerror (errno));
           abort ();
       }
   else if (state.st_mode & (S_IXUSR | S_IRWXG | S_IRWXO))
     {
-      g_warning ("%s: database permissions are too loose, repairing\n",
+      g_warning ("%s: database permissions are too loose, repairing",
                  __FUNCTION__);
       if (chmod (database ? database : sql_default_database (),
                  S_IRUSR | S_IWUSR))
         {
-          g_warning ("%s: chmod failed: %s\n",
+          g_warning ("%s: chmod failed: %s",
                      __FUNCTION__,
                      strerror (errno));
           abort ();
@@ -261,7 +261,7 @@ sql_open (const char *database)
   if (sqlite3_open (database ? database : sql_default_database (),
                     &gvmd_db))
     {
-      g_warning ("%s: sqlite3_open failed: %s\n",
+      g_warning ("%s: sqlite3_open failed: %s",
                  __FUNCTION__,
                  sqlite3_errmsg (gvmd_db));
       return -1;
@@ -269,7 +269,7 @@ sql_open (const char *database)
 
   sqlite3_busy_timeout (gvmd_db, BUSY_TIMEOUT);
 
-  g_debug ("   %s: db open, max retry sleep time is %i\n",
+  g_debug ("   %s: db open, max retry sleep time is %i",
            __FUNCTION__,
            GVM_SQLITE_SLEEP_MAX);
 
@@ -295,7 +295,7 @@ sql_close ()
      * sqlite3.pVdbe points to.  This is the list of open statements
      * in the current implementation (and subject to change without
      * notice). */
-    g_warning ("%s: attempt to close db with open statement(s)\n",
+    g_warning ("%s: attempt to close db with open statement(s)",
                __FUNCTION__);
   gvmd_db = NULL;
 }
@@ -377,7 +377,7 @@ sql_prepare_internal (int retry, int log, const char* sql, va_list args,
   formatted = g_strdup_vprintf (sql, args);
 
   if (log)
-    g_debug ("   sql: %s\n", formatted);
+    g_debug ("   sql: %s", formatted);
 
   if (retry == 0)
     sqlite3_busy_timeout (gvmd_db, 0);
@@ -412,7 +412,7 @@ sql_prepare_internal (int retry, int log, const char* sql, va_list args,
         {
           if (sqlite_stmt == NULL)
             {
-              g_warning ("%s: sqlite3_prepare failed with NULL stmt: %s\n",
+              g_warning ("%s: sqlite3_prepare failed with NULL stmt: %s",
                          __FUNCTION__,
                          sqlite3_errmsg (gvmd_db));
               if (retry == 0)
@@ -421,7 +421,7 @@ sql_prepare_internal (int retry, int log, const char* sql, va_list args,
             }
           break;
         }
-      g_warning ("%s: sqlite3_prepare failed: %s\n",
+      g_warning ("%s: sqlite3_prepare failed: %s",
                  __FUNCTION__,
                  sqlite3_errmsg (gvmd_db));
       if (retry == 0)
@@ -477,7 +477,7 @@ sql_exec_internal (int retry, sql_stmt_t *stmt)
         return 0;
       if (ret == SQLITE_ROW)
         return 1;
-      g_warning ("%s: sqlite3_step failed: %s\n",
+      g_warning ("%s: sqlite3_step failed: %s",
                  __FUNCTION__,
                  sqlite3_errmsg (gvmd_db));
       return -1;
@@ -677,7 +677,7 @@ sql_bind_blob (sql_stmt_t *stmt, int position, const void *value,
           continue;
         }
       if (ret == SQLITE_OK) break;
-      g_warning ("%s: sqlite3_bind_blob failed: %s\n",
+      g_warning ("%s: sqlite3_bind_blob failed: %s",
                  __FUNCTION__,
                  sqlite3_errmsg (gvmd_db));
       return -1;
@@ -718,7 +718,7 @@ sql_bind_text (sql_stmt_t *stmt, int position, const gchar *value,
           continue;
         }
       if (ret == SQLITE_OK) break;
-      g_warning ("%s: sqlite3_bind_text failed: %s\n",
+      g_warning ("%s: sqlite3_bind_text failed: %s",
                  __FUNCTION__,
                  sqlite3_errmsg (gvmd_db));
       return -1;
@@ -767,7 +767,7 @@ sql_reset (sql_stmt_t *stmt)
       if (ret == SQLITE_DONE || ret == SQLITE_OK) break;
       if (ret == SQLITE_ERROR || ret == SQLITE_MISUSE)
         {
-          g_warning ("%s: sqlite3_reset failed: %s\n",
+          g_warning ("%s: sqlite3_reset failed: %s",
                      __FUNCTION__,
                      sqlite3_errmsg (gvmd_db));
           return -1;


### PR DESCRIPTION
These are left over from long ago, before the logging would
automatically add the trailing newline.  Better to only have one
style, and neater without the newline.