### PR TITLE
Add setting "Tickets Top Dashboard Configuration" 

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -63468,6 +63468,14 @@ modify_setting (const gchar *uuid, const gchar *name,
       /* All SecInfo */
       else if (strcmp (uuid, "4c7b1ea7-b7e6-4d12-9791-eb9f72b6f864") == 0)
         setting_name = g_strdup ("All SecInfo Top Dashboard Configuration");
+
+      /*
+       * Remediation dashboards
+       */
+
+      /* Tickets */
+      else if (strcmp (uuid, "70b0626f-a835-478e-8194-e09f97887a15") == 0)
+        setting_name = g_strdup ("Tickets Top Dashboard Configuration");
     }
 
   if (setting_name)


### PR DESCRIPTION
This adds "70b0626f-a835-478e-8194-e09f97887a15" as the UUID for the
setting to store the configuration of Tickets dashboard in GSA.