### PR TITLE
Remove "pgp" credential type in GMP doc

### DIFF
--- a/src/schema_formats/XML/OMP.xml.in
+++ b/src/schema_formats/XML/OMP.xml.in
@@ -10585,7 +10585,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <t>
               <alts>
                 <alt>cc</alt>
-                <alt>pgp</alt>
                 <alt>pw</alt>
                 <alt>smime</alt>
                 <alt>snmp</alt>


### PR DESCRIPTION
This type is not available in version 7.0.