### PR TITLE
Add handling of Auth-SNMP-(Success|Failure) to HTML and LaTeX report …

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,8 @@ Main changes compared to gvm 8.0+beta2:
 * Remediation support has been added (GMP CREATE_TICKET, GET_TICKETS, etc).
 * Missing data in credentials no longer prevents slave tasks from starting.
   Instead the scan will start without the credential.
+* Handling of failed/successful SNMP Authentication has been added to the
+  HTML and LaTeX report formats.
 
 
 gvmd 8.0+beta2 (2018-12-05)

--- a/report_formats/HTML/HTML.xsl
+++ b/report_formats/HTML/HTML.xsl
@@ -879,6 +879,52 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         </td>
       </tr>
     </xsl:for-each>
+    <xsl:for-each select="/report/host[ip=$host]/detail[name='Auth-SNMP-Success']">
+      <tr>
+        <td>
+          <xsl:value-of select="$host"/>
+          <xsl:choose>
+            <xsl:when test="string-length(/report/host[ip=$host]/detail[name='hostname']/value) &gt; 0">
+              <xsl:text> (</xsl:text>
+              <xsl:value-of select="/report/host[ip=$host]/detail[name='hostname']/value/text()"/>
+              <xsl:text>)</xsl:text>
+            </xsl:when>
+          </xsl:choose>
+        </td>
+        <td>
+          <xsl:text>SNMP</xsl:text>
+        </td>
+        <td>
+          <xsl:text>Success</xsl:text>
+        </td>
+        <td>
+          <xsl:value-of select="value/text()"/>
+        </td>
+      </tr>
+    </xsl:for-each>
+    <xsl:for-each select="/report/host[ip=$host]/detail[name='Auth-SNMP-Failure']">
+      <tr>
+        <td>
+          <xsl:value-of select="$host"/>
+          <xsl:choose>
+            <xsl:when test="string-length(/report/host[ip=$host]/detail[name='hostname']/value) &gt; 0">
+              <xsl:text> (</xsl:text>
+              <xsl:value-of select="/report/host[ip=$host]/detail[name='hostname']/value/text()"/>
+              <xsl:text>)</xsl:text>
+            </xsl:when>
+          </xsl:choose>
+        </td>
+        <td>
+          <xsl:text>SNMP</xsl:text>
+        </td>
+        <td>
+          <xsl:text>Failure</xsl:text>
+        </td>
+        <td>
+          <xsl:value-of select="value/text()"/>
+        </td>
+      </tr>
+    </xsl:for-each>
   </xsl:template>
 
   <xsl:template match="report">

--- a/src/report_formats/LaTeX/latex.xsl
+++ b/src/report_formats/LaTeX/latex.xsl
@@ -697,6 +697,40 @@ advice given in each description, in order to rectify the issue.
       <xsl:text> &amp; </xsl:text>
       <xsl:value-of select="value/text()"/>\\ \hline
     </xsl:for-each>
+    <xsl:for-each select="/report/host[ip=$host]/detail[name='Auth-SNMP-Success']">
+      <xsl:value-of select="$host"/>
+      <xsl:choose>
+        <xsl:when test="string-length(/report/host[ip=$host]/detail[name='hostname']/value) &gt; 0">
+          <xsl:text> - </xsl:text>
+          <xsl:call-template name="escape_text">
+            <xsl:with-param name="string" select="/report/host[ip=$host]/detail[name='hostname']/value/text()"/>
+          </xsl:call-template>
+        </xsl:when>
+      </xsl:choose>
+      <xsl:text> &amp; </xsl:text>
+      <xsl:text>SNMP</xsl:text>
+      <xsl:text> &amp; </xsl:text>
+      <xsl:text>Success</xsl:text>
+      <xsl:text> &amp; </xsl:text>
+      <xsl:value-of select="value/text()"/>\\ \hline
+    </xsl:for-each>
+    <xsl:for-each select="/report/host[ip=$host]/detail[name='Auth-SNMP-Failure']">
+      <xsl:value-of select="$host"/>
+      <xsl:choose>
+        <xsl:when test="string-length(/report/host[ip=$host]/detail[name='hostname']/value) &gt; 0">
+          <xsl:text> - </xsl:text>
+          <xsl:call-template name="escape_text">
+            <xsl:with-param name="string" select="/report/host[ip=$host]/detail[name='hostname']/value/text()"/>
+          </xsl:call-template>
+        </xsl:when>
+      </xsl:choose>
+      <xsl:text> &amp; </xsl:text>
+      <xsl:text>SNMP</xsl:text>
+      <xsl:text> &amp; </xsl:text>
+      <xsl:text>Failure</xsl:text>
+      <xsl:text> &amp; </xsl:text>
+      <xsl:value-of select="value/text()"/>\\ \hline
+    </xsl:for-each>
   </xsl:template>
 
   <!-- The Results Overview section. -->


### PR DESCRIPTION
…formats.

Those HostDetails are now sent by snmp_detect.nasl (OID: 1.3.6.1.4.1.25623.1.0.10265)

References:

https://github.com/greenbone/gsa/commit/37de0c1eed7e1061e8811cdacae80657213e04f1
https://github.com/greenbone/gsa/pull/1139
https://github.com/greenbone/gvmd/pull/346