### PR TITLE
Prevent Codecov from commenting on PRs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: off


### PR DESCRIPTION
These comments take up a lot of space on the PR, and result in extra
email.  We can see from the check results if the PR introduces a
coverage problem.