### PR TITLE
Validate Sourcefire data in modify_credential [7.0]

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -8265,6 +8265,15 @@ modify_alert (const char *alert_id, const char *name, const char *comment,
               return ret;
             }
 
+          ret = validate_sourcefire_data (method, name, &data);
+          if (ret)
+            {
+              g_free (name);
+              g_free (data);
+              sql_rollback ();
+              return ret;
+            }
+
           ret = validate_tippingpoint_data (method, name, &data);
           if (ret)
             {


### PR DESCRIPTION
The validation was missing here and only done in create_credential.