### PR TITLE
[7.0] Add password credential for PKCS12 decryption in Sourcefire alert

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,8 @@ Main changes since 7.0.3:
   Instead the scan will start without the credential.
 * Handling of failed/successful SNMP Authentication has been added to the
   HTML and LaTeX report formats.
+* A new password-only credential type has been added
+* The Sourcefire alert now accepts a password credential for PKCS12 decryption.
 
 openvas-manager 7.0.3 (2018-03-29)
 

--- a/src/alert_methods/Sourcefire/alert
+++ b/src/alert_methods/Sourcefire/alert
@@ -24,6 +24,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 
-greenbone_sourcefire_connector -server=$1 -port=$2 -pkcs12=$3 $4
+greenbone_sourcefire_connector -server=$1 -port=$2 -pkcs12=$3 -password="\"$5\"" $4
 EXIT_CODE=$?
 exit $EXIT_CODE

--- a/src/manage.c
+++ b/src/manage.c
@@ -6006,6 +6006,8 @@ credential_full_type (const char* abbreviation)
     return NULL;
   else if (strcasecmp (abbreviation, "cc") == 0)
     return "client certificate";
+  else if (strcasecmp (abbreviation, "pw") == 0)
+    return "password only";
   else if (strcasecmp (abbreviation, "snmp") == 0)
     return "SNMP";
   else if (strcasecmp (abbreviation, "up") == 0)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -7541,7 +7541,8 @@ validate_sourcefire_data (alert_method_t method, const gchar *name,
             {
               char *sourcefire_credential_type;
               sourcefire_credential_type = credential_type (credential);
-              if (strcmp (sourcefire_credential_type, "up"))
+              if (strcmp (sourcefire_credential_type, "up")
+                  && strcmp (sourcefire_credential_type, "pw"))
                 {
                   free (sourcefire_credential_type);
                   return 81;
@@ -42575,6 +42576,7 @@ create_credential (const char* name, const char* comment, const char* login,
   if (given_type && strcmp (given_type, ""))
     {
       if (strcmp (given_type, "cc")
+          && strcmp (given_type, "pw")
           && strcmp (given_type, "snmp")
           && strcmp (given_type, "up")
           && strcmp (given_type, "usk"))
@@ -42615,11 +42617,13 @@ create_credential (const char* name, const char* comment, const char* login,
 
   if (login == NULL
       && strcmp (quoted_type, "cc")
+      && strcmp (quoted_type, "pw")
       && strcmp (quoted_type, "snmp"))
     ret = 5;
   else if (given_password == NULL && auto_generate == 0
-           && strcmp (quoted_type, "up") == 0)
-      // username password requires a password
+           && (strcmp (quoted_type, "up") == 0
+               || strcmp (quoted_type, "pw") == 0))
+      // (username) password requires a password
     ret = 6;
   else if (key_private == NULL && auto_generate == 0
            && (strcmp (quoted_type, "cc") == 0
@@ -43207,7 +43211,8 @@ modify_credential (const char *credential_id,
                                         key_private_to_use,
                                         NULL);
         }
-      else if (strcmp (type, "up") == 0)
+      else if (strcmp (type, "up") == 0
+               || strcmp (type, "pw") == 0)
         {
           if (password)
             set_credential_password (credential, password);

--- a/src/omp.c
+++ b/src/omp.c
@@ -22250,6 +22250,23 @@ omp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                                         " type 'up'"));
                     log_event_fail ("alert", "Alert", NULL, "created");
                     break;
+                  case 80:
+                    {
+                      SEND_TO_CLIENT_OR_FAIL
+                        ("<create_alert_response"
+                         " status=\"" STATUS_ERROR_MISSING "\""
+                         " status_text=\"Credential for Sourcefire"
+                         " PKCS12 password not found\"/>");
+                      log_event_fail ("alert", "Alert", NULL, "created");
+                    }
+                    break;
+                  case 81:
+                    SEND_TO_CLIENT_OR_FAIL
+                     (XML_ERROR_SYNTAX ("create_alert",
+                                        "Sourcefire credential must have"
+                                        " type 'up'"));
+                    log_event_fail ("alert", "Alert", NULL, "created");
+                    break;
                   case 99:
                     SEND_TO_CLIENT_OR_FAIL
                      (XML_ERROR_SYNTAX ("create_alert",
@@ -25999,6 +26016,23 @@ omp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                                     "vFire credential must have"
                                     " type 'up'"));
                 log_event_fail ("alert", "Alert", NULL, "created");
+                break;
+              case 80:
+                {
+                  SEND_TO_CLIENT_OR_FAIL
+                     ("<create_alert_response"
+                      " status=\"" STATUS_ERROR_MISSING "\""
+                      " status_text=\"Credential for Sourcefire"
+                      " PKCS12 password not found\"/>");
+                  log_event_fail ("alert", "Alert", NULL, "modified");
+                }
+                break;
+              case 81:
+                SEND_TO_CLIENT_OR_FAIL
+                   (XML_ERROR_SYNTAX ("create_alert",
+                                      "Sourcefire credential must have"
+                                      " type 'up'"));
+                log_event_fail ("alert", "Alert", NULL, "modified");
                 break;
               case 99:
                 SEND_TO_CLIENT_OR_FAIL

--- a/src/omp.c
+++ b/src/omp.c
@@ -22264,7 +22264,7 @@ omp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                     SEND_TO_CLIENT_OR_FAIL
                      (XML_ERROR_SYNTAX ("create_alert",
                                         "Sourcefire credential must have"
-                                        " type 'up'"));
+                                        " type 'pw' or 'up'"));
                     log_event_fail ("alert", "Alert", NULL, "created");
                     break;
                   case 99:

--- a/src/schema_formats/XML/OMP.xml.in
+++ b/src/schema_formats/XML/OMP.xml.in
@@ -4050,6 +4050,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         <t>
           <alts>
             <alt>cc</alt>
+            <alt>pw</alt>
             <alt>snmp</alt>
             <alt>up</alt>
             <alt>usk</alt>
@@ -10583,6 +10584,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <pattern>
             <t>
               <alts>
+                <alt>cc</alt>
+                <alt>pgp</alt>
+                <alt>pw</alt>
+                <alt>smime</alt>
+                <alt>snmp</alt>
                 <alt>up</alt>
                 <alt>usk</alt>
               </alts>


### PR DESCRIPTION
This is a backport of #350
* A new password-only credential type has been added
* The Sourcefire alert now accepts a password credential for PKCS12 decryption.
* CHANGES and GMP doc are updated accordingly