### PR TITLE
Add password credential for PKCS12 decryption in Sourcefire alert

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,8 @@ Main changes compared to gvm 8.0+beta2:
   Instead the scan will start without the credential.
 * Handling of failed/successful SNMP Authentication has been added to the
   HTML and LaTeX report formats.
+* A new password-only credential type has been added
+* The Sourcefire alert now accepts a password credential for PKCS12 decryption.
 
 
 gvmd 8.0+beta2 (2018-12-05)

--- a/src/alert_methods/Sourcefire/alert
+++ b/src/alert_methods/Sourcefire/alert
@@ -19,6 +19,6 @@
 
 # Escalator method script: Sourcefire connector.
 
-greenbone_sourcefire_connector -server=$1 -port=$2 -pkcs12=$3 $4
+greenbone_sourcefire_connector -server=$1 -port=$2 -pkcs12=$3 -password="\"$5\"" $4
 EXIT_CODE=$?
 exit $EXIT_CODE

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -21997,7 +21997,7 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                     SEND_TO_CLIENT_OR_FAIL
                      (XML_ERROR_SYNTAX ("create_alert",
                                         "Sourcefire credential must have"
-                                        " type 'up'"));
+                                        " type 'pw' or 'up'"));
                     log_event_fail ("alert", "Alert", NULL, "created");
                     break;
                   case 99:

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -21983,6 +21983,23 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                                         " type 'up'"));
                     log_event_fail ("alert", "Alert", NULL, "created");
                     break;
+                  case 80:
+                    {
+                      SEND_TO_CLIENT_OR_FAIL
+                        ("<create_alert_response"
+                         " status=\"" STATUS_ERROR_MISSING "\""
+                         " status_text=\"Credential for Sourcefire"
+                         " PKCS12 password not found\"/>");
+                      log_event_fail ("alert", "Alert", NULL, "created");
+                    }
+                    break;
+                  case 81:
+                    SEND_TO_CLIENT_OR_FAIL
+                     (XML_ERROR_SYNTAX ("create_alert",
+                                        "Sourcefire credential must have"
+                                        " type 'up'"));
+                    log_event_fail ("alert", "Alert", NULL, "created");
+                    break;
                   case 99:
                     SEND_TO_CLIENT_OR_FAIL
                      (XML_ERROR_SYNTAX ("create_alert",
@@ -25652,6 +25669,23 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                                      "vFire credential must have"
                                      " type 'up'"));
                 log_event_fail ("alert", "Alert", NULL, "created");
+                break;
+              case 80:
+                {
+                  SEND_TO_CLIENT_OR_FAIL
+                     ("<create_alert_response"
+                      " status=\"" STATUS_ERROR_MISSING "\""
+                      " status_text=\"Credential for Sourcefire"
+                      " PKCS12 password not found\"/>");
+                  log_event_fail ("alert", "Alert", NULL, "modified");
+                }
+                break;
+              case 81:
+                SEND_TO_CLIENT_OR_FAIL
+                   (XML_ERROR_SYNTAX ("create_alert",
+                                      "Sourcefire credential must have"
+                                      " type 'up'"));
+                log_event_fail ("alert", "Alert", NULL, "modified");
                 break;
               case 99:
                 SEND_TO_CLIENT_OR_FAIL

--- a/src/manage.c
+++ b/src/manage.c
@@ -6130,6 +6130,8 @@ credential_full_type (const char* abbreviation)
     return NULL;
   else if (strcasecmp (abbreviation, "cc") == 0)
     return "client certificate";
