### PR TITLE
Remove smb_file_path_type alert data type, add improvements from #320

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,9 +12,10 @@ gvmd 8.0+beta3 (work in progress)
 Main changes compared to gvm 8.0+beta2:
 * The new alert method "Alemba vFire" has been added.
 * GMP CREATE_ASSET, its GMP doc and usage by GSA are now more consistent.
-* The SMB alert will now try to create directories as needed
-* The file path of SMB alerts can now be configured to be used only for the
-  directory, appending the report filename from the user's settings.
+* The SMB alert will now try to create directories as needed.
+* The file path of SMB alerts can now be set to a directory, using the default
+  report filename from the user's settings. 
+* The file extension from the report format will now be added by SMB alerts.
 * The tag "smb-alert:file_path" on tasks will override the file path of
   SMB alerts.
 * Remediation support has been added (GMP CREATE_TICKET, GET_TICKETS, etc).

--- a/src/alert_methods/SMB/alert
+++ b/src/alert_methods/SMB/alert
@@ -134,16 +134,20 @@ def main():
 
     # get list of subdirectory paths
     dest_parts = dest_path.split('\\')
-    dest_subpaths = [dest_parts[0]]
+    dest_subpaths = []
+    make_dest = ''
     if len(dest_parts) >= 2:
-        make_dest = dest_parts[0]
-        for i in range(1, len(dest_parts)):
-            dest_subpaths.append(make_dest)
-            make_dest += '\\' + dest_parts[i]
+        for i in range(0, len(dest_parts) - 1):
+            if dest_parts[i]:
+                if make_dest:
+                    make_dest += '\\' + dest_parts[i]
+                else:
+                    make_dest = dest_parts[i]
+                dest_subpaths.append(make_dest)
 
     # Find first existing path
     first_existing_path_index = -1
-    for i in range(len(dest_subpaths)-1, 0, -1):
+    for i in range(len(dest_subpaths)-1, -1, -1):
         if smb_dir_exists(auth_path, share, dest_subpaths[i]):
             first_existing_path_index = i
             break

--- a/src/alert_methods/SMB/alert
+++ b/src/alert_methods/SMB/alert
@@ -136,6 +136,13 @@ def main():
     dest_parts = dest_path.split('\\')
     dest_subpaths = []
     make_dest = ''
+    for i in range(0, len(dest_parts)):
+        if dest_parts[i].endswith('.'):
+            print("File or subdirectory names must not be '.', '..' or"
+                  " end with a dot",
+                  file=sys.stderr)
+            sys.exit(1)
+
     if len(dest_parts) >= 2:
         for i in range(0, len(dest_parts) - 1):
             if dest_parts[i]:


### PR DESCRIPTION
Whether the smb_file_path is handled as a directory is now based on
whether the path ends in a slash, making smb_file_path_type obsolete.
The file extension from the report format is now always added to the
path, even if it is a filename.
The existing CHANGES entries have been updated accordingly.

Also, improvements in handling the SMB alert file file path from #320
are ported to the master branch.