### PR TITLE
Add newline before body in included report emails (8.0)

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -9046,7 +9046,7 @@ email_write_content (FILE *content_file,
                    "Content-Type: multipart/mixed;"
                    " boundary=\""
                  : "Content-Type: text/plain; charset=utf-8\n"
-                   "Content-Transfer-Encoding: 8bit"),
+                   "Content-Transfer-Encoding: 8bit\n"),
                /* @todo Future callers may give email containing this string. */
                (attachment ? "=-=-=-=-=" : ""),
                (attachment ? "\"\n" : ""),


### PR DESCRIPTION
An empty line after the headers is required by RFC 5322 and was missing
for alerts including a report (rather than attaching the report).
This could cause problems for some email clients.