### PR TITLE
Remove calls to gvm_auth_tear_down()

### DIFF
--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -906,9 +906,6 @@ cleanup ()
   g_debug ("   Exiting");
   if (log_config) log_config_free ();
 
-  /* Tear down authentication system conf, if any. */
-  gvm_auth_tear_down ();
-
   /* Delete pidfile if this process is the parent. */
   if (is_parent == 1) pidfile_remove ("gvmd");
 }
@@ -1254,7 +1251,6 @@ fork_update_nvt_cache ()
         cleanup_manage_process (FALSE);
         if (manager_socket > -1) close (manager_socket);
         if (manager_socket_2 > -1) close (manager_socket_2);
-        gvm_auth_tear_down ();
 
         /* Update the cache. */
 


### PR DESCRIPTION
This function was removed from gvm-libs.