### PR TITLE
Add case for TCP-SYN only alive test preferences (8.0)

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -2106,7 +2106,16 @@ send_alive_test_preferences (target_t target)
 
   if (sendf_to_server ("Ping Host[checkbox]:TCP ping tries also TCP-SYN ping"
                        " <|> %s\n",
-                       (alive_test & ALIVE_TEST_TCP_SYN_SERVICE)
+                       ((alive_test & ALIVE_TEST_TCP_SYN_SERVICE)
+                        && (alive_test & ALIVE_TEST_TCP_ACK_SERVICE))
+                        ? "yes"
+                        : "no"))
+    return -1;
+
+  if (sendf_to_server ("Ping Host[checkbox]:TCP ping tries only TCP-SYN ping"
+                       " <|> %s\n",
+                       ((alive_test & ALIVE_TEST_TCP_SYN_SERVICE)
+                        && !(alive_test & ALIVE_TEST_TCP_ACK_SERVICE))
                         ? "yes"
                         : "no"))
     return -1;


### PR DESCRIPTION
When the alive test of a target requests only TCP-SYN without TCP-ACK,
a "Ping Host" NVT preference is sent to use TCP-SYN only.