### PR TITLE
Remove smb_file_path_type alert data type. (7.0)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,9 +11,10 @@ openvas-manager 7.0.4 (work in progress)
 
 Main changes since 7.0.3:
 * The new alert method "Alemba vFire" has been added.
-* The SMB alert will now try to create directories as needed
-* The file path of SMB alerts can now be configured to be used only for the
-  directory, appending the report filename from the user's settings.
+* The SMB alert will now try to create directories as needed.
+* The file path of SMB alerts can now be set to a directory, using the default
+  report filename from the user's settings. 
+* The file extension from the report format will now be added by SMB alerts.
 * The tag "smb-alert:file_path" on tasks will override the file path of
   SMB alerts.
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -7411,16 +7411,6 @@ validate_smb_data (alert_method_t method, const gchar *name, gchar **data)
             }
         }
 
-      if (strcmp (name, "smb_file_path_type") == 0)
-        {
-          if (*data
-              && strcmp (*data, "")
-              && strcasecmp (*data, "directory")
-              && strcasecmp (*data, "full"))
-            {
-              return 43;
-            }
-        }
     }
 
   return 0;
@@ -13055,7 +13045,8 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
       case ALERT_METHOD_SMB:
         {
           char *credential_id, *username, *password;
-          char *share_path, *file_path_format, *file_path_type;
+          char *share_path, *file_path_format;
+          gboolean file_path_is_dir;
           report_format_t report_format;
           gchar *file_path, *report_content, *extension;
           gsize content_length;
@@ -13089,7 +13080,6 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
 
           credential_id = alert_data (alert, "method", "smb_credential");
           share_path = alert_data (alert, "method", "smb_share_path");
-          file_path_type = alert_data (alert, "method", "smb_file_path_type");
 
           file_path_format
             = sql_string ("SELECT value FROM tags"
@@ -13102,14 +13092,16 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
           if (file_path_format == NULL)
             file_path_format = alert_data (alert, "method", "smb_file_path");
 
+          file_path_is_dir = g_str_has_suffix (file_path_format, "\\");
+
           report_content = NULL;
           extension = NULL;
           report_format = 0;
 
           g_debug ("smb_credential: %s", credential_id);
           g_debug ("smb_share_path: %s", share_path);
-          g_debug ("smb_file_path: %s", file_path_format);
-          g_debug ("smb_file_path_type: %s", file_path_type);
+          g_debug ("smb_file_path: %s (%s)",
+                   file_path_format, file_path_is_dir ? "dir" : "file");
 
           ret = report_content_for_alert
                   (alert, report, task, get,
@@ -13128,8 +13120,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
               return ret ? ret : -1;
             }
 
-          if (file_path_type
-              && strcasecmp (file_path_type, "directory") == 0)
+          if (file_path_is_dir)
             {
               char *dirname, *filename;
 
@@ -13146,7 +13137,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
           else
             {
               file_path = generate_report_filename (report, report_format,
-                                                    file_path_format, FALSE);
+                                                    file_path_format, TRUE);
             }
 
           credential = 0;


### PR DESCRIPTION
Whether the smb_file_path is handled as a directory is now based on
whether the path ends in a slash, making smb_file_path_type obsolete.
The file extension from the report format is now always added to the
path, even if it is a filename.
The existing CHANGES entries have been updated accordingly.