+  else if (strcasecmp (abbreviation, "pw") == 0)
+    return "password only";
   else if (strcasecmp (abbreviation, "snmp") == 0)
     return "SNMP";
   else if (strcasecmp (abbreviation, "up") == 0)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -7469,7 +7469,8 @@ validate_sourcefire_data (alert_method_t method, const gchar *name,
             {
               char *sourcefire_credential_type;
               sourcefire_credential_type = credential_type (credential);
-              if (strcmp (sourcefire_credential_type, "up"))
+              if (strcmp (sourcefire_credential_type, "up")
+                  && strcmp (sourcefire_credential_type, "pw"))
                 {
                   free (sourcefire_credential_type);
                   return 81;
@@ -41123,6 +41124,7 @@ create_credential (const char* name, const char* comment, const char* login,
     {
       if (strcmp (given_type, "cc")
           && strcmp (given_type, "pgp")
+          && strcmp (given_type, "pw")
           && strcmp (given_type, "snmp")
           && strcmp (given_type, "smime")
           && strcmp (given_type, "up")
@@ -41167,12 +41169,14 @@ create_credential (const char* name, const char* comment, const char* login,
   if (login == NULL
       && strcmp (quoted_type, "cc")
       && strcmp (quoted_type, "pgp")
+      && strcmp (quoted_type, "pw")
       && strcmp (quoted_type, "smime")
       && strcmp (quoted_type, "snmp"))
     ret = 5;
   else if (given_password == NULL && auto_generate == 0
-           && strcmp (quoted_type, "up") == 0)
-      // username password requires a password
+           && (strcmp (quoted_type, "up") == 0
+               || strcmp (quoted_type, "pw") == 0))
+      // (username) password requires a password
     ret = 6;
   else if (key_private == NULL && auto_generate == 0
            && (strcmp (quoted_type, "cc") == 0
@@ -41776,7 +41780,8 @@ modify_credential (const char *credential_id,
                                         key_private_to_use,
                                         NULL);
         }
-      else if (strcmp (type, "up") == 0)
+      else if (strcmp (type, "up") == 0
+               || strcmp (type, "pw") == 0)
         {
           if (password)
             set_credential_password (credential, password);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -7443,6 +7443,46 @@ validate_vfire_data (alert_method_t method, const gchar *name,
 }
 
 /**
+ * @brief Validate method data for the Sourcefire method.
+ *
+ * @param[in]  method          Method that data corresponds to.
+ * @param[in]  name            Name of data.
+ * @param[in]  data            The data.
+ *
+ * @return 0 valid, 80 credential not found, 81 invalid credential type
+ */
+static int
+validate_sourcefire_data (alert_method_t method, const gchar *name,
+                          gchar **data)
+{
+  if (method == ALERT_METHOD_SOURCEFIRE)
+    {
+      if (strcmp (name, "pkcs12_credential") == 0)
+        {
+          credential_t credential;
+          if (find_credential_with_permission (*data, &credential,
+                                               "get_credentials"))
+            return -1;
+          else if (credential == 0)
+            return 80;
+          else
+            {
+              char *sourcefire_credential_type;
+              sourcefire_credential_type = credential_type (credential);
+              if (strcmp (sourcefire_credential_type, "up"))
+                {
+                  free (sourcefire_credential_type);
+                  return 81;
+                }
+              free (sourcefire_credential_type);
+            }
+        }
+    }
+
+  return 0;
+}
+
+/**
  * @brief Check alert params.
  *
  * @param[in]  event           Type of event.
@@ -7703,6 +7743,15 @@ create_alert (const char* name, const char* comment, const char* filter_id,
         }
 
       ret = validate_smb_data (method, data_name, &data);
+      if (ret)
+        {
+          g_free (data_name);
+          g_free (data);
+          sql_rollback ();
+          return ret;
+        }
+
+      ret = validate_sourcefire_data (method, data_name, &data);
       if (ret)
         {
           g_free (data_name);
@@ -10183,19 +10232,20 @@ smb_send_to_host (const char *password, const char *username,
 /**
  * @brief Send a report to a Sourcefire Defense Center.
  *
- * @param[in]  ip         IP of center.
- * @param[in]  port       Port of center.
- * @param[in]  pkcs12_64  PKCS12 content in base64.
- * @param[in]  report     Report in "Sourcefire" format.
+ * @param[in]  ip               IP of center.
+ * @param[in]  port             Port of center.
+ * @param[in]  pkcs12_64        PKCS12 content in base64.
+ * @param[in]  pkcs12_password  Password for encrypted PKCS12.
+ * @param[in]  report           Report in "Sourcefire" format.
  *
  * @return 0 success, -1 error.
  */
 static int
 send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
-                    const char *report)
+                    const char *pkcs12_password, const char *report)
 {
   gchar *script, *script_dir;
-  gchar *report_file, *pkcs12_file, *pkcs12;
+  gchar *report_file, *pkcs12_file, *pkcs12, *clean_password;
   gchar *clean_ip, *clean_port;
   char report_dir[] = "/tmp/gvmd_escalate_XXXXXX";
   GError *error;
@@ -10248,6 +10298,8 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
       return -1;
     }
 
+  clean_password = g_shell_quote (pkcs12_password ? pkcs12_password : "");
+
   /* Setup file names. */
 
   script_dir = g_build_filename (GVMD_DATA_DIR,
@@ -10261,6 +10313,7 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
     {
       g_free (report_file);
       g_free (pkcs12_file);
+      g_free (clean_password);
       g_free (script);
       g_free (script_dir);
       return -1;
@@ -10281,6 +10334,7 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
                    strerror (errno));
         g_free (report_file);
         g_free (pkcs12_file);
+        g_free (clean_password);
         g_free (previous_dir);
         g_free (script);
         g_free (script_dir);
@@ -10294,6 +10348,7 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
                    strerror (errno));
         g_free (report_file);
         g_free (pkcs12_file);
+        g_free (clean_password);
         g_free (previous_dir);
         g_free (script);
         g_free (script_dir);
@@ -10306,16 +10361,18 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
     clean_ip = g_shell_quote (ip);
     clean_port = g_shell_quote (port);
 
-    command = g_strdup_printf ("%s %s %s %s %s > /dev/null"
+    command = g_strdup_printf ("%s %s %s %s %s %s > /dev/null"
                                " 2> /dev/null",
                                script,
                                clean_ip,
                                clean_port,
                                pkcs12_file,
-                               report_file);
+                               report_file,
+                               clean_password);
     g_free (script);
     g_free (clean_ip);
     g_free (clean_port);
+    g_free (clean_password);
 
     g_debug ("   command: %s", command);
 
@@ -13223,8 +13280,9 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
         }
       case ALERT_METHOD_SOURCEFIRE:
         {
-          char *ip, *port, *pkcs12;
-          gchar *report_content;
+          char *ip, *port, *pkcs12, *pkcs12_credential_id;
+          credential_t pkcs12_credential;
+          gchar *pkcs12_password, *report_content;
           gsize content_length;
           report_format_t report_format;
           int ret;
@@ -13257,17 +13315,51 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
           if (port == NULL)
             port = g_strdup ("8307");
           pkcs12 = alert_data (alert, "method", "pkcs12");
+          pkcs12_credential_id = alert_data (alert, "method",
+                                             "pkcs12_credential");
+
+          if (pkcs12_credential_id == NULL
+              || strcmp (pkcs12_credential_id, "") == 0)
+            {
+              pkcs12_password = g_strdup ("");
+            }
+          else if (find_credential_with_permission (pkcs12_credential_id,
+                                               &pkcs12_credential,
+                                               "get_credentials"))
+            {
+              g_free (ip);
+              g_free (port);
+              g_free (pkcs12);
+              g_free (pkcs12_credential_id);
+              return -1;
+            }
+          else if (pkcs12_credential == 0)
+            {
+              g_free (ip);
+              g_free (port);
+              g_free (pkcs12);
+              g_free (pkcs12_credential_id);
+              return -4;
+            }
+          else
+            {
+              g_free (pkcs12_credential_id);
+              pkcs12_password = credential_encrypted_value (pkcs12_credential,
+                                                            "password");
+            }
 
           g_debug ("  sourcefire   ip: %s", ip);
           g_debug ("  sourcefire port: %s", port);
           g_debug ("sourcefire pkcs12: %s", pkcs12);
 
-          ret = send_to_sourcefire (ip, port, pkcs12, report_content);
+          ret = send_to_sourcefire (ip, port, pkcs12, pkcs12_password,
+                                    report_content);
 
           free (ip);
           g_free (port);
           free (pkcs12);
           g_free (report_content);
+          g_free (pkcs12_password);
 
           return ret;
         }

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -4059,6 +4059,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <alts>
             <alt>cc</alt>
             <alt>pgp</alt>
+            <alt>pw</alt>
             <alt>smime</alt>
             <alt>snmp</alt>
             <alt>up</alt>
@@ -10784,6 +10785,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <pattern>
             <t>
               <alts>
+                <alt>cc</alt>
+                <alt>pgp</alt>
+                <alt>pw</alt>
+                <alt>smime</alt>
+                <alt>snmp</alt>
                 <alt>up</alt>
                 <alt>usk</alt>
               </alts>


### PR DESCRIPTION
* A new password-only credential type has been added
* The Sourcefire alert now accepts a password credential for PKCS12 decryption.
* CHANGES and GMP doc are updated accordingly