### PR TITLE
Nvt pref name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 205)
+set (GVMD_DATABASE_VERSION 206)
 
 set (GVMD_SCAP_DATABASE_VERSION 15)
 

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -10120,19 +10120,17 @@ void
 buffer_config_preference_xml (GString *buffer, iterator_t *prefs,
                               config_t config, int hide_passwords)
 {
-  char *real_name, *type, *value, *nvt;
+  char *real_name, *type, *value, *oid, *nvt = NULL;
   const char *default_value;
-  char *oid = NULL;
 
-  real_name = nvt_preference_iterator_real_name (prefs);
+  oid = nvt_preference_iterator_oid (prefs);
   type = nvt_preference_iterator_type (prefs);
-  value = nvt_preference_iterator_config_value (prefs, config);
-  nvt = nvt_preference_iterator_nvt (prefs);
-
+  real_name = nvt_preference_iterator_real_name (prefs);
   default_value = nvt_preference_iterator_value (prefs);
+  value = nvt_preference_iterator_config_value (prefs, config);
 
-  if (nvt) oid = nvt_oid (nvt);
-
+  if (oid)
+    nvt = nvt_name (oid);
   buffer_xml_append_printf (buffer,
                             "<preference>"
                             "<nvt oid=\"%s\"><name>%s</name></nvt>"
@@ -10189,11 +10187,11 @@ buffer_config_preference_xml (GString *buffer, iterator_t *prefs,
 
   buffer_xml_append_printf (buffer, "</preference>");
 
-  free (real_name);
-  free (type);
-  free (value);
-  free (nvt);
-  free (oid);
+  g_free (real_name);
+  g_free (type);
+  g_free (value);
+  g_free (nvt);
+  g_free (oid);
 }
 
 /**
@@ -15639,12 +15637,11 @@ handle_get_preferences (gmp_parser_t *gmp_parser, GError **error)
     }
   else
     {
-      char *nvt_name = manage_nvt_name (nvt);
+      char *nvt_oid = get_preferences_data->nvt_oid;
       SEND_TO_CLIENT_OR_FAIL ("<get_preferences_response"
                               " status=\"" STATUS_OK "\""
                               " status_text=\"" STATUS_OK_TEXT "\">");
-      init_nvt_preference_iterator (&prefs, nvt_name);
-      free (nvt_name);
+      init_nvt_preference_iterator (&prefs, nvt_oid);
       if (get_preferences_data->preference)
         while (next (&prefs))
           {

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -15648,11 +15648,11 @@ handle_get_preferences (gmp_parser_t *gmp_parser, GError **error)
       if (get_preferences_data->preference)
         while (next (&prefs))
           {
-            char *name = strstr (nvt_preference_iterator_name (&prefs), "]:");
-            if (name
-                && (strcmp (name + 2,
-                            get_preferences_data->preference)
-                    == 0))
+            char *name = strstr (nvt_preference_iterator_name (&prefs), ":");
+            if (name)
+              name = strstr (name + 1, ":");
+            if (name && (strcmp (name + 1, get_preferences_data->preference)
+                         == 0))
               {
                 GString *buffer = g_string_new ("");
                 buffer_config_preference_xml (buffer, &prefs, config, 1);

--- a/src/manage.c
+++ b/src/manage.c
@@ -1676,18 +1676,15 @@ send_config_preferences (config_t config, const char* section_name,
 
       if (pref_files)
         {
-          int type_start = -1, type_end = -1, count;
-
+          char **splits;
+          int is_file = 0;
           /* OID:PrefType:PrefName value */
-          count = sscanf (pref_name, "%*[^:]:%n%*[^:]%n:", &type_start,
-                          &type_end);
-          if (count == 0
-              && type_start > 0
-              && type_end > 0
-              && (strncmp (pref_name + type_start,
-                           "file",
-                           type_end - type_start)
-                  == 0))
+          splits = g_strsplit (pref_name, ":", 3);
+          if (splits && g_strv_length (splits) == 3
+              && strcmp (splits[1], "file") == 0)
+            is_file = 1;
+          g_strfreev (splits);
+          if (is_file)
             {
               GSList *head;
               char *uuid;

--- a/src/manage.c
+++ b/src/manage.c
@@ -8237,7 +8237,7 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count,
       if (preferences)
         {
           iterator_t prefs;
-          const char *nvt_name = nvt_iterator_name (nvts);
+          const char *nvt_oid = nvt_iterator_oid (nvts);
 
           /* Send the preferences for the NVT. */
 
@@ -8248,7 +8248,7 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count,
                              timeout ? timeout : "",
                              default_timeout ? default_timeout : "");
 
-          init_nvt_preference_iterator (&prefs, nvt_name);
+          init_nvt_preference_iterator (&prefs, nvt_oid);
           while (next (&prefs))
             buffer_config_preference_xml (buffer, &prefs, config, 1);
           cleanup_iterator (&prefs);

--- a/src/manage.c
+++ b/src/manage.c
@@ -2097,14 +2097,14 @@ send_alive_test_preferences (target_t target)
   if (alive_test == 0)
     return 0;
 
-  if (sendf_to_server ("Ping Host[checkbox]:Do a TCP ping <|> %s\n",
+  if (sendf_to_server (OID_PING_HOST ":checkbox:Do a TCP ping <|> %s\n",
                        alive_test & ALIVE_TEST_TCP_ACK_SERVICE
                        || alive_test & ALIVE_TEST_TCP_SYN_SERVICE
                         ? "yes"
                         : "no"))
     return -1;
 
-  if (sendf_to_server ("Ping Host[checkbox]:TCP ping tries also TCP-SYN ping"
+  if (sendf_to_server (OID_PING_HOST ":checkbox:TCP ping tries also TCP-SYN ping"
                        " <|> %s\n",
                        ((alive_test & ALIVE_TEST_TCP_SYN_SERVICE)
                         && (alive_test & ALIVE_TEST_TCP_ACK_SERVICE))
@@ -2112,7 +2112,7 @@ send_alive_test_preferences (target_t target)
                         : "no"))
     return -1;
 
-  if (sendf_to_server ("Ping Host[checkbox]:TCP ping tries only TCP-SYN ping"
+  if (sendf_to_server (OID_PING_HOST ":checkbox:TCP ping tries only TCP-SYN ping"
                        " <|> %s\n",
                        ((alive_test & ALIVE_TEST_TCP_SYN_SERVICE)
                         && !(alive_test & ALIVE_TEST_TCP_ACK_SERVICE))
@@ -2120,19 +2120,19 @@ send_alive_test_preferences (target_t target)
                         : "no"))
     return -1;
 
-  if (sendf_to_server ("Ping Host[checkbox]:Do an ICMP ping <|> %s\n",
+  if (sendf_to_server (OID_PING_HOST ":checkbox:Do an ICMP ping <|> %s\n",
                        (alive_test & ALIVE_TEST_ICMP)
                         ? "yes"
                         : "no"))
     return -1;
 
-  if (sendf_to_server ("Ping Host[checkbox]:Use ARP <|> %s\n",
+  if (sendf_to_server (OID_PING_HOST ":checkbox:Use ARP <|> %s\n",
                        (alive_test & ALIVE_TEST_ARP)
                         ? "yes"
                         : "no"))
     return -1;
 
-  if (sendf_to_server ("Ping Host[checkbox]:"
+  if (sendf_to_server (OID_PING_HOST ":checkbox:"
                        "Mark unrechable Hosts as dead (not scanning) <|> %s\n",
                        (alive_test & ALIVE_TEST_CONSIDER_ALIVE)
                         ? "no"
@@ -2142,7 +2142,7 @@ send_alive_test_preferences (target_t target)
   if (alive_test == ALIVE_TEST_CONSIDER_ALIVE)
     {
       /* Also select a method, otherwise Ping Host logs a warning. */
-      if (sendf_to_server ("Ping Host[checkbox]:Do a TCP ping <|> yes\n"))
+      if (sendf_to_server (OID_PING_HOST ":checkbox:Do a TCP ping <|> yes\n"))
         return -1;
     }
 
@@ -5357,15 +5357,15 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
           const char *user = credential_iterator_login (&credentials);
           const char *password = credential_iterator_password (&credentials);
 
-          if (sendf_to_server ("SSH Authorization[entry]:SSH login name:"
+          if (sendf_to_server (OID_SSH_AUTH ":entry:SSH login name:"
                                " <|> %s\n",
                                user ? user : "")
               || (credential_iterator_private_key (&credentials)
-                   ? sendf_to_server ("SSH Authorization[password]:"
+                   ? sendf_to_server (OID_SSH_AUTH ":password:"
                                       "SSH key passphrase:"
                                       " <|> %s\n",
                                       password ? password : "")
-                   : sendf_to_server ("SSH Authorization[password]:"
+                   : sendf_to_server (OID_SSH_AUTH ":password:"
                                       "SSH password (unsafe!):"
                                       " <|> %s\n",
                                       password ? password : "")))
@@ -5396,8 +5396,7 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
                 (gpointer) g_strdup (credential_iterator_private_key
                                       (&credentials)));
 
-              if (sendf_to_server ("SSH Authorization[file]:"
-                                   "SSH private key:"
+              if (sendf_to_server (OID_SSH_AUTH ":file:SSH private key:"
                                    " <|> %s\n",
                                    file_uuid))
                 goto fail;
@@ -5416,9 +5415,9 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
           const char *user = credential_iterator_login (&credentials);
           const char *password = credential_iterator_password (&credentials);
 
-          if (sendf_to_server ("SMB Authorization[entry]:SMB login: <|> %s\n",
+          if (sendf_to_server (OID_SMB_AUTH ":entry:SMB login: <|> %s\n",
                                user ? user : "")
-              || sendf_to_server ("SMB Authorization[password]:SMB password:"
+              || sendf_to_server (OID_SMB_AUTH ":password:SMB password:"
                                   " <|> %s\n",
                                   password ? password : ""))
             {
@@ -5447,10 +5446,10 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
           const char *user = credential_iterator_login (&credentials);
           const char *password = credential_iterator_password (&credentials);
 
-          if (sendf_to_server ("ESXi Authorization[entry]:ESXi login name:"
+          if (sendf_to_server (OID_ESXI_AUTH ":entry:ESXi login name:"
                                " <|> %s\n",
                                user ? user : "")
-              || sendf_to_server ("ESXi Authorization[password]:ESXi login password:"
+              || sendf_to_server (OID_ESXI_AUTH ":password:ESXi login password:"
                                   " <|> %s\n",
                                   password ? password : ""))
             {
@@ -5486,25 +5485,25 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
           const char *privacy_algorithm
             = credential_iterator_privacy_algorithm (&credentials);
 
-          if (sendf_to_server ("SNMP Authorization[password]:SNMP Community:"
+          if (sendf_to_server (OID_SNMP_AUTH ":password:SNMP Community:"
                                " <|> %s\n",
                                community ? community : "")
-              || sendf_to_server ("SNMP Authorization[entry]:SNMPv3 Username:"
+              || sendf_to_server (OID_SNMP_AUTH ":entry:SNMPv3 Username:"
                                   " <|> %s\n",
                                   user ? user : "")
-              || sendf_to_server ("SNMP Authorization[password]:"
+              || sendf_to_server (OID_SNMP_AUTH ":password:"
                                   "SNMPv3 Password:"
                                   " <|> %s\n",
                                   password ? password : "")
-              || sendf_to_server ("SNMP Authorization[radio]:"
+              || sendf_to_server (OID_SNMP_AUTH ":radio:"
                                   "SNMPv3 Authentication Algorithm:"
                                   " <|> %s\n",
                                   auth_algorithm ? auth_algorithm : "")
-              || sendf_to_server ("SNMP Authorization[password]:"
+              || sendf_to_server (OID_SNMP_AUTH ":password:"
                                   "SNMPv3 Privacy Password:"
                                   " <|> %s\n",
                                   privacy_password ? privacy_password : "")
-              || sendf_to_server ("SNMP Authorization[radio]:"
+              || sendf_to_server (OID_SNMP_AUTH ":radio:"
                                   "SNMPv3 Privacy Algorithm:"
                                   " <|> %s\n",
                                   privacy_algorithm ? privacy_algorithm : ""))

--- a/src/manage.c
+++ b/src/manage.c
@@ -1621,10 +1621,10 @@ nvt_selector_plugins (config_t config)
 static gchar*
 preference_value (const char* name, const char* full_value)
 {
-  char *bracket = strchr (name, '[');
+  char *bracket = strchr (name, ':');
   if (bracket)
     {
-      if (strncmp (bracket, "[radio]:", strlen ("[radio]:")) == 0)
+      if (strncmp (bracket, ":radio:", strlen (":radio:")) == 0)
         {
           char *semicolon = strchr (full_value, ';');
           if (semicolon)
@@ -1678,8 +1678,8 @@ send_config_preferences (config_t config, const char* section_name,
         {
           int type_start = -1, type_end = -1, count;
 
-          /* LDAPsearch[entry]:Timeout value */
-          count = sscanf (pref_name, "%*[^[][%n%*[^]]%n]:", &type_start,
+          /* OID:PrefType:PrefName value */
+          count = sscanf (pref_name, "%*[^:]:%n%*[^:]%n:", &type_start,
                           &type_end);
           if (count == 0
               && type_start > 0

--- a/src/manage.h
+++ b/src/manage.h
@@ -40,6 +40,47 @@
 #include <gvm/osp/osp.h>          /* for osp_connection_t */
 
 
+
+/**
+ * @brief OID of ping_host.nasl
+ */
+#define OID_PING_HOST "1.3.6.1.4.1.25623.1.0.100315"
+
+/**
+ * @brief OID of ssh_authorization_init.nasl
+ */
+#define OID_SSH_AUTH "1.3.6.1.4.1.25623.1.0.103591"
+
+/**
+ * @brief OID of smb_authorization.nasl
+ */
+#define OID_SMB_AUTH "1.3.6.1.4.1.25623.1.0.90023"
+
+/**
+ * @brief OID of gb_esxi_authorization.nasl
+ */
+#define OID_ESXI_AUTH "1.3.6.1.4.1.25623.1.0.105058"
+
+/**
+ * @brief OID of gb_snmp_authorization.nasl
+ */
+#define OID_SNMP_AUTH "1.3.6.1.4.1.25623.1.0.105076"
+
+/**
+ * @brief OID of find_services.nasl
+ */
+#define OID_SERVICES "1.3.6.1.4.1.25623.1.0.10330"
+
+/**
+ * @brief OID of logins.nasl
+ */
+#define OID_LOGINS "1.3.6.1.4.1.25623.1.0.10870"
+
+/**
+ * @brief OID of global_settings.nasl
+ */
+#define OID_GLOBAL_SETTINGS "1.3.6.1.4.1.25623.1.0.12288"
+
 /**
  * @brief Flag with all Glib log levels.
  */

--- a/src/manage.h
+++ b/src/manage.h
@@ -1942,7 +1942,7 @@ char *
 manage_nvt_name (nvt_t);
 
 char *
-nvt_oid (const char *);
+nvt_name (const char *);
 
 char*
 nvts_feed_version ();
@@ -2101,7 +2101,7 @@ char*
 nvt_preference_iterator_type (iterator_t*);
 
 char*
-nvt_preference_iterator_nvt (iterator_t*);
+nvt_preference_iterator_oid (iterator_t*);
 
 int
 nvt_preference_count (const char *);

--- a/src/manage_config_discovery.c
+++ b/src/manage_config_discovery.c
@@ -941,13 +941,13 @@ make_config_discovery (char *const uuid, char *const selector_name)
   sql ("INSERT INTO config_preferences (config, type, name, value)"
        " VALUES ((SELECT id FROM configs WHERE uuid = '%s'),"
        "         'PLUGINS_PREFS',"
-       "         'Ping Host[checkbox]:Mark unrechable Hosts as dead (not scanning)',"
+       "         '" OID_PING_HOST ":checkbox:Mark unrechable Hosts as dead (not scanning)',"
        " 'yes');",
        uuid);
   sql ("INSERT INTO config_preferences (config, type, name, value)"
        " VALUES ((SELECT id FROM configs WHERE uuid = '%s'),"
        "         'PLUGINS_PREFS',"
-       "         'Ping Host[checkbox]:Report about unrechable Hosts',"
+       "         '" OID_PING_HOST ":checkbox:Report about unrechable Hosts',"
        "         'no');",
        uuid);
 
@@ -955,7 +955,7 @@ make_config_discovery (char *const uuid, char *const selector_name)
   sql ("INSERT INTO config_preferences (config, type, name, value)"
        " VALUES ((SELECT id FROM configs WHERE uuid = '%s'),"
        "         'PLUGINS_PREFS',"
-       "         'Services[radio]:Test SSL based services',"
+       "         '" OID_SERVICES ":radio:Test SSL based services',"
        "         'All;Known SSL ports;None');",
        uuid);
 }
@@ -975,7 +975,7 @@ check_config_discovery (const char *uuid)
   sql ("UPDATE config_preferences SET value = 'no'"
        " WHERE config = (SELECT id FROM configs WHERE uuid = '%s')"
        " AND type = 'PLUGINS_PREFS'"
-       " AND name = 'Ping Host[checkbox]:Report about unrechable Hosts'"
+       " AND name = '" OID_PING_HOST ":checkbox:Report about unrechable Hosts'"
        " AND value = 'yes';",
        uuid);
 

--- a/src/manage_config_host_discovery.c
+++ b/src/manage_config_host_discovery.c
@@ -84,29 +84,24 @@ make_config_host_discovery (char *const uuid, char *const selector_name)
   sql ("INSERT INTO config_preferences (config, type, name, value)"
        " VALUES (%llu,"
        "         'PLUGINS_PREFS',"
-       "         'Ping Host[checkbox]:Mark unrechable Hosts as dead (not scanning)',"
+       "         '" OID_PING_HOST ":checkbox:Mark unrechable Hosts as dead (not scanning)',"
        "         'yes');",
        config);
 
   sql ("INSERT INTO config_preferences (config, type, name, value)"
        " VALUES (%llu,"
        "         'PLUGINS_PREFS',"
-       "         'Ping Host[checkbox]:Report about reachable Hosts',"
+       "         '" OID_PING_HOST ":checkbox:Report about reachable Hosts',"
        "         'yes');",
        config);
 
   sql ("INSERT INTO config_preferences (config, type, name, value)"
        " VALUES (%llu,"
        "         'PLUGINS_PREFS',"
-       "         'Ping Host[checkbox]:Report about unrechable Hosts',"
+       "         '" OID_PING_HOST ":checkbox:Report about unrechable Hosts',"
        "         'no');",
        config);
 }
-
-/**
- * @brief Preference name.
- */
-#define NAME "Global variable settings[checkbox]:Strictly unauthenticated"
 
 /**
  * @brief Ensure the Host Discovery config is up to date.
@@ -127,14 +122,14 @@ check_config_host_discovery (const char *uuid)
   if (sql_int ("SELECT count (*) FROM config_preferences"
                " WHERE config = (SELECT id FROM configs WHERE uuid = '%s')"
                "       AND type = 'PLUGINS_PREFS'"
-               "       AND name = '" NAME "';",
+               "       AND name = '" OID_GLOBAL_SETTINGS ":checkbox:Strictly unauthenticated';",
                uuid)
       == 0)
     {
       sql ("INSERT INTO config_preferences (config, type, name, value)"
            " VALUES ((SELECT id FROM configs WHERE uuid = '%s'),"
            "         'PLUGINS_PREFS',"
-           "         '" NAME "',"
+           "         '" OID_GLOBAL_SETTINGS ":checkbox:Strictly unauthenticated',"
            "         'yes');",
            uuid);
       update = 1;

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -15161,6 +15161,109 @@ migrate_204_to_205 ()
   return 0;
 }
 
+/**
+ * @brief Converts old NVT preferences to the new format.
+ *
+ * @param[in]  table_name  The name of the table to update.
+ */
+static void
+replace_preference_names_205_to_206 (const char *table_name)
+{
+  iterator_t preferences;
+
+  init_iterator (&preferences,
+                 "SELECT id, name"
+                 " FROM \"%s\""
+                 " WHERE name LIKE '%%[%%]:%%';",
+                 table_name);
+
+  while (next (&preferences))
+    {
+      resource_t rowid;
+      const char *old_name;
+      char *start, *end;
+      gchar *nvt_name, *type, *preference;
+      char *oid, *new_name, *quoted_nvt_name, *quoted_new_name;
+
+      rowid = iterator_int64 (&preferences, 0);
+      old_name = iterator_string (&preferences, 1);
+
+      // Text before first "["
+      end = strstr (old_name, "[");
+      nvt_name = g_strndup (old_name, end - old_name);
+      // Text between first "[" and first "]"
+      start = end + 1;
+      end = strstr (start, "]");
+      type = g_strndup (start, end - start);
+      // Text after first ":" after first "]"
+      start = strstr (end, ":") + 1;
+      preference = g_strdup (start);
+
+      // Find OID:
+      quoted_nvt_name = sql_quote (nvt_name);
+      oid = sql_string ("SELECT oid FROM nvts WHERE name = '%s';",
+                        quoted_nvt_name);
+
+      // Update
+      if (oid)
+        {
+          new_name = g_strdup_printf ("%s:%s:%s", oid, type, preference);
+          quoted_new_name = sql_quote (new_name);
+          sql ("UPDATE \"%s\" SET name = '%s' WHERE id = %llu",
+              table_name, quoted_new_name, rowid);
+        }
+      else
+        g_warning ("No NVT named '%s' found", nvt_name);
+
+      g_free (nvt_name);
+      g_free (quoted_nvt_name);
+      g_free (type);
+      g_free (preference);
+      free (oid);
+      g_free (new_name);
+      g_free (quoted_new_name);
+    }
+  cleanup_iterator (&preferences);
+}
+
+/**
+ * @brief Migrate the database from version 205 to version 206.
+ *
+ * @return 0 success, -1 error.
+ */
+int
+migrate_205_to_206 ()
+{
+  sql_begin_immediate ();
+
+  /* Ensure that the database is currently version 205. */
+
+  if (manage_db_version () != 205)
+    {
+      sql_rollback ();
+      return -1;
+    }
+
+  /* Update the database. */
+
+  /* Change NVT preferences to new style */
+  replace_preference_names_205_to_206 ("nvt_preferences");
+
+  /* Change config preferences to new style */
+  replace_preference_names_205_to_206 ("config_preferences");
+
+  /* Change trash config preferences to new style */
+  replace_preference_names_205_to_206 ("config_preferences_trash");
+
+  /* Set the database version to 206. */
+
+  set_db_version (206);
+
+  sql_commit ();
+
+  return 0;
+}
+
 #undef UPDATE_CHART_SETTINGS
 #undef UPDATE_DASHBOARD_SETTINGS
 
@@ -15384,7 +15487,8 @@ static migrator_t database_migrators[]
     {202, migrate_201_to_202},
     {203, migrate_202_to_203},
     {204, migrate_203_to_204},
-    {205, migrate_204_to_205},
+    {205, migrate_204_to_205}, // v8.0: rev 205
+    {206, migrate_205_to_206},
     /* End marker. */
     {-1, NULL}};
 

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -15213,7 +15213,11 @@ replace_preference_names_205_to_206 (const char *table_name)
               table_name, quoted_new_name, rowid);
         }
       else
-        g_warning ("No NVT named '%s' found", nvt_name);
+        {
+          new_name = NULL;
+          quoted_new_name = NULL;
+          g_warning ("No NVT named '%s' found", nvt_name);
+        }
 
       g_free (nvt_name);
       g_free (quoted_nvt_name);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -15404,12 +15404,12 @@ setup_full_config_prefs (config_t config, int safe_checks,
 
   sql ("INSERT into config_preferences (config, type, name, value)"
        " VALUES (%i, 'PLUGINS_PREFS',"
-       " 'Ping Host[checkbox]:Mark unrechable Hosts as dead (not scanning)',"
+       " '" OID_PING_HOST ":checkbox:Mark unrechable Hosts as dead (not scanning)',"
        " 'yes');",
        config);
   sql ("INSERT into config_preferences (config, type, name, value)"
        " VALUES (%i, 'PLUGINS_PREFS',"
-       " 'Login configurations[checkbox]:NTLMSSP',"
+       " '" OID_LOGINS ":checkbox:NTLMSSP',"
        " 'yes');",
        config);
 }

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -41069,17 +41069,17 @@ manage_nvt_preferences_enable ()
  * @brief Initialise an NVT preference iterator.
  *
  * @param[in]  iterator  Iterator.
- * @param[in]  name      Name of NVT, NULL for all preferences.
+ * @param[in]  oid       OID of NVT, NULL for all preferences.
  */
 void
-init_nvt_preference_iterator (iterator_t* iterator, const char *name)
+init_nvt_preference_iterator (iterator_t* iterator, const char *oid)
 {
-  if (name)
+  if (oid)
     {
-      gchar *quoted_name = sql_quote (name);
+      gchar *quoted_oid = sql_quote (oid);
       init_iterator (iterator,
                      "SELECT name, value FROM nvt_preferences"
-                     " WHERE name %s '%s[%%'"
+                     " WHERE name %s '%s:%%'"
                      " AND name != 'cache_folder'"
                      " AND name != 'include_folders'"
                      " AND name != 'nasl_no_signature_check'"
@@ -41092,10 +41092,10 @@ init_nvt_preference_iterator (iterator_t* iterator, const char *name)
                      " AND name != 'max_hosts'"
                      " ORDER BY name ASC",
                      sql_ilike_op (),
-                     quoted_name,
-                     quoted_name,
+                     quoted_oid,
+                     quoted_oid,
                      sql_ilike_op ());
-      g_free (quoted_name);
+      g_free (quoted_oid);
     }
   else
     init_iterator (iterator,
@@ -41146,19 +41146,16 @@ char*
 nvt_preference_iterator_real_name (iterator_t* iterator)
 {
   const char *ret;
+  char *real_name = NULL;
   if (iterator->done) return NULL;
   ret = iterator_string (iterator, 0);
   if (ret)
     {
-      int value_start = -1, value_end = -1, count;
-      /* OID:PrefType:PrefName value */
-      count = sscanf (ret, "%*[^:]:%*[^:]:%n%*[ -~]%n", &value_start, &value_end);
-      if (count == 0 && value_start > 0 && value_end > 0)
-        {
-          ret += value_start;
-          return g_strdup (ret);
-        }
-      return g_strdup (ret);
+      char **splits = g_strsplit (ret, ":", 3);
+      if (splits && g_strv_length (splits) == 3)
+        real_name = g_strdup (splits[2]);
+      g_strfreev (splits);
+      return real_name ?: g_strdup (ret);
     }
   return NULL;
 }
@@ -41174,18 +41171,16 @@ char*
 nvt_preference_iterator_type (iterator_t* iterator)
 {
   const char *ret;
+  char *type = NULL;
   if (iterator->done) return NULL;
   ret = iterator_string (iterator, 0);
   if (ret)
     {
-      int type_start = -1, type_end = -1, count;
-      count = sscanf (ret, "%*[^:]:%n%*[^:]%n:", &type_start, &type_end);
-      if (count == 0 && type_start > 0 && type_end > 0)
-        {
-          ret += type_start;
-          return g_strndup (ret, type_end - type_start);
-        }
-      return NULL;
+      char **splits = g_strsplit (ret, ":", 3);
+      if (splits && g_strv_length (splits) == 3)
+        type = g_strdup (splits[1]);
+      g_strfreev (splits);
+      return type ?: NULL;
     }
   return NULL;
 }
@@ -41198,20 +41193,19 @@ nvt_preference_iterator_type (iterator_t* iterator)
  * @return NVT.
  */
 char*
-nvt_preference_iterator_nvt (iterator_t* iterator)
+nvt_preference_iterator_oid (iterator_t* iterator)
 {
   const char *ret;
+  char *oid = NULL;
   if (iterator->done) return NULL;
   ret = iterator_string (iterator, 0);
   if (ret)
     {
-      int type_start = -1, count;
-      count = sscanf (ret, "%*[^:]%n:%*[^:]:", &type_start);
-      if (count == 0 && type_start > 0)
-        {
-          return g_strndup (ret, type_start);
-        }
-      return NULL;
+      char **splits = g_strsplit (ret, ":", 3);
+      if (splits && g_strv_length (splits) == 3)
+        oid = g_strdup (splits[0]);
+      g_strfreev (splits);
+      return oid ?: NULL;
     }
   return NULL;
 }

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -89,19 +89,19 @@ manage_nvt_name (nvt_t nvt)
 }
 
 /**
- * @brief Guess the OID of an NVT given a name.
+ * @brief Get the name of an NVT given its OID.
  *
- * @param[in]  name  Name of NVT.
+ * @param[in]  oid  OID of NVT.
  *
- * @return OID of NVT if possible, else NULL.
+ * @return Name of NVT if possible, else NULL.
  */
 char *
-nvt_oid (const char *name)
+nvt_name (const char *oid)
 {
-  gchar *quoted_name = sql_quote (name);
-  char *ret = sql_string ("SELECT oid FROM nvts WHERE name = '%s' LIMIT 1;",
-                          quoted_name);
-  g_free (quoted_name);
+  gchar *quoted_oid = sql_quote (oid);
+  char *ret = sql_string ("SELECT name FROM nvts WHERE oid = '%s' LIMIT 1;",
+                          quoted_oid);
+  g_free (quoted_oid);
   return ret;
 }
 

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -909,7 +909,7 @@ nvt_default_timeout (const char* oid)
   return sql_string ("SELECT value FROM nvt_preferences"
                      " WHERE name = (SELECT name FROM nvts"
                      "               WHERE oid = '%s')"
-                     "              || '[entry]:Timeout'",
+                     "              || ':entry:Timeout'",
                      oid);
 }
 

--- a/src/otp.c
+++ b/src/otp.c
@@ -1347,15 +1347,15 @@ process_otp_scanner_input ()
 
                   {
                     int value_start = -1, value_end = -1, count;
-                    char name[21];
-                    /* LDAPsearch[entry]:Timeout value */
-                    count = sscanf (field, "%20[^[][%*[^]]]:%n%*[ -~]%n",
+                    char name[128];
+                    /* OID:PrefType:PrefName value */
+                    count = sscanf (field, "%128[^:]:%*[^:]:%n%*[ -~]%n",
                                     name, &value_start, &value_end);
                     if (count == 1 && value_start > 0 && value_end > 0
-                        && ((strcmp (name, "SSH Authorization") == 0)
-                            || (strcmp (name, "SNMP Authorization") == 0)
-                            || (strcmp (name, "ESXi Authorization") == 0)
-                            || (strcmp (name, "SMB Authorization") == 0)))
+                        && ((strcmp (name, "1.3.6.1.4.1.25623.1.0.103591") == 0)
+                            || (strcmp (name, "1.3.6.1.4.1.25623.1.0.105076") == 0)
+                            || (strcmp (name, "1.3.6.1.4.1.25623.1.0.105058") == 0)
+                            || (strcmp (name, "1.3.6.1.4.1.25623.1.0.90023") == 0)))
                       current_scanner_preference = NULL;
                     else
                       current_scanner_preference = g_strdup (field);

--- a/src/otp.c
+++ b/src/otp.c
@@ -1352,10 +1352,10 @@ process_otp_scanner_input ()
                     count = sscanf (field, "%128[^:]:%*[^:]:%n%*[ -~]%n",
                                     name, &value_start, &value_end);
                     if (count == 1 && value_start > 0 && value_end > 0
-                        && ((strcmp (name, "1.3.6.1.4.1.25623.1.0.103591") == 0)
-                            || (strcmp (name, "1.3.6.1.4.1.25623.1.0.105076") == 0)
-                            || (strcmp (name, "1.3.6.1.4.1.25623.1.0.105058") == 0)
-                            || (strcmp (name, "1.3.6.1.4.1.25623.1.0.90023") == 0)))
+                        && ((strcmp (name, OID_SSH_AUTH) == 0)
+                            || (strcmp (name, OID_SNMP_AUTH) == 0)
+                            || (strcmp (name, OID_ESXI_AUTH) == 0)
+                            || (strcmp (name, OID_SMB_AUTH) == 0)))
                       current_scanner_preference = NULL;
                     else
                       current_scanner_preference = g_strdup (field);

--- a/src/otp.c
+++ b/src/otp.c
@@ -1346,19 +1346,19 @@ process_otp_scanner_input ()
                     }
 
                   {
-                    int value_start = -1, value_end = -1, count;
-                    char name[128];
+                    char **splits;
                     /* OID:PrefType:PrefName value */
-                    count = sscanf (field, "%128[^:]:%*[^:]:%n%*[ -~]%n",
-                                    name, &value_start, &value_end);
-                    if (count == 1 && value_start > 0 && value_end > 0
-                        && ((strcmp (name, OID_SSH_AUTH) == 0)
-                            || (strcmp (name, OID_SNMP_AUTH) == 0)
-                            || (strcmp (name, OID_ESXI_AUTH) == 0)
-                            || (strcmp (name, OID_SMB_AUTH) == 0)))
+
+                    splits = g_strsplit (field, ":", 3);
+                    if (splits && g_strv_length (splits) == 3
+                        && ((strcmp (splits[0], OID_SSH_AUTH) == 0)
+                            || (strcmp (splits[0], OID_SNMP_AUTH) == 0)
+                            || (strcmp (splits[0], OID_ESXI_AUTH) == 0)
+                            || (strcmp (splits[0], OID_SMB_AUTH) == 0)))
                       current_scanner_preference = NULL;
                     else
                       current_scanner_preference = g_strdup (field);
+                    g_strfreev (splits);
                     set_scanner_state (SCANNER_PREFERENCE_VALUE);
                     switch (parse_scanner_preference_value (&messages))
                       {

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -15531,7 +15531,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       <response>
         <get_preferences_response status="200" status_text="OK">
           <preference>
-            <name>Services[entry]:Network connection timeout :</name>
+            <name>1.3.6.1.4.1.25623.1.0.10330:entry:Network connection timeout :</name>
             <value>5</value>
           </preference>
           <truncated>...</truncated>
@@ -15547,7 +15547,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       <response>
         <get_preferences_response status="200" status_text="OK">
           <preference>
-            <name>Services[entry]:Network connection timeout :</name>
+            <name>1.3.6.1.4.1.25623.1.0.10330:entry:Network connection timeout :</name>
             <value>5</value>
             <default>5</default>
           </preference>
@@ -23773,7 +23773,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         <modify_config config_id="254cd3ef-bbe1-4d58-859d-21b8d0c046c6">
           <preference>
             <nvt oid="1.3.6.1.4.1.25623.1.0.14259"></nvt>
-            <name>Nmap (NASL wrapper)[checkbox]:UDP port scan</name>
+            <name>1.3.6.1.4.1.25623.1.0.14259:checkbox:UDP port scan</name>
             <value>eWVz</value>
           </preference>
         </modify_config>
@@ -23788,7 +23788,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       <request>
         <modify_config config_id="254cd3ef-bbe1-4d58-859d-21b8d0c046c6">
           <preference>
-            <name>scanner[scanner]:vhosts</name>
+            <name>scanner:scanner:vhosts</name>
             <value>ZXhhbXBsZQ==</value>
           </preference>
         </modify_config>


### PR DESCRIPTION
Change NVT preferences format to OID:PrefType:PrefName. This allows plugins to change their script names without breaking existing configs.

PR contains changes needed to be able to rebuild/update nvt's and run scans with https://github.com/greenbone/openvas-scanner/pull/275 using default configs (+ docmentation updates, changes I did on my way while grepping the code for hardcoded values etc,.)

Still needed:
- Migrators for existing scan configs.
- Code for pattern matching that uses sscanf() calls could be simplified and made more readable by using g_str_split(pref, ":", 2) instead, but I didn't want to make the PR more intrusive.