### PR TITLE
Init part fields as the handlers expect them to exist

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -6735,6 +6735,9 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
         else if (strcasecmp ("MODIFY_ALERT", element_name) == 0)
           {
             modify_alert_data->event_data = make_array ();
+
+            gvm_append_string (&modify_alert_data->part_data, "");
+            gvm_append_string (&modify_alert_data->part_name, "");
             gvm_append_string (&modify_alert_data->event, "");
             modify_alert_data->condition_data = make_array ();
             gvm_append_string (&modify_alert_data->condition, "");


### PR DESCRIPTION
This modifies MODIFY_ALERT.  CREATE_ALERT already does this.