### PR TITLE
[7.0] Add handling of Auth-SNMP-(Success|Failure) to HTML and LaTeX report …

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,8 @@ Main changes since 7.0.3:
   SMB alerts.
 * Missing data in credentials no longer prevents slave tasks from starting.
   Instead the scan will start without the credential.
+* Handling of failed/successful SNMP Authentication has been added to the
+  HTML and LaTeX report formats.
 
 openvas-manager 7.0.3 (2018-03-29)
 

--- a/src/report_formats/HTML/HTML.xsl
+++ b/src/report_formats/HTML/HTML.xsl
@@ -883,6 +883,52 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         </td>
       </tr>
     </xsl:for-each>
+    <xsl:for-each select="/report/host[ip=$host]/detail[name='Auth-SNMP-Success']">
+      <tr>
+        <td>
+          <xsl:value-of select="$host"/>
+          <xsl:choose>
+            <xsl:when test="string-length(/report/host[ip=$host]/detail[name='hostname']/value) &gt; 0">
+              <xsl:text> (</xsl:text>
+              <xsl:value-of select="/report/host[ip=$host]/detail[name='hostname']/value/text()"/>
+              <xsl:text>)</xsl:text>
+            </xsl:when>
+          </xsl:choose>
+        </td>
+        <td>
+          <xsl:text>SNMP</xsl:text>
+        </td>
+        <td>
+          <xsl:text>Success</xsl:text>
+        </td>
+        <td>
+          <xsl:value-of select="value/text()"/>
+        </td>
+      </tr>
+    </xsl:for-each>
+    <xsl:for-each select="/report/host[ip=$host]/detail[name='Auth-SNMP-Failure']">
+      <tr>
+        <td>
+          <xsl:value-of select="$host"/>
+          <xsl:choose>
+            <xsl:when test="string-length(/report/host[ip=$host]/detail[name='hostname']/value) &gt; 0">
+              <xsl:text> (</xsl:text>
+              <xsl:value-of select="/report/host[ip=$host]/detail[name='hostname']/value/text()"/>
+              <xsl:text>)</xsl:text>
+            </xsl:when>
+          </xsl:choose>
+        </td>
+        <td>
+          <xsl:text>SNMP</xsl:text>
+        </td>
+        <td>
+          <xsl:text>Failure</xsl:text>
+        </td>
+        <td>
+          <xsl:value-of select="value/text()"/>
+        </td>
+      </tr>
+    </xsl:for-each>
   </xsl:template>
 
   <xsl:template match="report">

--- a/src/report_formats/LaTeX/latex.xsl
+++ b/src/report_formats/LaTeX/latex.xsl
@@ -730,6 +730,40 @@ advice given in each description, in order to rectify the issue.
       <xsl:text> &amp; </xsl:text>
       <xsl:value-of select="value/text()"/>\\ \hline
     </xsl:for-each>
+    <xsl:for-each select="/report/host[ip=$host]/detail[name='Auth-SNMP-Success']">
+      <xsl:value-of select="$host"/>
+      <xsl:choose>
+        <xsl:when test="string-length(/report/host[ip=$host]/detail[name='hostname']/value) &gt; 0">
+          <xsl:text> - </xsl:text>
+          <xsl:call-template name="escape_text">
+            <xsl:with-param name="string" select="/report/host[ip=$host]/detail[name='hostname']/value/text()"/>
+          </xsl:call-template>
+        </xsl:when>
+      </xsl:choose>
+      <xsl:text> &amp; </xsl:text>
+      <xsl:text>SNMP</xsl:text>
+      <xsl:text> &amp; </xsl:text>
+      <xsl:text>Success</xsl:text>
+      <xsl:text> &amp; </xsl:text>
+      <xsl:value-of select="value/text()"/>\\ \hline
+    </xsl:for-each>
+    <xsl:for-each select="/report/host[ip=$host]/detail[name='Auth-SNMP-Failure']">
+      <xsl:value-of select="$host"/>
+      <xsl:choose>
+        <xsl:when test="string-length(/report/host[ip=$host]/detail[name='hostname']/value) &gt; 0">
+          <xsl:text> - </xsl:text>
+          <xsl:call-template name="escape_text">
+            <xsl:with-param name="string" select="/report/host[ip=$host]/detail[name='hostname']/value/text()"/>
+          </xsl:call-template>
+        </xsl:when>
+      </xsl:choose>
+      <xsl:text> &amp; </xsl:text>
+      <xsl:text>SNMP</xsl:text>
+      <xsl:text> &amp; </xsl:text>
+      <xsl:text>Failure</xsl:text>
+      <xsl:text> &amp; </xsl:text>
+      <xsl:value-of select="value/text()"/>\\ \hline
+    </xsl:for-each>
   </xsl:template>
 
   <!-- The Results Overview section. -->


### PR DESCRIPTION
…formats.

Backport of #345 to the openvas-manager-7.0 branch