### PR TITLE
Use a "connection forker" typedef

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -30116,8 +30116,7 @@ int
 init_gmp (GSList *log_config, int nvt_cache_mode, const gchar *database,
           int max_ips_per_target, int max_email_attachment_size,
           int max_email_include_size, int max_email_message_size,
-          int (*fork_connection) (gvm_connection_t *, gchar*),
-          int skip_db_check)
+          manage_connection_forker_t fork_connection, int skip_db_check)
 {
   g_log_set_handler (G_LOG_DOMAIN,
                      ALL_LOG_LEVELS,

--- a/src/gmp.h
+++ b/src/gmp.h
@@ -25,6 +25,7 @@
 #ifndef _GVMD_GMP_H
 #define _GVMD_GMP_H
 
+#include "manage.h"
 #include "types.h"
 #include <gvm/util/serverutils.h>
 #include <glib.h>
@@ -48,8 +49,7 @@
 
 int
 init_gmp (GSList*, int, const gchar*, int, int, int, int,
-          int (*) (gvm_connection_t *, gchar*),
-          int);
+          manage_connection_forker_t, int);
 
 void
 init_gmp_process (int, const gchar*, int (*) (const char*, void*), void*,

--- a/src/gmpd.c
+++ b/src/gmpd.c
@@ -108,8 +108,7 @@ int
 init_gmpd (GSList *log_config, int nvt_cache_mode, const gchar *database,
            int max_ips_per_target, int max_email_attachment_size,
            int max_email_include_size, int max_email_message_size,
-           int (*fork_connection) (gvm_connection_t *, gchar*),
-           int skip_db_check)
+           manage_connection_forker_t fork_connection, int skip_db_check)
 {
   return init_gmp (log_config, nvt_cache_mode, database, max_ips_per_target,
                    max_email_attachment_size, max_email_include_size,

--- a/src/gmpd.h
+++ b/src/gmpd.h
@@ -25,6 +25,7 @@
 #ifndef _GVMD_GMPD_H
 #define _GVMD_GMPD_H
 
+#include "manage.h"
 #include "types.h"
 #include <gvm/util/serverutils.h>
 #include <glib.h>
@@ -45,8 +46,7 @@
 
 int
 init_gmpd (GSList*, int, const gchar*, int, int, int, int,
-           int (*) (gvm_connection_t *, gchar *),
-           int);
+           manage_connection_forker_t, int);
 
 void
 init_gmpd_process (const gchar *, gchar **);

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -656,8 +656,8 @@ accept_and_maybe_fork (int server_socket, sigset_t *sigmask_current)
  * @return PID parent on success, 0 child on success, -1 error.
  */
 static int
-fork_connection_internal (gvm_connection_t *client_connection, gchar* uuid,
-                          int scheduler)
+fork_connection_internal (gvm_connection_t *client_connection,
+                          const char* uuid, int scheduler)
 {
   int pid, parent_client_socket, ret;
   int sockets[2];
@@ -848,7 +848,8 @@ fork_connection_internal (gvm_connection_t *client_connection, gchar* uuid,
  * @return PID parent on success, 0 child on success, -1 error.
  */
 static int
-fork_connection_for_scheduler (gvm_connection_t *client_connection, gchar* uuid)
+fork_connection_for_scheduler (gvm_connection_t *client_connection,
+                               const char* uuid)
 {
   return fork_connection_internal (client_connection, uuid, 1);
 }
@@ -862,7 +863,8 @@ fork_connection_for_scheduler (gvm_connection_t *client_connection, gchar* uuid)
  * @return PID parent on success, 0 child on success, -1 error.
  */
 static int
-fork_connection_for_event (gvm_connection_t *client_connection, gchar* uuid)
+fork_connection_for_event (gvm_connection_t *client_connection,
+                           const char* uuid)
 {
   return fork_connection_internal (client_connection, uuid, 0);
 }

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -657,7 +657,7 @@ accept_and_maybe_fork (int server_socket, sigset_t *sigmask_current)
  */
 static int
 fork_connection_internal (gvm_connection_t *client_connection,
-                          const char* uuid, int scheduler)
+                          const gchar* uuid, int scheduler)
 {
   int pid, parent_client_socket, ret;
   int sockets[2];
@@ -849,7 +849,7 @@ fork_connection_internal (gvm_connection_t *client_connection,
  */
 static int
 fork_connection_for_scheduler (gvm_connection_t *client_connection,
-                               const char* uuid)
+                               const gchar* uuid)
 {
   return fork_connection_internal (client_connection, uuid, 1);
 }
@@ -864,7 +864,7 @@ fork_connection_for_scheduler (gvm_connection_t *client_connection,
  */
 static int
 fork_connection_for_event (gvm_connection_t *client_connection,
-                           const char* uuid)
+                           const gchar* uuid)
 {
   return fork_connection_internal (client_connection, uuid, 0);
 }

--- a/src/manage.c
+++ b/src/manage.c
@@ -6781,7 +6781,7 @@ manage_auth_allow_all (int scheduled)
  *
  * @return UUID of user that scheduled the current task.
  */
-const char*
+const gchar*
 get_scheduled_user_uuid ()
 {
   return schedule_user_uuid;
@@ -6794,7 +6794,7 @@ get_scheduled_user_uuid ()
  * @param user_uuid UUID of user that scheduled the current task.
  */
 void
-set_scheduled_user_uuid (const char* user_uuid)
+set_scheduled_user_uuid (const gchar* user_uuid)
 {
   gchar *user_uuid_copy = user_uuid ? g_strdup (user_uuid) : NULL;
   g_free (schedule_user_uuid);

--- a/src/manage.c
+++ b/src/manage.c
@@ -6756,7 +6756,7 @@ manage_auth_allow_all (int scheduled)
  *
  * @return UUID of user that scheduled the current task.
  */
-gchar*
+const char*
 get_scheduled_user_uuid ()
 {
   return schedule_user_uuid;
@@ -6764,13 +6764,16 @@ get_scheduled_user_uuid ()
 
 /**
  * @brief Set UUID of user that scheduled the current task.
+ * The previous value is freed and a copy of the UUID is created.
  *
  * @param user_uuid UUID of user that scheduled the current task.
  */
 void
-set_scheduled_user_uuid (gchar* user_uuid)
+set_scheduled_user_uuid (const char* user_uuid)
 {
-  schedule_user_uuid = user_uuid;
+  gchar *user_uuid_copy = user_uuid ? g_strdup (user_uuid) : NULL;
+  g_free (schedule_user_uuid);
+  schedule_user_uuid = user_uuid_copy;
 }
 
 /**
@@ -6833,7 +6836,7 @@ scheduled_task_free (scheduled_task_t *scheduled_task)
  */
 static int
 scheduled_task_start (scheduled_task_t *scheduled_task,
-                      int (*fork_connection) (gvm_connection_t *, gchar *),
+                      manage_connection_forker_t fork_connection,
                       sigset_t *sigmask_current)
 {
   char title[128];
@@ -7040,7 +7043,7 @@ scheduled_task_start (scheduled_task_t *scheduled_task,
  */
 static int
 scheduled_task_stop (scheduled_task_t *scheduled_task,
-                     int (*fork_connection) (gvm_connection_t *, gchar *),
+                     manage_connection_forker_t fork_connection,
                      sigset_t *sigmask_current)
 {
   char title[128];
@@ -7127,7 +7130,7 @@ manage_sync (sigset_t *sigmask_current,
  * @return 0 success, 1 failed to get lock, -1 error.
  */
 int
-manage_schedule (int (*fork_connection) (gvm_connection_t *, gchar *),
+manage_schedule (manage_connection_forker_t fork_connection,
                  gboolean run_tasks,
                  sigset_t *sigmask_current)
 {

--- a/src/manage.h
+++ b/src/manage.h
@@ -65,10 +65,15 @@ typedef struct
   gchar *value;   ///< Param value.
 } name_value_t;
 
+/**
+ * @brief Fork helper function type.
+ */
+typedef int (*manage_connection_forker_t) (gvm_connection_t * conn,
+                                           const char* uuid);
+
 int
 init_manage (GSList*, int, const gchar *, int, int, int, int,
-             int (*) (gvm_connection_t *, gchar *),
-             int);
+             manage_connection_forker_t, int);
 
 int
 init_manage_helper (GSList *, const gchar *, int);
@@ -2784,17 +2789,17 @@ delete_schedule (const char*, int);
 void
 manage_auth_allow_all (int);
 
-gchar*
+const char*
 get_scheduled_user_uuid ();
 
 void
-set_scheduled_user_uuid (gchar* uuid);
+set_scheduled_user_uuid (const char* uuid);
 
 void
 manage_sync (sigset_t *, int (*fork_update_nvt_cache) ());
 
 int
-manage_schedule (int (*) (gvm_connection_t *, gchar *),
+manage_schedule (manage_connection_forker_t,
                  gboolean,
                  sigset_t *);
 

--- a/src/manage.h
+++ b/src/manage.h
@@ -69,7 +69,7 @@ typedef struct
  * @brief Fork helper function type.
  */
 typedef int (*manage_connection_forker_t) (gvm_connection_t * conn,
-                                           const char* uuid);
+                                           const gchar* uuid);
 
 int
 init_manage (GSList*, int, const gchar *, int, int, int, int,
@@ -2792,11 +2792,11 @@ delete_schedule (const char*, int);
 void
 manage_auth_allow_all (int);
 
-const char*
+const gchar*
 get_scheduled_user_uuid ();
 
 void
-set_scheduled_user_uuid (const char* uuid);
+set_scheduled_user_uuid (const gchar* uuid);
 
 void
 manage_sync (sigset_t *, int (*fork_update_nvt_cache) ());

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -487,7 +487,7 @@ type_build_select (const char *, const char *, const get_data_t *,
 /**
  * @brief Function to fork a connection that will accept GMP requests.
  */
-static int (*manage_fork_connection) (gvm_connection_t *, gchar*) = NULL;
+static manage_connection_forker_t manage_fork_connection;
 
 /**
  * @brief Max number of hosts per target.
@@ -17640,8 +17640,7 @@ init_manage_internal (GSList *log_config,
                       int max_email_include_size,
                       int max_email_message_size,
                       int stop_tasks,
-                      int (*fork_connection)
-                             (gvm_connection_t *, gchar *),
+                      manage_connection_forker_t fork_connection,
                       int skip_db_check,
                       int check_encryption_key)
 {
@@ -17781,7 +17780,7 @@ int
 init_manage (GSList *log_config, int nvt_cache_mode, const gchar *database,
              int max_ips_per_target, int max_email_attachment_size,
              int max_email_include_size, int max_email_message_size,
-             int (*fork_connection) (gvm_connection_t*, gchar*),
+             manage_connection_forker_t fork_connection,
              int skip_db_check)
 {
   return init_manage_internal (log_config,
@@ -18371,7 +18370,7 @@ authenticate (credentials_t* credentials)
            * scheduled tasks and alerts.  Take the stored uuid
            * to be able to tell apart locally authenticated vs remotely
            * authenticated users (in order to fetch the correct rules). */
-          credentials->uuid = get_scheduled_user_uuid ();
+          credentials->uuid = g_strdup (get_scheduled_user_uuid ());
           if (*credentials->uuid)
             {
               if (credentials_setup (credentials))


### PR DESCRIPTION
Functions with a parameter to give a function for forking a new process
now use a new typedef, manage_connection_forker_t, for the function
signature definition to ensure consistency.
The user UUID is now a const and other functions have been adjusted
accordingly.