### PR TITLE
Clang format 8.0

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,44 @@
+---
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: 'false'
+AlignConsecutiveDeclarations: 'false'
+AlignEscapedNewlines: Left
+AlignOperands: 'true'
+AlignTrailingComments: 'true'
+AllowAllParametersOfDeclarationOnNextLine: 'false'
+AllowShortBlocksOnASingleLine: 'false'
+AllowShortCaseLabelsOnASingleLine: 'false'
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: 'false'
+AllowShortLoopsOnASingleLine: 'false'
+AlwaysBreakAfterReturnType: All
+AlwaysBreakBeforeMultilineStrings: 'false'
+BinPackArguments: 'true'
+BinPackParameters: 'true'
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: GNU
+BreakBeforeTernaryOperators: 'true'
+BreakStringLiterals: 'true'
+ColumnLimit: '80'
+ContinuationIndentWidth: '2'
+DerivePointerAlignment: 'false'
+IncludeBlocks: Regroup
+IndentCaseLabels: 'false'
+IndentWidth: '2'
+IndentWrappedFunctionNames: 'false'
+KeepEmptyLinesAtTheStartOfBlocks: 'false'
+Language: Cpp
+MaxEmptyLinesToKeep: '1'
+PointerAlignment: Right
+ReflowComments: 'true'
+SortIncludes: 'true'
+SpaceAfterCStyleCast: 'true'
+SpaceBeforeAssignmentOperators: 'true'
+SpaceBeforeParens: Always
+SpaceInEmptyParentheses: 'false'
+SpacesInCStyleCastParentheses: 'false'
+SpacesInParentheses: 'false'
+SpacesInSquareBrackets: 'false'
+UseTab: Never
+
+...

--- a/.clang-format
+++ b/.clang-format
@@ -13,7 +13,7 @@ AllowShortIfStatementsOnASingleLine: 'false'
 AllowShortLoopsOnASingleLine: 'false'
 AlwaysBreakAfterReturnType: All
 AlwaysBreakBeforeMultilineStrings: 'false'
-BinPackArguments: 'true'
+BinPackArguments: 'false'
 BinPackParameters: 'true'
 BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeBraces: GNU

--- a/.clang-format
+++ b/.clang-format
@@ -14,7 +14,7 @@ AllowShortLoopsOnASingleLine: 'false'
 AlwaysBreakAfterReturnType: All
 AlwaysBreakBeforeMultilineStrings: 'false'
 BinPackArguments: 'false'
-BinPackParameters: 'true'
+BinPackParameters: 'false'
 BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeBraces: GNU
 BreakBeforeTernaryOperators: 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,18 @@ if (NOT CMAKE_BUILD_TYPE MATCHES "Release")
   endif (EXISTS "${CMAKE_SOURCE_DIR}/.git/")
 endif (NOT CMAKE_BUILD_TYPE MATCHES "Release")
 
+## make format
+message (STATUS "Looking for clang-format...")
+find_program (CLANG_FORMAT clang-format)
+
+if (CLANG_FORMAT)
+  message (STATUS "Looking for clang-format... ${CLANG_FORMAT}")
+  add_custom_target(format COMMAND ${CLANG_FORMAT} "-i" "./src/*.c" "./src/*.h"
+                    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+else (CLANG_FORMAT)
+  message (STATUS "clang-format not found...")
+endif (CLANG_FORMAT)
+
 # Set beta version if this is a beta release series,
 # unset if this is a stable release series.
 set (PROJECT_BETA_RELEASE 4)

--- a/src/comm.c
+++ b/src/comm.c
@@ -100,7 +100,8 @@ sendn_to_server (const void *msg, size_t n)
   if (TO_SERVER_BUFFER_SIZE - to_server_end < n)
     {
       g_debug ("   sendn_to_server: available space (%i) < n (%zu)",
-               TO_SERVER_BUFFER_SIZE - to_server_end, n);
+               TO_SERVER_BUFFER_SIZE - to_server_end,
+               n);
       return 1;
     }
 

--- a/src/comm.c
+++ b/src/comm.c
@@ -81,7 +81,8 @@ int to_server_start = 0;
 unsigned int
 to_server_buffer_space ()
 {
-  if (to_server_end < to_server_start) abort ();
+  if (to_server_end < to_server_start)
+    abort ();
   return (unsigned int) (to_server_end - to_server_start);
 }
 
@@ -94,7 +95,7 @@ to_server_buffer_space ()
  * @return 0 for success, any other value for failure.
  */
 int
-sendn_to_server (const void * msg, size_t n)
+sendn_to_server (const void *msg, size_t n)
 {
   if (TO_SERVER_BUFFER_SIZE - to_server_end < n)
     {
@@ -119,7 +120,7 @@ sendn_to_server (const void * msg, size_t n)
  * @return 0 for success, any other value for failure.
  */
 int
-send_to_server (const char * msg)
+send_to_server (const char *msg)
 {
   return sendn_to_server (msg, strlen (msg));
 }
@@ -132,10 +133,10 @@ send_to_server (const char * msg)
  * @return 0 for success, any other value for failure.
  */
 int
-sendf_to_server (const char* format, ...)
+sendf_to_server (const char *format, ...)
 {
   va_list args;
-  gchar* msg;
+  gchar *msg;
   int ret;
   va_start (args, format);
   msg = g_strdup_vprintf (format, args);

--- a/src/comm.h
+++ b/src/comm.h
@@ -28,15 +28,15 @@
 #define _GVMD_COMM_H
 
 #include <glib.h>
+#include <netinet/in.h>
 #include <sys/socket.h>
 #include <sys/types.h>
-#include <netinet/in.h>
 
 int
 send_to_server (const char *);
 
 int
-sendf_to_server (const char*, ...);
+sendf_to_server (const char *, ...);
 
 int
 sendn_to_server (const void *, size_t);

--- a/src/gmp.h
+++ b/src/gmp.h
@@ -27,9 +27,10 @@
 
 #include "manage.h"
 #include "types.h"
-#include <gvm/util/serverutils.h>
+
 #include <glib.h>
 #include <gnutls/gnutls.h>
+#include <gvm/util/serverutils.h>
 #include <sys/types.h>
 
 /**
@@ -48,11 +49,11 @@
 #define TRUNCATE_TEXT_SUFFIX "[...]\n(text truncated)"
 
 int
-init_gmp (GSList*, int, const gchar*, int, int, int, int,
+init_gmp (GSList *, int, const gchar *, int, int, int, int,
           manage_connection_forker_t, int);
 
 void
-init_gmp_process (int, const gchar*, int (*) (const char*, void*), void*,
+init_gmp_process (int, const gchar *, int (*) (const char *, void *), void *,
                   gchar **);
 
 int

--- a/src/gmp.h
+++ b/src/gmp.h
@@ -49,11 +49,21 @@
 #define TRUNCATE_TEXT_SUFFIX "[...]\n(text truncated)"
 
 int
-init_gmp (GSList *, int, const gchar *, int, int, int, int,
-          manage_connection_forker_t, int);
+init_gmp (GSList *,
+          int,
+          const gchar *,
+          int,
+          int,
+          int,
+          int,
+          manage_connection_forker_t,
+          int);
 
 void
-init_gmp_process (int, const gchar *, int (*) (const char *, void *), void *,
+init_gmp_process (int,
+                  const gchar *,
+                  int (*) (const char *, void *),
+                  void *,
                   gchar **);
 
 int

--- a/src/gmp_base.c
+++ b/src/gmp_base.c
@@ -87,8 +87,8 @@ append_attribute (const gchar **attribute_names, const gchar **attribute_values,
                   const char *attribute_name, gchar **string)
 {
   const gchar *attribute;
-  if (find_attribute (attribute_names, attribute_values, attribute_name,
-                      &attribute))
+  if (find_attribute (
+        attribute_names, attribute_values, attribute_name, &attribute))
     {
       gvm_append_string (string, attribute);
       return 1;
@@ -157,7 +157,8 @@ send_element_error_to_client (const char *command, const char *element,
   /** @todo Set gerror so parsing terminates. */
   msg = g_strdup_printf ("<%s_response status=\"" STATUS_ERROR_SYNTAX
                          "\" status_text=\"Bogus element: %s\"/>",
-                         command, element);
+                         command,
+                         element);
   ret = send_to_client (msg, write_to_client, write_to_client_data);
   g_free (msg);
   return ret;
@@ -182,9 +183,11 @@ send_find_error_to_client (const char *command, const char *type,
 
   msg = g_strdup_printf ("<%s_response status=\"" STATUS_ERROR_MISSING
                          "\" status_text=\"Failed to find %s '%s'\"/>",
-                         command, type, id);
-  ret = send_to_client (msg, gmp_parser->client_writer,
-                        gmp_parser->client_writer_data);
+                         command,
+                         type,
+                         id);
+  ret = send_to_client (
+    msg, gmp_parser->client_writer, gmp_parser->client_writer_data);
   g_free (msg);
   return ret;
 }
@@ -198,7 +201,9 @@ void
 error_send_to_client (GError **error)
 {
   g_debug ("   send_to_client out of space in to_client");
-  g_set_error (error, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
+  g_set_error (error,
+               G_MARKUP_ERROR,
+               G_MARKUP_ERROR_PARSE,
                "Manager out of space for reply to client.");
 }
 
@@ -240,19 +245,34 @@ log_event_internal (const char *type, const char *type_name, const char *id,
         name = NULL;
 
       if (name)
-        g_log (domain, G_LOG_LEVEL_MESSAGE, "%s %s (%s) %s %s by %s", type_name,
-               name, id, fail ? "could not be" : "has been", action,
+        g_log (domain,
+               G_LOG_LEVEL_MESSAGE,
+               "%s %s (%s) %s %s by %s",
+               type_name,
+               name,
+               id,
+               fail ? "could not be" : "has been",
+               action,
                current_credentials.username);
       else
-        g_log (domain, G_LOG_LEVEL_MESSAGE, "%s %s %s %s by %s", type_name, id,
-               fail ? "could not be" : "has been", action,
+        g_log (domain,
+               G_LOG_LEVEL_MESSAGE,
+               "%s %s %s %s by %s",
+               type_name,
+               id,
+               fail ? "could not be" : "has been",
+               action,
                current_credentials.username);
 
       free (name);
     }
   else
-    g_log (domain, G_LOG_LEVEL_MESSAGE, "%s %s %s by %s", type_name,
-           fail ? "could not be" : "has been", action,
+    g_log (domain,
+           G_LOG_LEVEL_MESSAGE,
+           "%s %s %s by %s",
+           type_name,
+           fail ? "could not be" : "has been",
+           action,
            current_credentials.username);
 
   g_free (domain);

--- a/src/gmp_base.c
+++ b/src/gmp_base.c
@@ -27,17 +27,17 @@
  * @file gmp_base.c
  * @brief GVM GMP layer: Base facilities.
  *
- * GMP base facilities used by all modules, but not exported for users of the GMP
- * layer (i.e. gmpd.c).
+ * GMP base facilities used by all modules, but not exported for users of the
+ * GMP layer (i.e. gmpd.c).
  */
 
 #include "gmp_base.h"
+
 #include "manage.h"
 
+#include <gvm/base/strings.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <gvm/base/strings.h>
 
 #undef G_LOG_DOMAIN
 /**
@@ -56,10 +56,8 @@
  * @return 1 if found, else 0.
  */
 int
-find_attribute (const gchar **attribute_names,
-                const gchar **attribute_values,
-                const char *attribute_name,
-                const gchar **attribute_value)
+find_attribute (const gchar **attribute_names, const gchar **attribute_values,
+                const char *attribute_name, const gchar **attribute_value)
 {
   while (*attribute_names && *attribute_values)
     if (strcmp (*attribute_names, attribute_name))
@@ -85,12 +83,10 @@ find_attribute (const gchar **attribute_names,
  * @return 1 if found and appended, else 0.
  */
 int
-append_attribute (const gchar **attribute_names,
-                  const gchar **attribute_values,
-                  const char *attribute_name,
-                  gchar **string)
+append_attribute (const gchar **attribute_names, const gchar **attribute_values,
+                  const char *attribute_name, gchar **string)
 {
-  const gchar* attribute;
+  const gchar *attribute;
   if (find_attribute (attribute_names, attribute_values, attribute_name,
                       &attribute))
     {
@@ -119,7 +115,6 @@ buffer_xml_append_printf (GString *buffer, const char *format, ...)
   g_free (msg);
 }
 
-
 /* Communication. */
 
 /**
@@ -132,9 +127,9 @@ buffer_xml_append_printf (GString *buffer, const char *format, ...)
  * @return TRUE if send to client failed, else FALSE.
  */
 gboolean
-send_to_client (const char* msg,
-                int (*user_send_to_client) (const char*, void*),
-                void* user_send_to_client_data)
+send_to_client (const char *msg,
+                int (*user_send_to_client) (const char *, void *),
+                void *user_send_to_client_data)
 {
   if (user_send_to_client && msg)
     return user_send_to_client (msg, user_send_to_client_data);
@@ -152,19 +147,17 @@ send_to_client (const char* msg,
  * @return TRUE if out of space in to_client, else FALSE.
  */
 gboolean
-send_element_error_to_client (const char* command, const char* element,
-                              int (*write_to_client) (const char*, void*),
-                              void* write_to_client_data)
+send_element_error_to_client (const char *command, const char *element,
+                              int (*write_to_client) (const char *, void *),
+                              void *write_to_client_data)
 {
   gchar *msg;
   gboolean ret;
 
   /** @todo Set gerror so parsing terminates. */
-  msg = g_strdup_printf ("<%s_response status=\""
-                         STATUS_ERROR_SYNTAX
+  msg = g_strdup_printf ("<%s_response status=\"" STATUS_ERROR_SYNTAX
                          "\" status_text=\"Bogus element: %s\"/>",
-                         command,
-                         element);
+                         command, element);
   ret = send_to_client (msg, write_to_client, write_to_client_data);
   g_free (msg);
   return ret;
@@ -181,14 +174,13 @@ send_element_error_to_client (const char* command, const char* element,
  * @return TRUE if out of space in to_client, else FALSE.
  */
 gboolean
-send_find_error_to_client (const char* command, const char* type,
-                           const char* id, gmp_parser_t *gmp_parser)
+send_find_error_to_client (const char *command, const char *type,
+                           const char *id, gmp_parser_t *gmp_parser)
 {
   gchar *msg;
   gboolean ret;
 
-  msg = g_strdup_printf ("<%s_response status=\""
-                         STATUS_ERROR_MISSING
+  msg = g_strdup_printf ("<%s_response status=\"" STATUS_ERROR_MISSING
                          "\" status_text=\"Failed to find %s '%s'\"/>",
                          command, type, id);
   ret = send_to_client (msg, gmp_parser->client_writer,
@@ -203,7 +195,7 @@ send_find_error_to_client (const char* command, const char* type,
  * @param [out]  error  The error.
  */
 void
-error_send_to_client (GError** error)
+error_send_to_client (GError **error)
 {
   g_debug ("   send_to_client out of space in to_client");
   g_set_error (error, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
@@ -216,10 +208,9 @@ error_send_to_client (GError** error)
  * @param [out]  error  The error.
  */
 void
-internal_error_send_to_client (GError** error)
+internal_error_send_to_client (GError **error)
 {
-  g_set_error (error, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
-               "Internal Error.");
+  g_set_error (error, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE, "Internal Error.");
 }
 
 /**
@@ -245,33 +236,23 @@ log_event_internal (const char *type, const char *type_name, const char *id,
 
       if (manage_resource_name (type, id, &name))
         name = NULL;
-      else if ((name == NULL)
-               && manage_trash_resource_name (type, id, &name))
+      else if ((name == NULL) && manage_trash_resource_name (type, id, &name))
         name = NULL;
 
       if (name)
-        g_log (domain, G_LOG_LEVEL_MESSAGE,
-               "%s %s (%s) %s %s by %s",
-               type_name, name, id,
-               fail ? "could not be" : "has been",
-               action,
+        g_log (domain, G_LOG_LEVEL_MESSAGE, "%s %s (%s) %s %s by %s", type_name,
+               name, id, fail ? "could not be" : "has been", action,
                current_credentials.username);
       else
-        g_log (domain, G_LOG_LEVEL_MESSAGE,
-               "%s %s %s %s by %s",
-               type_name, id,
-               fail ? "could not be" : "has been",
-               action,
+        g_log (domain, G_LOG_LEVEL_MESSAGE, "%s %s %s %s by %s", type_name, id,
+               fail ? "could not be" : "has been", action,
                current_credentials.username);
 
       free (name);
     }
   else
-    g_log (domain, G_LOG_LEVEL_MESSAGE,
-           "%s %s %s by %s",
-           type_name,
-           fail ? "could not be" : "has been",
-           action,
+    g_log (domain, G_LOG_LEVEL_MESSAGE, "%s %s %s by %s", type_name,
+           fail ? "could not be" : "has been", action,
            current_credentials.username);
 
   g_free (domain);

--- a/src/gmp_base.c
+++ b/src/gmp_base.c
@@ -56,8 +56,10 @@
  * @return 1 if found, else 0.
  */
 int
-find_attribute (const gchar **attribute_names, const gchar **attribute_values,
-                const char *attribute_name, const gchar **attribute_value)
+find_attribute (const gchar **attribute_names,
+                const gchar **attribute_values,
+                const char *attribute_name,
+                const gchar **attribute_value)
 {
   while (*attribute_names && *attribute_values)
     if (strcmp (*attribute_names, attribute_name))
@@ -83,8 +85,10 @@ find_attribute (const gchar **attribute_names, const gchar **attribute_values,
  * @return 1 if found and appended, else 0.
  */
 int
-append_attribute (const gchar **attribute_names, const gchar **attribute_values,
-                  const char *attribute_name, gchar **string)
+append_attribute (const gchar **attribute_names,
+                  const gchar **attribute_values,
+                  const char *attribute_name,
+                  gchar **string)
 {
   const gchar *attribute;
   if (find_attribute (
@@ -147,7 +151,8 @@ send_to_client (const char *msg,
  * @return TRUE if out of space in to_client, else FALSE.
  */
 gboolean
-send_element_error_to_client (const char *command, const char *element,
+send_element_error_to_client (const char *command,
+                              const char *element,
                               int (*write_to_client) (const char *, void *),
                               void *write_to_client_data)
 {
@@ -175,8 +180,10 @@ send_element_error_to_client (const char *command, const char *element,
  * @return TRUE if out of space in to_client, else FALSE.
  */
 gboolean
-send_find_error_to_client (const char *command, const char *type,
-                           const char *id, gmp_parser_t *gmp_parser)
+send_find_error_to_client (const char *command,
+                           const char *type,
+                           const char *id,
+                           gmp_parser_t *gmp_parser)
 {
   gchar *msg;
   gboolean ret;
@@ -228,8 +235,11 @@ internal_error_send_to_client (GError **error)
  * @param[in]   fail        Whether it is a fail event.
  */
 static void
-log_event_internal (const char *type, const char *type_name, const char *id,
-                    const char *action, int fail)
+log_event_internal (const char *type,
+                    const char *type_name,
+                    const char *id,
+                    const char *action,
+                    int fail)
 {
   gchar *domain;
 
@@ -287,7 +297,9 @@ log_event_internal (const char *type, const char *type_name, const char *id,
  * @param[in]   action      Action done.
  */
 void
-log_event (const char *type, const char *type_name, const char *id,
+log_event (const char *type,
+           const char *type_name,
+           const char *id,
            const char *action)
 {
   log_event_internal (type, type_name, id, action, 0);
@@ -302,7 +314,9 @@ log_event (const char *type, const char *type_name, const char *id,
  * @param[in]   action      Action done.
  */
 void
-log_event_fail (const char *type, const char *type_name, const char *id,
+log_event_fail (const char *type,
+                const char *type_name,
+                const char *id,
                 const char *action)
 {
   log_event_internal (type, type_name, id, action, 1);

--- a/src/gmp_base.h
+++ b/src/gmp_base.h
@@ -54,11 +54,15 @@ gboolean
 send_to_client (const char *, int (*) (const char *, void *), void *);
 
 gboolean
-send_element_error_to_client (const char *, const char *,
-                              int (*) (const char *, void *), void *);
+send_element_error_to_client (const char *,
+                              const char *,
+                              int (*) (const char *, void *),
+                              void *);
 
 gboolean
-send_find_error_to_client (const char *, const char *, const char *,
+send_find_error_to_client (const char *,
+                           const char *,
+                           const char *,
                            gmp_parser_t *);
 
 void

--- a/src/gmp_base.h
+++ b/src/gmp_base.h
@@ -76,19 +76,19 @@ internal_error_send_to_client (GError **);
  * @param[in]   format    Format string for message.
  * @param[in]   args      Arguments for format string.
  */
-#define SENDF_TO_CLIENT_OR_FAIL(format, args...)             \
-  do                                                         \
-    {                                                        \
-      gchar *msg = g_markup_printf_escaped (format, ##args); \
-      if (send_to_client (msg, gmp_parser->client_writer,    \
-                          gmp_parser->client_writer_data))   \
-        {                                                    \
-          g_free (msg);                                      \
-          error_send_to_client (error);                      \
-          return;                                            \
-        }                                                    \
-      g_free (msg);                                          \
-    }                                                        \
+#define SENDF_TO_CLIENT_OR_FAIL(format, args...)                             \
+  do                                                                         \
+    {                                                                        \
+      gchar *msg = g_markup_printf_escaped (format, ##args);                 \
+      if (send_to_client (                                                   \
+            msg, gmp_parser->client_writer, gmp_parser->client_writer_data)) \
+        {                                                                    \
+          g_free (msg);                                                      \
+          error_send_to_client (error);                                      \
+          return;                                                            \
+        }                                                                    \
+      g_free (msg);                                                          \
+    }                                                                        \
   while (0)
 
 /**
@@ -99,16 +99,16 @@ internal_error_send_to_client (GError **);
  *
  * @param[in]   msg    The message, a string.
  */
-#define SEND_TO_CLIENT_OR_FAIL(msg)                        \
-  do                                                       \
-    {                                                      \
-      if (send_to_client (msg, gmp_parser->client_writer,  \
-                          gmp_parser->client_writer_data)) \
-        {                                                  \
-          error_send_to_client (error);                    \
-          return;                                          \
-        }                                                  \
-    }                                                      \
+#define SEND_TO_CLIENT_OR_FAIL(msg)                                          \
+  do                                                                         \
+    {                                                                        \
+      if (send_to_client (                                                   \
+            msg, gmp_parser->client_writer, gmp_parser->client_writer_data)) \
+        {                                                                    \
+          error_send_to_client (error);                                      \
+          return;                                                            \
+        }                                                                    \
+    }                                                                        \
   while (0)
 
 void
@@ -362,15 +362,17 @@ log_event_fail (const char *, const char *, const char *, const char *);
     {                                                                          \
       char *str;                                                               \
       if (scanner_current_loading && scanner_total_loading)                    \
-        str =                                                                  \
-          g_strdup_printf ("<%s_response status='%s' "                         \
-                           "status_text='Scanner loading nvts (%d/%d)'/>",     \
-                           tag, STATUS_SERVICE_DOWN, scanner_current_loading,  \
-                           scanner_total_loading);                             \
+        str = g_strdup_printf ("<%s_response status='%s' "                     \
+                               "status_text='Scanner loading nvts (%d/%d)'/>", \
+                               tag,                                            \
+                               STATUS_SERVICE_DOWN,                            \
+                               scanner_current_loading,                        \
+                               scanner_total_loading);                         \
       else                                                                     \
-        str =                                                                  \
-          g_strdup_printf ("<%s_response status='%s' status_text='%s'/>", tag, \
-                           STATUS_SERVICE_DOWN, STATUS_SERVICE_DOWN_TEXT);     \
+        str = g_strdup_printf ("<%s_response status='%s' status_text='%s'/>",  \
+                               tag,                                            \
+                               STATUS_SERVICE_DOWN,                            \
+                               STATUS_SERVICE_DOWN_TEXT);                      \
       SEND_TO_CLIENT_OR_FAIL (str);                                            \
       g_free (str);                                                            \
     }                                                                          \

--- a/src/gmp_base.h
+++ b/src/gmp_base.h
@@ -33,12 +33,12 @@
  */
 typedef struct
 {
-  int (*client_writer) (const char*, void*);  ///< Writes to the client.
-  void* client_writer_data;       ///< Argument to client_writer.
-  int importing;                  ///< Whether the current op is importing.
-  int read_over;                  ///< Read over any child elements.
-  int parent_state;               ///< Parent state when reading over.
-  gchar **disabled_commands;      ///< Disabled commands.
+  int (*client_writer) (const char *, void *); ///< Writes to the client.
+  void *client_writer_data;                    ///< Argument to client_writer.
+  int importing;             ///< Whether the current op is importing.
+  int read_over;             ///< Read over any child elements.
+  int parent_state;          ///< Parent state when reading over.
+  gchar **disabled_commands; ///< Disabled commands.
 } gmp_parser_t;
 
 int
@@ -51,12 +51,11 @@ void
 buffer_xml_append_printf (GString *, const char *, ...);
 
 gboolean
-send_to_client (const char *, int (*) (const char*, void*), void *);
+send_to_client (const char *, int (*) (const char *, void *), void *);
 
 gboolean
 send_element_error_to_client (const char *, const char *,
-                              int (*) (const char*, void*),
-                              void *);
+                              int (*) (const char *, void *), void *);
 
 gboolean
 send_find_error_to_client (const char *, const char *, const char *,
@@ -77,19 +76,19 @@ internal_error_send_to_client (GError **);
  * @param[in]   format    Format string for message.
  * @param[in]   args      Arguments for format string.
  */
-#define SENDF_TO_CLIENT_OR_FAIL(format, args...)                             \
-  do                                                                         \
-    {                                                                        \
-      gchar* msg = g_markup_printf_escaped (format , ## args);               \
-      if (send_to_client (msg, gmp_parser->client_writer,                    \
-                          gmp_parser->client_writer_data))                   \
-        {                                                                    \
-          g_free (msg);                                                      \
-          error_send_to_client (error);                                      \
-          return;                                                            \
-        }                                                                    \
-      g_free (msg);                                                          \
-    }                                                                        \
+#define SENDF_TO_CLIENT_OR_FAIL(format, args...)             \
+  do                                                         \
+    {                                                        \
+      gchar *msg = g_markup_printf_escaped (format, ##args); \
+      if (send_to_client (msg, gmp_parser->client_writer,    \
+                          gmp_parser->client_writer_data))   \
+        {                                                    \
+          g_free (msg);                                      \
+          error_send_to_client (error);                      \
+          return;                                            \
+        }                                                    \
+      g_free (msg);                                          \
+    }                                                        \
   while (0)
 
 /**
@@ -100,16 +99,16 @@ internal_error_send_to_client (GError **);
  *
  * @param[in]   msg    The message, a string.
  */
-#define SEND_TO_CLIENT_OR_FAIL(msg)                                          \
-  do                                                                         \
-    {                                                                        \
-      if (send_to_client (msg, gmp_parser->client_writer,                    \
-                          gmp_parser->client_writer_data))                   \
-        {                                                                    \
-          error_send_to_client (error);                                      \
-          return;                                                            \
-        }                                                                    \
-    }                                                                        \
+#define SEND_TO_CLIENT_OR_FAIL(msg)                        \
+  do                                                       \
+    {                                                      \
+      if (send_to_client (msg, gmp_parser->client_writer,  \
+                          gmp_parser->client_writer_data)) \
+        {                                                  \
+          error_send_to_client (error);                    \
+          return;                                          \
+        }                                                  \
+    }                                                      \
   while (0)
 
 void
@@ -118,7 +117,6 @@ log_event (const char *, const char *, const char *, const char *);
 void
 log_event_fail (const char *, const char *, const char *, const char *);
 
-
 /* Status codes. */
 
 /* HTTP status codes used:
@@ -134,112 +132,112 @@ log_event_fail (const char *, const char *, const char *, const char *);
 /**
  * @brief Response code for a syntax error.
  */
-#define STATUS_ERROR_SYNTAX            "400"
+#define STATUS_ERROR_SYNTAX "400"
 
 /**
  * @brief Response code when authorisation is required.
  */
-#define STATUS_ERROR_MUST_AUTH         "401"
+#define STATUS_ERROR_MUST_AUTH "401"
 
 /**
  * @brief Response code when authorisation is required.
  */
-#define STATUS_ERROR_MUST_AUTH_TEXT    "Authenticate first"
+#define STATUS_ERROR_MUST_AUTH_TEXT "Authenticate first"
 
 /**
  * @brief Response code for forbidden access.
  */
-#define STATUS_ERROR_ACCESS            "403"
+#define STATUS_ERROR_ACCESS "403"
 
 /**
  * @brief Response code text for forbidden access.
  */
-#define STATUS_ERROR_ACCESS_TEXT       "Access to resource forbidden"
+#define STATUS_ERROR_ACCESS_TEXT "Access to resource forbidden"
 
 /**
  * @brief Response code for a missing resource.
  */
-#define STATUS_ERROR_MISSING           "404"
+#define STATUS_ERROR_MISSING "404"
 
 /**
  * @brief Response code text for a missing resource.
  */
-#define STATUS_ERROR_MISSING_TEXT      "Resource missing"
+#define STATUS_ERROR_MISSING_TEXT "Resource missing"
 
 /**
  * @brief Response code for a busy resource.
  */
-#define STATUS_ERROR_BUSY              "409"
+#define STATUS_ERROR_BUSY "409"
 
 /**
  * @brief Response code text for a busy resource.
  */
-#define STATUS_ERROR_BUSY_TEXT         "Resource busy"
+#define STATUS_ERROR_BUSY_TEXT "Resource busy"
 
 /**
  * @brief Response code when authorisation failed.
  */
-#define STATUS_ERROR_AUTH_FAILED       "400"
+#define STATUS_ERROR_AUTH_FAILED "400"
 
 /**
  * @brief Response code text when authorisation failed.
  */
-#define STATUS_ERROR_AUTH_FAILED_TEXT  "Authentication failed"
+#define STATUS_ERROR_AUTH_FAILED_TEXT "Authentication failed"
 
 /**
  * @brief Response code on success.
  */
-#define STATUS_OK                      "200"
+#define STATUS_OK "200"
 
 /**
  * @brief Response code text on success.
  */
-#define STATUS_OK_TEXT                 "OK"
+#define STATUS_OK_TEXT "OK"
 
 /**
  * @brief Response code on success, when a resource is created.
  */
-#define STATUS_OK_CREATED              "201"
+#define STATUS_OK_CREATED "201"
 
 /**
  * @brief Response code on success, when a resource is created.
  */
-#define STATUS_OK_CREATED_TEXT         "OK, resource created"
+#define STATUS_OK_CREATED_TEXT "OK, resource created"
 
 /**
  * @brief Response code on success, when the operation will finish later.
  */
-#define STATUS_OK_REQUESTED            "202"
+#define STATUS_OK_REQUESTED "202"
 
 /**
  * @brief Response code text on success, when the operation will finish later.
  */
-#define STATUS_OK_REQUESTED_TEXT       "OK, request submitted"
+#define STATUS_OK_REQUESTED_TEXT "OK, request submitted"
 
 /**
  * @brief Response code for an internal error.
  */
-#define STATUS_INTERNAL_ERROR          "500"
+#define STATUS_INTERNAL_ERROR "500"
 
 /**
  * @brief Response code text for an internal error.
  */
-#define STATUS_INTERNAL_ERROR_TEXT     "Internal error"
+#define STATUS_INTERNAL_ERROR_TEXT "Internal error"
 
 /**
  * @brief Response code when a service is unavailable.
  */
-#define STATUS_SERVICE_UNAVAILABLE     "503"
+#define STATUS_SERVICE_UNAVAILABLE "503"
 
 /**
  * @brief Response code when a service is down.
  */
-#define STATUS_SERVICE_DOWN            "503"
+#define STATUS_SERVICE_DOWN "503"
 
 /**
  * @brief Response code text when a service is down.
  */
-#define STATUS_SERVICE_DOWN_TEXT       "Service temporarily down"
+#define STATUS_SERVICE_DOWN_TEXT "Service temporarily down"
 
 /**
  * @brief Expand to XML for a STATUS_ERROR_SYNTAX response.
@@ -247,20 +245,20 @@ log_event_fail (const char *, const char *, const char *, const char *);
  * @param  tag   Name of the command generating the response.
  * @param  text  Text for the status_text attribute of the response.
  */
-#define XML_ERROR_SYNTAX(tag, text)                      \
- "<" tag "_response"                                     \
- " status=\"" STATUS_ERROR_SYNTAX "\""                   \
- " status_text=\"" text "\"/>"
+#define XML_ERROR_SYNTAX(tag, text)     \
+  "<" tag "_response"                   \
+  " status=\"" STATUS_ERROR_SYNTAX "\"" \
+  " status_text=\"" text "\"/>"
 
 /**
  * @brief Expand to XML for a STATUS_ERROR_ACCESS response.
  *
  * @param  tag  Name of the command generating the response.
  */
-#define XML_ERROR_ACCESS(tag)                            \
- "<" tag "_response"                                     \
- " status=\"" STATUS_ERROR_ACCESS "\""                   \
- " status_text=\"" STATUS_ERROR_ACCESS_TEXT "\"/>"
+#define XML_ERROR_ACCESS(tag)           \
+  "<" tag "_response"                   \
+  " status=\"" STATUS_ERROR_ACCESS "\"" \
+  " status_text=\"" STATUS_ERROR_ACCESS_TEXT "\"/>"
 
 /**
  * @brief Expand to XML for a STATUS_SERVICE_UNAVAILABLE response.
@@ -268,111 +266,114 @@ log_event_fail (const char *, const char *, const char *, const char *);
  * @param  tag   Name of the command generating the response.
  * @param  text  Status text.
  */
-#define XML_ERROR_UNAVAILABLE(tag, text)                  \
- "<" tag "_response"                                      \
- " status=\"" STATUS_SERVICE_UNAVAILABLE "\""             \
- " status_text=\"" text "\"/>"
+#define XML_ERROR_UNAVAILABLE(tag, text)       \
+  "<" tag "_response"                          \
+  " status=\"" STATUS_SERVICE_UNAVAILABLE "\"" \
+  " status_text=\"" text "\"/>"
 
 /**
  * @brief Expand to XML for a STATUS_ERROR_MISSING response.
  *
  * @param  tag  Name of the command generating the response.
  */
-#define XML_ERROR_MISSING(tag)                           \
- "<" tag "_response"                                     \
- " status=\"" STATUS_ERROR_MISSING "\""                  \
- " status_text=\"" STATUS_ERROR_MISSING_TEXT "\"/>"
+#define XML_ERROR_MISSING(tag)           \
+  "<" tag "_response"                    \
+  " status=\"" STATUS_ERROR_MISSING "\"" \
+  " status_text=\"" STATUS_ERROR_MISSING_TEXT "\"/>"
 
 /**
  * @brief Expand to XML for a STATUS_ERROR_AUTH_FAILED response.
  *
  * @param  tag  Name of the command generating the response.
  */
-#define XML_ERROR_AUTH_FAILED(tag)                       \
- "<" tag "_response"                                     \
- " status=\"" STATUS_ERROR_AUTH_FAILED "\""              \
- " status_text=\"" STATUS_ERROR_AUTH_FAILED_TEXT "\"/>"
+#define XML_ERROR_AUTH_FAILED(tag)           \
+  "<" tag "_response"                        \
+  " status=\"" STATUS_ERROR_AUTH_FAILED "\"" \
+  " status_text=\"" STATUS_ERROR_AUTH_FAILED_TEXT "\"/>"
 
 /**
  * @brief Expand to XML for a STATUS_ERROR_BUSY response.
  *
  * @param  tag  Name of the command generating the response.
  */
-#define XML_ERROR_BUSY(tag)                              \
- "<" tag "_response"                                     \
- " status=\"" STATUS_ERROR_BUSY "\""                     \
- " status_text=\"" STATUS_ERROR_BUSY_TEXT "\"/>"
+#define XML_ERROR_BUSY(tag)           \
+  "<" tag "_response"                 \
+  " status=\"" STATUS_ERROR_BUSY "\"" \
+  " status_text=\"" STATUS_ERROR_BUSY_TEXT "\"/>"
 
 /**
  * @brief Expand to XML for a STATUS_OK response.
  *
  * @param  tag  Name of the command generating the response.
  */
-#define XML_OK(tag)                                      \
- "<" tag "_response"                                     \
- " status=\"" STATUS_OK "\""                             \
- " status_text=\"" STATUS_OK_TEXT "\"/>"
+#define XML_OK(tag)           \
+  "<" tag "_response"         \
+  " status=\"" STATUS_OK "\"" \
+  " status_text=\"" STATUS_OK_TEXT "\"/>"
 
 /**
  * @brief Expand to XML for a STATUS_OK_CREATED response.
  *
  * @param  tag  Name of the command generating the response.
  */
-#define XML_OK_CREATED(tag)                              \
- "<" tag "_response"                                     \
- " status=\"" STATUS_OK_CREATED "\""                     \
- " status_text=\"" STATUS_OK_CREATED_TEXT "\"/>"
+#define XML_OK_CREATED(tag)           \
+  "<" tag "_response"                 \
+  " status=\"" STATUS_OK_CREATED "\"" \
+  " status_text=\"" STATUS_OK_CREATED_TEXT "\"/>"
 
 /**
  * @brief Expand to XML for a STATUS_OK_CREATED response with %s for ID.
  *
  * @param  tag  Name of the command generating the response.
  */
-#define XML_OK_CREATED_ID(tag)                           \
- "<" tag "_response"                                     \
- " status=\"" STATUS_OK_CREATED "\""                     \
- " status_text=\"" STATUS_OK_CREATED_TEXT "\""           \
- " id=\"%s\"/>"
+#define XML_OK_CREATED_ID(tag)                  \
+  "<" tag "_response"                           \
+  " status=\"" STATUS_OK_CREATED "\""           \
+  " status_text=\"" STATUS_OK_CREATED_TEXT "\"" \
+  " id=\"%s\"/>"
 
 /**
  * @brief Expand to XML for a STATUS_OK_REQUESTED response.
  *
  * @param  tag  Name of the command generating the response.
  */
-#define XML_OK_REQUESTED(tag)                            \
- "<" tag "_response"                                     \
- " status=\"" STATUS_OK_REQUESTED "\""                   \
- " status_text=\"" STATUS_OK_REQUESTED_TEXT "\"/>"
+#define XML_OK_REQUESTED(tag)           \
+  "<" tag "_response"                   \
+  " status=\"" STATUS_OK_REQUESTED "\"" \
+  " status_text=\"" STATUS_OK_REQUESTED_TEXT "\"/>"
 
 /**
  * @brief Expand to XML for a STATUS_INTERNAL_ERROR response.
  *
  * @param  tag  Name of the command generating the response.
  */
-#define XML_INTERNAL_ERROR(tag)                          \
- "<" tag "_response"                                     \
- " status=\"" STATUS_INTERNAL_ERROR "\""                 \
- " status_text=\"" STATUS_INTERNAL_ERROR_TEXT "\"/>"
+#define XML_INTERNAL_ERROR(tag)           \
+  "<" tag "_response"                     \
+  " status=\"" STATUS_INTERNAL_ERROR "\"" \
+  " status_text=\"" STATUS_INTERNAL_ERROR_TEXT "\"/>"
 
 /**
  * @brief Sends XML for a STATUS_SERVICE_DOWN response.
  *
  * @param  tag  Name of the command generating the response.
  */
-#define SEND_XML_SERVICE_DOWN(tag)                                            \
-  do {                                                                        \
-    char *str;                                                                \
-    if (scanner_current_loading && scanner_total_loading)                     \
-      str = g_strdup_printf ("<%s_response status='%s' "                      \
-                             "status_text='Scanner loading nvts (%d/%d)'/>",  \
-                             tag, STATUS_SERVICE_DOWN,                        \
-                             scanner_current_loading, scanner_total_loading); \
-    else                                                                      \
-      str = g_strdup_printf ("<%s_response status='%s' status_text='%s'/>",   \
-                             tag, STATUS_SERVICE_DOWN,                        \
-                             STATUS_SERVICE_DOWN_TEXT);                       \
-    SEND_TO_CLIENT_OR_FAIL(str);                                              \
-    g_free (str);                                                             \
-  } while (0);
+#define SEND_XML_SERVICE_DOWN(tag)                                             \
+  do                                                                           \
+    {                                                                          \
+      char *str;                                                               \
+      if (scanner_current_loading && scanner_total_loading)                    \
+        str =                                                                  \
+          g_strdup_printf ("<%s_response status='%s' "                         \
+                           "status_text='Scanner loading nvts (%d/%d)'/>",     \
+                           tag, STATUS_SERVICE_DOWN, scanner_current_loading,  \
+                           scanner_total_loading);                             \
+      else                                                                     \
+        str =                                                                  \
+          g_strdup_printf ("<%s_response status='%s' status_text='%s'/>", tag, \
+                           STATUS_SERVICE_DOWN, STATUS_SERVICE_DOWN_TEXT);     \
+      SEND_TO_CLIENT_OR_FAIL (str);                                            \
+      g_free (str);                                                            \
+    }                                                                          \
+  while (0);
 
 #endif /* not _GVMD_GMP_BASE_H */

--- a/src/gmp_delete.c
+++ b/src/gmp_delete.c
@@ -94,8 +94,8 @@ delete_start (const gchar *type, const gchar *type_capital,
   append_attribute (attribute_names, attribute_values, id_name, &delete.id);
   g_free (id_name);
 
-  if (find_attribute (attribute_names, attribute_values, "ultimate",
-                      &attribute))
+  if (find_attribute (
+        attribute_names, attribute_values, "ultimate", &attribute))
     delete.ultimate = strcmp (attribute, "0");
   else
     delete.ultimate = 0;
@@ -137,8 +137,8 @@ delete_run (gmp_parser_t *gmp_parser, GError **error)
       log_event_fail (delete.type, delete.type_capital, delete.id, "deleted");
       break;
     case 2:
-      if (send_find_error_to_client (delete.command, delete.type, delete.id,
-                                     gmp_parser))
+      if (send_find_error_to_client (
+            delete.command, delete.type, delete.id, gmp_parser))
         {
           error_send_to_client (error);
           return;

--- a/src/gmp_delete.c
+++ b/src/gmp_delete.c
@@ -84,8 +84,10 @@ delete_reset ()
  * @param[in]  attribute_values  All attribute values.
  */
 void
-delete_start (const gchar *type, const gchar *type_capital,
-              const gchar **attribute_names, const gchar **attribute_values)
+delete_start (const gchar *type,
+              const gchar *type_capital,
+              const gchar **attribute_names,
+              const gchar **attribute_values)
 {
   const gchar *attribute;
   gchar *id_name, *command;

--- a/src/gmp_delete.h
+++ b/src/gmp_delete.h
@@ -26,9 +26,9 @@
 #ifndef _GVMD_GMP_DELETE_H
 #define _GVMD_GMP_DELETE_H
 
-#include <glib.h>
-
 #include "gmp_base.h"
+
+#include <glib.h>
 
 void
 delete_start (const gchar *, const gchar *, const gchar **, const gchar **);

--- a/src/gmp_get.c
+++ b/src/gmp_get.c
@@ -70,8 +70,8 @@ get_data_parse_attributes (get_data_t *data, const gchar *type,
   append_attribute (attribute_names, attribute_values, name, &data->id);
   g_free (name);
 
-  append_attribute (attribute_names, attribute_values, "filt_id",
-                    &data->filt_id);
+  append_attribute (
+    attribute_names, attribute_values, "filt_id", &data->filt_id);
 
   if (find_attribute (attribute_names, attribute_values, "trash", &attribute))
     data->trash = strcmp (attribute, "0");
@@ -83,14 +83,14 @@ get_data_parse_attributes (get_data_t *data, const gchar *type,
   else
     data->details = 0;
 
-  if (find_attribute (attribute_names, attribute_values, "ignore_pagination",
-                      &attribute))
+  if (find_attribute (
+        attribute_names, attribute_values, "ignore_pagination", &attribute))
     data->ignore_pagination = strcmp (attribute, "0");
   else
     data->ignore_pagination = 0;
 
-  append_attribute (attribute_names, attribute_values, "filter_replace",
-                    &data->filter_replace);
+  append_attribute (
+    attribute_names, attribute_values, "filter_replace", &data->filter_replace);
 }
 
 /**
@@ -179,8 +179,8 @@ init_get (gchar *command, get_data_t *get, const gchar *setting_name,
           gchar *new_filter, *clean;
 
           clean = manage_clean_filter_remove (term, get->filter_replace);
-          new_filter = g_strdup_printf ("%s=%s %s", get->filter_replace,
-                                        replacement, clean);
+          new_filter = g_strdup_printf (
+            "%s=%s %s", get->filter_replace, replacement, clean);
           g_free (clean);
           if (get->filter)
             {
@@ -203,8 +203,8 @@ init_get (gchar *command, get_data_t *get, const gchar *setting_name,
    * This is used by get_next when the result set is empty, to determine if
    * the query should be rerun with first 1.
    */
-  manage_filter_controls (filter ? filter : get->filter, first, NULL, NULL,
-                          NULL);
+  manage_filter_controls (
+    filter ? filter : get->filter, first, NULL, NULL, NULL);
 
   g_free (filter);
 
@@ -332,7 +332,8 @@ send_get_common (const char *type, get_data_t *get, iterator_t *iterator,
     "<writable>%i</writable>"
     "<in_use>%i</in_use>"
     "<permissions>",
-    type, get_iterator_uuid (iterator) ? get_iterator_uuid (iterator) : "",
+    type,
+    get_iterator_uuid (iterator) ? get_iterator_uuid (iterator) : "",
     get_iterator_owner_name (iterator) ? get_iterator_owner_name (iterator)
                                        : "",
     get_iterator_name (iterator) ? get_iterator_name (iterator) : "",
@@ -343,7 +344,8 @@ send_get_common (const char *type, get_data_t *get, iterator_t *iterator,
     get_iterator_modification_time (iterator)
       ? get_iterator_modification_time (iterator)
       : "",
-    writable, in_use);
+    writable,
+    in_use);
 
   if (/* The user is the owner. */
       (current_credentials.username && get_iterator_owner_name (iterator)
@@ -363,10 +365,11 @@ send_get_common (const char *type, get_data_t *get, iterator_t *iterator,
               && permission_is_admin (get_iterator_uuid (iterator)))
           && acl_user_can_everything (current_credentials.uuid)))
     {
-      buffer_xml_append_printf (buffer, "<permission>"
-                                        "<name>Everything</name>"
-                                        "</permission>"
-                                        "</permissions>");
+      buffer_xml_append_printf (buffer,
+                                "<permission>"
+                                "<name>Everything</name>"
+                                "</permission>"
+                                "</permissions>");
     }
   else if (current_credentials.uuid && (strcmp (type, "user") == 0)
            && acl_user_can_super_everyone (get_iterator_uuid (iterator))
@@ -374,8 +377,9 @@ send_get_common (const char *type, get_data_t *get, iterator_t *iterator,
     {
       /* Resource is the Super Admin. */
       buffer_xml_append_printf (
-        buffer, "<permission><name>get_users</name></permission>"
-                "</permissions>");
+        buffer,
+        "<permission><name>get_users</name></permission>"
+        "</permissions>");
     }
   else
     {
@@ -473,7 +477,8 @@ buffer_get_filter_xml (GString *msg, const char *type, const get_data_t *get,
   buffer_xml_append_printf (msg,
                             "<filters id=\"%s\">"
                             "<term>%s</term>",
-                            get->filt_id ? get->filt_id : "", filter_term);
+                            get->filt_id ? get->filt_id : "",
+                            filter_term);
 
   if (get->filt_id && strcmp (get->filt_id, "")
       && (find_filter_with_permission (get->filt_id, &filter, "get_filters")
@@ -504,14 +509,16 @@ buffer_get_filter_xml (GString *msg, const char *type, const get_data_t *get,
                        : (keyword_special (keyword)
                             ? ""
                             : keyword_relation_symbol (keyword->relation)),
-        keyword->quoted ? "\"" : "", keyword->string ? keyword->string : "",
+        keyword->quoted ? "\"" : "",
+        keyword->string ? keyword->string : "",
         keyword->quoted ? "\"" : "");
       point++;
     }
   filter_free (split);
 
-  buffer_xml_append_printf (msg, "</keywords>"
-                                 "</filters>");
+  buffer_xml_append_printf (msg,
+                            "</keywords>"
+                            "</filters>");
   return 0;
 }
 
@@ -552,8 +559,8 @@ send_get_end_internal (const char *type, get_data_t *get, int get_counts,
   else
     filter = NULL;
 
-  manage_filter_controls (filter ? filter : get->filter, &first, &max,
-                          &sort_field, &sort_order);
+  manage_filter_controls (
+    filter ? filter : get->filter, &first, &max, &sort_field, &sort_order);
 
   if (get->ignore_pagination && (strcmp (type, "task") == 0))
     {
@@ -587,8 +594,8 @@ send_get_end_internal (const char *type, get_data_t *get, int get_counts,
           if (value == NULL)
             {
               filter = new_filter;
-              new_filter = g_strdup_printf ("apply_overrides=%i %s",
-                                            APPLY_OVERRIDES_DEFAULT, filter);
+              new_filter = g_strdup_printf (
+                "apply_overrides=%i %s", APPLY_OVERRIDES_DEFAULT, filter);
               g_free (filter);
             }
           g_free (value);
@@ -619,8 +626,11 @@ send_get_end_internal (const char *type, get_data_t *get, int get_counts,
                             "<field>%s<order>%s</order></field>"
                             "</sort>"
                             "<%s start=\"%i\" max=\"%i\"/>",
-                            sort_field, sort_order ? "ascending" : "descending",
-                            type_many->str, first, max);
+                            sort_field,
+                            sort_order ? "ascending" : "descending",
+                            type_many->str,
+                            first,
+                            max);
   if (get_counts)
     buffer_xml_append_printf (msg,
                               "<%s_count>"
@@ -628,7 +638,11 @@ send_get_end_internal (const char *type, get_data_t *get, int get_counts,
                               "<filtered>%i</filtered>"
                               "<page>%i</page>"
                               "</%s_count>",
-                              type, full, filtered, count, type);
+                              type,
+                              full,
+                              filtered,
+                              count,
+                              type);
   buffer_xml_append_printf (msg, "</get_%s_response>", type_many->str);
   g_string_free (type_many, TRUE);
   g_free (sort_field);
@@ -662,8 +676,8 @@ send_get_end (const char *type, get_data_t *get, int count, int filtered,
               int full, int (*write_to_client) (const char *, void *),
               void *write_to_client_data)
 {
-  return send_get_end_internal (type, get, 1, count, filtered, full,
-                                write_to_client, write_to_client_data);
+  return send_get_end_internal (
+    type, get, 1, count, filtered, full, write_to_client, write_to_client_data);
 }
 
 /**
@@ -682,6 +696,6 @@ send_get_end_no_counts (const char *type, get_data_t *get,
                         int (*write_to_client) (const char *, void *),
                         void *write_to_client_data)
 {
-  return send_get_end_internal (type, get, 0, 0, 0, 0, write_to_client,
-                                write_to_client_data);
+  return send_get_end_internal (
+    type, get, 0, 0, 0, 0, write_to_client, write_to_client_data);
 }

--- a/src/gmp_get.c
+++ b/src/gmp_get.c
@@ -31,6 +31,7 @@
  */
 
 #include "gmp_get.h"
+
 #include "gmp_base.h"
 #include "manage_acl.h"
 
@@ -63,31 +64,27 @@ get_data_parse_attributes (get_data_t *data, const gchar *type,
 
   data->type = g_strdup (type);
 
-  append_attribute (attribute_names, attribute_values, "filter",
-                    &data->filter);
+  append_attribute (attribute_names, attribute_values, "filter", &data->filter);
 
   name = g_strdup_printf ("%s_id", type);
-  append_attribute (attribute_names, attribute_values, name,
-                    &data->id);
+  append_attribute (attribute_names, attribute_values, name, &data->id);
   g_free (name);
 
   append_attribute (attribute_names, attribute_values, "filt_id",
                     &data->filt_id);
 
-  if (find_attribute (attribute_names, attribute_values,
-                      "trash", &attribute))
+  if (find_attribute (attribute_names, attribute_values, "trash", &attribute))
     data->trash = strcmp (attribute, "0");
   else
     data->trash = 0;
 
-  if (find_attribute (attribute_names, attribute_values,
-                      "details", &attribute))
+  if (find_attribute (attribute_names, attribute_values, "details", &attribute))
     data->details = strcmp (attribute, "0");
   else
     data->details = 0;
 
-  if (find_attribute (attribute_names, attribute_values,
-                      "ignore_pagination", &attribute))
+  if (find_attribute (attribute_names, attribute_values, "ignore_pagination",
+                      &attribute))
     data->ignore_pagination = strcmp (attribute, "0");
   else
     data->ignore_pagination = 0;
@@ -107,7 +104,7 @@ get_data_parse_attributes (get_data_t *data, const gchar *type,
  * @return 0 success, -1 error.
  */
 int
-init_get (gchar *command, get_data_t * get, const gchar *setting_name,
+init_get (gchar *command, get_data_t *get, const gchar *setting_name,
           int *first)
 {
   gchar *filter, *replacement;
@@ -182,11 +179,8 @@ init_get (gchar *command, get_data_t * get, const gchar *setting_name,
           gchar *new_filter, *clean;
 
           clean = manage_clean_filter_remove (term, get->filter_replace);
-          new_filter = g_strdup_printf
-                        ("%s=%s %s",
-                         get->filter_replace,
-                         replacement,
-                         clean);
+          new_filter = g_strdup_printf ("%s=%s %s", get->filter_replace,
+                                        replacement, clean);
           g_free (clean);
           if (get->filter)
             {
@@ -234,37 +228,37 @@ init_get (gchar *command, get_data_t * get, const gchar *setting_name,
  */
 int
 get_next (iterator_t *resources, get_data_t *get, int *first, int *count,
-          int (*init) (iterator_t*, const get_data_t *))
+          int (*init) (iterator_t *, const get_data_t *))
 {
   if (next (resources) == FALSE)
-   {
-     gchar *new_filter;
+    {
+      gchar *new_filter;
 
-     if (get->filt_id && strcmp (get->filt_id, FILT_ID_NONE))
-       /* If filtering by a named filter, then just end, because changing
-        * the filter term would probably surprise the user. */
-       return 1;
+      if (get->filt_id && strcmp (get->filt_id, FILT_ID_NONE))
+        /* If filtering by a named filter, then just end, because changing
+         * the filter term would probably surprise the user. */
+        return 1;
 
-     if (*first == 0)
-       return 1;
+      if (*first == 0)
+        return 1;
 
-     if (*first == 1 || *count > 0)
-       /* Some results were found or first was 1, so stop iterating. */
-       return 1;
+      if (*first == 1 || *count > 0)
+        /* Some results were found or first was 1, so stop iterating. */
+        return 1;
 
-     /* Reset the iterator with first 1, and start again. */
-     cleanup_iterator (resources);
-     new_filter = g_strdup_printf ("first=1 %s", get->filter);
-     g_free (get->filter);
-     get->filter = new_filter;
-     if (init (resources, get))
-       return -1;
-     *count = 0;
-     *first = 1;
-     if (next (resources) == FALSE)
-       return 1;
-   }
- return 0;
+      /* Reset the iterator with first 1, and start again. */
+      cleanup_iterator (resources);
+      new_filter = g_strdup_printf ("first=1 %s", get->filter);
+      g_free (get->filter);
+      get->filter = new_filter;
+      if (init (resources, get))
+        return -1;
+      *count = 0;
+      *first = 1;
+      if (next (resources) == FALSE)
+        return 1;
+    }
+  return 0;
 }
 
 /**
@@ -277,8 +271,8 @@ get_next (iterator_t *resources, get_data_t *get, int *first, int *count,
  * @return 0 success, 1 send to client failed.
  */
 int
-send_get_start (const char *type, int (*write_to_client) (const char*, void*),
-                void* write_to_client_data)
+send_get_start (const char *type, int (*write_to_client) (const char *, void *),
+                void *write_to_client_data)
 {
   gchar *msg;
 
@@ -292,7 +286,6 @@ send_get_start (const char *type, int (*write_to_client) (const char*, void*),
                                    " status=\"" STATUS_OK "\""
                                    " status_text=\"" STATUS_OK_TEXT "\">",
                                    type);
-
 
   if (send_to_client (msg, write_to_client, write_to_client_data))
     {
@@ -318,8 +311,8 @@ send_get_start (const char *type, int (*write_to_client) (const char*, void*),
  */
 int
 send_get_common (const char *type, get_data_t *get, iterator_t *iterator,
-                 int (*write_to_client) (const char *, void*),
-                 void* write_to_client_data, int writable, int in_use)
+                 int (*write_to_client) (const char *, void *),
+                 void *write_to_client_data, int writable, int in_use)
 {
   GString *buffer;
   const char *tag_type;
@@ -328,41 +321,32 @@ send_get_common (const char *type, get_data_t *get, iterator_t *iterator,
 
   buffer = g_string_new ("");
 
-  buffer_xml_append_printf (buffer,
-                            "<%s id=\"%s\">"
-                            "<owner><name>%s</name></owner>"
-                            "<name>%s</name>"
-                            "<comment>%s</comment>"
-                            "<creation_time>%s</creation_time>"
-                            "<modification_time>%s</modification_time>"
-                            "<writable>%i</writable>"
-                            "<in_use>%i</in_use>"
-                            "<permissions>",
-                            type,
-                            get_iterator_uuid (iterator)
-                            ? get_iterator_uuid (iterator)
-                            : "",
-                            get_iterator_owner_name (iterator)
-                            ? get_iterator_owner_name (iterator)
-                            : "",
-                            get_iterator_name (iterator)
-                            ? get_iterator_name (iterator)
-                            : "",
-                            get_iterator_comment (iterator)
-                            ? get_iterator_comment (iterator)
-                            : "",
-                            get_iterator_creation_time (iterator)
-                            ? get_iterator_creation_time (iterator)
-                            : "",
-                            get_iterator_modification_time (iterator)
-                            ? get_iterator_modification_time (iterator)
-                            : "",
-                            writable,
-                            in_use);
+  buffer_xml_append_printf (
+    buffer,
+    "<%s id=\"%s\">"
+    "<owner><name>%s</name></owner>"
+    "<name>%s</name>"
+    "<comment>%s</comment>"
+    "<creation_time>%s</creation_time>"
+    "<modification_time>%s</modification_time>"
+    "<writable>%i</writable>"
+    "<in_use>%i</in_use>"
+    "<permissions>",
+    type, get_iterator_uuid (iterator) ? get_iterator_uuid (iterator) : "",
+    get_iterator_owner_name (iterator) ? get_iterator_owner_name (iterator)
+                                       : "",
+    get_iterator_name (iterator) ? get_iterator_name (iterator) : "",
+    get_iterator_comment (iterator) ? get_iterator_comment (iterator) : "",
+    get_iterator_creation_time (iterator)
+      ? get_iterator_creation_time (iterator)
+      : "",
+    get_iterator_modification_time (iterator)
+      ? get_iterator_modification_time (iterator)
+      : "",
+    writable, in_use);
 
   if (/* The user is the owner. */
-      (current_credentials.username
-       && get_iterator_owner_name (iterator)
+      (current_credentials.username && get_iterator_owner_name (iterator)
        && (strcmp (get_iterator_owner_name (iterator),
                    current_credentials.username)
            == 0))
@@ -379,21 +363,19 @@ send_get_common (const char *type, get_data_t *get, iterator_t *iterator,
               && permission_is_admin (get_iterator_uuid (iterator)))
           && acl_user_can_everything (current_credentials.uuid)))
     {
-      buffer_xml_append_printf (buffer,
-                                "<permission>"
-                                "<name>Everything</name>"
-                                "</permission>"
-                                "</permissions>");
+      buffer_xml_append_printf (buffer, "<permission>"
+                                        "<name>Everything</name>"
+                                        "</permission>"
+                                        "</permissions>");
     }
-  else if (current_credentials.uuid
-           && (strcmp (type, "user") == 0)
+  else if (current_credentials.uuid && (strcmp (type, "user") == 0)
            && acl_user_can_super_everyone (get_iterator_uuid (iterator))
            && strcmp (get_iterator_uuid (iterator), current_credentials.uuid))
     {
       /* Resource is the Super Admin. */
-      buffer_xml_append_printf (buffer,
-                                "<permission><name>get_users</name></permission>"
-                                "</permissions>");
+      buffer_xml_append_printf (
+        buffer, "<permission><name>get_users</name></permission>"
+                "</permissions>");
     }
   else
     {
@@ -417,9 +399,8 @@ send_get_common (const char *type, get_data_t *get, iterator_t *iterator,
     }
 
   tag_type = get->subtype ? get->subtype : get->type;
-  tag_count = resource_tag_count (tag_type,
-                                  get_iterator_resource (iterator),
-                                  1);
+  tag_count =
+    resource_tag_count (tag_type, get_iterator_resource (iterator), 1);
 
   if (tag_count)
     {
@@ -430,9 +411,8 @@ send_get_common (const char *type, get_data_t *get, iterator_t *iterator,
                                     "<count>%i</count>",
                                     tag_count);
 
-          init_resource_tag_iterator (&tags, tag_type,
-                                      get_iterator_resource (iterator),
-                                      1, NULL, 1);
+          init_resource_tag_iterator (
+            &tags, tag_type, get_iterator_resource (iterator), 1, NULL, 1);
 
           while (next (&tags))
             {
@@ -450,8 +430,7 @@ send_get_common (const char *type, get_data_t *get, iterator_t *iterator,
 
           cleanup_iterator (&tags);
 
-          buffer_xml_append_printf (buffer,
-                                    "</user_tags>");
+          buffer_xml_append_printf (buffer, "</user_tags>");
         }
       else
         {
@@ -484,9 +463,8 @@ send_get_common (const char *type, get_data_t *get, iterator_t *iterator,
  * @return Always 0.
  */
 int
-buffer_get_filter_xml (GString *msg, const char* type,
-                       const get_data_t *get, const char* filter_term,
-                       const char *extra_xml)
+buffer_get_filter_xml (GString *msg, const char *type, const get_data_t *get,
+                       const char *filter_term, const char *extra_xml)
 {
   keyword_t **point;
   array_t *split;
@@ -495,52 +473,45 @@ buffer_get_filter_xml (GString *msg, const char* type,
   buffer_xml_append_printf (msg,
                             "<filters id=\"%s\">"
                             "<term>%s</term>",
-                            get->filt_id ? get->filt_id : "",
-                            filter_term);
+                            get->filt_id ? get->filt_id : "", filter_term);
 
-  if (get->filt_id
-      && strcmp (get->filt_id, "")
+  if (get->filt_id && strcmp (get->filt_id, "")
       && (find_filter_with_permission (get->filt_id, &filter, "get_filters")
           == 0)
       && filter != 0)
-    buffer_xml_append_printf (msg,
-                              "<name>%s</name>",
-                              filter_name (filter));
+    buffer_xml_append_printf (msg, "<name>%s</name>", filter_name (filter));
 
   if (extra_xml)
     g_string_append (msg, extra_xml);
 
-  buffer_xml_append_printf (msg,
-                            "<keywords>");
+  buffer_xml_append_printf (msg, "<keywords>");
 
   split = split_filter (filter_term);
-  point = (keyword_t**) split->pdata;
+  point = (keyword_t **) split->pdata;
   while (*point)
     {
       keyword_t *keyword;
       keyword = *point;
-      buffer_xml_append_printf (msg,
-                                "<keyword>"
-                                "<column>%s</column>"
-                                "<relation>%s</relation>"
-                                "<value>%s%s%s</value>"
-                                "</keyword>",
-                                keyword->column ? keyword->column : "",
-                                keyword->equal
-                                  ? "="
-                                  : (keyword_special (keyword)
-                                       ? ""
-                                       : keyword_relation_symbol (keyword->relation)),
-                                keyword->quoted ? "\"" : "",
-                                keyword->string ? keyword->string : "",
-                                keyword->quoted ? "\"" : "");
+      buffer_xml_append_printf (
+        msg,
+        "<keyword>"
+        "<column>%s</column>"
+        "<relation>%s</relation>"
+        "<value>%s%s%s</value>"
+        "</keyword>",
+        keyword->column ? keyword->column : "",
+        keyword->equal ? "="
+                       : (keyword_special (keyword)
+                            ? ""
+                            : keyword_relation_symbol (keyword->relation)),
+        keyword->quoted ? "\"" : "", keyword->string ? keyword->string : "",
+        keyword->quoted ? "\"" : "");
       point++;
     }
   filter_free (split);
 
-  buffer_xml_append_printf (msg,
-                            "</keywords>"
-                            "</filters>");
+  buffer_xml_append_printf (msg, "</keywords>"
+                                 "</filters>");
   return 0;
 }
 
@@ -562,8 +533,8 @@ buffer_get_filter_xml (GString *msg, const char* type,
 static int
 send_get_end_internal (const char *type, get_data_t *get, int get_counts,
                        int count, int filtered, int full,
-                       int (*write_to_client) (const char *, void*),
-                       void* write_to_client_data)
+                       int (*write_to_client) (const char *, void *),
+                       void *write_to_client_data)
 {
   gchar *sort_field, *filter;
   int first, max, sort_order;
@@ -581,11 +552,10 @@ send_get_end_internal (const char *type, get_data_t *get, int get_counts,
   else
     filter = NULL;
 
-  manage_filter_controls (filter ? filter : get->filter,
-                          &first, &max, &sort_field, &sort_order);
+  manage_filter_controls (filter ? filter : get->filter, &first, &max,
+                          &sort_field, &sort_order);
 
-  if (get->ignore_pagination
-      && (strcmp (type, "task") == 0))
+  if (get->ignore_pagination && (strcmp (type, "task") == 0))
     {
       first = 1;
       max = -1;
@@ -598,8 +568,7 @@ send_get_end_internal (const char *type, get_data_t *get, int get_counts,
       gchar *new_filter;
       new_filter = manage_clean_filter (filter ? filter : get->filter);
       g_free (filter);
-      if ((strcmp (type, "task") == 0)
-          || (strcmp (type, "report") == 0)
+      if ((strcmp (type, "task") == 0) || (strcmp (type, "report") == 0)
           || (strcmp (type, "result") == 0))
         {
           gchar *value;
@@ -608,9 +577,8 @@ send_get_end_internal (const char *type, get_data_t *get, int get_counts,
           if (value == NULL)
             {
               filter = new_filter;
-              new_filter = g_strdup_printf ("min_qod=%i %s",
-                                            MIN_QOD_DEFAULT,
-                                            filter);
+              new_filter =
+                g_strdup_printf ("min_qod=%i %s", MIN_QOD_DEFAULT, filter);
               g_free (filter);
             }
           g_free (value);
@@ -620,8 +588,7 @@ send_get_end_internal (const char *type, get_data_t *get, int get_counts,
             {
               filter = new_filter;
               new_filter = g_strdup_printf ("apply_overrides=%i %s",
-                                            APPLY_OVERRIDES_DEFAULT,
-                                            filter);
+                                            APPLY_OVERRIDES_DEFAULT, filter);
               g_free (filter);
             }
           g_free (value);
@@ -630,13 +597,10 @@ send_get_end_internal (const char *type, get_data_t *get, int get_counts,
     }
   else
     {
-      if ((strcmp (type, "task") == 0)
-          || (strcmp (type, "report") == 0)
+      if ((strcmp (type, "task") == 0) || (strcmp (type, "report") == 0)
           || (strcmp (type, "result") == 0))
-        filter = manage_clean_filter("apply_overrides="
-                                     G_STRINGIFY (APPLY_OVERRIDES_DEFAULT)
-                                     " min_qod="
-                                     G_STRINGIFY (MIN_QOD_DEFAULT));
+        filter = manage_clean_filter ("apply_overrides=" G_STRINGIFY (
+          APPLY_OVERRIDES_DEFAULT) " min_qod=" G_STRINGIFY (MIN_QOD_DEFAULT));
       else
         filter = manage_clean_filter ("");
     }
@@ -655,11 +619,8 @@ send_get_end_internal (const char *type, get_data_t *get, int get_counts,
                             "<field>%s<order>%s</order></field>"
                             "</sort>"
                             "<%s start=\"%i\" max=\"%i\"/>",
-                            sort_field,
-                            sort_order ? "ascending" : "descending",
-                            type_many->str,
-                            first,
-                            max);
+                            sort_field, sort_order ? "ascending" : "descending",
+                            type_many->str, first, max);
   if (get_counts)
     buffer_xml_append_printf (msg,
                               "<%s_count>"
@@ -667,14 +628,8 @@ send_get_end_internal (const char *type, get_data_t *get, int get_counts,
                               "<filtered>%i</filtered>"
                               "<page>%i</page>"
                               "</%s_count>",
-                              type,
-                              full,
-                              filtered,
-                              count,
-                              type);
-  buffer_xml_append_printf (msg,
-                            "</get_%s_response>",
-                            type_many->str);
+                              type, full, filtered, count, type);
+  buffer_xml_append_printf (msg, "</get_%s_response>", type_many->str);
   g_string_free (type_many, TRUE);
   g_free (sort_field);
   g_free (filter);
@@ -704,8 +659,8 @@ send_get_end_internal (const char *type, get_data_t *get, int get_counts,
  */
 int
 send_get_end (const char *type, get_data_t *get, int count, int filtered,
-              int full, int (*write_to_client) (const char *, void*),
-              void* write_to_client_data)
+              int full, int (*write_to_client) (const char *, void *),
+              void *write_to_client_data)
 {
   return send_get_end_internal (type, get, 1, count, filtered, full,
                                 write_to_client, write_to_client_data);
@@ -724,8 +679,8 @@ send_get_end (const char *type, get_data_t *get, int count, int filtered,
  */
 int
 send_get_end_no_counts (const char *type, get_data_t *get,
-                        int (*write_to_client) (const char *, void*),
-                        void* write_to_client_data)
+                        int (*write_to_client) (const char *, void *),
+                        void *write_to_client_data)
 {
   return send_get_end_internal (type, get, 0, 0, 0, 0, write_to_client,
                                 write_to_client_data);

--- a/src/gmp_get.c
+++ b/src/gmp_get.c
@@ -55,7 +55,8 @@
  * @param[in]  data  Command data.
  */
 void
-get_data_parse_attributes (get_data_t *data, const gchar *type,
+get_data_parse_attributes (get_data_t *data,
+                           const gchar *type,
                            const gchar **attribute_names,
                            const gchar **attribute_values)
 {
@@ -104,7 +105,9 @@ get_data_parse_attributes (get_data_t *data, const gchar *type,
  * @return 0 success, -1 error.
  */
 int
-init_get (gchar *command, get_data_t *get, const gchar *setting_name,
+init_get (gchar *command,
+          get_data_t *get,
+          const gchar *setting_name,
           int *first)
 {
   gchar *filter, *replacement;
@@ -227,7 +230,10 @@ init_get (gchar *command, get_data_t *get, const gchar *setting_name,
  * @return What to do next: 0 continue, 1 end, -1 fail.
  */
 int
-get_next (iterator_t *resources, get_data_t *get, int *first, int *count,
+get_next (iterator_t *resources,
+          get_data_t *get,
+          int *first,
+          int *count,
           int (*init) (iterator_t *, const get_data_t *))
 {
   if (next (resources) == FALSE)
@@ -271,7 +277,8 @@ get_next (iterator_t *resources, get_data_t *get, int *first, int *count,
  * @return 0 success, 1 send to client failed.
  */
 int
-send_get_start (const char *type, int (*write_to_client) (const char *, void *),
+send_get_start (const char *type,
+                int (*write_to_client) (const char *, void *),
                 void *write_to_client_data)
 {
   gchar *msg;
@@ -310,9 +317,13 @@ send_get_start (const char *type, int (*write_to_client) (const char *, void *),
  * @return 0 success, 1 send error.
  */
 int
-send_get_common (const char *type, get_data_t *get, iterator_t *iterator,
+send_get_common (const char *type,
+                 get_data_t *get,
+                 iterator_t *iterator,
                  int (*write_to_client) (const char *, void *),
-                 void *write_to_client_data, int writable, int in_use)
+                 void *write_to_client_data,
+                 int writable,
+                 int in_use)
 {
   GString *buffer;
   const char *tag_type;
@@ -467,8 +478,11 @@ send_get_common (const char *type, get_data_t *get, iterator_t *iterator,
  * @return Always 0.
  */
 int
-buffer_get_filter_xml (GString *msg, const char *type, const get_data_t *get,
-                       const char *filter_term, const char *extra_xml)
+buffer_get_filter_xml (GString *msg,
+                       const char *type,
+                       const get_data_t *get,
+                       const char *filter_term,
+                       const char *extra_xml)
 {
   keyword_t **point;
   array_t *split;
@@ -538,8 +552,12 @@ buffer_get_filter_xml (GString *msg, const char *type, const get_data_t *get,
  *         term.
  */
 static int
-send_get_end_internal (const char *type, get_data_t *get, int get_counts,
-                       int count, int filtered, int full,
+send_get_end_internal (const char *type,
+                       get_data_t *get,
+                       int get_counts,
+                       int count,
+                       int filtered,
+                       int full,
                        int (*write_to_client) (const char *, void *),
                        void *write_to_client_data)
 {
@@ -672,8 +690,12 @@ send_get_end_internal (const char *type, get_data_t *get, int get_counts,
  *         term.
  */
 int
-send_get_end (const char *type, get_data_t *get, int count, int filtered,
-              int full, int (*write_to_client) (const char *, void *),
+send_get_end (const char *type,
+              get_data_t *get,
+              int count,
+              int filtered,
+              int full,
+              int (*write_to_client) (const char *, void *),
               void *write_to_client_data)
 {
   return send_get_end_internal (
@@ -692,7 +714,8 @@ send_get_end (const char *type, get_data_t *get, int count, int filtered,
  *         term.
  */
 int
-send_get_end_no_counts (const char *type, get_data_t *get,
+send_get_end_no_counts (const char *type,
+                        get_data_t *get,
                         int (*write_to_client) (const char *, void *),
                         void *write_to_client_data)
 {

--- a/src/gmp_get.h
+++ b/src/gmp_get.h
@@ -29,7 +29,9 @@
 #include "manage.h"
 
 void
-get_data_parse_attributes (get_data_t *, const gchar *, const gchar **,
+get_data_parse_attributes (get_data_t *,
+                           const gchar *,
+                           const gchar **,
                            const gchar **);
 
 int
@@ -65,7 +67,10 @@ init_get (gchar *, get_data_t *, const gchar *, int *);
     }
 
 int
-get_next (iterator_t *, get_data_t *, int *, int *,
+get_next (iterator_t *,
+          get_data_t *,
+          int *,
+          int *,
           int (*) (iterator_t *, const get_data_t *));
 
 int
@@ -90,8 +95,13 @@ send_get_start (const char *, int (*) (const char *, void *), void *);
   while (0)
 
 int
-send_get_common (const char *, get_data_t *, iterator_t *,
-                 int (*) (const char *, void *), void *, int, int);
+send_get_common (const char *,
+                 get_data_t *,
+                 iterator_t *,
+                 int (*) (const char *, void *),
+                 void *,
+                 int,
+                 int);
 
 /**
  * @brief Send common part of GET response to client, returning on fail.
@@ -123,16 +133,26 @@ send_get_common (const char *, get_data_t *, iterator_t *,
   while (0)
 
 int
-buffer_get_filter_xml (GString *, const char *, const get_data_t *,
-                       const char *, const char *);
+buffer_get_filter_xml (GString *,
+                       const char *,
+                       const get_data_t *,
+                       const char *,
+                       const char *);
 
 int
-send_get_end (const char *, get_data_t *, int, int, int,
-              int (*) (const char *, void *), void *);
+send_get_end (const char *,
+              get_data_t *,
+              int,
+              int,
+              int,
+              int (*) (const char *, void *),
+              void *);
 
 int
-send_get_end_no_counts (const char *, get_data_t *,
-                        int (*) (const char *, void *), void *);
+send_get_end_no_counts (const char *,
+                        get_data_t *,
+                        int (*) (const char *, void *),
+                        void *);
 
 /**
  * @brief Send end of GET response to client, returning on fail.

--- a/src/gmp_get.h
+++ b/src/gmp_get.h
@@ -41,25 +41,27 @@ init_get (gchar *, get_data_t *, const gchar *, int *);
  * @param[in]  type     Resource type.
  * @param[in]  capital  Resource type, capitalised.
  */
-#define INIT_GET(type, capital)                                            \
-  count = 0;                                                               \
-  ret = init_get ("get_" G_STRINGIFY (type) "s", &get_##type##s_data->get, \
-                  G_STRINGIFY (capital) "s", &first);                      \
-  if (ret)                                                                 \
-    {                                                                      \
-      switch (ret)                                                         \
-        {                                                                  \
-        case 99:                                                           \
-          SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX (                       \
-            "get_" G_STRINGIFY (type) "s", "Permission denied"));          \
-          break;                                                           \
-        default:                                                           \
-          internal_error_send_to_client (error);                           \
-          return;                                                          \
-        }                                                                  \
-      get_##type##s_data_reset (get_##type##s_data);                       \
-      set_client_state (CLIENT_AUTHENTIC);                                 \
-      return;                                                              \
+#define INIT_GET(type, capital)                                   \
+  count = 0;                                                      \
+  ret = init_get ("get_" G_STRINGIFY (type) "s",                  \
+                  &get_##type##s_data->get,                       \
+                  G_STRINGIFY (capital) "s",                      \
+                  &first);                                        \
+  if (ret)                                                        \
+    {                                                             \
+      switch (ret)                                                \
+        {                                                         \
+        case 99:                                                  \
+          SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX (              \
+            "get_" G_STRINGIFY (type) "s", "Permission denied")); \
+          break;                                                  \
+        default:                                                  \
+          internal_error_send_to_client (error);                  \
+          return;                                                 \
+        }                                                         \
+      get_##type##s_data_reset (get_##type##s_data);              \
+      set_client_state (CLIENT_AUTHENTIC);                        \
+      return;                                                     \
     }
 
 int
@@ -75,16 +77,16 @@ send_get_start (const char *, int (*) (const char *, void *), void *);
  * @param[in]  type  Type of resource.
  * @param[in]  get   GET data.
  */
-#define SEND_GET_START(type)                               \
-  do                                                       \
-    {                                                      \
-      if (send_get_start (type, gmp_parser->client_writer, \
-                          gmp_parser->client_writer_data)) \
-        {                                                  \
-          error_send_to_client (error);                    \
-          return;                                          \
-        }                                                  \
-    }                                                      \
+#define SEND_GET_START(type)                                                  \
+  do                                                                          \
+    {                                                                         \
+      if (send_get_start (                                                    \
+            type, gmp_parser->client_writer, gmp_parser->client_writer_data)) \
+        {                                                                     \
+          error_send_to_client (error);                                       \
+          return;                                                             \
+        }                                                                     \
+    }                                                                         \
   while (0)
 
 int
@@ -102,7 +104,10 @@ send_get_common (const char *, get_data_t *, iterator_t *,
   do                                                                       \
     {                                                                      \
       if (send_get_common (                                                \
-            G_STRINGIFY (type), get, iterator, gmp_parser->client_writer,  \
+            G_STRINGIFY (type),                                            \
+            get,                                                           \
+            iterator,                                                      \
+            gmp_parser->client_writer,                                     \
             gmp_parser->client_writer_data,                                \
             (get)->trash                                                   \
               ? trash_##type##_writable (get_iterator_resource (iterator)) \
@@ -135,17 +140,21 @@ send_get_end_no_counts (const char *, get_data_t *,
  * @param[in]  type  Type of resource.
  * @param[in]  get   GET data.
  */
-#define SEND_GET_END(type, get, count, filtered)                               \
-  do                                                                           \
-    {                                                                          \
-      if (send_get_end (type, get, count, filtered,                            \
-                        resource_count (type, get), gmp_parser->client_writer, \
-                        gmp_parser->client_writer_data))                       \
-        {                                                                      \
-          error_send_to_client (error);                                        \
-          return;                                                              \
-        }                                                                      \
-    }                                                                          \
+#define SEND_GET_END(type, get, count, filtered)         \
+  do                                                     \
+    {                                                    \
+      if (send_get_end (type,                            \
+                        get,                             \
+                        count,                           \
+                        filtered,                        \
+                        resource_count (type, get),      \
+                        gmp_parser->client_writer,       \
+                        gmp_parser->client_writer_data)) \
+        {                                                \
+          error_send_to_client (error);                  \
+          return;                                        \
+        }                                                \
+    }                                                    \
   while (0)
 
 #endif /* not _GVMD_GMP_GET_H */

--- a/src/gmp_get.h
+++ b/src/gmp_get.h
@@ -41,36 +41,33 @@ init_get (gchar *, get_data_t *, const gchar *, int *);
  * @param[in]  type     Resource type.
  * @param[in]  capital  Resource type, capitalised.
  */
-#define INIT_GET(type, capital)                                          \
-  count = 0;                                                             \
-  ret = init_get ("get_" G_STRINGIFY (type) "s",                         \
-                  &get_ ## type ## s_data->get,                          \
-                  G_STRINGIFY (capital) "s",                             \
-                  &first);                                               \
-  if (ret)                                                               \
-    {                                                                    \
-      switch (ret)                                                       \
-        {                                                                \
-          case 99:                                                       \
-            SEND_TO_CLIENT_OR_FAIL                                       \
-             (XML_ERROR_SYNTAX ("get_" G_STRINGIFY (type) "s",           \
-                                "Permission denied"));                   \
-            break;                                                       \
-          default:                                                       \
-            internal_error_send_to_client (error);                       \
-            return;                                                      \
-        }                                                                \
-      get_ ## type ## s_data_reset (get_ ## type ## s_data);             \
-      set_client_state (CLIENT_AUTHENTIC);                               \
-      return;                                                            \
+#define INIT_GET(type, capital)                                            \
+  count = 0;                                                               \
+  ret = init_get ("get_" G_STRINGIFY (type) "s", &get_##type##s_data->get, \
+                  G_STRINGIFY (capital) "s", &first);                      \
+  if (ret)                                                                 \
+    {                                                                      \
+      switch (ret)                                                         \
+        {                                                                  \
+        case 99:                                                           \
+          SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX (                       \
+            "get_" G_STRINGIFY (type) "s", "Permission denied"));          \
+          break;                                                           \
+        default:                                                           \
+          internal_error_send_to_client (error);                           \
+          return;                                                          \
+        }                                                                  \
+      get_##type##s_data_reset (get_##type##s_data);                       \
+      set_client_state (CLIENT_AUTHENTIC);                                 \
+      return;                                                              \
     }
 
 int
 get_next (iterator_t *, get_data_t *, int *, int *,
-          int (*) (iterator_t*, const get_data_t *));
+          int (*) (iterator_t *, const get_data_t *));
 
 int
-send_get_start (const char *, int (*) (const char*, void*), void*);
+send_get_start (const char *, int (*) (const char *, void *), void *);
 
 /**
  * @brief Send start of GET response to client, returning on fail.
@@ -78,21 +75,21 @@ send_get_start (const char *, int (*) (const char*, void*), void*);
  * @param[in]  type  Type of resource.
  * @param[in]  get   GET data.
  */
-#define SEND_GET_START(type)                                                 \
-  do                                                                         \
-    {                                                                        \
-      if (send_get_start (type, gmp_parser->client_writer,                   \
-                          gmp_parser->client_writer_data))                   \
-        {                                                                    \
-          error_send_to_client (error);                                      \
-          return;                                                            \
-        }                                                                    \
-    }                                                                        \
+#define SEND_GET_START(type)                               \
+  do                                                       \
+    {                                                      \
+      if (send_get_start (type, gmp_parser->client_writer, \
+                          gmp_parser->client_writer_data)) \
+        {                                                  \
+          error_send_to_client (error);                    \
+          return;                                          \
+        }                                                  \
+    }                                                      \
   while (0)
 
 int
 send_get_common (const char *, get_data_t *, iterator_t *,
-                 int (*) (const char *, void*), void *, int, int);
+                 int (*) (const char *, void *), void *, int, int);
 
 /**
  * @brief Send common part of GET response to client, returning on fail.
@@ -101,31 +98,23 @@ send_get_common (const char *, get_data_t *, iterator_t *,
  * @param[in]  get       GET data.
  * @param[in]  iterator  Iterator.
  */
-#define SEND_GET_COMMON(type, get, iterator)                                   \
-  do                                                                           \
-    {                                                                          \
-      if (send_get_common (G_STRINGIFY (type), get, iterator,                  \
-                           gmp_parser->client_writer,                          \
-                           gmp_parser->client_writer_data,                     \
-                           (get)->trash                                        \
-                            ? trash_ ## type ## _writable                      \
-                               (get_iterator_resource                          \
-                                 (iterator))                                   \
-                            : type ## _writable                                \
-                               (get_iterator_resource                          \
-                                 (iterator)),                                  \
-                           (get)->trash                                        \
-                            ? trash_ ## type ## _in_use                        \
-                               (get_iterator_resource                          \
-                                 (iterator))                                   \
-                            : type ## _in_use                                  \
-                               (get_iterator_resource                          \
-                                 (iterator))))                                 \
-        {                                                                      \
-          error_send_to_client (error);                                        \
-          return;                                                              \
-        }                                                                      \
-    }                                                                          \
+#define SEND_GET_COMMON(type, get, iterator)                               \
+  do                                                                       \
+    {                                                                      \
+      if (send_get_common (                                                \
+            G_STRINGIFY (type), get, iterator, gmp_parser->client_writer,  \
+            gmp_parser->client_writer_data,                                \
+            (get)->trash                                                   \
+              ? trash_##type##_writable (get_iterator_resource (iterator)) \
+              : type##_writable (get_iterator_resource (iterator)),        \
+            (get)->trash                                                   \
+              ? trash_##type##_in_use (get_iterator_resource (iterator))   \
+              : type##_in_use (get_iterator_resource (iterator))))         \
+        {                                                                  \
+          error_send_to_client (error);                                    \
+          return;                                                          \
+        }                                                                  \
+    }                                                                      \
   while (0)
 
 int
@@ -146,18 +135,17 @@ send_get_end_no_counts (const char *, get_data_t *,
  * @param[in]  type  Type of resource.
  * @param[in]  get   GET data.
  */
-#define SEND_GET_END(type, get, count, filtered)                             \
-  do                                                                         \
-    {                                                                        \
-      if (send_get_end (type, get, count, filtered,                          \
-                        resource_count (type, get),                          \
-                        gmp_parser->client_writer,                           \
-                        gmp_parser->client_writer_data))                     \
-        {                                                                    \
-          error_send_to_client (error);                                      \
-          return;                                                            \
-        }                                                                    \
-    }                                                                        \
+#define SEND_GET_END(type, get, count, filtered)                               \
+  do                                                                           \
+    {                                                                          \
+      if (send_get_end (type, get, count, filtered,                            \
+                        resource_count (type, get), gmp_parser->client_writer, \
+                        gmp_parser->client_writer_data))                       \
+        {                                                                      \
+          error_send_to_client (error);                                        \
+          return;                                                              \
+        }                                                                      \
+    }                                                                          \
   while (0)
 
 #endif /* not _GVMD_GMP_GET_H */

--- a/src/gmp_tickets.c
+++ b/src/gmp_tickets.c
@@ -348,7 +348,8 @@ create_ticket_reset ()
  * @param[in]  attribute_values  All attribute values.
  */
 void
-create_ticket_start (gmp_parser_t *gmp_parser, const gchar **attribute_names,
+create_ticket_start (gmp_parser_t *gmp_parser,
+                     const gchar **attribute_names,
                      const gchar **attribute_values)
 {
   memset (&create_ticket_data, 0, sizeof (create_ticket_t));
@@ -366,7 +367,8 @@ create_ticket_start (gmp_parser_t *gmp_parser, const gchar **attribute_names,
  * @param[in]  attribute_values  All attribute values.
  */
 void
-create_ticket_element_start (gmp_parser_t *gmp_parser, const gchar *name,
+create_ticket_element_start (gmp_parser_t *gmp_parser,
+                             const gchar *name,
                              const gchar **attribute_names,
                              const gchar **attribute_values)
 {
@@ -553,7 +555,8 @@ create_ticket_run (gmp_parser_t *gmp_parser, GError **error)
  * @return 0 success, 1 command finished.
  */
 int
-create_ticket_element_end (gmp_parser_t *gmp_parser, GError **error,
+create_ticket_element_end (gmp_parser_t *gmp_parser,
+                           GError **error,
                            const gchar *name)
 {
   xml_handle_end_element (create_ticket_data.context, name);
@@ -617,7 +620,8 @@ modify_ticket_reset ()
  * @param[in]  attribute_values  All attribute values.
  */
 void
-modify_ticket_start (gmp_parser_t *gmp_parser, const gchar **attribute_names,
+modify_ticket_start (gmp_parser_t *gmp_parser,
+                     const gchar **attribute_names,
                      const gchar **attribute_values)
 {
   memset (&modify_ticket_data, 0, sizeof (modify_ticket_t));
@@ -635,7 +639,8 @@ modify_ticket_start (gmp_parser_t *gmp_parser, const gchar **attribute_names,
  * @param[in]  attribute_values  All attribute values.
  */
 void
-modify_ticket_element_start (gmp_parser_t *gmp_parser, const gchar *name,
+modify_ticket_element_start (gmp_parser_t *gmp_parser,
+                             const gchar *name,
                              const gchar **attribute_names,
                              const gchar **attribute_values)
 {
@@ -784,7 +789,8 @@ modify_ticket_run (gmp_parser_t *gmp_parser, GError **error)
  * @return 0 success, 1 command finished.
  */
 int
-modify_ticket_element_end (gmp_parser_t *gmp_parser, GError **error,
+modify_ticket_element_end (gmp_parser_t *gmp_parser,
+                           GError **error,
                            const gchar *name)
 {
   xml_handle_end_element (modify_ticket_data.context, name);

--- a/src/gmp_tickets.c
+++ b/src/gmp_tickets.c
@@ -84,8 +84,8 @@ void
 get_tickets_start (const gchar **attribute_names,
                    const gchar **attribute_values)
 {
-  get_data_parse_attributes (&get_tickets_data.get, "ticket", attribute_names,
-                             attribute_values);
+  get_data_parse_attributes (
+    &get_tickets_data.get, "ticket", attribute_names, attribute_values);
 }
 
 /**
@@ -128,8 +128,8 @@ get_tickets_run (gmp_parser_t *gmp_parser, GError **error)
       switch (ret)
         {
         case 1:
-          if (send_find_error_to_client ("get_tickets", "ticket",
-                                         get_tickets_data.get.id, gmp_parser))
+          if (send_find_error_to_client (
+                "get_tickets", "ticket", get_tickets_data.get.id, gmp_parser))
             {
               error_send_to_client (error);
               get_tickets_reset ();
@@ -137,7 +137,8 @@ get_tickets_run (gmp_parser_t *gmp_parser, GError **error)
             }
           break;
         case 2:
-          if (send_find_error_to_client ("get_tickets", "filter",
+          if (send_find_error_to_client ("get_tickets",
+                                         "filter",
                                          get_tickets_data.get.filt_id,
                                          gmp_parser))
             {
@@ -162,8 +163,8 @@ get_tickets_run (gmp_parser_t *gmp_parser, GError **error)
       iterator_t results;
       int orphan;
 
-      ret = get_next (&tickets, &get_tickets_data.get, &first, &count,
-                      init_ticket_iterator);
+      ret = get_next (
+        &tickets, &get_tickets_data.get, &first, &count, init_ticket_iterator);
       if (ret == 1)
         break;
       if (ret == -1)
@@ -179,28 +180,29 @@ get_tickets_run (gmp_parser_t *gmp_parser, GError **error)
 
       /* Send ticket info. */
 
-      SENDF_TO_CLIENT_OR_FAIL (
-        "<assigned_to>"
-        "<user id=\"%s\">"
-        "<name>%s</name>"
-        "</user>"
-        "</assigned_to>"
-        "<severity>%1.1f</severity>"
-        "<host>%s</host>"
-        "<location>%s</location>"
-        "<solution_type>%s</solution_type>"
-        "<status>%s</status>"
-        "<open_time>%s</open_time>"
-        "<open_note>%s</open_note>"
-        "<nvt oid=\"%s\"/>",
-        ticket_iterator_user_id (&tickets),
-        ticket_iterator_user_name (&tickets),
-        ticket_iterator_severity (&tickets), ticket_iterator_host (&tickets),
-        ticket_iterator_location (&tickets),
-        ticket_iterator_solution_type (&tickets),
-        ticket_iterator_status (&tickets), ticket_iterator_open_time (&tickets),
-        ticket_iterator_open_note (&tickets),
-        ticket_iterator_nvt_oid (&tickets));
+      SENDF_TO_CLIENT_OR_FAIL ("<assigned_to>"
+                               "<user id=\"%s\">"
+                               "<name>%s</name>"
+                               "</user>"
+                               "</assigned_to>"
+                               "<severity>%1.1f</severity>"
+                               "<host>%s</host>"
+                               "<location>%s</location>"
+                               "<solution_type>%s</solution_type>"
+                               "<status>%s</status>"
+                               "<open_time>%s</open_time>"
+                               "<open_note>%s</open_note>"
+                               "<nvt oid=\"%s\"/>",
+                               ticket_iterator_user_id (&tickets),
+                               ticket_iterator_user_name (&tickets),
+                               ticket_iterator_severity (&tickets),
+                               ticket_iterator_host (&tickets),
+                               ticket_iterator_location (&tickets),
+                               ticket_iterator_solution_type (&tickets),
+                               ticket_iterator_status (&tickets),
+                               ticket_iterator_open_time (&tickets),
+                               ticket_iterator_open_note (&tickets),
+                               ticket_iterator_nvt_oid (&tickets));
 
       if (ticket_iterator_task_id (&tickets))
         SENDF_TO_CLIENT_OR_FAIL (
@@ -271,14 +273,15 @@ get_tickets_run (gmp_parser_t *gmp_parser, GError **error)
                 "<timestamp>%s</timestamp>"
                 "</report>"
                 "</fix_verified_report>",
-                ticket_iterator_fix_verified_report_id (&tickets), timestamp);
+                ticket_iterator_fix_verified_report_id (&tickets),
+                timestamp);
             }
         }
 
       /* Send results that are linked to ticket. */
 
-      if (init_ticket_result_iterator (&results, get_iterator_uuid (&tickets),
-                                       get_tickets_data.get.trash))
+      if (init_ticket_result_iterator (
+            &results, get_iterator_uuid (&tickets), get_tickets_data.get.trash))
         {
           internal_error_send_to_client (error);
           get_tickets_reset ();
@@ -350,8 +353,8 @@ create_ticket_start (gmp_parser_t *gmp_parser, const gchar **attribute_names,
 {
   memset (&create_ticket_data, 0, sizeof (create_ticket_t));
   create_ticket_data.context = g_malloc0 (sizeof (context_data_t));
-  create_ticket_element_start (gmp_parser, "create_ticket", attribute_names,
-                               attribute_values);
+  create_ticket_element_start (
+    gmp_parser, "create_ticket", attribute_names, attribute_values);
 }
 
 /**
@@ -367,8 +370,8 @@ create_ticket_element_start (gmp_parser_t *gmp_parser, const gchar *name,
                              const gchar **attribute_names,
                              const gchar **attribute_values)
 {
-  xml_handle_start_element (create_ticket_data.context, name, attribute_names,
-                            attribute_values);
+  xml_handle_start_element (
+    create_ticket_data.context, name, attribute_names, attribute_values);
 }
 
 /**
@@ -393,8 +396,8 @@ create_ticket_run (gmp_parser_t *gmp_parser, GError **error)
       /* Copy from an existing ticket and exit. */
 
       comment = entity_child (entity, "comment");
-      switch (copy_ticket (comment ? entity_text (comment) : "",
-                           entity_text (copy), &new_ticket))
+      switch (copy_ticket (
+        comment ? entity_text (comment) : "", entity_text (copy), &new_ticket))
         {
         case 0:
           {
@@ -411,8 +414,8 @@ create_ticket_run (gmp_parser_t *gmp_parser, GError **error)
           log_event_fail ("ticket", "Ticket", NULL, "created");
           break;
         case 2:
-          if (send_find_error_to_client ("create_ticket", "ticket",
-                                         entity_text (copy), gmp_parser))
+          if (send_find_error_to_client (
+                "create_ticket", "ticket", entity_text (copy), gmp_parser))
             {
               error_send_to_client (error);
               return;
@@ -481,18 +484,23 @@ create_ticket_run (gmp_parser_t *gmp_parser, GError **error)
 
   if ((result_id == NULL) || (strlen (result_id) == 0))
     SEND_TO_CLIENT_OR_FAIL (
-      XML_ERROR_SYNTAX ("create_ticket", "CREATE_TICKET RESULT must have an id"
-                                         " attribute"));
+      XML_ERROR_SYNTAX ("create_ticket",
+                        "CREATE_TICKET RESULT must have an id"
+                        " attribute"));
   else if ((user_id == NULL) || (strlen (user_id) == 0))
     SEND_TO_CLIENT_OR_FAIL (
-      XML_ERROR_SYNTAX ("create_ticket", "CREATE_TICKET USER must have an id"
-                                         " attribute"));
+      XML_ERROR_SYNTAX ("create_ticket",
+                        "CREATE_TICKET USER must have an id"
+                        " attribute"));
   else if (strlen (entity_text (open_note)) == 0)
     SEND_TO_CLIENT_OR_FAIL (
       XML_ERROR_SYNTAX ("create_ticket", "CREATE_TICKET OPEN_NOTE is empty"));
   else
-    switch (create_ticket (comment ? entity_text (comment) : "", result_id,
-                           user_id, entity_text (open_note), &new_ticket))
+    switch (create_ticket (comment ? entity_text (comment) : "",
+                           result_id,
+                           user_id,
+                           entity_text (open_note),
+                           &new_ticket))
       {
       case 0:
         {
@@ -504,8 +512,8 @@ create_ticket_run (gmp_parser_t *gmp_parser, GError **error)
         }
       case 1:
         log_event_fail ("ticket", "Ticket", NULL, "created");
-        if (send_find_error_to_client ("create_ticket", "user", user_id,
-                                       gmp_parser))
+        if (send_find_error_to_client (
+              "create_ticket", "user", user_id, gmp_parser))
           {
             error_send_to_client (error);
             return;
@@ -513,8 +521,8 @@ create_ticket_run (gmp_parser_t *gmp_parser, GError **error)
         break;
       case 2:
         log_event_fail ("ticket", "Ticket", NULL, "created");
-        if (send_find_error_to_client ("create_ticket", "result", result_id,
-                                       gmp_parser))
+        if (send_find_error_to_client (
+              "create_ticket", "result", result_id, gmp_parser))
           {
             error_send_to_client (error);
             return;
@@ -614,8 +622,8 @@ modify_ticket_start (gmp_parser_t *gmp_parser, const gchar **attribute_names,
 {
   memset (&modify_ticket_data, 0, sizeof (modify_ticket_t));
   modify_ticket_data.context = g_malloc0 (sizeof (context_data_t));
-  modify_ticket_element_start (gmp_parser, "modify_ticket", attribute_names,
-                               attribute_values);
+  modify_ticket_element_start (
+    gmp_parser, "modify_ticket", attribute_names, attribute_values);
 }
 
 /**
@@ -631,8 +639,8 @@ modify_ticket_element_start (gmp_parser_t *gmp_parser, const gchar *name,
                              const gchar **attribute_names,
                              const gchar **attribute_values)
 {
-  xml_handle_start_element (modify_ticket_data.context, name, attribute_names,
-                            attribute_values);
+  xml_handle_start_element (
+    modify_ticket_data.context, name, attribute_names, attribute_values);
 }
 
 /**
@@ -677,9 +685,10 @@ modify_ticket_run (gmp_parser_t *gmp_parser, GError **error)
       user_id = entity_attribute (user, "id");
       if ((user_id == NULL) || (strlen (user_id) == 0))
         {
-          SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX (
-            "modify_ticket", "MODIFY_TICKET USER must have an id"
-                             " attribute"));
+          SEND_TO_CLIENT_OR_FAIL (
+            XML_ERROR_SYNTAX ("modify_ticket",
+                              "MODIFY_TICKET USER must have an id"
+                              " attribute"));
           modify_ticket_reset ();
           return;
         }
@@ -691,10 +700,12 @@ modify_ticket_run (gmp_parser_t *gmp_parser, GError **error)
 
   if (ticket_id == NULL)
     SEND_TO_CLIENT_OR_FAIL (
-      XML_ERROR_SYNTAX ("modify_ticket", "MODIFY_TICKET requires a ticket_id"
-                                         " attribute"));
+      XML_ERROR_SYNTAX ("modify_ticket",
+                        "MODIFY_TICKET requires a ticket_id"
+                        " attribute"));
   else
-    switch (modify_ticket (ticket_id, comment ? entity_text (comment) : NULL,
+    switch (modify_ticket (ticket_id,
+                           comment ? entity_text (comment) : NULL,
                            status ? entity_text (status) : NULL,
                            open_note ? entity_text (open_note) : NULL,
                            fixed_note ? entity_text (fixed_note) : NULL,
@@ -712,8 +723,8 @@ modify_ticket_run (gmp_parser_t *gmp_parser, GError **error)
         break;
       case 2:
         log_event_fail ("ticket", "Ticket", ticket_id, "modified");
-        if (send_find_error_to_client ("modify_ticket", "ticket", ticket_id,
-                                       gmp_parser))
+        if (send_find_error_to_client (
+              "modify_ticket", "ticket", ticket_id, gmp_parser))
           {
             error_send_to_client (error);
             return;
@@ -721,8 +732,8 @@ modify_ticket_run (gmp_parser_t *gmp_parser, GError **error)
         break;
       case 3:
         log_event_fail ("ticket", "Ticket", ticket_id, "modified");
-        if (send_find_error_to_client ("modify_ticket", "user", user_id,
-                                       gmp_parser))
+        if (send_find_error_to_client (
+              "modify_ticket", "user", user_id, gmp_parser))
           {
             error_send_to_client (error);
             return;
@@ -819,7 +830,8 @@ buffer_result_tickets_xml (GString *buffer, result_t result)
     {
       buffer_xml_append_printf (buffer, "<tickets>");
       while (next (&tickets))
-        buffer_xml_append_printf (buffer, "<ticket id=\"%s\"/>",
+        buffer_xml_append_printf (buffer,
+                                  "<ticket id=\"%s\"/>",
                                   result_ticket_iterator_ticket_id (&tickets));
       buffer_xml_append_printf (buffer, "</tickets>");
       cleanup_iterator (&tickets);

--- a/src/gmp_tickets.c
+++ b/src/gmp_tickets.c
@@ -31,15 +31,15 @@
  */
 
 #include "gmp_tickets.h"
+
 #include "gmp_base.h"
 #include "gmp_get.h"
 #include "manage_tickets.h"
 
 #include <glib.h>
+#include <gvm/util/xmlutils.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <gvm/util/xmlutils.h>
 
 #undef G_LOG_DOMAIN
 /**
@@ -47,7 +47,6 @@
  */
 #define G_LOG_DOMAIN "md    gmp"
 
-
 /* GET_TICKETS. */
 
 /**
@@ -55,7 +54,7 @@
  */
 typedef struct
 {
-  get_data_t get;    ///< Get args.
+  get_data_t get; ///< Get args.
 } get_tickets_t;
 
 /**
@@ -85,8 +84,7 @@ void
 get_tickets_start (const gchar **attribute_names,
                    const gchar **attribute_values)
 {
-  get_data_parse_attributes (&get_tickets_data.get, "ticket",
-                             attribute_names,
+  get_data_parse_attributes (&get_tickets_data.get, "ticket", attribute_names,
                              attribute_values);
 }
 
@@ -104,23 +102,19 @@ get_tickets_run (gmp_parser_t *gmp_parser, GError **error)
 
   count = 0;
 
-  ret = init_get ("get_tickets",
-                  &get_tickets_data.get,
-                  "Tickets",
-                  &first);
+  ret = init_get ("get_tickets", &get_tickets_data.get, "Tickets", &first);
   if (ret)
     {
       switch (ret)
         {
-          case 99:
-            SEND_TO_CLIENT_OR_FAIL
-             (XML_ERROR_SYNTAX ("get_tickets",
-                                "Permission denied"));
-            break;
-          default:
-            internal_error_send_to_client (error);
-            get_tickets_reset ();
-            return;
+        case 99:
+          SEND_TO_CLIENT_OR_FAIL (
+            XML_ERROR_SYNTAX ("get_tickets", "Permission denied"));
+          break;
+        default:
+          internal_error_send_to_client (error);
+          get_tickets_reset ();
+          return;
         }
       get_tickets_reset ();
       return;
@@ -133,31 +127,28 @@ get_tickets_run (gmp_parser_t *gmp_parser, GError **error)
     {
       switch (ret)
         {
-          case 1:
-            if (send_find_error_to_client ("get_tickets",
-                                           "ticket",
-                                           get_tickets_data.get.id,
-                                           gmp_parser))
-              {
-                error_send_to_client (error);
-                get_tickets_reset ();
-                return;
-              }
-            break;
-          case 2:
-            if (send_find_error_to_client
-                  ("get_tickets", "filter",
-                   get_tickets_data.get.filt_id, gmp_parser))
-              {
-                error_send_to_client (error);
-                get_tickets_reset ();
-                return;
-              }
-            break;
-          case -1:
-            SEND_TO_CLIENT_OR_FAIL
-              (XML_INTERNAL_ERROR ("get_tickets"));
-            break;
+        case 1:
+          if (send_find_error_to_client ("get_tickets", "ticket",
+                                         get_tickets_data.get.id, gmp_parser))
+            {
+              error_send_to_client (error);
+              get_tickets_reset ();
+              return;
+            }
+          break;
+        case 2:
+          if (send_find_error_to_client ("get_tickets", "filter",
+                                         get_tickets_data.get.filt_id,
+                                         gmp_parser))
+            {
+              error_send_to_client (error);
+              get_tickets_reset ();
+              return;
+            }
+          break;
+        case -1:
+          SEND_TO_CLIENT_OR_FAIL (XML_INTERNAL_ERROR ("get_tickets"));
+          break;
         }
       get_tickets_reset ();
       return;
@@ -171,8 +162,8 @@ get_tickets_run (gmp_parser_t *gmp_parser, GError **error)
       iterator_t results;
       int orphan;
 
-      ret = get_next (&tickets, &get_tickets_data.get, &first,
-                      &count, init_ticket_iterator);
+      ret = get_next (&tickets, &get_tickets_data.get, &first, &count,
+                      init_ticket_iterator);
       if (ret == 1)
         break;
       if (ret == -1)
@@ -188,39 +179,38 @@ get_tickets_run (gmp_parser_t *gmp_parser, GError **error)
 
       /* Send ticket info. */
 
-      SENDF_TO_CLIENT_OR_FAIL ("<assigned_to>"
-                               "<user id=\"%s\">"
-                               "<name>%s</name>"
-                               "</user>"
-                               "</assigned_to>"
-                               "<severity>%1.1f</severity>"
-                               "<host>%s</host>"
-                               "<location>%s</location>"
-                               "<solution_type>%s</solution_type>"
-                               "<status>%s</status>"
-                               "<open_time>%s</open_time>"
-                               "<open_note>%s</open_note>"
-                               "<nvt oid=\"%s\"/>",
-                               ticket_iterator_user_id (&tickets),
-                               ticket_iterator_user_name (&tickets),
-                               ticket_iterator_severity (&tickets),
-                               ticket_iterator_host (&tickets),
-                               ticket_iterator_location (&tickets),
-                               ticket_iterator_solution_type (&tickets),
-                               ticket_iterator_status (&tickets),
-                               ticket_iterator_open_time (&tickets),
-                               ticket_iterator_open_note (&tickets),
-                               ticket_iterator_nvt_oid (&tickets));
+      SENDF_TO_CLIENT_OR_FAIL (
+        "<assigned_to>"
+        "<user id=\"%s\">"
+        "<name>%s</name>"
+        "</user>"
+        "</assigned_to>"
+        "<severity>%1.1f</severity>"
+        "<host>%s</host>"
+        "<location>%s</location>"
+        "<solution_type>%s</solution_type>"
+        "<status>%s</status>"
+        "<open_time>%s</open_time>"
+        "<open_note>%s</open_note>"
+        "<nvt oid=\"%s\"/>",
+        ticket_iterator_user_id (&tickets),
+        ticket_iterator_user_name (&tickets),
+        ticket_iterator_severity (&tickets), ticket_iterator_host (&tickets),
+        ticket_iterator_location (&tickets),
+        ticket_iterator_solution_type (&tickets),
+        ticket_iterator_status (&tickets), ticket_iterator_open_time (&tickets),
+        ticket_iterator_open_note (&tickets),
+        ticket_iterator_nvt_oid (&tickets));
 
       if (ticket_iterator_task_id (&tickets))
-        SENDF_TO_CLIENT_OR_FAIL ("<task id=\"%s\">"
-                                 "<name>%s</name>"
-                                 "<trash>%i</trash>"
-                                 "</task>",
-                                 ticket_iterator_task_id (&tickets),
-                                 ticket_iterator_task_name (&tickets),
-                                 task_in_trash_id (ticket_iterator_task_id
-                                                    (&tickets)));
+        SENDF_TO_CLIENT_OR_FAIL (
+          "<task id=\"%s\">"
+          "<name>%s</name>"
+          "<trash>%i</trash>"
+          "</task>",
+          ticket_iterator_task_id (&tickets),
+          ticket_iterator_task_name (&tickets),
+          task_in_trash_id (ticket_iterator_task_id (&tickets)));
 
       if (ticket_iterator_report_id (&tickets))
         {
@@ -247,7 +237,7 @@ get_tickets_run (gmp_parser_t *gmp_parser, GError **error)
 
       if (ticket_iterator_fixed_note (&tickets))
         SENDF_TO_CLIENT_OR_FAIL ("<fixed_note>%s</fixed_note>",
-                                  ticket_iterator_fixed_note (&tickets));
+                                 ticket_iterator_fixed_note (&tickets));
 
       if (ticket_iterator_closed_time (&tickets)
           && strlen (ticket_iterator_closed_time (&tickets)))
@@ -261,34 +251,33 @@ get_tickets_run (gmp_parser_t *gmp_parser, GError **error)
       if (ticket_iterator_fix_verified_time (&tickets)
           && strlen (ticket_iterator_fix_verified_time (&tickets)))
         {
-          SENDF_TO_CLIENT_OR_FAIL ("<fix_verified_time>%s</fix_verified_time>",
-                                   ticket_iterator_fix_verified_time (&tickets));
+          SENDF_TO_CLIENT_OR_FAIL (
+            "<fix_verified_time>%s</fix_verified_time>",
+            ticket_iterator_fix_verified_time (&tickets));
           if (ticket_iterator_fix_verified_report_id (&tickets))
             {
               gchar *timestamp;
 
-              if (report_timestamp (ticket_iterator_fix_verified_report_id
-                                     (&tickets),
-                                    &timestamp))
+              if (report_timestamp (
+                    ticket_iterator_fix_verified_report_id (&tickets),
+                    &timestamp))
                 g_error ("%s: error getting timestamp of verified report,"
                          " aborting",
                          __FUNCTION__);
 
-              SENDF_TO_CLIENT_OR_FAIL ("<fix_verified_report>"
-                                       "<report id=\"%s\">"
-                                       "<timestamp>%s</timestamp>"
-                                       "</report>"
-                                       "</fix_verified_report>",
-                                       ticket_iterator_fix_verified_report_id
-                                        (&tickets),
-                                       timestamp);
+              SENDF_TO_CLIENT_OR_FAIL (
+                "<fix_verified_report>"
+                "<report id=\"%s\">"
+                "<timestamp>%s</timestamp>"
+                "</report>"
+                "</fix_verified_report>",
+                ticket_iterator_fix_verified_report_id (&tickets), timestamp);
             }
         }
 
       /* Send results that are linked to ticket. */
 
-      if (init_ticket_result_iterator (&results,
-                                       get_iterator_uuid (&tickets),
+      if (init_ticket_result_iterator (&results, get_iterator_uuid (&tickets),
                                        get_tickets_data.get.trash))
         {
           internal_error_send_to_client (error);
@@ -310,15 +299,12 @@ get_tickets_run (gmp_parser_t *gmp_parser, GError **error)
       count++;
     }
   cleanup_iterator (&tickets);
-  filtered = get_tickets_data.get.id
-              ? 1
-              : ticket_count (&get_tickets_data.get);
+  filtered = get_tickets_data.get.id ? 1 : ticket_count (&get_tickets_data.get);
   SEND_GET_END ("ticket", &get_tickets_data.get, count, filtered);
 
   get_tickets_reset ();
 }
 
-
 /* CREATE_TICKET. */
 
 /**
@@ -326,7 +312,7 @@ get_tickets_run (gmp_parser_t *gmp_parser, GError **error)
  */
 typedef struct
 {
-  context_data_t *context;     ///< XML parser context.
+  context_data_t *context; ///< XML parser context.
 } create_ticket_t;
 
 /**
@@ -359,8 +345,7 @@ create_ticket_reset ()
  * @param[in]  attribute_values  All attribute values.
  */
 void
-create_ticket_start (gmp_parser_t *gmp_parser,
-                     const gchar **attribute_names,
+create_ticket_start (gmp_parser_t *gmp_parser, const gchar **attribute_names,
                      const gchar **attribute_values)
 {
   memset (&create_ticket_data, 0, sizeof (create_ticket_t));
@@ -409,47 +394,41 @@ create_ticket_run (gmp_parser_t *gmp_parser, GError **error)
 
       comment = entity_child (entity, "comment");
       switch (copy_ticket (comment ? entity_text (comment) : "",
-                           entity_text (copy),
-                           &new_ticket))
+                           entity_text (copy), &new_ticket))
         {
-          case 0:
+        case 0:
+          {
+            char *uuid;
+            uuid = ticket_uuid (new_ticket);
+            SENDF_TO_CLIENT_OR_FAIL (XML_OK_CREATED_ID ("create_ticket"), uuid);
+            log_event ("ticket", "Ticket", uuid, "created");
+            free (uuid);
+            break;
+          }
+        case 1:
+          SEND_TO_CLIENT_OR_FAIL (
+            XML_ERROR_SYNTAX ("create_ticket", "Ticket exists already"));
+          log_event_fail ("ticket", "Ticket", NULL, "created");
+          break;
+        case 2:
+          if (send_find_error_to_client ("create_ticket", "ticket",
+                                         entity_text (copy), gmp_parser))
             {
-              char *uuid;
-              uuid = ticket_uuid (new_ticket);
-              SENDF_TO_CLIENT_OR_FAIL (XML_OK_CREATED_ID ("create_ticket"),
-                                       uuid);
-              log_event ("ticket", "Ticket", uuid, "created");
-              free (uuid);
-              break;
+              error_send_to_client (error);
+              return;
             }
-          case 1:
-            SEND_TO_CLIENT_OR_FAIL
-             (XML_ERROR_SYNTAX ("create_ticket",
-                                "Ticket exists already"));
-            log_event_fail ("ticket", "Ticket", NULL, "created");
-            break;
-          case 2:
-            if (send_find_error_to_client ("create_ticket", "ticket",
-                                           entity_text (copy),
-                                           gmp_parser))
-              {
-                error_send_to_client (error);
-                return;
-              }
-            log_event_fail ("ticket", "Ticket", NULL, "created");
-            break;
-          case 99:
-            SEND_TO_CLIENT_OR_FAIL
-             (XML_ERROR_SYNTAX ("create_ticket",
-                                "Permission denied"));
-            log_event_fail ("ticket", "Ticket", NULL, "created");
-            break;
-          case -1:
-          default:
-            SEND_TO_CLIENT_OR_FAIL
-             (XML_INTERNAL_ERROR ("create_ticket"));
-            log_event_fail ("ticket", "Ticket", NULL, "created");
-            break;
+          log_event_fail ("ticket", "Ticket", NULL, "created");
+          break;
+        case 99:
+          SEND_TO_CLIENT_OR_FAIL (
+            XML_ERROR_SYNTAX ("create_ticket", "Permission denied"));
+          log_event_fail ("ticket", "Ticket", NULL, "created");
+          break;
+        case -1:
+        default:
+          SEND_TO_CLIENT_OR_FAIL (XML_INTERNAL_ERROR ("create_ticket"));
+          log_event_fail ("ticket", "Ticket", NULL, "created");
+          break;
         }
       create_ticket_reset ();
       return;
@@ -462,9 +441,8 @@ create_ticket_run (gmp_parser_t *gmp_parser, GError **error)
   open_note = entity_child (entity, "open_note");
   if (open_note == NULL)
     {
-      SEND_TO_CLIENT_OR_FAIL
-       (XML_ERROR_SYNTAX ("create_ticket",
-                          "CREATE_TICKET requires an OPEN_NOTE"));
+      SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX (
+        "create_ticket", "CREATE_TICKET requires an OPEN_NOTE"));
       create_ticket_reset ();
       return;
     }
@@ -472,9 +450,8 @@ create_ticket_run (gmp_parser_t *gmp_parser, GError **error)
   result = entity_child (entity, "result");
   if (result == NULL)
     {
-      SEND_TO_CLIENT_OR_FAIL
-       (XML_ERROR_SYNTAX ("create_ticket",
-                          "CREATE_TICKET requires a RESULT"));
+      SEND_TO_CLIENT_OR_FAIL (
+        XML_ERROR_SYNTAX ("create_ticket", "CREATE_TICKET requires a RESULT"));
       create_ticket_reset ();
       return;
     }
@@ -482,9 +459,8 @@ create_ticket_run (gmp_parser_t *gmp_parser, GError **error)
   assigned_to = entity_child (entity, "assigned_to");
   if (assigned_to == NULL)
     {
-      SEND_TO_CLIENT_OR_FAIL
-       (XML_ERROR_SYNTAX ("create_ticket",
-                          "CREATE_TICKET requires an ASSIGNED_TO element"));
+      SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX (
+        "create_ticket", "CREATE_TICKET requires an ASSIGNED_TO element"));
       create_ticket_reset ();
       return;
     }
@@ -492,9 +468,8 @@ create_ticket_run (gmp_parser_t *gmp_parser, GError **error)
   user = entity_child (assigned_to, "user");
   if (user == NULL)
     {
-      SEND_TO_CLIENT_OR_FAIL
-       (XML_ERROR_SYNTAX ("create_ticket",
-                          "CREATE_TICKET requires USER in ASSIGNED_TO"));
+      SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX (
+        "create_ticket", "CREATE_TICKET requires USER in ASSIGNED_TO"));
       create_ticket_reset ();
       return;
     }
@@ -505,31 +480,24 @@ create_ticket_run (gmp_parser_t *gmp_parser, GError **error)
   user_id = entity_attribute (user, "id");
 
   if ((result_id == NULL) || (strlen (result_id) == 0))
-    SEND_TO_CLIENT_OR_FAIL
-     (XML_ERROR_SYNTAX ("create_ticket",
-                        "CREATE_TICKET RESULT must have an id"
-                        " attribute"));
+    SEND_TO_CLIENT_OR_FAIL (
+      XML_ERROR_SYNTAX ("create_ticket", "CREATE_TICKET RESULT must have an id"
+                                         " attribute"));
   else if ((user_id == NULL) || (strlen (user_id) == 0))
-    SEND_TO_CLIENT_OR_FAIL
-     (XML_ERROR_SYNTAX ("create_ticket",
-                        "CREATE_TICKET USER must have an id"
-                        " attribute"));
+    SEND_TO_CLIENT_OR_FAIL (
+      XML_ERROR_SYNTAX ("create_ticket", "CREATE_TICKET USER must have an id"
+                                         " attribute"));
   else if (strlen (entity_text (open_note)) == 0)
-    SEND_TO_CLIENT_OR_FAIL
-     (XML_ERROR_SYNTAX ("create_ticket",
-                        "CREATE_TICKET OPEN_NOTE is empty"));
-  else switch (create_ticket
-                (comment ? entity_text (comment) : "",
-                 result_id,
-                 user_id,
-                 entity_text (open_note),
-                 &new_ticket))
-    {
+    SEND_TO_CLIENT_OR_FAIL (
+      XML_ERROR_SYNTAX ("create_ticket", "CREATE_TICKET OPEN_NOTE is empty"));
+  else
+    switch (create_ticket (comment ? entity_text (comment) : "", result_id,
+                           user_id, entity_text (open_note), &new_ticket))
+      {
       case 0:
         {
           char *uuid = ticket_uuid (new_ticket);
-          SENDF_TO_CLIENT_OR_FAIL (XML_OK_CREATED_ID ("create_ticket"),
-                                   uuid);
+          SENDF_TO_CLIENT_OR_FAIL (XML_OK_CREATED_ID ("create_ticket"), uuid);
           log_event ("ticket", "Ticket", uuid, "created");
           free (uuid);
           break;
@@ -553,9 +521,8 @@ create_ticket_run (gmp_parser_t *gmp_parser, GError **error)
           }
         break;
       case 99:
-        SEND_TO_CLIENT_OR_FAIL
-         (XML_ERROR_SYNTAX ("create_ticket",
-                            "Permission denied"));
+        SEND_TO_CLIENT_OR_FAIL (
+          XML_ERROR_SYNTAX ("create_ticket", "Permission denied"));
         log_event_fail ("ticket", "Ticket", NULL, "created");
         break;
       case -1:
@@ -563,7 +530,7 @@ create_ticket_run (gmp_parser_t *gmp_parser, GError **error)
         SEND_TO_CLIENT_OR_FAIL (XML_INTERNAL_ERROR ("create_ticket"));
         log_event_fail ("ticket", "Ticket", NULL, "created");
         break;
-    }
+      }
 
   create_ticket_reset ();
 }
@@ -602,7 +569,6 @@ create_ticket_element_text (const gchar *text, gsize text_len)
   xml_handle_text (create_ticket_data.context, text, text_len);
 }
 
-
 /* MODIFY_TICKET. */
 
 /**
@@ -610,7 +576,7 @@ create_ticket_element_text (const gchar *text, gsize text_len)
  */
 typedef struct
 {
-  context_data_t *context;     ///< XML parser context.
+  context_data_t *context; ///< XML parser context.
 } modify_ticket_t;
 
 /**
@@ -643,8 +609,7 @@ modify_ticket_reset ()
  * @param[in]  attribute_values  All attribute values.
  */
 void
-modify_ticket_start (gmp_parser_t *gmp_parser,
-                     const gchar **attribute_names,
+modify_ticket_start (gmp_parser_t *gmp_parser, const gchar **attribute_names,
                      const gchar **attribute_values)
 {
   memset (&modify_ticket_data, 0, sizeof (modify_ticket_t));
@@ -703,9 +668,8 @@ modify_ticket_run (gmp_parser_t *gmp_parser, GError **error)
       user = entity_child (assigned_to, "user");
       if (user == NULL)
         {
-          SEND_TO_CLIENT_OR_FAIL
-           (XML_ERROR_SYNTAX ("modify_ticket",
-                              "MODIFY_TICKET requires USER in ASSIGNED_TO"));
+          SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX (
+            "modify_ticket", "MODIFY_TICKET requires USER in ASSIGNED_TO"));
           modify_ticket_reset ();
           return;
         }
@@ -713,10 +677,9 @@ modify_ticket_run (gmp_parser_t *gmp_parser, GError **error)
       user_id = entity_attribute (user, "id");
       if ((user_id == NULL) || (strlen (user_id) == 0))
         {
-          SEND_TO_CLIENT_OR_FAIL
-           (XML_ERROR_SYNTAX ("modify_ticket",
-                              "MODIFY_TICKET USER must have an id"
-                              " attribute"));
+          SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX (
+            "modify_ticket", "MODIFY_TICKET USER must have an id"
+                             " attribute"));
           modify_ticket_reset ();
           return;
         }
@@ -727,27 +690,24 @@ modify_ticket_run (gmp_parser_t *gmp_parser, GError **error)
   /* Modify the ticket. */
 
   if (ticket_id == NULL)
-    SEND_TO_CLIENT_OR_FAIL
-     (XML_ERROR_SYNTAX ("modify_ticket",
-                        "MODIFY_TICKET requires a ticket_id"
-                        " attribute"));
-  else switch (modify_ticket
-                (ticket_id,
-                 comment ? entity_text (comment) : NULL,
-                 status ? entity_text (status) : NULL,
-                 open_note ? entity_text (open_note) : NULL,
-                 fixed_note ? entity_text (fixed_note) : NULL,
-                 closed_note ? entity_text (closed_note) : NULL,
-                 user_id))
-    {
+    SEND_TO_CLIENT_OR_FAIL (
+      XML_ERROR_SYNTAX ("modify_ticket", "MODIFY_TICKET requires a ticket_id"
+                                         " attribute"));
+  else
+    switch (modify_ticket (ticket_id, comment ? entity_text (comment) : NULL,
+                           status ? entity_text (status) : NULL,
+                           open_note ? entity_text (open_note) : NULL,
+                           fixed_note ? entity_text (fixed_note) : NULL,
+                           closed_note ? entity_text (closed_note) : NULL,
+                           user_id))
+      {
       case 0:
         SENDF_TO_CLIENT_OR_FAIL (XML_OK ("modify_ticket"));
         log_event ("ticket", "Ticket", ticket_id, "modified");
         break;
       case 1:
-        SEND_TO_CLIENT_OR_FAIL
-         (XML_ERROR_SYNTAX ("modify_ticket",
-                            "Ticket exists already"));
+        SEND_TO_CLIENT_OR_FAIL (
+          XML_ERROR_SYNTAX ("modify_ticket", "Ticket exists already"));
         log_event_fail ("ticket", "Ticket", ticket_id, "modified");
         break;
       case 2:
@@ -769,42 +729,36 @@ modify_ticket_run (gmp_parser_t *gmp_parser, GError **error)
           }
         break;
       case 4:
-        SEND_TO_CLIENT_OR_FAIL
-         (XML_ERROR_SYNTAX ("modify_ticket",
-                            "Error in status"));
+        SEND_TO_CLIENT_OR_FAIL (
+          XML_ERROR_SYNTAX ("modify_ticket", "Error in status"));
         log_event_fail ("ticket", "Ticket", ticket_id, "modified");
         break;
       case 5:
-        SEND_TO_CLIENT_OR_FAIL
-         (XML_ERROR_SYNTAX ("modify_ticket",
-                            "Fixed STATUS requires a FIXED_NOTE"));
+        SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX (
+          "modify_ticket", "Fixed STATUS requires a FIXED_NOTE"));
         log_event_fail ("ticket", "Ticket", ticket_id, "modified");
         break;
       case 6:
-        SEND_TO_CLIENT_OR_FAIL
-         (XML_ERROR_SYNTAX ("modify_ticket",
-                            "Closed STATUS requires a CLOSED_NOTE"));
+        SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX (
+          "modify_ticket", "Closed STATUS requires a CLOSED_NOTE"));
         log_event_fail ("ticket", "Ticket", ticket_id, "modified");
         break;
       case 7:
-        SEND_TO_CLIENT_OR_FAIL
-         (XML_ERROR_SYNTAX ("modify_ticket",
-                            "Open STATUS requires an OPEN_NOTE"));
+        SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX (
+          "modify_ticket", "Open STATUS requires an OPEN_NOTE"));
         log_event_fail ("ticket", "Ticket", ticket_id, "modified");
         break;
       case 99:
-        SEND_TO_CLIENT_OR_FAIL
-         (XML_ERROR_SYNTAX ("modify_ticket",
-                            "Permission denied"));
+        SEND_TO_CLIENT_OR_FAIL (
+          XML_ERROR_SYNTAX ("modify_ticket", "Permission denied"));
         log_event_fail ("ticket", "Ticket", ticket_id, "modified");
         break;
       case -1:
       default:
-        SEND_TO_CLIENT_OR_FAIL
-         (XML_INTERNAL_ERROR ("modify_ticket"));
+        SEND_TO_CLIENT_OR_FAIL (XML_INTERNAL_ERROR ("modify_ticket"));
         log_event_fail ("ticket", "Ticket", ticket_id, "modified");
         break;
-    }
+      }
 
   modify_ticket_reset ();
 }
@@ -843,7 +797,6 @@ modify_ticket_element_text (const gchar *text, gsize text_len)
   xml_handle_text (modify_ticket_data.context, text, text_len);
 }
 
-
 /* Result ticket support. */
 
 /**
@@ -866,10 +819,8 @@ buffer_result_tickets_xml (GString *buffer, result_t result)
     {
       buffer_xml_append_printf (buffer, "<tickets>");
       while (next (&tickets))
-        buffer_xml_append_printf (buffer,
-                                  "<ticket id=\"%s\"/>",
-                                  result_ticket_iterator_ticket_id
-                                   (&tickets));
+        buffer_xml_append_printf (buffer, "<ticket id=\"%s\"/>",
+                                  result_ticket_iterator_ticket_id (&tickets));
       buffer_xml_append_printf (buffer, "</tickets>");
       cleanup_iterator (&tickets);
     }

--- a/src/gmp_tickets.h
+++ b/src/gmp_tickets.h
@@ -39,7 +39,9 @@ void
 create_ticket_start (gmp_parser_t *, const gchar **, const gchar **);
 
 void
-create_ticket_element_start (gmp_parser_t *, const gchar *, const gchar **,
+create_ticket_element_start (gmp_parser_t *,
+                             const gchar *,
+                             const gchar **,
                              const gchar **);
 
 int
@@ -52,7 +54,9 @@ void
 modify_ticket_start (gmp_parser_t *, const gchar **, const gchar **);
 
 void
-modify_ticket_element_start (gmp_parser_t *, const gchar *, const gchar **,
+modify_ticket_element_start (gmp_parser_t *,
+                             const gchar *,
+                             const gchar **,
                              const gchar **);
 
 int

--- a/src/gmpd.c
+++ b/src/gmpd.c
@@ -105,10 +105,15 @@ static int gmpd_nvt_cache_mode = 0;
  *         -4 max_ips_per_target out of range.
  */
 int
-init_gmpd (GSList *log_config, int nvt_cache_mode, const gchar *database,
-           int max_ips_per_target, int max_email_attachment_size,
-           int max_email_include_size, int max_email_message_size,
-           manage_connection_forker_t fork_connection, int skip_db_check)
+init_gmpd (GSList *log_config,
+           int nvt_cache_mode,
+           const gchar *database,
+           int max_ips_per_target,
+           int max_email_attachment_size,
+           int max_email_include_size,
+           int max_email_message_size,
+           manage_connection_forker_t fork_connection,
+           int skip_db_check)
 {
   return init_gmp (log_config,
                    nvt_cache_mode,
@@ -475,7 +480,8 @@ session_clean (gvm_connection_t *client_connection)
  * @return 0 success, 1 scanner still loading, -1 error, -2 scanner has no cert.
  */
 int
-serve_gmp (gvm_connection_t *client_connection, const gchar *database,
+serve_gmp (gvm_connection_t *client_connection,
+           const gchar *database,
            gchar **disable)
 {
   int nfds, scan_handler = 0, rc = 0;

--- a/src/gmpd.c
+++ b/src/gmpd.c
@@ -110,9 +110,15 @@ init_gmpd (GSList *log_config, int nvt_cache_mode, const gchar *database,
            int max_email_include_size, int max_email_message_size,
            manage_connection_forker_t fork_connection, int skip_db_check)
 {
-  return init_gmp (log_config, nvt_cache_mode, database, max_ips_per_target,
-                   max_email_attachment_size, max_email_include_size,
-                   max_email_message_size, fork_connection, skip_db_check);
+  return init_gmp (log_config,
+                   nvt_cache_mode,
+                   database,
+                   max_ips_per_target,
+                   max_email_attachment_size,
+                   max_email_include_size,
+                   max_email_message_size,
+                   fork_connection,
+                   skip_db_check);
 }
 
 /**
@@ -144,7 +150,8 @@ read_from_client_unix (int client_socket)
   while (from_client_end < from_buffer_size)
     {
       int count;
-      count = read (client_socket, from_client + from_client_end,
+      count = read (client_socket,
+                    from_client + from_client_end,
                     from_buffer_size - from_client_end);
       if (count < 0)
         {
@@ -154,7 +161,8 @@ read_from_client_unix (int client_socket)
           if (errno == EINTR)
             /* Interrupted, try read again. */
             continue;
-          g_warning ("%s: failed to read from client: %s", __FUNCTION__,
+          g_warning ("%s: failed to read from client: %s",
+                     __FUNCTION__,
                      strerror (errno));
           return -1;
         }
@@ -193,9 +201,9 @@ read_from_client_tls (gnutls_session_t *client_session)
   while (from_client_end < from_buffer_size)
     {
       ssize_t count;
-      count =
-        gnutls_record_recv (*client_session, from_client + from_client_end,
-                            from_buffer_size - from_client_end);
+      count = gnutls_record_recv (*client_session,
+                                  from_client + from_client_end,
+                                  from_buffer_size - from_client_end);
       if (count < 0)
         {
           if (count == GNUTLS_E_AGAIN)
@@ -216,10 +224,11 @@ read_from_client_tls (gnutls_session_t *client_session)
             {
               int alert = gnutls_alert_get (*client_session);
               const char *alert_name = gnutls_alert_get_name (alert);
-              g_warning ("%s: TLS Alert %d: %s", __FUNCTION__, alert,
-                         alert_name);
+              g_warning (
+                "%s: TLS Alert %d: %s", __FUNCTION__, alert, alert_name);
             }
-          g_warning ("%s: failed to read from client: %s", __FUNCTION__,
+          g_warning ("%s: failed to read from client: %s",
+                     __FUNCTION__,
                      gnutls_strerror ((int) count));
           return -1;
         }
@@ -274,7 +283,8 @@ write_to_client_tls (gnutls_session_t *client_session)
   while (to_client_start < to_client_end)
     {
       ssize_t count;
-      count = gnutls_record_send (*client_session, to_client + to_client_start,
+      count = gnutls_record_send (*client_session,
+                                  to_client + to_client_start,
                                   to_client_end - to_client_start);
       if (count < 0)
         {
@@ -287,7 +297,8 @@ write_to_client_tls (gnutls_session_t *client_session)
           if (count == GNUTLS_E_REHANDSHAKE)
             /** @todo Rehandshake. */
             continue;
-          g_warning ("%s: failed to write to client: %s", __FUNCTION__,
+          g_warning ("%s: failed to write to client: %s",
+                     __FUNCTION__,
                      gnutls_strerror ((int) count));
           return -1;
         }
@@ -314,7 +325,8 @@ write_to_client_unix (int client_socket)
   while (to_client_start < to_client_end)
     {
       ssize_t count;
-      count = write (client_socket, to_client + to_client_start,
+      count = write (client_socket,
+                     to_client + to_client_start,
                      to_client_end - to_client_start);
       if (count < 0)
         {
@@ -324,7 +336,8 @@ write_to_client_unix (int client_socket)
           if (errno == EINTR)
             /* Interrupted, try write again. */
             continue;
-          g_warning ("%s: failed to write to client: %s", __FUNCTION__,
+          g_warning ("%s: failed to write to client: %s",
+                     __FUNCTION__,
                      strerror (errno));
           return -1;
         }
@@ -380,7 +393,8 @@ gmpd_send_to_client (const char *msg, void *write_to_client_data)
         case 0: /* Wrote everything in to_client. */
           break;
         case -1: /* Error. */
-          g_debug ("   %s full (%i < %zu); client write failed", __FUNCTION__,
+          g_debug ("   %s full (%i < %zu); client write failed",
+                   __FUNCTION__,
                    ((buffer_size_t) TO_CLIENT_BUFFER_SIZE) - to_client_end,
                    strlen (msg));
           return TRUE;
@@ -479,9 +493,11 @@ serve_gmp (gvm_connection_t *client_connection, const gchar *database,
     g_debug ("   Serving GMP");
 
   /* Initialise the XML parser and the manage library. */
-  init_gmp_process (gmpd_nvt_cache_mode, database,
+  init_gmp_process (gmpd_nvt_cache_mode,
+                    database,
                     (int (*) (const char *, void *)) gmpd_send_to_client,
-                    (void *) client_connection, disable);
+                    (void *) client_connection,
+                    disable);
 
   /* Setup the scanner address and try to connect. */
   if (gmpd_nvt_cache_mode && !openvas_scanner_connected ())
@@ -545,7 +561,8 @@ serve_gmp (gvm_connection_t *client_connection, const gchar *database,
 
       if (termination_signal)
         {
-          g_debug ("%s: Received %s signal.", __FUNCTION__,
+          g_debug ("%s: Received %s signal.",
+                   __FUNCTION__,
                    sys_siglist[get_termination_signal ()]);
 
           if (openvas_scanner_connected ())
@@ -656,8 +673,8 @@ serve_gmp (gvm_connection_t *client_connection, const gchar *database,
         }
       else if (ret < 0)
         {
-          g_warning ("%s: child select failed: %s", __FUNCTION__,
-                     strerror (errno));
+          g_warning (
+            "%s: child select failed: %s", __FUNCTION__, strerror (errno));
           rc = -1;
           goto client_free;
         }
@@ -696,10 +713,12 @@ serve_gmp (gvm_connection_t *client_connection, const gchar *database,
           if (from_client_end > initial_start)
             {
               if (g_strstr_len (from_client + initial_start,
-                                from_client_end - initial_start, "<password>"))
+                                from_client_end - initial_start,
+                                "<password>"))
                 g_debug ("<= client  Input may contain password, suppressed");
               else
-                g_debug ("<= client  \"%.*s\"", from_client_end - initial_start,
+                g_debug ("<= client  \"%.*s\"",
+                         from_client_end - initial_start,
                          from_client + initial_start);
             }
 

--- a/src/gmpd.h
+++ b/src/gmpd.h
@@ -46,8 +46,15 @@
 #define FROM_BUFFER_SIZE 1048576
 
 int
-init_gmpd (GSList *, int, const gchar *, int, int, int, int,
-           manage_connection_forker_t, int);
+init_gmpd (GSList *,
+           int,
+           const gchar *,
+           int,
+           int,
+           int,
+           int,
+           manage_connection_forker_t,
+           int);
 
 void
 init_gmpd_process (const gchar *, gchar **);

--- a/src/gmpd.h
+++ b/src/gmpd.h
@@ -27,10 +27,11 @@
 
 #include "manage.h"
 #include "types.h"
-#include <gvm/util/serverutils.h>
+
 #include <glib.h>
-#include <netinet/in.h>
 #include <gnutls/gnutls.h>
+#include <gvm/util/serverutils.h>
+#include <netinet/in.h>
 
 /**
  * @brief Maximum number of seconds spent trying to read the protocol.
@@ -45,13 +46,13 @@
 #define FROM_BUFFER_SIZE 1048576
 
 int
-init_gmpd (GSList*, int, const gchar*, int, int, int, int,
+init_gmpd (GSList *, int, const gchar *, int, int, int, int,
            manage_connection_forker_t, int);
 
 void
 init_gmpd_process (const gchar *, gchar **);
 
 int
-serve_gmp (gvm_connection_t*, const gchar*, gchar**);
+serve_gmp (gvm_connection_t *, const gchar *, gchar **);
 
 #endif /* not _GVMD_GMPD_H */

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -649,7 +649,8 @@ accept_and_maybe_fork (int server_socket, sigset_t *sigmask_current)
  */
 static int
 fork_connection_internal (gvm_connection_t *client_connection,
-                          const gchar *uuid, int scheduler)
+                          const gchar *uuid,
+                          int scheduler)
 {
   int pid, parent_client_socket, ret;
   int sockets[2];
@@ -1440,9 +1441,13 @@ serve_and_schedule ()
  * @return 0 success, -1 error.
  */
 static int
-manager_listen (const char *address_str_unix, const char *address_str_tls,
-                const char *port_str, const char *socket_owner,
-                const char *socket_group, const char *socket_mode, int *soc)
+manager_listen (const char *address_str_unix,
+                const char *address_str_tls,
+                const char *port_str,
+                const char *socket_owner,
+                const char *socket_group,
+                const char *socket_mode,
+                int *soc)
 {
   struct sockaddr *address;
   struct sockaddr_un address_unix;

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -454,11 +454,12 @@ serve_client (int server_socket, gvm_connection_t *client_connection)
       int optval;
 
       optval = 1;
-      if (setsockopt (server_socket, SOL_SOCKET, SO_KEEPALIVE, &optval,
-                      sizeof (int)))
+      if (setsockopt (
+            server_socket, SOL_SOCKET, SO_KEEPALIVE, &optval, sizeof (int)))
         {
           g_critical ("%s: failed to set SO_KEEPALIVE on scanner socket: %s",
-                      __FUNCTION__, strerror (errno));
+                      __FUNCTION__,
+                      strerror (errno));
           exit (EXIT_FAILURE);
         }
     }
@@ -466,8 +467,8 @@ serve_client (int server_socket, gvm_connection_t *client_connection)
   if (client_watch_interval)
     {
       watcher_data = connection_watcher_data_new (client_connection);
-      pthread_create (&watch_thread, NULL, watch_client_connection,
-                      watcher_data);
+      pthread_create (
+        &watch_thread, NULL, watch_client_connection, watcher_data);
     }
   else
     {
@@ -477,7 +478,8 @@ serve_client (int server_socket, gvm_connection_t *client_connection)
   if (client_connection->tls
       && gvm_server_attach (client_connection->socket, &client_session))
     {
-      g_debug ("%s: failed to attach client session to socket %i", __FUNCTION__,
+      g_debug ("%s: failed to attach client session to socket %i",
+               __FUNCTION__,
                client_connection->socket);
       goto fail;
     }
@@ -486,7 +488,8 @@ serve_client (int server_socket, gvm_connection_t *client_connection)
    * error" removes the data between `select' and `read'. */
   if (fcntl (client_connection->socket, F_SETFL, O_NONBLOCK) == -1)
     {
-      g_warning ("%s: failed to set real client socket flag: %s", __FUNCTION__,
+      g_warning ("%s: failed to set real client socket flag: %s",
+                 __FUNCTION__,
                  strerror (errno));
       goto fail;
     }
@@ -560,7 +563,8 @@ accept_and_maybe_fork (int server_socket, sigset_t *sigmask_current)
       if (errno == EAGAIN || errno == EWOULDBLOCK)
         /* The connection is gone, return to select. */
         return;
-      g_critical ("%s: failed to accept client connection: %s", __FUNCTION__,
+      g_critical ("%s: failed to accept client connection: %s",
+                  __FUNCTION__,
                   strerror (errno));
       exit (EXIT_FAILURE);
     }
@@ -590,7 +594,8 @@ accept_and_maybe_fork (int server_socket, sigset_t *sigmask_current)
         if (sigaction (SIGCHLD, &action, NULL) == -1)
           {
             g_critical ("%s: failed to set client SIGCHLD handler: %s",
-                        __FUNCTION__, strerror (errno));
+                        __FUNCTION__,
+                        strerror (errno));
             shutdown (client_socket, SHUT_RDWR);
             close (client_socket);
             exit (EXIT_FAILURE);
@@ -602,7 +607,8 @@ accept_and_maybe_fork (int server_socket, sigset_t *sigmask_current)
         if (fcntl (client_socket, F_SETFL, O_NONBLOCK) == -1)
           {
             g_critical ("%s: failed to set client socket flag: %s",
-                        __FUNCTION__, strerror (errno));
+                        __FUNCTION__,
+                        strerror (errno));
             shutdown (client_socket, SHUT_RDWR);
             close (client_socket);
             exit (EXIT_FAILURE);
@@ -619,8 +625,8 @@ accept_and_maybe_fork (int server_socket, sigset_t *sigmask_current)
       }
     case -1:
       /* Parent when error, return to select. */
-      g_warning ("%s: failed to fork child: %s", __FUNCTION__,
-                 strerror (errno));
+      g_warning (
+        "%s: failed to fork child: %s", __FUNCTION__, strerror (errno));
       close (client_socket);
       break;
     default:
@@ -709,7 +715,8 @@ fork_connection_internal (gvm_connection_t *client_connection,
       if (sigaction (SIGCHLD, &action, NULL) == -1)
         {
           g_critical ("%s: failed to set client SIGCHLD handler: %s",
-                      __FUNCTION__, strerror (errno));
+                      __FUNCTION__,
+                      strerror (errno));
           shutdown (parent_client_socket, SHUT_RDWR);
           close (parent_client_socket);
           exit (EXIT_FAILURE);
@@ -720,7 +727,8 @@ fork_connection_internal (gvm_connection_t *client_connection,
        */
       if (fcntl (parent_client_socket, F_SETFL, O_NONBLOCK) == -1)
         {
-          g_critical ("%s: failed to set client socket flag: %s", __FUNCTION__,
+          g_critical ("%s: failed to set client socket flag: %s",
+                      __FUNCTION__,
                       strerror (errno));
           shutdown (parent_client_socket, SHUT_RDWR);
           close (parent_client_socket);
@@ -740,8 +748,12 @@ fork_connection_internal (gvm_connection_t *client_connection,
 
       if (use_tls)
         {
-          if (gvm_server_new (GNUTLS_SERVER, CACERT, SCANNERCERT, SCANNERKEY,
-                              &client_session, &client_credentials))
+          if (gvm_server_new (GNUTLS_SERVER,
+                              CACERT,
+                              SCANNERCERT,
+                              SCANNERKEY,
+                              &client_session,
+                              &client_credentials))
             {
               g_critical ("%s: client server initialisation failed",
                           __FUNCTION__);
@@ -755,7 +767,8 @@ fork_connection_internal (gvm_connection_t *client_connection,
 
       /* Serve client. */
 
-      g_debug ("%s: serving GMP to client on socket %i", __FUNCTION__,
+      g_debug ("%s: serving GMP to client on socket %i",
+               __FUNCTION__,
                parent_client_socket);
 
       memset (client_connection, 0, sizeof (*client_connection));
@@ -795,7 +808,10 @@ fork_connection_internal (gvm_connection_t *client_connection,
 
       if (use_tls)
         {
-          if (gvm_server_new (GNUTLS_CLIENT, CACERT, CLIENTCERT, CLIENTKEY,
+          if (gvm_server_new (GNUTLS_CLIENT,
+                              CACERT,
+                              CLIENTCERT,
+                              CLIENTKEY,
                               &client_connection->session,
                               &client_connection->credentials))
             exit (EXIT_FAILURE);
@@ -805,7 +821,8 @@ fork_connection_internal (gvm_connection_t *client_connection,
             exit (EXIT_FAILURE);
         }
 
-      g_debug ("%s: all set to request GMP on socket %i", __FUNCTION__,
+      g_debug ("%s: all set to request GMP on socket %i",
+               __FUNCTION__,
                client_connection->socket);
 
       return 0;
@@ -878,8 +895,8 @@ cleanup ()
   if (log_stream != NULL)
     {
       if (fclose (log_stream))
-        g_critical ("%s: failed to close log stream: %s", __FUNCTION__,
-                    strerror (errno));
+        g_critical (
+          "%s: failed to close log stream: %s", __FUNCTION__, strerror (errno));
     }
 #endif /* LOG */
   g_debug ("   Exiting");
@@ -913,8 +930,8 @@ setup_signal_handler (int signal, void (*handler) (int), int block)
   action.sa_handler = handler;
   if (sigaction (signal, &action, NULL) == -1)
     {
-      g_critical ("%s: failed to register %s handler", __FUNCTION__,
-                  sys_siglist[signal]);
+      g_critical (
+        "%s: failed to register %s handler", __FUNCTION__, sys_siglist[signal]);
       exit (EXIT_FAILURE);
     }
 }
@@ -944,8 +961,8 @@ setup_signal_handler_info (int signal,
   action.sa_sigaction = handler;
   if (sigaction (signal, &action, NULL) == -1)
     {
-      g_critical ("%s: failed to register %s handler", __FUNCTION__,
-                  sys_siglist[signal]);
+      g_critical (
+        "%s: failed to register %s handler", __FUNCTION__, sys_siglist[signal]);
       exit (EXIT_FAILURE);
     }
 }
@@ -1078,11 +1095,15 @@ update_nvt_cache (int register_cleanup)
 
   proctitle_set ("gvmd: Updating NVT cache");
 
-  switch (init_gmpd (log_config, -1, database, manage_max_hosts (),
+  switch (init_gmpd (log_config,
+                     -1,
+                     database,
+                     manage_max_hosts (),
                      0, /* Max email attachment size. */
                      0, /* Max email include size. */
                      0, /* Max email message size. */
-                     NULL, 1 /* Skip DB check (including table creation). */))
+                     NULL,
+                     1 /* Skip DB check (including table creation). */))
     {
     case 0:
       break;
@@ -1317,13 +1338,13 @@ serve_and_schedule ()
         }
 
       if ((time (NULL) - last_schedule_time) >= SCHEDULE_PERIOD)
-        switch (manage_schedule (fork_connection_for_scheduler,
-                                 scheduling_enabled, sigmask_normal))
+        switch (manage_schedule (
+          fork_connection_for_scheduler, scheduling_enabled, sigmask_normal))
           {
           case 0:
             last_schedule_time = time (NULL);
-            g_debug ("%s: last_schedule_time: %li", __FUNCTION__,
-                     last_schedule_time);
+            g_debug (
+              "%s: last_schedule_time: %li", __FUNCTION__, last_schedule_time);
             break;
           case 1:
             break;
@@ -1372,12 +1393,13 @@ serve_and_schedule ()
         }
 
       if ((time (NULL) - last_schedule_time) >= SCHEDULE_PERIOD)
-        switch (manage_schedule (fork_connection_for_scheduler,
-                                 scheduling_enabled, sigmask_normal))
+        switch (manage_schedule (
+          fork_connection_for_scheduler, scheduling_enabled, sigmask_normal))
           {
           case 0:
             last_schedule_time = time (NULL);
-            g_debug ("%s: last_schedule_time 2: %li", __FUNCTION__,
+            g_debug ("%s: last_schedule_time 2: %li",
+                     __FUNCTION__,
                      last_schedule_time);
             break;
           case 1:
@@ -1438,11 +1460,12 @@ manager_listen (const char *address_str_unix, const char *address_str_tls,
       /* UNIX file socket. */
 
       address_unix.sun_family = AF_UNIX;
-      strncpy (address_unix.sun_path, address_str_unix,
+      strncpy (address_unix.sun_path,
+               address_str_unix,
                sizeof (address_unix.sun_path) - 1);
 
-      g_debug ("%s: address_unix.sun_path: %s", __FUNCTION__,
-               address_unix.sun_path);
+      g_debug (
+        "%s: address_unix.sun_path: %s", __FUNCTION__, address_unix.sun_path);
 
       *soc = socket (AF_UNIX, SOCK_STREAM, 0);
       if (*soc == -1)
@@ -1683,139 +1706,387 @@ main (int argc, char **argv)
   lockfile_t lockfile_checking, lockfile_serving;
   GOptionContext *option_context;
   static GOptionEntry option_entries[] = {
-    {"backup", '\0', 0, G_OPTION_ARG_NONE, &backup_database,
-     "Backup the database.", NULL},
-    {"check-alerts", '\0', 0, G_OPTION_ARG_NONE, &check_alerts,
-     "Check SecInfo alerts.", NULL},
-    {"client-watch-interval", '\0', 0, G_OPTION_ARG_INT, &client_watch_interval,
+    {"backup",
+     '\0',
+     0,
+     G_OPTION_ARG_NONE,
+     &backup_database,
+     "Backup the database.",
+     NULL},
+    {"check-alerts",
+     '\0',
+     0,
+     G_OPTION_ARG_NONE,
+     &check_alerts,
+     "Check SecInfo alerts.",
+     NULL},
+    {"client-watch-interval",
+     '\0',
+     0,
+     G_OPTION_ARG_INT,
+     &client_watch_interval,
      "Check if client connection was closed every <number> seconds."
      " 0 to disable. Defaults to " G_STRINGIFY (
        DEFAULT_CLIENT_WATCH_INTERVAL) " seconds.",
      "<number>"},
-    {"database", 'd', 0, G_OPTION_ARG_STRING, &database,
-     "Use <file/name> as database for SQLite/Postgres.", "<file/name>"},
-    {"disable-cmds", '\0', 0, G_OPTION_ARG_STRING, &disable,
-     "Disable comma-separated <commands>.", "<commands>"},
-    {"disable-encrypted-credentials", '\0', 0, G_OPTION_ARG_NONE,
-     &disable_encrypted_credentials, "Do not encrypt or decrypt credentials.",
+    {"database",
+     'd',
+     0,
+     G_OPTION_ARG_STRING,
+     &database,
+     "Use <file/name> as database for SQLite/Postgres.",
+     "<file/name>"},
+    {"disable-cmds",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &disable,
+     "Disable comma-separated <commands>.",
+     "<commands>"},
+    {"disable-encrypted-credentials",
+     '\0',
+     0,
+     G_OPTION_ARG_NONE,
+     &disable_encrypted_credentials,
+     "Do not encrypt or decrypt credentials.",
      NULL},
-    {"disable-password-policy", '\0', 0, G_OPTION_ARG_NONE,
-     &disable_password_policy, "Do not restrict passwords to the policy.",
+    {"disable-password-policy",
+     '\0',
+     0,
+     G_OPTION_ARG_NONE,
+     &disable_password_policy,
+     "Do not restrict passwords to the policy.",
      NULL},
-    {"disable-scheduling", '\0', 0, G_OPTION_ARG_NONE, &disable_scheduling,
-     "Disable task scheduling.", NULL},
-    {"create-user", '\0', 0, G_OPTION_ARG_STRING, &create_user,
-     "Create admin user <username> and exit.", "<username>"},
-    {"delete-user", '\0', 0, G_OPTION_ARG_STRING, &delete_user,
-     "Delete user <username> and exit.", "<username>"},
-    {"get-users", '\0', 0, G_OPTION_ARG_NONE, &get_users,
-     "List users and exit.", NULL},
-    {"create-scanner", '\0', 0, G_OPTION_ARG_STRING, &create_scanner,
-     "Create global scanner <scanner> and exit.", "<scanner>"},
-    {"modify-scanner", '\0', 0, G_OPTION_ARG_STRING, &modify_scanner,
-     "Modify scanner <scanner-uuid> and exit.", "<scanner-uuid>"},
-    {"scanner-name", '\0', 0, G_OPTION_ARG_STRING, &scanner_name,
-     "Name for --modify-scanner.", "<name>"},
-    {"scanner-host", '\0', 0, G_OPTION_ARG_STRING, &scanner_host,
+    {"disable-scheduling",
+     '\0',
+     0,
+     G_OPTION_ARG_NONE,
+     &disable_scheduling,
+     "Disable task scheduling.",
+     NULL},
+    {"create-user",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &create_user,
+     "Create admin user <username> and exit.",
+     "<username>"},
+    {"delete-user",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &delete_user,
+     "Delete user <username> and exit.",
+     "<username>"},
+    {"get-users",
+     '\0',
+     0,
+     G_OPTION_ARG_NONE,
+     &get_users,
+     "List users and exit.",
+     NULL},
+    {"create-scanner",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &create_scanner,
+     "Create global scanner <scanner> and exit.",
+     "<scanner>"},
+    {"modify-scanner",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &modify_scanner,
+     "Modify scanner <scanner-uuid> and exit.",
+     "<scanner-uuid>"},
+    {"scanner-name",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &scanner_name,
+     "Name for --modify-scanner.",
+     "<name>"},
+    {"scanner-host",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &scanner_host,
      "Scanner host for --create-scanner and --modify-scanner. Default "
      "is " OPENVASSD_ADDRESS ".",
      "<scanner-host>"},
-    {"scanner-port", '\0', 0, G_OPTION_ARG_STRING, &scanner_port,
+    {"scanner-port",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &scanner_port,
      "Scanner port for --create-scanner and --modify-scanner. Default "
      "is " G_STRINGIFY (OPENVASSD_PORT) ".",
      "<scanner-port>"},
-    {"scanner-type", '\0', 0, G_OPTION_ARG_STRING, &scanner_type,
+    {"scanner-type",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &scanner_type,
      "Scanner type for --create-scanner and --modify-scanner. Either 'OpenVAS' "
      "or 'OSP'.",
      "<scanner-type>"},
-    {"scanner-ca-pub", '\0', 0, G_OPTION_ARG_STRING, &scanner_ca_pub,
+    {"scanner-ca-pub",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &scanner_ca_pub,
      "Scanner CA Certificate path for --[create|modify]-scanner.",
      "<scanner-ca-pub>"},
-    {"scanner-key-pub", '\0', 0, G_OPTION_ARG_STRING, &scanner_key_pub,
+    {"scanner-key-pub",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &scanner_key_pub,
      "Scanner Certificate path for --[create|modify]-scanner.",
      "<scanner-key-public>"},
-    {"scanner-key-priv", '\0', 0, G_OPTION_ARG_STRING, &scanner_key_priv,
+    {"scanner-key-priv",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &scanner_key_priv,
      "Scanner private key path for --[create|modify]-scanner.",
      "<scanner-key-private>"},
-    {"verify-scanner", '\0', 0, G_OPTION_ARG_STRING, &verify_scanner,
-     "Verify scanner <scanner-uuid> and exit.", "<scanner-uuid>"},
-    {"delete-scanner", '\0', 0, G_OPTION_ARG_STRING, &delete_scanner,
-     "Delete scanner <scanner-uuid> and exit.", "<scanner-uuid>"},
-    {"get-scanners", '\0', 0, G_OPTION_ARG_NONE, &get_scanners,
-     "List scanners and exit.", NULL},
-    {"secinfo-commit-size", '\0', 0, G_OPTION_ARG_INT, &secinfo_commit_size,
+    {"verify-scanner",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &verify_scanner,
+     "Verify scanner <scanner-uuid> and exit.",
+     "<scanner-uuid>"},
+    {"delete-scanner",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &delete_scanner,
+     "Delete scanner <scanner-uuid> and exit.",
+     "<scanner-uuid>"},
+    {"get-scanners",
+     '\0',
+     0,
+     G_OPTION_ARG_NONE,
+     &get_scanners,
+     "List scanners and exit.",
+     NULL},
+    {"secinfo-commit-size",
+     '\0',
+     0,
+     G_OPTION_ARG_INT,
+     &secinfo_commit_size,
      "During CERT and SCAP sync, commit updates to the database every <number> "
      "items, 0 for unlimited, default: " G_STRINGIFY (
        SECINFO_COMMIT_SIZE_DEFAULT),
      "<number>"},
-    {"schedule-timeout", '\0', 0, G_OPTION_ARG_INT, &schedule_timeout,
+    {"schedule-timeout",
+     '\0',
+     0,
+     G_OPTION_ARG_INT,
+     &schedule_timeout,
      "Time out tasks that are more than <time> minutes overdue. -1 to disable, "
      "0 for minimum time, default: " G_STRINGIFY (SCHEDULE_TIMEOUT_DEFAULT),
      "<time>"},
-    {"foreground", 'f', 0, G_OPTION_ARG_NONE, &foreground, "Run in foreground.",
+    {"foreground",
+     'f',
+     0,
+     G_OPTION_ARG_NONE,
+     &foreground,
+     "Run in foreground.",
      NULL},
-    {"inheritor", '\0', 0, G_OPTION_ARG_STRING, &inheritor,
-     "Have <username> inherit from deleted user.", "<username>"},
-    {"listen", 'a', 0, G_OPTION_ARG_STRING, &manager_address_string,
-     "Listen on <address>.", "<address>"},
-    {"listen2", '\0', 0, G_OPTION_ARG_STRING, &manager_address_string_2,
-     "Listen also on <address>.", "<address>"},
-    {"listen-owner", '\0', 0, G_OPTION_ARG_STRING, &listen_owner,
-     "Owner of the unix socket", "<string>"},
-    {"listen-group", '\0', 0, G_OPTION_ARG_STRING, &listen_group,
-     "Group of the unix socket", "<string>"},
-    {"listen-mode", '\0', 0, G_OPTION_ARG_STRING, &listen_mode,
-     "File mode of the unix socket", "<string>"},
-    {"max-ips-per-target", '\0', 0, G_OPTION_ARG_INT, &max_ips_per_target,
-     "Maximum number of IPs per target.", "<number>"},
-    {"max-email-attachment-size", '\0', 0, G_OPTION_ARG_INT,
+    {"inheritor",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &inheritor,
+     "Have <username> inherit from deleted user.",
+     "<username>"},
+    {"listen",
+     'a',
+     0,
+     G_OPTION_ARG_STRING,
+     &manager_address_string,
+     "Listen on <address>.",
+     "<address>"},
+    {"listen2",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &manager_address_string_2,
+     "Listen also on <address>.",
+     "<address>"},
+    {"listen-owner",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &listen_owner,
+     "Owner of the unix socket",
+     "<string>"},
+    {"listen-group",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &listen_group,
+     "Group of the unix socket",
+     "<string>"},
+    {"listen-mode",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &listen_mode,
+     "File mode of the unix socket",
+     "<string>"},
+    {"max-ips-per-target",
+     '\0',
+     0,
+     G_OPTION_ARG_INT,
+     &max_ips_per_target,
+     "Maximum number of IPs per target.",
+     "<number>"},
+    {"max-email-attachment-size",
+     '\0',
+     0,
+     G_OPTION_ARG_INT,
      &max_email_attachment_size,
-     "Maximum size of alert email attachments, in bytes.", "<number>"},
-    {"max-email-include-size", '\0', 0, G_OPTION_ARG_INT,
+     "Maximum size of alert email attachments, in bytes.",
+     "<number>"},
+    {"max-email-include-size",
+     '\0',
+     0,
+     G_OPTION_ARG_INT,
      &max_email_include_size,
-     "Maximum size of inlined content in alert emails, in bytes.", "<number>"},
-    {"max-email-message-size", '\0', 0, G_OPTION_ARG_INT,
+     "Maximum size of inlined content in alert emails, in bytes.",
+     "<number>"},
+    {"max-email-message-size",
+     '\0',
+     0,
+     G_OPTION_ARG_INT,
      &max_email_message_size,
      "Maximum size of user-defined message text in alert emails, in bytes.",
      "<number>"},
-    {"migrate", 'm', 0, G_OPTION_ARG_NONE, &migrate_database,
-     "Migrate the database and exit.", NULL},
-    {"modify-setting", '\0', 0, G_OPTION_ARG_STRING, &modify_setting,
-     "Modify setting <uuid> and exit.", "<uuid>"},
-    {"encrypt-all-credentials", '\0', 0, G_OPTION_ARG_NONE,
-     &encrypt_all_credentials, "(Re-)Encrypt all credentials.", NULL},
-    {"decrypt-all-credentials", '\0', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE,
-     &decrypt_all_credentials, NULL, NULL},
-    {"new-password", '\0', 0, G_OPTION_ARG_STRING, &new_password,
-     "Modify user's password and exit.", "<password>"},
-    {"optimize", '\0', 0, G_OPTION_ARG_STRING, &optimize,
+    {"migrate",
+     'm',
+     0,
+     G_OPTION_ARG_NONE,
+     &migrate_database,
+     "Migrate the database and exit.",
+     NULL},
+    {"modify-setting",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &modify_setting,
+     "Modify setting <uuid> and exit.",
+     "<uuid>"},
+    {"encrypt-all-credentials",
+     '\0',
+     0,
+     G_OPTION_ARG_NONE,
+     &encrypt_all_credentials,
+     "(Re-)Encrypt all credentials.",
+     NULL},
+    {"decrypt-all-credentials",
+     '\0',
+     G_OPTION_FLAG_HIDDEN,
+     G_OPTION_ARG_NONE,
+     &decrypt_all_credentials,
+     NULL,
+     NULL},
+    {"new-password",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &new_password,
+     "Modify user's password and exit.",
+     "<password>"},
+    {"optimize",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &optimize,
      "Run an optimization: vacuum, analyze, cleanup-config-prefs, "
      "cleanup-port-names, cleanup-result-severities, cleanup-schedule-times, "
      "rebuild-report-cache or update-report-cache.",
      "<name>"},
-    {"password", '\0', 0, G_OPTION_ARG_STRING, &password,
-     "Password, for --create-user.", "<password>"},
-    {"port", 'p', 0, G_OPTION_ARG_STRING, &manager_port_string,
-     "Use port number <number>.", "<number>"},
-    {"port2", '\0', 0, G_OPTION_ARG_STRING, &manager_port_string_2,
-     "Use port number <number> for address 2.", "<number>"},
-    {"role", '\0', 0, G_OPTION_ARG_STRING, &role,
-     "Role for --create-user and --get-users.", "<role>"},
-    {"unix-socket", 'c', 0, G_OPTION_ARG_STRING, &manager_address_string_unix,
-     "Listen on UNIX socket at <filename>.", "<filename>"},
-    {"user", '\0', 0, G_OPTION_ARG_STRING, &user, "User for --new-password.",
+    {"password",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &password,
+     "Password, for --create-user.",
+     "<password>"},
+    {"port",
+     'p',
+     0,
+     G_OPTION_ARG_STRING,
+     &manager_port_string,
+     "Use port number <number>.",
+     "<number>"},
+    {"port2",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &manager_port_string_2,
+     "Use port number <number> for address 2.",
+     "<number>"},
+    {"role",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &role,
+     "Role for --create-user and --get-users.",
+     "<role>"},
+    {"unix-socket",
+     'c',
+     0,
+     G_OPTION_ARG_STRING,
+     &manager_address_string_unix,
+     "Listen on UNIX socket at <filename>.",
+     "<filename>"},
+    {"user",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &user,
+     "User for --new-password.",
      "<username>"},
-    {"gnutls-priorities", '\0', 0, G_OPTION_ARG_STRING, &priorities,
+    {"gnutls-priorities",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &priorities,
      "Sets the GnuTLS priorities for the Manager socket.",
      "<priorities-string>"},
-    {"dh-params", '\0', 0, G_OPTION_ARG_STRING, &dh_params,
-     "Diffie-Hellman parameters file", "<file>"},
-    {"value", '\0', 0, G_OPTION_ARG_STRING, &value,
-     "Value for --modify-setting.", "<value>"},
-    {"verbose", 'v', 0, G_OPTION_ARG_NONE, &verbose,
-     "Has no effect.  See INSTALL.md for logging config.", NULL},
-    {"version", '\0', 0, G_OPTION_ARG_NONE, &print_version,
-     "Print version and exit.", NULL},
+    {"dh-params",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &dh_params,
+     "Diffie-Hellman parameters file",
+     "<file>"},
+    {"value",
+     '\0',
+     0,
+     G_OPTION_ARG_STRING,
+     &value,
+     "Value for --modify-setting.",
+     "<value>"},
+    {"verbose",
+     'v',
+     0,
+     G_OPTION_ARG_NONE,
+     &verbose,
+     "Has no effect.  See INSTALL.md for logging config.",
+     NULL},
+    {"version",
+     '\0',
+     0,
+     G_OPTION_ARG_NONE,
+     &print_version,
+     "Print version and exit.",
+     NULL},
     {NULL}};
 
   /* Set locale based on environment variables. */
@@ -1830,8 +2101,8 @@ main (int argc, char **argv)
   if (!g_option_context_parse (option_context, &argc, &argv, &error))
     {
       g_option_context_free (option_context);
-      g_critical ("%s: g_option_context_parse: %s", __FUNCTION__,
-                  error->message);
+      g_critical (
+        "%s: g_option_context_parse: %s", __FUNCTION__, error->message);
       exit (EXIT_FAILURE);
     }
   g_option_context_free (option_context);
@@ -1941,10 +2212,13 @@ main (int argc, char **argv)
 #ifdef GVMD_GIT_REVISION
   g_message ("   Greenbone Vulnerability Manager version %s (GIT revision %s) "
              "(DB revision %i)",
-             GVMD_VERSION, GVMD_GIT_REVISION, manage_db_supported_version ());
+             GVMD_VERSION,
+             GVMD_GIT_REVISION,
+             manage_db_supported_version ());
 #else
   g_message ("   Greenbone Vulnerability Manager version %s (DB revision %i)",
-             GVMD_VERSION, manage_db_supported_version ());
+             GVMD_VERSION,
+             manage_db_supported_version ());
 #endif
 
   /* Get exclusivity on the startup locks.
@@ -2105,8 +2379,8 @@ main (int argc, char **argv)
       password_policy =
         g_build_filename (GVM_SYSCONF_DIR, "pwpolicy.conf", NULL);
       if (g_file_test (password_policy, G_FILE_TEST_EXISTS) == FALSE)
-        g_warning ("%s: password policy missing: %s", __FUNCTION__,
-                   password_policy);
+        g_warning (
+          "%s: password policy missing: %s", __FUNCTION__, password_policy);
       g_free (password_policy);
     }
 
@@ -2160,9 +2434,15 @@ main (int argc, char **argv)
           return EXIT_FAILURE;
         }
       stype = g_strdup_printf ("%u", type);
-      ret = manage_create_scanner (
-        log_config, database, create_scanner, scanner_host, scanner_port, stype,
-        scanner_ca_pub, scanner_key_pub, scanner_key_priv);
+      ret = manage_create_scanner (log_config,
+                                   database,
+                                   create_scanner,
+                                   scanner_host,
+                                   scanner_port,
+                                   stype,
+                                   scanner_ca_pub,
+                                   scanner_key_pub,
+                                   scanner_key_priv);
       g_free (stype);
       log_config_free ();
       if (ret)
@@ -2201,9 +2481,16 @@ main (int argc, char **argv)
       else
         stype = NULL;
 
-      ret = manage_modify_scanner (
-        log_config, database, modify_scanner, scanner_name, scanner_host,
-        scanner_port, stype, scanner_ca_pub, scanner_key_pub, scanner_key_priv);
+      ret = manage_modify_scanner (log_config,
+                                   database,
+                                   modify_scanner,
+                                   scanner_name,
+                                   scanner_host,
+                                   scanner_port,
+                                   stype,
+                                   scanner_ca_pub,
+                                   scanner_key_pub,
+                                   scanner_key_priv);
       g_free (stype);
       log_config_free ();
       if (ret)
@@ -2349,8 +2636,8 @@ main (int argc, char **argv)
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
 
-      ret = manage_modify_setting (log_config, database, user, modify_setting,
-                                   value);
+      ret = manage_modify_setting (
+        log_config, database, user, modify_setting, value);
       log_config_free ();
       if (ret)
         return EXIT_FAILURE;
@@ -2421,7 +2708,8 @@ main (int argc, char **argv)
           break;
         case -1:
           /* Parent when error. */
-          g_critical ("%s: failed to fork into background: %s", __FUNCTION__,
+          g_critical ("%s: failed to fork into background: %s",
+                      __FUNCTION__,
                       strerror (errno));
           log_config_free ();
           exit (EXIT_FAILURE);
@@ -2436,9 +2724,15 @@ main (int argc, char **argv)
 
   /* Initialise GMP daemon. */
 
-  switch (init_gmpd (log_config, 0, database, max_ips_per_target,
-                     max_email_attachment_size, max_email_include_size,
-                     max_email_message_size, fork_connection_for_event, 0))
+  switch (init_gmpd (log_config,
+                     0,
+                     database,
+                     max_ips_per_target,
+                     max_email_attachment_size,
+                     max_email_include_size,
+                     max_email_message_size,
+                     fork_connection_for_event,
+                     0))
     {
     case 0:
       break;
@@ -2450,7 +2744,8 @@ main (int argc, char **argv)
     case -4:
       g_critical ("%s: --max-ips-per-target out of range"
                   " (min=1, max=%i, requested=%i)",
-                  __FUNCTION__, MANAGE_ABSOLUTE_MAX_IPS_PER_TARGET,
+                  __FUNCTION__,
+                  MANAGE_ABSOLUTE_MAX_IPS_PER_TARGET,
                   max_ips_per_target);
       log_config_free ();
       exit (EXIT_FAILURE);
@@ -2500,7 +2795,8 @@ main (int argc, char **argv)
   if (g_mkdir_with_parents (GVM_LOG_DIR, 0755) /* "rwxr-xr-x" */
       == -1)
     {
-      g_critical ("%s: failed to create log directory: %s", __FUNCTION__,
+      g_critical ("%s: failed to create log directory: %s",
+                  __FUNCTION__,
                   strerror (errno));
       exit (EXIT_FAILURE);
     }
@@ -2508,8 +2804,8 @@ main (int argc, char **argv)
   log_stream = fopen (LOG_FILE, "w");
   if (log_stream == NULL)
     {
-      g_critical ("%s: failed to open log file: %s", __FUNCTION__,
-                  strerror (errno));
+      g_critical (
+        "%s: failed to open log file: %s", __FUNCTION__, strerror (errno));
       exit (EXIT_FAILURE);
     }
 #endif
@@ -2528,8 +2824,12 @@ main (int argc, char **argv)
 
   if (use_tls)
     {
-      if (gvm_server_new (GNUTLS_SERVER, CACERT, SCANNERCERT, SCANNERKEY,
-                          &client_session, &client_credentials))
+      if (gvm_server_new (GNUTLS_SERVER,
+                          CACERT,
+                          SCANNERCERT,
+                          SCANNERKEY,
+                          &client_session,
+                          &client_credentials))
         {
           g_critical ("%s: client server initialisation failed", __FUNCTION__);
           exit (EXIT_FAILURE);
@@ -2549,11 +2849,19 @@ main (int argc, char **argv)
                                    ? manager_address_string
                                    : (ipv6_is_enabled () ? "::" : "0.0.0.0"))
                               : NULL,
-                      manager_port_string, listen_owner, listen_group,
-                      listen_mode, &manager_socket))
+                      manager_port_string,
+                      listen_owner,
+                      listen_group,
+                      listen_mode,
+                      &manager_socket))
     return EXIT_FAILURE;
-  if (manager_listen (NULL, manager_address_string_2, manager_port_string_2,
-                      NULL, NULL, NULL, &manager_socket_2))
+  if (manager_listen (NULL,
+                      manager_address_string_2,
+                      manager_port_string_2,
+                      NULL,
+                      NULL,
+                      NULL,
+                      &manager_socket_2))
     return EXIT_FAILURE;
 
   /* Initialise the process for manage_schedule. */

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -32,7 +32,6 @@
 
 #include <glib.h>
 
-
 /* Types. */
 
 /**
@@ -50,7 +49,7 @@ typedef struct sql_stmt sql_stmt_t;
  */
 struct iterator
 {
-  sql_stmt_t* stmt;          ///< SQL statement.
+  sql_stmt_t *stmt;          ///< SQL statement.
   gboolean done;             ///< End flag.
   int prepared;              ///< Prepared flag.
   lsc_crypt_ctx_t crypt_ctx; ///< Encryption context.
@@ -61,13 +60,12 @@ struct iterator
  */
 typedef struct iterator iterator_t;
 
-
 /* Functions. */
 
 void
-cleanup_iterator (iterator_t*);
+cleanup_iterator (iterator_t *);
 
 gboolean
-next (iterator_t*);
+next (iterator_t *);
 
 #endif /* not _GVMD_ITERATOR_H */

--- a/src/lsc_crypt.c
+++ b/src/lsc_crypt.c
@@ -398,7 +398,8 @@ do_encrypt (lsc_crypt_ctx_t ctx, const void *plaintext, size_t plaintextlen)
  *         returned on error.
  */
 static char *
-do_decrypt (lsc_crypt_ctx_t ctx, const char *cipherstring,
+do_decrypt (lsc_crypt_ctx_t ctx,
+            const char *cipherstring,
             size_t *r_plaintextlen)
 {
   gpg_error_t err;
@@ -631,7 +632,8 @@ lsc_crypt_encrypt (lsc_crypt_ctx_t ctx, const char *first_name, ...)
  *         returned.
  */
 const char *
-lsc_crypt_decrypt (lsc_crypt_ctx_t ctx, const char *ciphertext,
+lsc_crypt_decrypt (lsc_crypt_ctx_t ctx,
+                   const char *ciphertext,
                    const char *name)
 {
   size_t namelen;

--- a/src/lsc_crypt.c
+++ b/src/lsc_crypt.c
@@ -187,11 +187,15 @@ create_the_key (lsc_crypt_ctx_t ctx)
   err = gpgme_op_genkey (ctx->encctx, parms, NULL, NULL);
   if (err)
     {
-      log_gpgme (G_LOG_LEVEL_WARNING, err, "error creating OpenPGP key '%s'",
+      log_gpgme (G_LOG_LEVEL_WARNING,
+                 err,
+                 "error creating OpenPGP key '%s'",
                  ENCRYPTION_KEY_UID);
       return -1;
     }
-  log_gpgme (G_LOG_LEVEL_INFO, 0, "OpenPGP key '%s' has been generated",
+  log_gpgme (G_LOG_LEVEL_INFO,
+             0,
+             "OpenPGP key '%s' has been generated",
              ENCRYPTION_KEY_UID);
   return 0;
 }
@@ -220,7 +224,8 @@ again:
   err = gpgme_op_keylist_start (ctx->encctx, "=" ENCRYPTION_KEY_UID, 0);
   if (err)
     {
-      log_gpgme (G_LOG_LEVEL_WARNING, err,
+      log_gpgme (G_LOG_LEVEL_WARNING,
+                 err,
                  "error starting search for OpenPGP key '%s'",
                  ENCRYPTION_KEY_UID);
       return NULL;
@@ -233,7 +238,9 @@ again:
       if (!key->can_encrypt || key->revoked || key->expired || key->disabled
           || key->invalid)
         {
-          log_gpgme (G_LOG_LEVEL_MESSAGE, 0, "skipping unusable OpenPGP key %s",
+          log_gpgme (G_LOG_LEVEL_MESSAGE,
+                     0,
+                     "skipping unusable OpenPGP key %s",
                      key->subkeys ? nonnull (key->subkeys->keyid) : "?");
           any_skipped = 1;
           continue;
@@ -284,8 +291,10 @@ again:
 
   if (err)
     {
-      log_gpgme (G_LOG_LEVEL_MESSAGE, err,
-                 "error searching for OpenPGP key '%s'", ENCRYPTION_KEY_UID);
+      log_gpgme (G_LOG_LEVEL_MESSAGE,
+                 err,
+                 "error searching for OpenPGP key '%s'",
+                 ENCRYPTION_KEY_UID);
       gpgme_key_unref (found);
       found = NULL;
     }
@@ -326,16 +335,20 @@ do_encrypt (lsc_crypt_ctx_t ctx, const void *plaintext, size_t plaintextlen)
   err = gpgme_data_new_from_mem (&in, plaintext, plaintextlen, 0);
   if (err)
     {
-      log_gpgme (G_LOG_LEVEL_WARNING, err,
-                 "%s: error creating data object from plaintext", G_STRFUNC);
+      log_gpgme (G_LOG_LEVEL_WARNING,
+                 err,
+                 "%s: error creating data object from plaintext",
+                 G_STRFUNC);
       return NULL;
     }
 
   err = gpgme_data_new (&out);
   if (err)
     {
-      log_gpgme (G_LOG_LEVEL_WARNING, err,
-                 "%s: error creating data object for ciphertext", G_STRFUNC);
+      log_gpgme (G_LOG_LEVEL_WARNING,
+                 err,
+                 "%s: error creating data object for ciphertext",
+                 G_STRFUNC);
       gpgme_data_release (in);
       return NULL;
     }
@@ -343,13 +356,13 @@ do_encrypt (lsc_crypt_ctx_t ctx, const void *plaintext, size_t plaintextlen)
   gpgme_set_armor (ctx->encctx, 0);
   keyarray[0] = ctx->enckey;
   keyarray[1] = NULL;
-  err = gpgme_op_encrypt (ctx->encctx, keyarray, GPGME_ENCRYPT_ALWAYS_TRUST, in,
-                          out);
+  err = gpgme_op_encrypt (
+    ctx->encctx, keyarray, GPGME_ENCRYPT_ALWAYS_TRUST, in, out);
   gpgme_data_release (in);
   if (err)
     {
-      log_gpgme (G_LOG_LEVEL_WARNING, err, "%s: error encrypting credential",
-                 G_STRFUNC);
+      log_gpgme (
+        G_LOG_LEVEL_WARNING, err, "%s: error encrypting credential", G_STRFUNC);
       gpgme_data_release (out);
       return NULL;
     }
@@ -402,8 +415,10 @@ do_decrypt (lsc_crypt_ctx_t ctx, const char *cipherstring,
   err = gpgme_data_new_from_mem (&in, ciphertext, ciphertextlen, 0);
   if (err)
     {
-      log_gpgme (G_LOG_LEVEL_WARNING, err,
-                 "%s: error creating data object from ciphertext", G_STRFUNC);
+      log_gpgme (G_LOG_LEVEL_WARNING,
+                 err,
+                 "%s: error creating data object from ciphertext",
+                 G_STRFUNC);
       g_free (ciphertext);
       return NULL;
     }
@@ -412,8 +427,10 @@ do_decrypt (lsc_crypt_ctx_t ctx, const char *cipherstring,
   err = gpgme_data_new (&out);
   if (err)
     {
-      log_gpgme (G_LOG_LEVEL_WARNING, err,
-                 "%s: error creating data object for plaintext", G_STRFUNC);
+      log_gpgme (G_LOG_LEVEL_WARNING,
+                 err,
+                 "%s: error creating data object for plaintext",
+                 G_STRFUNC);
       gpgme_data_release (in);
       g_free (ciphertext);
       return NULL;
@@ -431,13 +448,17 @@ do_decrypt (lsc_crypt_ctx_t ctx, const char *cipherstring,
       log_gpgme (G_LOG_LEVEL_WARNING, err, "error decrypting credential");
       decres = gpgme_op_decrypt_result (ctx->encctx);
       if (decres->unsupported_algorithm)
-        log_gpgme (G_LOG_LEVEL_INFO, 0, "   unsupported algorithm (%s)",
+        log_gpgme (G_LOG_LEVEL_INFO,
+                   0,
+                   "   unsupported algorithm (%s)",
                    decres->unsupported_algorithm);
       if (decres->wrong_key_usage)
         log_gpgme (G_LOG_LEVEL_INFO, 0, "   wrong key usage");
       for (recp = decres->recipients; recp; recp = recp->next)
-        log_gpgme (G_LOG_LEVEL_INFO, recp->status,
-                   "   encrypted to keyid %s, algo=%d", recp->keyid,
+        log_gpgme (G_LOG_LEVEL_INFO,
+                   recp->status,
+                   "   encrypted to keyid %s, algo=%d",
+                   recp->keyid,
                    recp->pubkey_algo);
       return NULL;
     }
@@ -566,7 +587,9 @@ lsc_crypt_encrypt (lsc_crypt_ctx_t ctx, const char *first_name, ...)
           if (len > MAX_VALUE_LENGTH)
             {
               g_warning ("%s: value for '%s' larger than our limit (%d)",
-                         G_STRFUNC, name, MAX_VALUE_LENGTH);
+                         G_STRFUNC,
+                         name,
+                         MAX_VALUE_LENGTH);
               g_string_free (stringbuf, TRUE);
               va_end (arg_ptr);
               return NULL;
@@ -680,7 +703,9 @@ lsc_crypt_decrypt (lsc_crypt_ctx_t ctx, const char *ciphertext,
           if (n > MAX_VALUE_LENGTH)
             {
               g_warning ("%s: value for '%s' larger than our limit (%d)",
-                         G_STRFUNC, name, MAX_VALUE_LENGTH);
+                         G_STRFUNC,
+                         name,
+                         MAX_VALUE_LENGTH);
               return NULL;
             }
           nl = g_malloc (sizeof *nl + namelen);
@@ -723,7 +748,9 @@ lsc_crypt_decrypt (lsc_crypt_ctx_t ctx, const char *ciphertext,
 failed:
   g_warning ("%s: decrypted credential data block is inconsistent;"
              " %zu bytes remaining at offset %zu",
-             G_STRFUNC, len, (size_t) (p - ctx->plaintext));
+             G_STRFUNC,
+             len,
+             (size_t) (p - ctx->plaintext));
 not_found:
   /* Cache a NULL value.  */
   nl = g_malloc (sizeof *nl + namelen);

--- a/src/lsc_crypt.h
+++ b/src/lsc_crypt.h
@@ -30,23 +30,26 @@
 /* (Defined in gvmd.c) */
 extern int disable_encrypted_credentials;
 
-
 struct lsc_crypt_ctx_s;
 typedef struct lsc_crypt_ctx_s *lsc_crypt_ctx_t;
 
-lsc_crypt_ctx_t lsc_crypt_new ();
+lsc_crypt_ctx_t
+lsc_crypt_new ();
 void lsc_crypt_release (lsc_crypt_ctx_t);
 
-int lsc_crypt_create_key ();
+int
+lsc_crypt_create_key ();
 
 void lsc_crypt_flush (lsc_crypt_ctx_t);
 
-char *lsc_crypt_encrypt (lsc_crypt_ctx_t,
-                         const char *, ...) G_GNUC_NULL_TERMINATED;
+char *
+lsc_crypt_encrypt (lsc_crypt_ctx_t, const char *, ...) G_GNUC_NULL_TERMINATED;
 
-const char *lsc_crypt_decrypt (lsc_crypt_ctx_t, const char *, const char *);
-const char *lsc_crypt_get_password (lsc_crypt_ctx_t, const char *);
-const char *lsc_crypt_get_private_key (lsc_crypt_ctx_t, const char *);
-
+const char *
+lsc_crypt_decrypt (lsc_crypt_ctx_t, const char *, const char *);
+const char *
+lsc_crypt_get_password (lsc_crypt_ctx_t, const char *);
+const char *
+lsc_crypt_get_private_key (lsc_crypt_ctx_t, const char *);
 
 #endif /* not _GVMD_LSC_CRYPT_H */

--- a/src/lsc_user.c
+++ b/src/lsc_user.c
@@ -26,15 +26,14 @@
 
 #include <glib.h>
 #include <glib/gstdio.h>
+#include <gvm/util/fileutils.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
-
-#include <gvm/util/fileutils.h>
+#include <unistd.h>
 
 #undef G_LOG_DOMAIN
 /**
@@ -42,7 +41,6 @@
  */
 #define G_LOG_DOMAIN "md manage"
 
-
 /* Key creation. */
 
 /**
@@ -85,7 +83,7 @@ create_ssh_key (const char *comment, const char *passphrase,
   /* Sanity check files. */
 
   dir = g_path_get_dirname (privpath);
-  if (g_mkdir_with_parents (dir, 0755 /* "rwxr-xr-x" */ ))
+  if (g_mkdir_with_parents (dir, 0755 /* "rwxr-xr-x" */))
     {
       g_warning ("%s: failed to access %s", __FUNCTION__, dir);
       g_free (dir);
@@ -102,20 +100,18 @@ create_ssh_key (const char *comment, const char *passphrase,
   if ((g_spawn_command_line_sync (command, &astdout, &astderr, &exit_status,
                                   &err)
        == FALSE)
-      || (WIFEXITED (exit_status) == 0)
-      || WEXITSTATUS (exit_status))
+      || (WIFEXITED (exit_status) == 0) || WEXITSTATUS (exit_status))
     {
       if (err)
         {
-          g_warning ("%s: failed to create private key: %s",
-                     __FUNCTION__, err->message);
+          g_warning ("%s: failed to create private key: %s", __FUNCTION__,
+                     err->message);
           g_error_free (err);
         }
       else
         g_warning ("%s: failed to create private key", __FUNCTION__);
-      g_debug ("%s: key-gen failed with %d (WIF %i, WEX %i).\n",
-               __FUNCTION__, exit_status, WIFEXITED (exit_status),
-               WEXITSTATUS (exit_status));
+      g_debug ("%s: key-gen failed with %d (WIF %i, WEX %i).\n", __FUNCTION__,
+               exit_status, WIFEXITED (exit_status), WEXITSTATUS (exit_status));
       g_debug ("%s: stdout: %s", __FUNCTION__, astdout);
       g_debug ("%s: stderr: %s", __FUNCTION__, astderr);
       g_free (command);
@@ -138,8 +134,7 @@ create_ssh_key (const char *comment, const char *passphrase,
  * @return 0 success, -1 error.
  */
 int
-lsc_user_keys_create (const gchar *password,
-                      gchar **private_key)
+lsc_user_keys_create (const gchar *password, gchar **private_key)
 {
   GError *error;
   gsize length;
@@ -165,14 +160,13 @@ lsc_user_keys_create (const gchar *password,
       goto free_exit;
     }
   ret = 0;
- free_exit:
+free_exit:
 
   g_free (key_path);
   gvm_file_remove_recurse (key_dir);
   return ret;
 }
 
-
 /* RPM package generation. */
 
 /**
@@ -186,8 +180,7 @@ lsc_user_keys_create (const gchar *password,
  * @return Path to rpm file if successful, NULL otherwise.
  */
 static gboolean
-lsc_user_rpm_create (const gchar *username,
-                     const gchar *public_key_path,
+lsc_user_rpm_create (const gchar *username, const gchar *public_key_path,
                      const gchar *to_filename)
 {
   gint exit_status;
@@ -211,11 +204,10 @@ lsc_user_rpm_create (const gchar *username,
   g_debug ("%s: copy key to temporary directory", __FUNCTION__);
   pubkey_basename = g_strdup_printf ("%s.pub", username);
   new_pubkey_filename = g_build_filename (tmpdir, pubkey_basename, NULL);
-  if (gvm_file_copy (public_key_path, new_pubkey_filename)
-      == FALSE)
+  if (gvm_file_copy (public_key_path, new_pubkey_filename) == FALSE)
     {
-      g_warning ("%s: failed to copy key file %s to %s",
-                 __FUNCTION__, public_key_path, new_pubkey_filename);
+      g_warning ("%s: failed to copy key file %s to %s", __FUNCTION__,
+                 public_key_path, new_pubkey_filename);
       g_free (pubkey_basename);
       g_free (new_pubkey_filename);
       return FALSE;
@@ -226,34 +218,22 @@ lsc_user_rpm_create (const gchar *username,
 
   g_debug ("%s: Attempting RPM build", __FUNCTION__);
   cmd = (gchar **) g_malloc (6 * sizeof (gchar *));
-  cmd[0] = g_build_filename (GVM_DATA_DIR,
-                             "gvm-lsc-rpm-creator.sh",
-                             NULL);
+  cmd[0] = g_build_filename (GVM_DATA_DIR, "gvm-lsc-rpm-creator.sh", NULL);
   cmd[1] = g_strdup (username);
   cmd[2] = g_strdup (new_pubkey_filename);
   cmd[3] = g_strdup (tmpdir);
   cmd[4] = g_strdup (to_filename);
   cmd[5] = NULL;
-  g_debug ("%s: Spawning in %s: %s %s %s %s %s",
-           __FUNCTION__, tmpdir, cmd[0], cmd[1], cmd[2], cmd[3], cmd[4]);
-  if ((g_spawn_sync (tmpdir,
-                     cmd,
-                     NULL,                  /* Environment. */
-                     G_SPAWN_SEARCH_PATH,
-                     NULL,                  /* Setup function. */
-                     NULL,
-                     &standard_out,
-                     &standard_err,
-                     &exit_status,
-                     NULL)
+  g_debug ("%s: Spawning in %s: %s %s %s %s %s", __FUNCTION__, tmpdir, cmd[0],
+           cmd[1], cmd[2], cmd[3], cmd[4]);
+  if ((g_spawn_sync (tmpdir, cmd, NULL,         /* Environment. */
+                     G_SPAWN_SEARCH_PATH, NULL, /* Setup function. */
+                     NULL, &standard_out, &standard_err, &exit_status, NULL)
        == FALSE)
-      || (WIFEXITED (exit_status) == 0)
-      || WEXITSTATUS (exit_status))
+      || (WIFEXITED (exit_status) == 0) || WEXITSTATUS (exit_status))
     {
       g_warning ("%s: failed to create the rpm: %d (WIF %i, WEX %i)",
-                 __FUNCTION__,
-                 exit_status,
-                 WIFEXITED (exit_status),
+                 __FUNCTION__, exit_status, WIFEXITED (exit_status),
                  WEXITSTATUS (exit_status));
       g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
       g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);
@@ -275,8 +255,8 @@ lsc_user_rpm_create (const gchar *username,
 
   if (gvm_file_remove_recurse (tmpdir) != 0 && success == TRUE)
     {
-      g_warning ("%s: failed to remove temporary directory %s",
-                 __FUNCTION__, tmpdir);
+      g_warning ("%s: failed to remove temporary directory %s", __FUNCTION__,
+                 tmpdir);
       success = FALSE;
     }
 
@@ -294,8 +274,8 @@ lsc_user_rpm_create (const gchar *username,
  * @return 0 success, -1 error.
  */
 int
-lsc_user_rpm_recreate (const gchar *name, const char *public_key,
-                       void **rpm, gsize *rpm_size)
+lsc_user_rpm_recreate (const gchar *name, const char *public_key, void **rpm,
+                       gsize *rpm_size)
 {
   GError *error;
   char rpm_dir[] = "/tmp/rpm_XXXXXX";
@@ -344,11 +324,11 @@ lsc_user_rpm_recreate (const gchar *name, const char *public_key,
 
   ret = 0;
 
- rm_exit:
+rm_exit:
 
   gvm_file_remove_recurse (rpm_dir);
 
- free_exit:
+free_exit:
 
   g_free (public_key_path);
 
@@ -357,7 +337,6 @@ lsc_user_rpm_recreate (const gchar *name, const char *public_key,
   return ret;
 }
 
-
 /* Deb generation. */
 
 /**
@@ -372,10 +351,8 @@ lsc_user_rpm_recreate (const gchar *name, const char *public_key,
  * @return Path to rpm file if successful, NULL otherwise.
  */
 static gboolean
-lsc_user_deb_create (const gchar *username,
-                     const gchar *public_key_path,
-                     const gchar *to_filename,
-                     const gchar *maintainer)
+lsc_user_deb_create (const gchar *username, const gchar *public_key_path,
+                     const gchar *to_filename, const gchar *maintainer)
 {
   gint exit_status;
   gchar *new_pubkey_filename = NULL;
@@ -398,11 +375,10 @@ lsc_user_deb_create (const gchar *username,
   g_debug ("%s: copy key to temporary directory", __FUNCTION__);
   pubkey_basename = g_strdup_printf ("%s.pub", username);
   new_pubkey_filename = g_build_filename (tmpdir, pubkey_basename, NULL);
-  if (gvm_file_copy (public_key_path, new_pubkey_filename)
-      == FALSE)
+  if (gvm_file_copy (public_key_path, new_pubkey_filename) == FALSE)
     {
-      g_warning ("%s: failed to copy key file %s to %s",
-                 __FUNCTION__, public_key_path, new_pubkey_filename);
+      g_warning ("%s: failed to copy key file %s to %s", __FUNCTION__,
+                 public_key_path, new_pubkey_filename);
       g_free (pubkey_basename);
       g_free (new_pubkey_filename);
       return FALSE;
@@ -413,36 +389,23 @@ lsc_user_deb_create (const gchar *username,
 
   g_debug ("%s: Attempting DEB build", __FUNCTION__);
   cmd = (gchar **) g_malloc (7 * sizeof (gchar *));
-  cmd[0] = g_build_filename (GVM_DATA_DIR,
-                             "gvm-lsc-deb-creator.sh",
-                             NULL);
+  cmd[0] = g_build_filename (GVM_DATA_DIR, "gvm-lsc-deb-creator.sh", NULL);
   cmd[1] = g_strdup (username);
   cmd[2] = g_strdup (new_pubkey_filename);
   cmd[3] = g_strdup (tmpdir);
   cmd[4] = g_strdup (to_filename);
   cmd[5] = g_strdup (maintainer);
   cmd[6] = NULL;
-  g_debug ("%s: Spawning in %s: %s %s %s %s %s %s",
-           __FUNCTION__, tmpdir,
+  g_debug ("%s: Spawning in %s: %s %s %s %s %s %s", __FUNCTION__, tmpdir,
            cmd[0], cmd[1], cmd[2], cmd[3], cmd[4], cmd[5]);
-  if ((g_spawn_sync (tmpdir,
-                     cmd,
-                     NULL,                  /* Environment. */
-                     G_SPAWN_SEARCH_PATH,
-                     NULL,                  /* Setup function. */
-                     NULL,
-                     &standard_out,
-                     &standard_err,
-                     &exit_status,
-                     NULL)
+  if ((g_spawn_sync (tmpdir, cmd, NULL,         /* Environment. */
+                     G_SPAWN_SEARCH_PATH, NULL, /* Setup function. */
+                     NULL, &standard_out, &standard_err, &exit_status, NULL)
        == FALSE)
-      || (WIFEXITED (exit_status) == 0)
-      || WEXITSTATUS (exit_status))
+      || (WIFEXITED (exit_status) == 0) || WEXITSTATUS (exit_status))
     {
       g_warning ("%s: failed to create the deb: %d (WIF %i, WEX %i)",
-                 __FUNCTION__,
-                 exit_status,
-                 WIFEXITED (exit_status),
+                 __FUNCTION__, exit_status, WIFEXITED (exit_status),
                  WEXITSTATUS (exit_status));
       g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
       g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);
@@ -465,8 +428,8 @@ lsc_user_deb_create (const gchar *username,
 
   if (gvm_file_remove_recurse (tmpdir) != 0 && success == TRUE)
     {
-      g_warning ("%s: failed to remove temporary directory %s",
-                 __FUNCTION__, tmpdir);
+      g_warning ("%s: failed to remove temporary directory %s", __FUNCTION__,
+                 tmpdir);
       success = FALSE;
     }
 
@@ -486,8 +449,7 @@ lsc_user_deb_create (const gchar *username,
  */
 int
 lsc_user_deb_recreate (const gchar *name, const char *public_key,
-                       const char *maintainer,
-                       void **deb, gsize *deb_size)
+                       const char *maintainer, void **deb, gsize *deb_size)
 {
   GError *error;
   char deb_dir[] = "/tmp/deb_XXXXXX";
@@ -516,7 +478,7 @@ lsc_user_deb_recreate (const gchar *name, const char *public_key,
   deb_path = g_build_filename (deb_dir, "p.deb", NULL);
   g_debug ("%s: deb_path: %s", __FUNCTION__, deb_path);
   if (lsc_user_deb_create (name, public_key_path, deb_path, maintainer)
-        == FALSE)
+      == FALSE)
     {
       g_free (deb_path);
       goto rm_exit;
@@ -537,11 +499,11 @@ lsc_user_deb_recreate (const gchar *name, const char *public_key,
 
   ret = 0;
 
- rm_exit:
+rm_exit:
 
   gvm_file_remove_recurse (deb_dir);
 
- free_exit:
+free_exit:
 
   g_free (public_key_path);
 
@@ -550,7 +512,6 @@ lsc_user_deb_recreate (const gchar *name, const char *public_key,
   return ret;
 }
 
-
 /* Exe generation. */
 
 /**
@@ -567,7 +528,7 @@ static int
 create_nsis_script (const gchar *script_name, const gchar *package_name,
                     const gchar *user_name, const gchar *password)
 {
-  FILE* fd;
+  FILE *fd;
 
   fd = fopen (script_name, "w");
   if (fd == NULL)
@@ -588,8 +549,8 @@ create_nsis_script (const gchar *script_name, const gchar *package_name,
   // For ms vista installers we need the UAC plugin and use the following lines:
   // This requires the user to have the UAC plugin installed and to provide the
   // the path to it.
-  //fprintf (fd, "# Request application privileges for Windows Vista\n");
-  //fprintf (fd, "RequestExecutionLevel admin\n\n");
+  // fprintf (fd, "# Request application privileges for Windows Vista\n");
+  // fprintf (fd, "RequestExecutionLevel admin\n\n");
 
   fprintf (fd, "#\n# Default (installer) section.\n#\n");
   fprintf (fd, "section\n\n");
@@ -604,20 +565,35 @@ create_nsis_script (const gchar *script_name, const gchar *package_name,
   // Need to find localized Administrators group name, create a
   // GetAdminGroupName - vb script (Thanks to Thomas Rotter)
   fprintf (fd, "# Create Thomas Rotters GetAdminGroupName.vb script\n");
-  fprintf (fd, "ExecWait \"cmd /C Echo Set objWMIService = GetObject($\\\"winmgmts:\\\\.\\root\\cimv2$\\\") > $\\\"%%temp%%\\GetAdminGroupName.vbs$\\\" \"\n");
-  fprintf (fd, "ExecWait \"cmd /C Echo Set colAccounts = objWMIService.ExecQuery ($\\\"Select * From Win32_Group Where SID = 'S-1-5-32-544'$\\\")  >> $\\\"%%temp%%\\GetAdminGroupName.vbs$\\\"\"\n");
-  fprintf (fd, "ExecWait \"cmd /C Echo For Each objAccount in colAccounts >> $\\\"%%temp%%\\GetAdminGroupName.vbs$\\\"\"\n");
-  fprintf (fd, "ExecWait \"cmd /C Echo Wscript.Echo objAccount.Name >> $\\\"%%temp%%\\GetAdminGroupName.vbs$\\\"\"\n");
-  fprintf (fd, "ExecWait \"cmd /C Echo Next >> $\\\"%%temp%%\\GetAdminGroupName.vbs$\\\"\"\n");
-  fprintf (fd, "ExecWait \"cmd /C cscript //nologo $\\\"%%temp%%\\GetAdminGroupName.vbs$\\\" > $\\\"%%temp%%\\AdminGroupName.txt$\\\"\"\n\n");
+  fprintf (fd, "ExecWait \"cmd /C Echo Set objWMIService = "
+               "GetObject($\\\"winmgmts:\\\\.\\root\\cimv2$\\\") > "
+               "$\\\"%%temp%%\\GetAdminGroupName.vbs$\\\" \"\n");
+  fprintf (fd,
+           "ExecWait \"cmd /C Echo Set colAccounts = objWMIService.ExecQuery "
+           "($\\\"Select * From Win32_Group Where SID = 'S-1-5-32-544'$\\\")  "
+           ">> $\\\"%%temp%%\\GetAdminGroupName.vbs$\\\"\"\n");
+  fprintf (fd, "ExecWait \"cmd /C Echo For Each objAccount in colAccounts >> "
+               "$\\\"%%temp%%\\GetAdminGroupName.vbs$\\\"\"\n");
+  fprintf (fd, "ExecWait \"cmd /C Echo Wscript.Echo objAccount.Name >> "
+               "$\\\"%%temp%%\\GetAdminGroupName.vbs$\\\"\"\n");
+  fprintf (fd, "ExecWait \"cmd /C Echo Next >> "
+               "$\\\"%%temp%%\\GetAdminGroupName.vbs$\\\"\"\n");
+  fprintf (fd, "ExecWait \"cmd /C cscript //nologo "
+               "$\\\"%%temp%%\\GetAdminGroupName.vbs$\\\" > "
+               "$\\\"%%temp%%\\AdminGroupName.txt$\\\"\"\n\n");
 
   /** @todo provide /comment:"GVM User" /fullname:"GVM Testuser" */
   fprintf (fd, "# Create batch script that installs the user\n");
-  fprintf (fd, "ExecWait \"cmd /C Echo Set /P AdminGroupName= ^<$\\\"%%temp%%\\AdminGroupName.txt$\\\" > $\\\"%%temp%%\\AddUser.bat$\\\"\" \n");
-  fprintf (fd, "ExecWait \"cmd /C Echo net user %s %s /add /active:yes >> $\\\"%%temp%%\\AddUser.bat$\\\"\"\n",
-           user_name,
-           password);
-  fprintf (fd, "ExecWait \"cmd /C Echo net localgroup %%AdminGroupName%% %%COMPUTERNAME%%\\%s /add >> $\\\"%%temp%%\\AddUser.bat$\\\"\"\n\n",
+  fprintf (fd, "ExecWait \"cmd /C Echo Set /P AdminGroupName= "
+               "^<$\\\"%%temp%%\\AdminGroupName.txt$\\\" > "
+               "$\\\"%%temp%%\\AddUser.bat$\\\"\" \n");
+  fprintf (fd,
+           "ExecWait \"cmd /C Echo net user %s %s /add /active:yes >> "
+           "$\\\"%%temp%%\\AddUser.bat$\\\"\"\n",
+           user_name, password);
+  fprintf (fd,
+           "ExecWait \"cmd /C Echo net localgroup %%AdminGroupName%% "
+           "%%COMPUTERNAME%%\\%s /add >> $\\\"%%temp%%\\AddUser.bat$\\\"\"\n\n",
            user_name);
 
   fprintf (fd, "# Execute AddUser script\n");
@@ -626,12 +602,15 @@ create_nsis_script (const gchar *script_name, const gchar *package_name,
   // Remove up temporary files for localized Administrators group names
   fprintf (fd, "# Remove temporary files for localized admin group names\n");
   fprintf (fd, "ExecWait \"del $\\\"%%temp%%\\AdminGroupName.txt$\\\"\"\n");
-  fprintf (fd, "ExecWait \"del $\\\"%%temp%%\\GetAdminGroupName.vbs$\\\"\"\n\n");
+  fprintf (fd,
+           "ExecWait \"del $\\\"%%temp%%\\GetAdminGroupName.vbs$\\\"\"\n\n");
   fprintf (fd, "ExecWait \"del $\\\"%%temp%%\\AddUser.bat$\\\"\"\n\n");
 
-  /** @todo Display note about NTLM and SMB signing and encryption, 'Easy Filesharing' in WIN XP */
+  /** @todo Display note about NTLM and SMB signing and encryption, 'Easy
+   * Filesharing' in WIN XP */
   fprintf (fd, "# Display message that everything seems to be fine\n");
-  fprintf (fd, "messageBox MB_OK \"A user has been added. An uninstaller is placed on your Desktop.\"\n\n");
+  fprintf (fd, "messageBox MB_OK \"A user has been added. An uninstaller is "
+               "placed on your Desktop.\"\n\n");
 
   fprintf (fd, "# Default (install) section end\n");
   fprintf (fd, "sectionEnd\n\n");
@@ -641,14 +620,15 @@ create_nsis_script (const gchar *script_name, const gchar *package_name,
   fprintf (fd, "section \"Uninstall\"\n\n");
 
   fprintf (fd, "# Run cmd to remove user\n");
-  fprintf (fd, "ExecWait \"net user %s /delete\"\n\n",
-           user_name);
+  fprintf (fd, "ExecWait \"net user %s /delete\"\n\n", user_name);
 
   /** @todo Uninstaller should remove itself */
-  fprintf (fd, "# Unistaller should remove itself (from desktop/installdir)\n\n");
+  fprintf (fd,
+           "# Unistaller should remove itself (from desktop/installdir)\n\n");
 
   fprintf (fd, "# Display message that everything seems to be fine\n");
-  fprintf (fd, "messageBox MB_OK \"A user has been removed. You can now safely remove the uninstaller from your Desktop.\"\n\n");
+  fprintf (fd, "messageBox MB_OK \"A user has been removed. You can now safely "
+               "remove the uninstaller from your Desktop.\"\n\n");
 
   fprintf (fd, "# Uninstaller section end\n");
   fprintf (fd, "sectionEnd\n\n");
@@ -684,26 +664,15 @@ execute_makensis (const gchar *nsis_script)
   cmd[1] = g_strdup (nsis_script);
   cmd[2] = NULL;
   g_debug ("--- executing makensis");
-  g_debug ("%s: Spawning in %s: %s %s",
-           __FUNCTION__,
-           dirname, cmd[0], cmd[1]);
-  if ((g_spawn_sync (dirname,
-                     cmd,
-                     NULL,                 /* Environment. */
-                     G_SPAWN_SEARCH_PATH,
-                     NULL,                 /* Setup func. */
-                     NULL,
-                     &standard_out,
-                     &standard_err,
-                     &exit_status,
-                     NULL) == FALSE)
-      || (WIFEXITED (exit_status) == 0)
-      || WEXITSTATUS (exit_status))
+  g_debug ("%s: Spawning in %s: %s %s", __FUNCTION__, dirname, cmd[0], cmd[1]);
+  if ((g_spawn_sync (dirname, cmd, NULL,        /* Environment. */
+                     G_SPAWN_SEARCH_PATH, NULL, /* Setup func. */
+                     NULL, &standard_out, &standard_err, &exit_status, NULL)
+       == FALSE)
+      || (WIFEXITED (exit_status) == 0) || WEXITSTATUS (exit_status))
     {
       g_warning ("%s: failed to create the exe: %d (WIF %i, WEX %i)",
-                 __FUNCTION__,
-                 exit_status,
-                 WIFEXITED (exit_status),
+                 __FUNCTION__, exit_status, WIFEXITED (exit_status),
                  WEXITSTATUS (exit_status));
       g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
       g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);
@@ -767,8 +736,8 @@ lsc_user_exe_create (const gchar *user_name, const gchar *password,
  * @return 0 success, -1 error.
  */
 int
-lsc_user_exe_recreate (const gchar *name, const gchar *password,
-                       void **exe, gsize *exe_size)
+lsc_user_exe_recreate (const gchar *name, const gchar *password, void **exe,
+                       gsize *exe_size)
 {
   GError *error;
   char exe_dir[] = "/tmp/exe_XXXXXX";
@@ -797,7 +766,7 @@ lsc_user_exe_recreate (const gchar *name, const gchar *password,
 
   ret = 0;
 
- rm_exit:
+rm_exit:
 
   gvm_file_remove_recurse (exe_dir);
 

--- a/src/lsc_user.c
+++ b/src/lsc_user.c
@@ -57,7 +57,8 @@
  * @return 0 if successful, -1 otherwise.
  */
 static int
-create_ssh_key (const char *comment, const char *passphrase,
+create_ssh_key (const char *comment,
+                const char *passphrase,
                 const char *privpath)
 {
   gchar *astdout = NULL;
@@ -190,7 +191,8 @@ free_exit:
  * @return Path to rpm file if successful, NULL otherwise.
  */
 static gboolean
-lsc_user_rpm_create (const gchar *username, const gchar *public_key_path,
+lsc_user_rpm_create (const gchar *username,
+                     const gchar *public_key_path,
                      const gchar *to_filename)
 {
   gint exit_status;
@@ -301,7 +303,9 @@ lsc_user_rpm_create (const gchar *username, const gchar *public_key_path,
  * @return 0 success, -1 error.
  */
 int
-lsc_user_rpm_recreate (const gchar *name, const char *public_key, void **rpm,
+lsc_user_rpm_recreate (const gchar *name,
+                       const char *public_key,
+                       void **rpm,
                        gsize *rpm_size)
 {
   GError *error;
@@ -378,8 +382,10 @@ free_exit:
  * @return Path to rpm file if successful, NULL otherwise.
  */
 static gboolean
-lsc_user_deb_create (const gchar *username, const gchar *public_key_path,
-                     const gchar *to_filename, const gchar *maintainer)
+lsc_user_deb_create (const gchar *username,
+                     const gchar *public_key_path,
+                     const gchar *to_filename,
+                     const gchar *maintainer)
 {
   gint exit_status;
   gchar *new_pubkey_filename = NULL;
@@ -493,8 +499,11 @@ lsc_user_deb_create (const gchar *username, const gchar *public_key_path,
  * @return 0 success, -1 error.
  */
 int
-lsc_user_deb_recreate (const gchar *name, const char *public_key,
-                       const char *maintainer, void **deb, gsize *deb_size)
+lsc_user_deb_recreate (const gchar *name,
+                       const char *public_key,
+                       const char *maintainer,
+                       void **deb,
+                       gsize *deb_size)
 {
   GError *error;
   char deb_dir[] = "/tmp/deb_XXXXXX";
@@ -570,8 +579,10 @@ free_exit:
  * @return 0 success, -1 error.
  */
 static int
-create_nsis_script (const gchar *script_name, const gchar *package_name,
-                    const gchar *user_name, const gchar *password)
+create_nsis_script (const gchar *script_name,
+                    const gchar *package_name,
+                    const gchar *user_name,
+                    const gchar *password)
 {
   FILE *fd;
 
@@ -762,7 +773,8 @@ execute_makensis (const gchar *nsis_script)
  * @return 0 success, -1 error.
  */
 static int
-lsc_user_exe_create (const gchar *user_name, const gchar *password,
+lsc_user_exe_create (const gchar *user_name,
+                     const gchar *password,
                      const gchar *to_filename)
 {
   gchar *dirname = g_path_get_dirname (to_filename);
@@ -799,7 +811,9 @@ lsc_user_exe_create (const gchar *user_name, const gchar *password,
  * @return 0 success, -1 error.
  */
 int
-lsc_user_exe_recreate (const gchar *name, const gchar *password, void **exe,
+lsc_user_exe_recreate (const gchar *name,
+                       const gchar *password,
+                       void **exe,
                        gsize *exe_size)
 {
   GError *error;

--- a/src/lsc_user.c
+++ b/src/lsc_user.c
@@ -92,26 +92,36 @@ create_ssh_key (const char *comment, const char *passphrase,
   g_free (dir);
 
   /* Spawn ssh-keygen. */
-  command = g_strconcat ("ssh-keygen -t rsa -f ", privpath, " -C \"", comment,
-                         "\" -P \"", passphrase, "\"", NULL);
+  command = g_strconcat ("ssh-keygen -t rsa -f ",
+                         privpath,
+                         " -C \"",
+                         comment,
+                         "\" -P \"",
+                         passphrase,
+                         "\"",
+                         NULL);
   g_debug ("command: ssh-keygen -t rsa -f %s -C \"%s\" -P \"********\"",
-           privpath, comment);
+           privpath,
+           comment);
 
-  if ((g_spawn_command_line_sync (command, &astdout, &astderr, &exit_status,
-                                  &err)
+  if ((g_spawn_command_line_sync (
+         command, &astdout, &astderr, &exit_status, &err)
        == FALSE)
       || (WIFEXITED (exit_status) == 0) || WEXITSTATUS (exit_status))
     {
       if (err)
         {
-          g_warning ("%s: failed to create private key: %s", __FUNCTION__,
-                     err->message);
+          g_warning (
+            "%s: failed to create private key: %s", __FUNCTION__, err->message);
           g_error_free (err);
         }
       else
         g_warning ("%s: failed to create private key", __FUNCTION__);
-      g_debug ("%s: key-gen failed with %d (WIF %i, WEX %i).\n", __FUNCTION__,
-               exit_status, WIFEXITED (exit_status), WEXITSTATUS (exit_status));
+      g_debug ("%s: key-gen failed with %d (WIF %i, WEX %i).\n",
+               __FUNCTION__,
+               exit_status,
+               WIFEXITED (exit_status),
+               WEXITSTATUS (exit_status));
       g_debug ("%s: stdout: %s", __FUNCTION__, astdout);
       g_debug ("%s: stderr: %s", __FUNCTION__, astderr);
       g_free (command);
@@ -206,8 +216,10 @@ lsc_user_rpm_create (const gchar *username, const gchar *public_key_path,
   new_pubkey_filename = g_build_filename (tmpdir, pubkey_basename, NULL);
   if (gvm_file_copy (public_key_path, new_pubkey_filename) == FALSE)
     {
-      g_warning ("%s: failed to copy key file %s to %s", __FUNCTION__,
-                 public_key_path, new_pubkey_filename);
+      g_warning ("%s: failed to copy key file %s to %s",
+                 __FUNCTION__,
+                 public_key_path,
+                 new_pubkey_filename);
       g_free (pubkey_basename);
       g_free (new_pubkey_filename);
       return FALSE;
@@ -224,16 +236,31 @@ lsc_user_rpm_create (const gchar *username, const gchar *public_key_path,
   cmd[3] = g_strdup (tmpdir);
   cmd[4] = g_strdup (to_filename);
   cmd[5] = NULL;
-  g_debug ("%s: Spawning in %s: %s %s %s %s %s", __FUNCTION__, tmpdir, cmd[0],
-           cmd[1], cmd[2], cmd[3], cmd[4]);
-  if ((g_spawn_sync (tmpdir, cmd, NULL,         /* Environment. */
-                     G_SPAWN_SEARCH_PATH, NULL, /* Setup function. */
-                     NULL, &standard_out, &standard_err, &exit_status, NULL)
+  g_debug ("%s: Spawning in %s: %s %s %s %s %s",
+           __FUNCTION__,
+           tmpdir,
+           cmd[0],
+           cmd[1],
+           cmd[2],
+           cmd[3],
+           cmd[4]);
+  if ((g_spawn_sync (tmpdir,
+                     cmd,
+                     NULL, /* Environment. */
+                     G_SPAWN_SEARCH_PATH,
+                     NULL, /* Setup function. */
+                     NULL,
+                     &standard_out,
+                     &standard_err,
+                     &exit_status,
+                     NULL)
        == FALSE)
       || (WIFEXITED (exit_status) == 0) || WEXITSTATUS (exit_status))
     {
       g_warning ("%s: failed to create the rpm: %d (WIF %i, WEX %i)",
-                 __FUNCTION__, exit_status, WIFEXITED (exit_status),
+                 __FUNCTION__,
+                 exit_status,
+                 WIFEXITED (exit_status),
                  WEXITSTATUS (exit_status));
       g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
       g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);
@@ -255,8 +282,8 @@ lsc_user_rpm_create (const gchar *username, const gchar *public_key_path,
 
   if (gvm_file_remove_recurse (tmpdir) != 0 && success == TRUE)
     {
-      g_warning ("%s: failed to remove temporary directory %s", __FUNCTION__,
-                 tmpdir);
+      g_warning (
+        "%s: failed to remove temporary directory %s", __FUNCTION__, tmpdir);
       success = FALSE;
     }
 
@@ -292,8 +319,8 @@ lsc_user_rpm_recreate (const gchar *name, const char *public_key, void **rpm,
 
   error = NULL;
   public_key_path = g_build_filename (key_dir, "key.pub", NULL);
-  g_file_set_contents (public_key_path, public_key, strlen (public_key),
-                       &error);
+  g_file_set_contents (
+    public_key_path, public_key, strlen (public_key), &error);
   if (error)
     goto free_exit;
 
@@ -377,8 +404,10 @@ lsc_user_deb_create (const gchar *username, const gchar *public_key_path,
   new_pubkey_filename = g_build_filename (tmpdir, pubkey_basename, NULL);
   if (gvm_file_copy (public_key_path, new_pubkey_filename) == FALSE)
     {
-      g_warning ("%s: failed to copy key file %s to %s", __FUNCTION__,
-                 public_key_path, new_pubkey_filename);
+      g_warning ("%s: failed to copy key file %s to %s",
+                 __FUNCTION__,
+                 public_key_path,
+                 new_pubkey_filename);
       g_free (pubkey_basename);
       g_free (new_pubkey_filename);
       return FALSE;
@@ -396,16 +425,32 @@ lsc_user_deb_create (const gchar *username, const gchar *public_key_path,
   cmd[4] = g_strdup (to_filename);
   cmd[5] = g_strdup (maintainer);
   cmd[6] = NULL;
-  g_debug ("%s: Spawning in %s: %s %s %s %s %s %s", __FUNCTION__, tmpdir,
-           cmd[0], cmd[1], cmd[2], cmd[3], cmd[4], cmd[5]);
-  if ((g_spawn_sync (tmpdir, cmd, NULL,         /* Environment. */
-                     G_SPAWN_SEARCH_PATH, NULL, /* Setup function. */
-                     NULL, &standard_out, &standard_err, &exit_status, NULL)
+  g_debug ("%s: Spawning in %s: %s %s %s %s %s %s",
+           __FUNCTION__,
+           tmpdir,
+           cmd[0],
+           cmd[1],
+           cmd[2],
+           cmd[3],
+           cmd[4],
+           cmd[5]);
+  if ((g_spawn_sync (tmpdir,
+                     cmd,
+                     NULL, /* Environment. */
+                     G_SPAWN_SEARCH_PATH,
+                     NULL, /* Setup function. */
+                     NULL,
+                     &standard_out,
+                     &standard_err,
+                     &exit_status,
+                     NULL)
        == FALSE)
       || (WIFEXITED (exit_status) == 0) || WEXITSTATUS (exit_status))
     {
       g_warning ("%s: failed to create the deb: %d (WIF %i, WEX %i)",
-                 __FUNCTION__, exit_status, WIFEXITED (exit_status),
+                 __FUNCTION__,
+                 exit_status,
+                 WIFEXITED (exit_status),
                  WEXITSTATUS (exit_status));
       g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
       g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);
@@ -428,8 +473,8 @@ lsc_user_deb_create (const gchar *username, const gchar *public_key_path,
 
   if (gvm_file_remove_recurse (tmpdir) != 0 && success == TRUE)
     {
-      g_warning ("%s: failed to remove temporary directory %s", __FUNCTION__,
-                 tmpdir);
+      g_warning (
+        "%s: failed to remove temporary directory %s", __FUNCTION__, tmpdir);
       success = FALSE;
     }
 
@@ -466,8 +511,8 @@ lsc_user_deb_recreate (const gchar *name, const char *public_key,
 
   error = NULL;
   public_key_path = g_build_filename (key_dir, "key.pub", NULL);
-  g_file_set_contents (public_key_path, public_key, strlen (public_key),
-                       &error);
+  g_file_set_contents (
+    public_key_path, public_key, strlen (public_key), &error);
   if (error)
     goto free_exit;
 
@@ -559,38 +604,45 @@ create_nsis_script (const gchar *script_name, const gchar *package_name,
   fprintf (fd, "setOutPath $INSTDIR\n\n");
 
   fprintf (fd, "# Uninstaller name\n");
-  fprintf (fd, "writeUninstaller $INSTDIR\\openvas_lsc_remove_%s.exe\n\n",
-           user_name);
+  fprintf (
+    fd, "writeUninstaller $INSTDIR\\openvas_lsc_remove_%s.exe\n\n", user_name);
 
   // Need to find localized Administrators group name, create a
   // GetAdminGroupName - vb script (Thanks to Thomas Rotter)
   fprintf (fd, "# Create Thomas Rotters GetAdminGroupName.vb script\n");
-  fprintf (fd, "ExecWait \"cmd /C Echo Set objWMIService = "
-               "GetObject($\\\"winmgmts:\\\\.\\root\\cimv2$\\\") > "
-               "$\\\"%%temp%%\\GetAdminGroupName.vbs$\\\" \"\n");
+  fprintf (fd,
+           "ExecWait \"cmd /C Echo Set objWMIService = "
+           "GetObject($\\\"winmgmts:\\\\.\\root\\cimv2$\\\") > "
+           "$\\\"%%temp%%\\GetAdminGroupName.vbs$\\\" \"\n");
   fprintf (fd,
            "ExecWait \"cmd /C Echo Set colAccounts = objWMIService.ExecQuery "
            "($\\\"Select * From Win32_Group Where SID = 'S-1-5-32-544'$\\\")  "
            ">> $\\\"%%temp%%\\GetAdminGroupName.vbs$\\\"\"\n");
-  fprintf (fd, "ExecWait \"cmd /C Echo For Each objAccount in colAccounts >> "
-               "$\\\"%%temp%%\\GetAdminGroupName.vbs$\\\"\"\n");
-  fprintf (fd, "ExecWait \"cmd /C Echo Wscript.Echo objAccount.Name >> "
-               "$\\\"%%temp%%\\GetAdminGroupName.vbs$\\\"\"\n");
-  fprintf (fd, "ExecWait \"cmd /C Echo Next >> "
-               "$\\\"%%temp%%\\GetAdminGroupName.vbs$\\\"\"\n");
-  fprintf (fd, "ExecWait \"cmd /C cscript //nologo "
-               "$\\\"%%temp%%\\GetAdminGroupName.vbs$\\\" > "
-               "$\\\"%%temp%%\\AdminGroupName.txt$\\\"\"\n\n");
+  fprintf (fd,
+           "ExecWait \"cmd /C Echo For Each objAccount in colAccounts >> "
+           "$\\\"%%temp%%\\GetAdminGroupName.vbs$\\\"\"\n");
+  fprintf (fd,
+           "ExecWait \"cmd /C Echo Wscript.Echo objAccount.Name >> "
+           "$\\\"%%temp%%\\GetAdminGroupName.vbs$\\\"\"\n");
+  fprintf (fd,
+           "ExecWait \"cmd /C Echo Next >> "
+           "$\\\"%%temp%%\\GetAdminGroupName.vbs$\\\"\"\n");
+  fprintf (fd,
+           "ExecWait \"cmd /C cscript //nologo "
+           "$\\\"%%temp%%\\GetAdminGroupName.vbs$\\\" > "
+           "$\\\"%%temp%%\\AdminGroupName.txt$\\\"\"\n\n");
 
   /** @todo provide /comment:"GVM User" /fullname:"GVM Testuser" */
   fprintf (fd, "# Create batch script that installs the user\n");
-  fprintf (fd, "ExecWait \"cmd /C Echo Set /P AdminGroupName= "
-               "^<$\\\"%%temp%%\\AdminGroupName.txt$\\\" > "
-               "$\\\"%%temp%%\\AddUser.bat$\\\"\" \n");
+  fprintf (fd,
+           "ExecWait \"cmd /C Echo Set /P AdminGroupName= "
+           "^<$\\\"%%temp%%\\AdminGroupName.txt$\\\" > "
+           "$\\\"%%temp%%\\AddUser.bat$\\\"\" \n");
   fprintf (fd,
            "ExecWait \"cmd /C Echo net user %s %s /add /active:yes >> "
            "$\\\"%%temp%%\\AddUser.bat$\\\"\"\n",
-           user_name, password);
+           user_name,
+           password);
   fprintf (fd,
            "ExecWait \"cmd /C Echo net localgroup %%AdminGroupName%% "
            "%%COMPUTERNAME%%\\%s /add >> $\\\"%%temp%%\\AddUser.bat$\\\"\"\n\n",
@@ -609,8 +661,9 @@ create_nsis_script (const gchar *script_name, const gchar *package_name,
   /** @todo Display note about NTLM and SMB signing and encryption, 'Easy
    * Filesharing' in WIN XP */
   fprintf (fd, "# Display message that everything seems to be fine\n");
-  fprintf (fd, "messageBox MB_OK \"A user has been added. An uninstaller is "
-               "placed on your Desktop.\"\n\n");
+  fprintf (fd,
+           "messageBox MB_OK \"A user has been added. An uninstaller is "
+           "placed on your Desktop.\"\n\n");
 
   fprintf (fd, "# Default (install) section end\n");
   fprintf (fd, "sectionEnd\n\n");
@@ -627,8 +680,9 @@ create_nsis_script (const gchar *script_name, const gchar *package_name,
            "# Unistaller should remove itself (from desktop/installdir)\n\n");
 
   fprintf (fd, "# Display message that everything seems to be fine\n");
-  fprintf (fd, "messageBox MB_OK \"A user has been removed. You can now safely "
-               "remove the uninstaller from your Desktop.\"\n\n");
+  fprintf (fd,
+           "messageBox MB_OK \"A user has been removed. You can now safely "
+           "remove the uninstaller from your Desktop.\"\n\n");
 
   fprintf (fd, "# Uninstaller section end\n");
   fprintf (fd, "sectionEnd\n\n");
@@ -665,14 +719,23 @@ execute_makensis (const gchar *nsis_script)
   cmd[2] = NULL;
   g_debug ("--- executing makensis");
   g_debug ("%s: Spawning in %s: %s %s", __FUNCTION__, dirname, cmd[0], cmd[1]);
-  if ((g_spawn_sync (dirname, cmd, NULL,        /* Environment. */
-                     G_SPAWN_SEARCH_PATH, NULL, /* Setup func. */
-                     NULL, &standard_out, &standard_err, &exit_status, NULL)
+  if ((g_spawn_sync (dirname,
+                     cmd,
+                     NULL, /* Environment. */
+                     G_SPAWN_SEARCH_PATH,
+                     NULL, /* Setup func. */
+                     NULL,
+                     &standard_out,
+                     &standard_err,
+                     &exit_status,
+                     NULL)
        == FALSE)
       || (WIFEXITED (exit_status) == 0) || WEXITSTATUS (exit_status))
     {
       g_warning ("%s: failed to create the exe: %d (WIF %i, WEX %i)",
-                 __FUNCTION__, exit_status, WIFEXITED (exit_status),
+                 __FUNCTION__,
+                 exit_status,
+                 WIFEXITED (exit_status),
                  WEXITSTATUS (exit_status));
       g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
       g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);

--- a/src/lsc_user.h
+++ b/src/lsc_user.h
@@ -31,12 +31,11 @@ int
 lsc_user_keys_create (const gchar *, gchar **);
 
 int
-lsc_user_rpm_recreate (const gchar *, const gchar *,
-                       void **, gsize *);
+lsc_user_rpm_recreate (const gchar *, const gchar *, void **, gsize *);
 
 int
-lsc_user_deb_recreate (const gchar *, const char *, const char *,
-                       void **, gsize *);
+lsc_user_deb_recreate (const gchar *, const char *, const char *, void **,
+                       gsize *);
 
 int
 lsc_user_exe_recreate (const gchar *, const gchar *, void **, gsize *);

--- a/src/lsc_user.h
+++ b/src/lsc_user.h
@@ -34,7 +34,10 @@ int
 lsc_user_rpm_recreate (const gchar *, const gchar *, void **, gsize *);
 
 int
-lsc_user_deb_recreate (const gchar *, const char *, const char *, void **,
+lsc_user_deb_recreate (const gchar *,
+                       const char *,
+                       const char *,
+                       void **,
                        gsize *);
 
 int

--- a/src/manage.c
+++ b/src/manage.c
@@ -301,8 +301,10 @@ truncate_private_key (const gchar *private_key)
  * @return 0 success, -1 error.
  */
 int
-get_certificate_info (const gchar *certificate, time_t *activation_time,
-                      time_t *expiration_time, gchar **fingerprint,
+get_certificate_info (const gchar *certificate,
+                      time_t *activation_time,
+                      time_t *expiration_time,
+                      gchar **fingerprint,
                       gchar **issuer)
 {
   gchar *cert_truncated;
@@ -508,7 +510,8 @@ truncate_text (gchar *string, size_t max_len, gboolean xml, const char *suffix)
  * @return Newly allocated string with XML escaped, truncated text.
  */
 gchar *
-xml_escape_text_truncated (const char *string, size_t max_len,
+xml_escape_text_truncated (const char *string,
+                           size_t max_len,
                            const char *suffix)
 {
   gchar *escaped;
@@ -630,7 +633,8 @@ type_is_scap (const char *type)
  * @return 0 success, -1 error, 99 permission denied.
  */
 static int
-check_available (const gchar *type, resource_t resource,
+check_available (const gchar *type,
+                 resource_t resource,
                  const gchar *permission)
 {
   if (resource)
@@ -898,8 +902,11 @@ delete_reports (task_t task)
  * @return Filter term.
  */
 static gchar *
-report_results_filter_term (int first, int rows, int apply_overrides,
-                            int autofp, int min_qod)
+report_results_filter_term (int first,
+                            int rows,
+                            int apply_overrides,
+                            int autofp,
+                            int min_qod)
 {
   return g_strdup_printf ("first=%d rows=%d"
                           " apply_overrides=%d autofp=%d min_qod=%d",
@@ -922,7 +929,10 @@ report_results_filter_term (int first, int rows, int apply_overrides,
  * @return GET data struct.
  */
 get_data_t *
-report_results_get_data (int first, int rows, int apply_overrides, int autofp,
+report_results_get_data (int first,
+                         int rows,
+                         int apply_overrides,
+                         int autofp,
                          int min_qod)
 {
   get_data_t *get = g_malloc (sizeof (get_data_t));
@@ -1038,7 +1048,8 @@ severity_data_add (severity_data_t *severity_data, double severity)
  * @param[in]   count           The number of occurrences to add.
  */
 void
-severity_data_add_count (severity_data_t *severity_data, double severity,
+severity_data_add_count (severity_data_t *severity_data,
+                         double severity,
                          int count)
 {
   (severity_data->counts)[severity_data_index (severity)] += count;
@@ -1060,7 +1071,8 @@ severity_data_add_count (severity_data_t *severity_data, double severity,
  */
 static int
 severity_data_range_count (const severity_data_t *severity_data,
-                           double min_severity, double max_severity)
+                           double min_severity,
+                           double max_severity)
 {
   int i, i_max, count;
 
@@ -1089,9 +1101,14 @@ severity_data_range_count (const severity_data_t *severity_data,
  */
 void
 severity_data_level_counts (const severity_data_t *severity_data,
-                            const gchar *severity_class, int *errors,
-                            int *debugs, int *false_positives, int *logs,
-                            int *lows, int *mediums, int *highs)
+                            const gchar *severity_class,
+                            int *errors,
+                            int *debugs,
+                            int *false_positives,
+                            int *logs,
+                            int *lows,
+                            int *mediums,
+                            int *highs)
 {
   if (errors)
     *errors =
@@ -1646,8 +1663,10 @@ preference_value (const char *name, const char *full_value)
  * @return 0 on success, -1 on failure.
  */
 static int
-send_config_preferences (config_t config, const char *section_name,
-                         GSList *task_files, GPtrArray *pref_files)
+send_config_preferences (config_t config,
+                         const char *section_name,
+                         GSList *task_files,
+                         GPtrArray *pref_files)
 {
   iterator_t prefs;
 
@@ -2520,9 +2539,13 @@ get_tasks_last_report (entity_t get_tasks)
  * @return 0 success, 1 giveup.
  */
 static int
-setup_ids (gvm_connection_t *connection, task_t task, entity_t get_tasks,
-           gchar **slave_config_uuid, gchar **slave_target_uuid,
-           gchar **slave_port_list_uuid, gchar **slave_ssh_credential_uuid,
+setup_ids (gvm_connection_t *connection,
+           task_t task,
+           entity_t get_tasks,
+           gchar **slave_config_uuid,
+           gchar **slave_target_uuid,
+           gchar **slave_port_list_uuid,
+           gchar **slave_ssh_credential_uuid,
            gchar **slave_smb_credential_uuid,
            gchar **slave_esxi_credential_uuid,
            gchar **slave_snmp_credential_uuid)
@@ -2646,11 +2669,15 @@ set_task_interrupted (task_t task, const gchar *message)
  * @return 0 success, 1 retry, 3 giveup.
  */
 static int
-slave_setup (gvm_connection_t *connection, const char *name, task_t task,
-             target_t target, credential_t target_ssh_credential,
+slave_setup (gvm_connection_t *connection,
+             const char *name,
+             task_t task,
+             target_t target,
+             credential_t target_ssh_credential,
              credential_t target_smb_credential,
              credential_t target_esxi_credential,
-             credential_t target_snmp_credential, report_t last_stopped_report)
+             credential_t target_snmp_credential,
+             report_t last_stopped_report)
 {
   const int ret_giveup = 3;
   int ret_fail, next_result;
@@ -3701,13 +3728,16 @@ giveup:
  *         task name.
  */
 static int
-handle_slave_task (task_t task, target_t target,
+handle_slave_task (task_t task,
+                   target_t target,
                    credential_t target_ssh_credential,
                    credential_t target_smb_credential,
                    credential_t target_esxi_credential,
                    credential_t target_snmp_credential,
-                   report_t last_stopped_report, gvm_connection_t *connection,
-                   const gchar *slave_id, const gchar *slave_name)
+                   report_t last_stopped_report,
+                   gvm_connection_t *connection,
+                   const gchar *slave_id,
+                   const gchar *slave_name)
 {
   char *name, *uuid;
   int ret;
@@ -3949,8 +3979,12 @@ task_scanner_options (task_t task, target_t target)
  * @param[in]   key_priv    Private key.
  */
 static void
-delete_osp_scan (const char *report_id, const char *host, int port,
-                 const char *ca_pub, const char *key_pub, const char *key_priv)
+delete_osp_scan (const char *report_id,
+                 const char *host,
+                 int port,
+                 const char *ca_pub,
+                 const char *key_pub,
+                 const char *key_priv)
 {
   osp_connection_t *connection;
 
@@ -3979,9 +4013,14 @@ delete_osp_scan (const char *report_id, const char *host, int port,
  * @return -1 on error, progress value between 0 and 100 on success.
  */
 static int
-get_osp_scan_report (const char *scan_id, const char *host, int port,
-                     const char *ca_pub, const char *key_pub,
-                     const char *key_priv, int details, char **report_xml)
+get_osp_scan_report (const char *scan_id,
+                     const char *host,
+                     int port,
+                     const char *ca_pub,
+                     const char *key_pub,
+                     const char *key_priv,
+                     int details,
+                     char **report_xml)
 {
   osp_connection_t *connection;
   int progress;
@@ -4156,7 +4195,9 @@ get_osp_task_options (task_t task, target_t target)
  * @return 0 success, -1 if scanner is down.
  */
 static int
-launch_osp_task (task_t task, target_t target, const char *scan_id,
+launch_osp_task (task_t task,
+                 target_t target,
+                 const char *scan_id,
                  char **error)
 {
   osp_connection_t *connection;
@@ -4702,9 +4743,13 @@ scanner_setup (scanner_t scanner)
  * @return 0 success, -1 error, 99 permission denied.
  */
 static int
-run_task_setup (task_t task, config_t *config, target_t *target,
-                port_list_t *port_list, credential_t *ssh_credential,
-                credential_t *smb_credential, credential_t *esxi_credential,
+run_task_setup (task_t task,
+                config_t *config,
+                target_t *target,
+                port_list_t *port_list,
+                credential_t *ssh_credential,
+                credential_t *smb_credential,
+                credential_t *esxi_credential,
                 credential_t *snmp_credential)
 {
   int ret;
@@ -4765,7 +4810,9 @@ run_task_setup (task_t task, config_t *config, target_t *target,
  * @return 0 success, -1 error, -3 creating the report failed.
  */
 static int
-run_task_prepare_report (task_t task, char **report_id, int from,
+run_task_prepare_report (task_t task,
+                         char **report_id,
+                         int from,
                          task_status_t run_status,
                          report_t *last_stopped_report)
 {
@@ -4835,8 +4882,11 @@ run_task_prepare_report (task_t task, char **report_id, int from,
  *         -1 error.
  */
 static int
-run_slave_or_gmp_task (task_t task, int from, char **report_id,
-                       gvm_connection_t *connection, const gchar *slave_id,
+run_slave_or_gmp_task (task_t task,
+                       int from,
+                       char **report_id,
+                       gvm_connection_t *connection,
+                       const gchar *slave_id,
                        const gchar *slave_name)
 {
   int ret, pid;
@@ -6191,8 +6241,10 @@ credential_full_type (const char *abbreviation)
  * -1 otherwise.
  */
 static int
-get_slave_system_report_types (const char *required_type, gchar ***start,
-                               gchar ***types, const char *slave_id)
+get_slave_system_report_types (const char *required_type,
+                               gchar ***start,
+                               gchar ***types,
+                               const char *slave_id)
 {
   scanner_t slave = 0;
   char *host, **end;
@@ -6305,8 +6357,10 @@ fail:
  *         -1 otherwise.
  */
 static int
-get_system_report_types (const char *required_type, gchar ***start,
-                         gchar ***types, const char *slave_id)
+get_system_report_types (const char *required_type,
+                         gchar ***start,
+                         gchar ***types,
+                         const char *slave_id)
 {
   gchar *astdout = NULL;
   gchar *astderr = NULL;
@@ -6403,7 +6457,8 @@ get_system_report_types (const char *required_type, gchar ***start,
  */
 int
 init_system_report_type_iterator (report_type_iterator_t *iterator,
-                                  const char *type, const char *slave_id)
+                                  const char *type,
+                                  const char *slave_id)
 {
   int ret;
 
@@ -6493,9 +6548,12 @@ report_type_iterator_title (report_type_iterator_t *iterator)
  * -1 otherwise.
  */
 static int
-slave_system_report (const char *name, const char *duration,
-                     const char *start_time, const char *end_time,
-                     const char *slave_id, char **report)
+slave_system_report (const char *name,
+                     const char *duration,
+                     const char *start_time,
+                     const char *end_time,
+                     const char *slave_id,
+                     char **report)
 {
   scanner_t slave = 0;
   char *host;
@@ -6607,9 +6665,12 @@ fail:
  *         5 authentication failed, 6 failed to get system report.
  */
 int
-manage_system_report (const char *name, const char *duration,
-                      const char *start_time, const char *end_time,
-                      const char *slave_id, char **report)
+manage_system_report (const char *name,
+                      const char *duration,
+                      const char *start_time,
+                      const char *end_time,
+                      const char *slave_id,
+                      char **report)
 {
   gchar *astdout = NULL;
   gchar *astderr = NULL;
@@ -6836,7 +6897,8 @@ typedef struct
  * @return Scheduled task structure.
  */
 static scheduled_task_t *
-scheduled_task_new (const gchar *task_uuid, const gchar *owner_uuid,
+scheduled_task_new (const gchar *task_uuid,
+                    const gchar *owner_uuid,
                     const gchar *owner_name)
 {
   scheduled_task_t *scheduled_task;
@@ -7161,7 +7223,8 @@ manage_sync (sigset_t *sigmask_current, int (*fork_update_nvt_cache) ())
  * @return 0 success, 1 failed to get lock, -1 error.
  */
 int
-manage_schedule (manage_connection_forker_t fork_connection, gboolean run_tasks,
+manage_schedule (manage_connection_forker_t fork_connection,
+                 gboolean run_tasks,
                  sigset_t *sigmask_current)
 {
   iterator_t schedules;
@@ -7713,8 +7776,11 @@ parse_tags (const char *scanner_tags, gchar **tags, gchar **cvss_base)
  * @return 0 success, -1 error.
  */
 int
-delete_slave_task (const gchar *host, int port, const gchar *username,
-                   const gchar *password, const char *slave_task_uuid)
+delete_slave_task (const gchar *host,
+                   int port,
+                   const gchar *username,
+                   const gchar *password,
+                   const char *slave_task_uuid)
 {
   int socket;
   gnutls_session_t session;
@@ -7938,7 +8004,9 @@ get_dfn_cert_adv_filename (char *item_id)
  *         result of the operation of NULL on failure.
  */
 static gchar *
-xsl_transform (gchar *stylesheet, gchar *xmlfile, gchar **param_names,
+xsl_transform (gchar *stylesheet,
+               gchar *xmlfile,
+               gchar **param_names,
                gchar **param_values)
 {
   int i, param_idx;
@@ -8038,8 +8106,13 @@ xsl_transform (gchar *stylesheet, gchar *xmlfile, gchar **param_names,
  * @return A dynamically allocated string containing the XML description.
  */
 gchar *
-get_nvti_xml (iterator_t *nvts, int details, int pref_count, int preferences,
-              const char *timeout, config_t config, int close_tag)
+get_nvti_xml (iterator_t *nvts,
+              int details,
+              int pref_count,
+              int preferences,
+              const char *timeout,
+              config_t config,
+              int close_tag)
 {
   const char *oid = nvt_iterator_oid (nvts);
   const char *name = nvt_iterator_name (nvts);
@@ -8509,7 +8582,8 @@ gvm_sync_script_perform_selftest (const gchar *sync_script, gchar **result)
  */
 gboolean
 gvm_get_sync_script_identification (const gchar *sync_script,
-                                    gchar **identification, int feed_type)
+                                    gchar **identification,
+                                    int feed_type)
 {
   g_assert (sync_script);
   if (identification)
@@ -8851,9 +8925,13 @@ gvm_migrate_secinfo (int feed_type)
 int
 manage_run_wizard (const gchar *wizard_name,
                    int (*run_command) (void *, gchar *, gchar **),
-                   void *run_command_data, array_t *params, int read_only,
-                   const char *mode, gchar **command_error,
-                   gchar **command_error_code, gchar **ret_response)
+                   void *run_command_data,
+                   array_t *params,
+                   int read_only,
+                   const char *mode,
+                   gchar **command_error,
+                   gchar **command_error_code,
+                   gchar **ret_response)
 {
   GString *params_xml;
   gchar *file, *file_name, *response, *extra, *extra_wrapped, *wizard;

--- a/src/manage.c
+++ b/src/manage.c
@@ -359,8 +359,8 @@ get_certificate_info (const gchar *certificate, time_t *activation_time,
 
           string = g_string_new ("");
 
-          gnutls_x509_crt_get_fingerprint (gnutls_cert, GNUTLS_DIG_MD5, buffer,
-                                           &buffer_size);
+          gnutls_x509_crt_get_fingerprint (
+            gnutls_cert, GNUTLS_DIG_MD5, buffer, &buffer_size);
 
           for (i = 0; i < buffer_size; i++)
             {
@@ -817,8 +817,8 @@ severity_to_level (double severity, int mode)
     }
   else
     {
-      g_warning ("%s: Invalid severity score given: %f", __FUNCTION__,
-                 severity);
+      g_warning (
+        "%s: Invalid severity score given: %f", __FUNCTION__, severity);
       return (NULL);
     }
 }
@@ -845,8 +845,8 @@ severity_to_type (double severity)
     return "Alarm";
   else
     {
-      g_warning ("%s: Invalid severity score given: %f", __FUNCTION__,
-                 severity);
+      g_warning (
+        "%s: Invalid severity score given: %f", __FUNCTION__, severity);
       return (NULL);
     }
 }
@@ -903,7 +903,11 @@ report_results_filter_term (int first, int rows, int apply_overrides,
 {
   return g_strdup_printf ("first=%d rows=%d"
                           " apply_overrides=%d autofp=%d min_qod=%d",
-                          first, rows, apply_overrides, autofp, min_qod);
+                          first,
+                          rows,
+                          apply_overrides,
+                          autofp,
+                          min_qod);
 }
 
 /**
@@ -1090,39 +1094,46 @@ severity_data_level_counts (const severity_data_t *severity_data,
                             int *lows, int *mediums, int *highs)
 {
   if (errors)
-    *errors = severity_data_range_count (
-      severity_data, level_min_severity ("Error", severity_class),
-      level_max_severity ("Error", severity_class));
+    *errors =
+      severity_data_range_count (severity_data,
+                                 level_min_severity ("Error", severity_class),
+                                 level_max_severity ("Error", severity_class));
 
   if (debugs)
-    *debugs = severity_data_range_count (
-      severity_data, level_min_severity ("Debug", severity_class),
-      level_max_severity ("Debug", severity_class));
+    *debugs =
+      severity_data_range_count (severity_data,
+                                 level_min_severity ("Debug", severity_class),
+                                 level_max_severity ("Debug", severity_class));
 
   if (false_positives)
     *false_positives = severity_data_range_count (
-      severity_data, level_min_severity ("False Positive", severity_class),
+      severity_data,
+      level_min_severity ("False Positive", severity_class),
       level_max_severity ("False Positive", severity_class));
 
   if (logs)
-    *logs = severity_data_range_count (
-      severity_data, level_min_severity ("Log", severity_class),
-      level_max_severity ("Log", severity_class));
+    *logs =
+      severity_data_range_count (severity_data,
+                                 level_min_severity ("Log", severity_class),
+                                 level_max_severity ("Log", severity_class));
 
   if (lows)
-    *lows = severity_data_range_count (
-      severity_data, level_min_severity ("low", severity_class),
-      level_max_severity ("low", severity_class));
+    *lows =
+      severity_data_range_count (severity_data,
+                                 level_min_severity ("low", severity_class),
+                                 level_max_severity ("low", severity_class));
 
   if (mediums)
-    *mediums = severity_data_range_count (
-      severity_data, level_min_severity ("medium", severity_class),
-      level_max_severity ("medium", severity_class));
+    *mediums =
+      severity_data_range_count (severity_data,
+                                 level_min_severity ("medium", severity_class),
+                                 level_max_severity ("medium", severity_class));
 
   if (highs)
-    *highs = severity_data_range_count (
-      severity_data, level_min_severity ("high", severity_class),
-      level_max_severity ("high", severity_class));
+    *highs =
+      severity_data_range_count (severity_data,
+                                 level_min_severity ("high", severity_class),
+                                 level_max_severity ("high", severity_class));
 }
 
 /* Task globals. */
@@ -1293,7 +1304,8 @@ event_description (event_t event, const void *event_data, const char *task_name)
     case EVENT_TASK_RUN_STATUS_CHANGED:
       if (task_name)
         return g_strdup_printf (
-          "The security scan task '%s' changed status to '%s'", task_name,
+          "The security scan task '%s' changed status to '%s'",
+          task_name,
           run_status_name ((task_status_t) event_data));
       return g_strdup_printf ("Task status changed to '%s'",
                               run_status_name ((task_status_t) event_data));
@@ -1670,8 +1682,8 @@ send_config_preferences (config_t config, const char *section_name,
           count =
             sscanf (pref_name, "%*[^[][%n%*[^]]%n]:", &type_start, &type_end);
           if (count == 0 && type_start > 0 && type_end > 0
-              && (strncmp (pref_name + type_start, "file",
-                           type_end - type_start)
+              && (strncmp (
+                    pref_name + type_start, "file", type_end - type_start)
                   == 0))
             {
               GSList *head;
@@ -2006,7 +2018,8 @@ send_file (const char *name, const char *content)
                        "name: %s\n"
                        "content: octet/stream\n"
                        "bytes: %i\n",
-                       name, content_len))
+                       name,
+                       content_len))
     return -1;
 
   if (sendn_to_server (content, content_len))
@@ -2041,7 +2054,8 @@ send_task_file (task_t task, const char *file)
                            "name: %s\n"
                            "content: octet/stream\n"
                            "bytes: %i\n",
-                           file, content_len))
+                           file,
+                           content_len))
         {
           g_free (content);
           cleanup_iterator (&files);
@@ -2284,25 +2298,32 @@ slave_connect (gvm_connection_t *connection)
     ca_cert = manage_default_ca_cert ();
   else
     ca_cert = NULL;
-  connection->socket = gvm_server_open_verify (
-    &connection->session, connection->host_string, connection->port,
-    ca_cert ? ca_cert : connection->ca_cert, connection->pub_key,
-    connection->priv_key, 1);
+  connection->socket =
+    gvm_server_open_verify (&connection->session,
+                            connection->host_string,
+                            connection->port,
+                            ca_cert ? ca_cert : connection->ca_cert,
+                            connection->pub_key,
+                            connection->priv_key,
+                            1);
   if (connection->socket == -1)
     {
-      g_warning ("%s: failed to open connection to %s on %i", __FUNCTION__,
-                 connection->host_string, connection->port);
+      g_warning ("%s: failed to open connection to %s on %i",
+                 __FUNCTION__,
+                 connection->host_string,
+                 connection->port);
       return -1;
     }
 
   {
     int optval;
     optval = 1;
-    if (setsockopt (connection->socket, SOL_SOCKET, SO_KEEPALIVE, &optval,
-                    sizeof (int)))
+    if (setsockopt (
+          connection->socket, SOL_SOCKET, SO_KEEPALIVE, &optval, sizeof (int)))
       {
         g_warning ("%s: failed to set SO_KEEPALIVE on slave socket: %s",
-                   __FUNCTION__, strerror (errno));
+                   __FUNCTION__,
+                   strerror (errno));
         gvm_connection_close (connection);
         return -1;
       }
@@ -2346,8 +2367,8 @@ slave_sleep_connect (gvm_connection_t *connection, task_t task)
           set_task_run_status (current_scanner_task, TASK_STATUS_STOPPED);
           return 3;
         }
-      g_debug ("   %s: sleeping for %i", __FUNCTION__,
-               RUN_SLAVE_TASK_SLEEP_SECONDS);
+      g_debug (
+        "   %s: sleeping for %i", __FUNCTION__, RUN_SLAVE_TASK_SLEEP_SECONDS);
       gvm_sleep (RUN_SLAVE_TASK_SLEEP_SECONDS);
     }
   while (slave_connect (connection));
@@ -2414,10 +2435,10 @@ update_end_times (entity_t report)
               && (scan_host_end_time (global_current_report, entity_text (ip))
                   == 0))
             {
-              set_scan_host_end_time (global_current_report, entity_text (ip),
-                                      entity_text (time));
-              if (manage_report_host_details (global_current_report,
-                                              entity_text (ip), end))
+              set_scan_host_end_time (
+                global_current_report, entity_text (ip), entity_text (time));
+              if (manage_report_host_details (
+                    global_current_report, entity_text (ip), end))
                 return -1;
             }
         }
@@ -2535,8 +2556,8 @@ setup_ids (gvm_connection_t *connection, task_t task, entity_t get_tasks,
           int ret;
 
           while (
-            (ret = gmp_get_targets (&connection->session, *slave_target_uuid, 0,
-                                    0, &get_targets)))
+            (ret = gmp_get_targets (
+               &connection->session, *slave_target_uuid, 0, 0, &get_targets)))
             {
               if (ret == 404)
                 {
@@ -2671,8 +2692,8 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
           /* Check if the task is running or complete on the slave. */
 
           while (
-            (ret = gmp_get_tasks (&connection->session, global_slave_task_uuid,
-                                  0, 0, &get_tasks)))
+            (ret = gmp_get_tasks (
+               &connection->session, global_slave_task_uuid, 0, 0, &get_tasks)))
             {
               if (ret == 404)
                 {
@@ -2712,17 +2733,21 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
                   if (global_slave_report_uuid == NULL)
                     {
                       g_warning ("%s: slave report %s missing UUID",
-                                 __FUNCTION__, global_slave_task_uuid);
+                                 __FUNCTION__,
+                                 global_slave_task_uuid);
                       goto fail;
                     }
 
-                  setup_ids (
-                    connection, task, get_tasks, &global_slave_config_uuid,
-                    &global_slave_target_uuid, &global_slave_port_list_uuid,
-                    &global_slave_ssh_credential_uuid,
-                    &global_slave_smb_credential_uuid,
-                    &global_slave_esxi_credential_uuid,
-                    &global_slave_snmp_credential_uuid);
+                  setup_ids (connection,
+                             task,
+                             get_tasks,
+                             &global_slave_config_uuid,
+                             &global_slave_target_uuid,
+                             &global_slave_port_list_uuid,
+                             &global_slave_ssh_credential_uuid,
+                             &global_slave_smb_credential_uuid,
+                             &global_slave_esxi_credential_uuid,
+                             &global_slave_snmp_credential_uuid);
                 }
               else
                 {
@@ -2734,13 +2759,16 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
                     case 0:
                       if (global_slave_report_uuid == NULL)
                         goto fail;
-                      setup_ids (
-                        connection, task, get_tasks, &global_slave_config_uuid,
-                        &global_slave_target_uuid, &global_slave_port_list_uuid,
-                        &global_slave_ssh_credential_uuid,
-                        &global_slave_smb_credential_uuid,
-                        &global_slave_esxi_credential_uuid,
-                        &global_slave_snmp_credential_uuid);
+                      setup_ids (connection,
+                                 task,
+                                 get_tasks,
+                                 &global_slave_config_uuid,
+                                 &global_slave_target_uuid,
+                                 &global_slave_port_list_uuid,
+                                 &global_slave_ssh_credential_uuid,
+                                 &global_slave_smb_credential_uuid,
+                                 &global_slave_esxi_credential_uuid,
+                                 &global_slave_snmp_credential_uuid);
                       set_task_run_status (task, TASK_STATUS_REQUESTED);
                       break;
                     case 1:
@@ -2811,7 +2839,8 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
                   cleanup_iterator (&credentials);
 
                   ret = gmp_create_lsc_credential_ext (
-                    &connection->session, opts,
+                    &connection->session,
+                    opts,
                     &global_slave_ssh_credential_uuid);
 
                   g_free (user_copy);
@@ -2866,7 +2895,8 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
                   cleanup_iterator (&credentials);
 
                   ret = gmp_create_lsc_credential_ext (
-                    &connection->session, opts,
+                    &connection->session,
+                    opts,
                     &global_slave_smb_credential_uuid);
 
                   g_free (smb_name);
@@ -2921,7 +2951,8 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
                   cleanup_iterator (&credentials);
 
                   ret = gmp_create_lsc_credential_ext (
-                    &connection->session, opts,
+                    &connection->session,
+                    opts,
                     &global_slave_esxi_credential_uuid);
 
                   g_free (esxi_name);
@@ -3014,7 +3045,8 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
                   cleanup_iterator (&credentials);
 
                   ret = gmp_create_lsc_credential_ext (
-                    &connection->session, opts,
+                    &connection->session,
+                    opts,
                     &global_slave_snmp_credential_uuid);
 
                   g_free (snmp_name);
@@ -3036,16 +3068,20 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
             }
         }
 
-      g_debug ("   %s: slave SSH credential uuid: %s", __FUNCTION__,
+      g_debug ("   %s: slave SSH credential uuid: %s",
+               __FUNCTION__,
                global_slave_ssh_credential_uuid);
 
-      g_debug ("   %s: slave SMB credential uuid: %s", __FUNCTION__,
+      g_debug ("   %s: slave SMB credential uuid: %s",
+               __FUNCTION__,
                global_slave_smb_credential_uuid);
 
-      g_debug ("   %s: slave ESXi credential uuid: %s", __FUNCTION__,
+      g_debug ("   %s: slave ESXi credential uuid: %s",
+               __FUNCTION__,
                global_slave_esxi_credential_uuid);
 
-      g_debug ("   %s: slave SNMP credential uuid: %s", __FUNCTION__,
+      g_debug ("   %s: slave SNMP credential uuid: %s",
+               __FUNCTION__,
                global_slave_snmp_credential_uuid);
 
       /* Create the target on the slave. */
@@ -3104,8 +3140,8 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
           opts.reverse_lookup_unify =
             reverse_lookup_unify ? atoi (reverse_lookup_unify) : 0;
 
-          ret = gmp_create_target_ext (&connection->session, opts,
-                                       &global_slave_target_uuid);
+          ret = gmp_create_target_ext (
+            &connection->session, opts, &global_slave_target_uuid);
           g_free (hosts_copy);
           g_free (exclude_hosts_copy);
           g_free (alive_tests_copy);
@@ -3114,14 +3150,18 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
             goto fail_credentials;
           if (ret)
             {
-              set_task_interrupted (task, "Failed to create target on slave."
-                                          "  Interrupting scan.");
+              set_task_interrupted (task,
+                                    "Failed to create target on slave."
+                                    "  Interrupting scan.");
               ret_fail = ret_giveup;
               goto fail_credentials;
             }
 
-          if (gmp_get_targets (&connection->session, global_slave_target_uuid,
-                               0, 0, &get_targets))
+          if (gmp_get_targets (&connection->session,
+                               global_slave_target_uuid,
+                               0,
+                               0,
+                               &get_targets))
             goto fail_target;
           child = entity_child (get_targets, "target");
           if (child == NULL)
@@ -3150,8 +3190,8 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
           goto fail_credentials;
         }
 
-      g_debug ("   %s: slave target uuid: %s", __FUNCTION__,
-               global_slave_target_uuid);
+      g_debug (
+        "   %s: slave target uuid: %s", __FUNCTION__, global_slave_target_uuid);
 
       /* Create the config on the slave. */
 
@@ -3223,15 +3263,16 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
           }
         cleanup_iterator (&prefs);
 
-        if (gvm_server_sendf (&connection->session, "</preferences>"
-                                                    "<nvt_selectors>"))
+        if (gvm_server_sendf (&connection->session,
+                              "</preferences>"
+                              "<nvt_selectors>"))
           {
             cleanup_iterator (&prefs);
             goto fail_target;
           }
 
-        init_nvt_selector_iterator (&selectors, NULL, config,
-                                    NVT_SELECTOR_TYPE_ANY);
+        init_nvt_selector_iterator (
+          &selectors, NULL, config, NVT_SELECTOR_TYPE_ANY);
         while (next (&selectors))
           {
             int type = nvt_selector_iterator_type (&selectors);
@@ -3252,18 +3293,19 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
           }
         cleanup_iterator (&selectors);
 
-        if (gvm_server_sendf (&connection->session, "</nvt_selectors>"
-                                                    "</config>"
-                                                    "</get_configs_response>"
-                                                    "</create_config>")
+        if (gvm_server_sendf (&connection->session,
+                              "</nvt_selectors>"
+                              "</config>"
+                              "</get_configs_response>"
+                              "</create_config>")
             || (gmp_read_create_response (&connection->session,
                                           &global_slave_config_uuid)
                 != 201))
           goto fail_target;
       }
 
-      g_debug ("   %s: slave config uuid: %s", __FUNCTION__,
-               global_slave_config_uuid);
+      g_debug (
+        "   %s: slave config uuid: %s", __FUNCTION__, global_slave_config_uuid);
 
       /* Create the task on the slave. */
 
@@ -3283,7 +3325,9 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
         uuid_report = report_uuid (global_current_report);
         comment = g_strdup_printf ("Slave task for master task %s (%s)"
                                    " report %s.",
-                                   name_task, uuid_task, uuid_report);
+                                   name_task,
+                                   uuid_task,
+                                   uuid_report);
         opts.comment = comment;
         free (uuid_task);
         free (name_task);
@@ -3308,8 +3352,8 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
         opts.schedule_id = NULL;
         opts.slave_id = NULL;
 
-        ret = gmp_create_task_ext (&connection->session, opts,
-                                   &global_slave_task_uuid);
+        ret = gmp_create_task_ext (
+          &connection->session, opts, &global_slave_task_uuid);
         g_free (comment);
         g_free (max_checks);
         g_free (max_hosts);
@@ -3321,7 +3365,8 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
 
       /* Start the task on the slave. */
 
-      if (gmp_start_task_report (&connection->session, global_slave_task_uuid,
+      if (gmp_start_task_report (&connection->session,
+                                 global_slave_task_uuid,
                                  &global_slave_report_uuid))
         goto fail_task;
       if (global_slave_report_uuid == NULL)
@@ -3359,8 +3404,9 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
               break;
             case 404:
               /* Resource Missing. */
-              set_task_interrupted (task, "Failed to find task on slave."
-                                          "  Interrupting scan.");
+              set_task_interrupted (task,
+                                    "Failed to find task on slave."
+                                    "  Interrupting scan.");
               goto giveup;
             default:
               goto fail_stop_task;
@@ -3395,13 +3441,14 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
           break;
         }
 
-      ret = gmp_get_tasks (&connection->session, global_slave_task_uuid, 0, 0,
-                           &get_tasks);
+      ret = gmp_get_tasks (
+        &connection->session, global_slave_task_uuid, 0, 0, &get_tasks);
       if (ret == 404)
         {
           /* Resource Missing. */
-          set_task_interrupted (task, "Task missing on slave."
-                                      "  Interrupting scan.");
+          set_task_interrupted (task,
+                                "Task missing on slave."
+                                "  Interrupting scan.");
           goto giveup;
         }
       else if (ret)
@@ -3416,8 +3463,9 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
       status = gmp_task_status (get_tasks);
       if (status == NULL)
         {
-          set_task_interrupted (task, "Error in slave task status."
-                                      "  Interrupting scan.");
+          set_task_interrupted (task,
+                                "Error in slave task status."
+                                "  Interrupting scan.");
           goto giveup;
         }
       status_done = (strcmp (status, "Done") == 0);
@@ -3460,8 +3508,9 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
           if ((ret == 404) && (ret2 == 404))
             {
               /* Resource Missing. */
-              set_task_interrupted (task, "Task report missing on slave."
-                                          "  Interrupting scan.");
+              set_task_interrupted (task,
+                                    "Task report missing on slave."
+                                    "  Interrupting scan.");
               goto giveup;
             }
           if (ret && ret2)
@@ -3544,24 +3593,24 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
 
   gmp_delete_task_ext (&connection->session, global_slave_task_uuid, del_opts);
   set_report_slave_task_uuid (global_current_report, "");
-  gmp_delete_config_ext (&connection->session, global_slave_config_uuid,
-                         del_opts);
-  gmp_delete_target_ext (&connection->session, global_slave_target_uuid,
-                         del_opts);
-  gmp_delete_port_list_ext (&connection->session, global_slave_port_list_uuid,
-                            del_opts);
+  gmp_delete_config_ext (
+    &connection->session, global_slave_config_uuid, del_opts);
+  gmp_delete_target_ext (
+    &connection->session, global_slave_target_uuid, del_opts);
+  gmp_delete_port_list_ext (
+    &connection->session, global_slave_port_list_uuid, del_opts);
   if (global_slave_ssh_credential_uuid)
-    gmp_delete_lsc_credential_ext (&connection->session,
-                                   global_slave_ssh_credential_uuid, del_opts);
+    gmp_delete_lsc_credential_ext (
+      &connection->session, global_slave_ssh_credential_uuid, del_opts);
   if (global_slave_smb_credential_uuid)
-    gmp_delete_lsc_credential_ext (&connection->session,
-                                   global_slave_smb_credential_uuid, del_opts);
+    gmp_delete_lsc_credential_ext (
+      &connection->session, global_slave_smb_credential_uuid, del_opts);
   if (global_slave_esxi_credential_uuid)
-    gmp_delete_lsc_credential_ext (&connection->session,
-                                   global_slave_esxi_credential_uuid, del_opts);
+    gmp_delete_lsc_credential_ext (
+      &connection->session, global_slave_esxi_credential_uuid, del_opts);
   if (global_slave_snmp_credential_uuid)
-    gmp_delete_lsc_credential_ext (&connection->session,
-                                   global_slave_snmp_credential_uuid, del_opts);
+    gmp_delete_lsc_credential_ext (
+      &connection->session, global_slave_snmp_credential_uuid, del_opts);
 succeed_stopped:
   free (global_slave_task_uuid);
   global_slave_task_uuid = NULL;
@@ -3594,32 +3643,32 @@ fail_task:
   set_report_slave_task_uuid (global_current_report, "");
   free (global_slave_task_uuid);
 fail_config:
-  gmp_delete_config_ext (&connection->session, global_slave_config_uuid,
-                         del_opts);
+  gmp_delete_config_ext (
+    &connection->session, global_slave_config_uuid, del_opts);
   free (global_slave_config_uuid);
 fail_target:
-  gmp_delete_target_ext (&connection->session, global_slave_target_uuid,
-                         del_opts);
+  gmp_delete_target_ext (
+    &connection->session, global_slave_target_uuid, del_opts);
   free (global_slave_target_uuid);
-  gmp_delete_port_list_ext (&connection->session, global_slave_port_list_uuid,
-                            del_opts);
+  gmp_delete_port_list_ext (
+    &connection->session, global_slave_port_list_uuid, del_opts);
   free (global_slave_port_list_uuid);
 fail_credentials:
   if (global_slave_snmp_credential_uuid)
-    gmp_delete_lsc_credential_ext (&connection->session,
-                                   global_slave_snmp_credential_uuid, del_opts);
+    gmp_delete_lsc_credential_ext (
+      &connection->session, global_slave_snmp_credential_uuid, del_opts);
   free (global_slave_snmp_credential_uuid);
   if (global_slave_esxi_credential_uuid)
-    gmp_delete_lsc_credential_ext (&connection->session,
-                                   global_slave_esxi_credential_uuid, del_opts);
+    gmp_delete_lsc_credential_ext (
+      &connection->session, global_slave_esxi_credential_uuid, del_opts);
   free (global_slave_esxi_credential_uuid);
   if (global_slave_smb_credential_uuid)
-    gmp_delete_lsc_credential_ext (&connection->session,
-                                   global_slave_smb_credential_uuid, del_opts);
+    gmp_delete_lsc_credential_ext (
+      &connection->session, global_slave_smb_credential_uuid, del_opts);
   free (global_slave_smb_credential_uuid);
   if (global_slave_ssh_credential_uuid)
-    gmp_delete_lsc_credential_ext (&connection->session,
-                                   global_slave_ssh_credential_uuid, del_opts);
+    gmp_delete_lsc_credential_ext (
+      &connection->session, global_slave_ssh_credential_uuid, del_opts);
   free (global_slave_ssh_credential_uuid);
 fail:
   g_debug ("   %s: fail (%i)", __FUNCTION__, ret_fail);
@@ -3707,9 +3756,13 @@ handle_slave_task (task_t task, target_t target,
         /* Login failed. */
 
         port_string = g_strdup_printf ("%i", connection->port);
-        result = make_result (task, connection->host_string, "", port_string,
+        result = make_result (task,
+                              connection->host_string,
+                              "",
+                              port_string,
                               /* NVT: Global variable settings. */
-                              "1.3.6.1.4.1.25623.1.0.12288", "Error Message",
+                              "1.3.6.1.4.1.25623.1.0.12288",
+                              "Error Message",
                               "Authentication with the slave failed.");
         g_free (port_string);
         if (global_current_report)
@@ -3727,7 +3780,8 @@ handle_slave_task (task_t task, target_t target,
           {
             if (current_signal)
               {
-                g_debug ("%s: Received %s signal.", __FUNCTION__,
+                g_debug ("%s: Received %s signal.",
+                         __FUNCTION__,
                          sys_siglist[get_termination_signal ()]);
               }
             if (global_current_report)
@@ -3746,7 +3800,8 @@ handle_slave_task (task_t task, target_t target,
     {
       if (get_termination_signal ())
         {
-          g_debug ("%s: Received %s signal.", __FUNCTION__,
+          g_debug ("%s: Received %s signal.",
+                   __FUNCTION__,
                    sys_siglist[get_termination_signal ()]);
           if (global_current_report)
             {
@@ -3758,9 +3813,14 @@ handle_slave_task (task_t task, target_t target,
           return 0;
         }
 
-      ret = slave_setup (connection, slave_task_name, task, target,
-                         target_ssh_credential, target_smb_credential,
-                         target_esxi_credential, target_snmp_credential,
+      ret = slave_setup (connection,
+                         slave_task_name,
+                         task,
+                         target,
+                         target_ssh_credential,
+                         target_smb_credential,
+                         target_esxi_credential,
+                         target_snmp_credential,
                          last_stopped_report);
       if (ret == 1)
         {
@@ -3837,7 +3897,8 @@ task_scanner_options (task_t task, target_t target)
             }
           if (!strcmp (type, "credential_up")
               && !strcmp (credential_iterator_type (&iter), "up"))
-            value = g_strdup_printf ("%s:%s", credential_iterator_login (&iter),
+            value = g_strdup_printf ("%s:%s",
+                                     credential_iterator_login (&iter),
                                      credential_iterator_password (&iter));
           else if (!strcmp (type, "credential_up"))
             {
@@ -3863,8 +3924,8 @@ task_scanner_options (task_t task, target_t target)
 
           if (!preference_iterator_value (&prefs))
             continue;
-          fname = g_strdup_printf ("%s/%s", GVM_SCAP_DATA_DIR "/",
-                                   preference_iterator_value (&prefs));
+          fname = g_strdup_printf (
+            "%s/%s", GVM_SCAP_DATA_DIR "/", preference_iterator_value (&prefs));
           value = gvm_file_as_base64 (fname);
           if (!value)
             continue;
@@ -3978,13 +4039,18 @@ handle_osp_scan (task_t task, report_t report, const char *scan_id)
           rc = -2;
           break;
         }
-      int progress = get_osp_scan_report (scan_id, host, port, ca_pub, key_pub,
-                                          key_priv, 0, NULL);
+      int progress = get_osp_scan_report (
+        scan_id, host, port, ca_pub, key_pub, key_priv, 0, NULL);
       if (progress == -1)
         {
-          result_t result = make_osp_result (
-            task, "", "", threat_message_type ("Error"),
-            "Erroneous scan progress value", "", "", QOD_DEFAULT);
+          result_t result = make_osp_result (task,
+                                             "",
+                                             "",
+                                             threat_message_type ("Error"),
+                                             "Erroneous scan progress value",
+                                             "",
+                                             "",
+                                             QOD_DEFAULT);
           report_add_result (report, result);
           rc = -1;
           break;
@@ -3997,13 +4063,19 @@ handle_osp_scan (task_t task, report_t report, const char *scan_id)
       else if (progress == 100)
         {
           /* Get the full OSP report. */
-          progress = get_osp_scan_report (scan_id, host, port, ca_pub, key_pub,
-                                          key_priv, 1, &report_xml);
+          progress = get_osp_scan_report (
+            scan_id, host, port, ca_pub, key_pub, key_priv, 1, &report_xml);
           if (progress != 100)
             {
-              result_t result = make_osp_result (
-                task, "", "", threat_message_type ("Error"),
-                "Erroneous scan progress value", "", "", QOD_DEFAULT);
+              result_t result =
+                make_osp_result (task,
+                                 "",
+                                 "",
+                                 threat_message_type ("Error"),
+                                 "Erroneous scan progress value",
+                                 "",
+                                 "",
+                                 QOD_DEFAULT);
               report_add_result (report, result);
               rc = -1;
               break;
@@ -4146,8 +4218,9 @@ fork_osp_scan_handler (task_t task, target_t target)
     case -1:
       /* Parent, failed to fork. */
       g_warning ("%s: Failed to fork: %s", __FUNCTION__, strerror (errno));
-      set_task_interrupted (task, "Error forking scan handler."
-                                  "  Interrupting scan.");
+      set_task_interrupted (task,
+                            "Error forking scan handler."
+                            "  Interrupting scan.");
       set_report_scan_run_status (global_current_report,
                                   TASK_STATUS_INTERRUPTED);
       global_current_report = (report_t) 0;
@@ -4168,8 +4241,14 @@ fork_osp_scan_handler (task_t task, target_t target)
       result_t result;
 
       g_warning ("OSP start_scan %s: %s", report_id, error);
-      result = make_osp_result (task, "", "", threat_message_type ("Error"),
-                                error, "", "", QOD_DEFAULT);
+      result = make_osp_result (task,
+                                "",
+                                "",
+                                threat_message_type ("Error"),
+                                error,
+                                "",
+                                "",
+                                QOD_DEFAULT);
       report_add_result (global_current_report, result);
       set_task_run_status (task, TASK_STATUS_DONE);
       set_report_scan_run_status (global_current_report, TASK_STATUS_DONE);
@@ -4295,8 +4374,8 @@ cve_scan_host (task_t task, gvm_host_t *gvm_host)
 
           start_time = time (NULL);
           prognosis_report_host = 0;
-          init_host_prognosis_iterator (&prognosis, report_host, 0, -1, NULL,
-                                        NULL, 0, NULL);
+          init_host_prognosis_iterator (
+            &prognosis, report_host, 0, -1, NULL, NULL, 0, NULL);
           while (next (&prognosis))
             {
               const char *app, *cve;
@@ -4314,18 +4393,23 @@ cve_scan_host (task_t task, gvm_host_t *gvm_host)
               cve = prognosis_iterator_cve (&prognosis);
               location = app_location (report_host, app);
 
-              desc = g_strdup_printf (
-                "The host carries the product: %s\n"
-                "It is vulnerable according to: %s.\n"
-                "%s%s%s"
-                "\n"
-                "%s",
-                app, cve, location ? "The product was found at: " : "",
-                location ? location : "", location ? ".\n" : "",
-                prognosis_iterator_description (&prognosis));
+              desc =
+                g_strdup_printf ("The host carries the product: %s\n"
+                                 "It is vulnerable according to: %s.\n"
+                                 "%s%s%s"
+                                 "\n"
+                                 "%s",
+                                 app,
+                                 cve,
+                                 location ? "The product was found at: " : "",
+                                 location ? location : "",
+                                 location ? ".\n" : "",
+                                 prognosis_iterator_description (&prognosis));
 
               g_debug ("%s: making result with severity %1.1f desc [%s]",
-                       __FUNCTION__, severity, desc);
+                       __FUNCTION__,
+                       severity,
+                       desc);
 
               result = make_cve_result (task, ip, cve, severity, desc);
               g_free (desc);
@@ -4333,20 +4417,36 @@ cve_scan_host (task_t task, gvm_host_t *gvm_host)
                 {
                   report_add_result (global_current_report, result);
 
-                  insert_report_host_detail (global_current_report, ip, "cve",
-                                             cve, "CVE Scanner", "App", app);
+                  insert_report_host_detail (global_current_report,
+                                             ip,
+                                             "cve",
+                                             cve,
+                                             "CVE Scanner",
+                                             "App",
+                                             app);
 
                   if (location)
                     {
-                      insert_report_host_detail (global_current_report, ip,
-                                                 "cve", cve, "CVE Scanner", app,
+                      insert_report_host_detail (global_current_report,
+                                                 ip,
+                                                 "cve",
+                                                 cve,
+                                                 "CVE Scanner",
+                                                 app,
                                                  location);
 
-                      insert_report_host_detail (global_current_report, ip,
-                                                 "cve", cve, "CVE Scanner",
-                                                 "detected_at", location);
-                      insert_report_host_detail (global_current_report, ip,
-                                                 "cve", cve, "CVE Scanner",
+                      insert_report_host_detail (global_current_report,
+                                                 ip,
+                                                 "cve",
+                                                 cve,
+                                                 "CVE Scanner",
+                                                 "detected_at",
+                                                 location);
+                      insert_report_host_detail (global_current_report,
+                                                 ip,
+                                                 "cve",
+                                                 cve,
+                                                 "CVE Scanner",
                                                  "detected_by",
                                                  /* Detected by itself. */
                                                  cve);
@@ -4361,8 +4461,13 @@ cve_scan_host (task_t task, gvm_host_t *gvm_host)
               /* Complete the report_host. */
 
               report_host_set_end_time (prognosis_report_host, time (NULL));
-              insert_report_host_detail (global_current_report, ip, "cve", "",
-                                         "CVE Scanner", "CVE Scan", "1");
+              insert_report_host_detail (global_current_report,
+                                         ip,
+                                         "cve",
+                                         "",
+                                         "CVE Scanner",
+                                         "CVE Scan",
+                                         "1");
             }
         }
       cleanup_iterator (&report_hosts);
@@ -4408,8 +4513,9 @@ fork_cve_scan_handler (task_t task, target_t target)
     case -1:
       /* Parent, failed to fork. */
       g_warning ("%s: Failed to fork: %s", __FUNCTION__, strerror (errno));
-      set_task_interrupted (task, "Error forking scan handler."
-                                  "  Interrupting scan.");
+      set_task_interrupted (task,
+                            "Error forking scan handler."
+                            "  Interrupting scan.");
       set_report_scan_run_status (global_current_report,
                                   TASK_STATUS_INTERRUPTED);
       global_current_report = (report_t) 0;
@@ -4438,8 +4544,9 @@ fork_cve_scan_handler (task_t task, target_t target)
   hosts = target_hosts (target);
   if (hosts == NULL)
     {
-      set_task_interrupted (task, "Error in target host list."
-                                  "  Interrupting scan.");
+      set_task_interrupted (task,
+                            "Error in target host list."
+                            "  Interrupting scan.");
       set_report_scan_run_status (global_current_report,
                                   TASK_STATUS_INTERRUPTED);
       exit (1);
@@ -4456,8 +4563,9 @@ fork_cve_scan_handler (task_t task, target_t target)
   while ((gvm_host = gvm_hosts_next (gvm_hosts)))
     if (cve_scan_host (task, gvm_host))
       {
-        set_task_interrupted (task, "Failed to get nthlast report."
-                                    "  Interrupting scan.");
+        set_task_interrupted (task,
+                              "Failed to get nthlast report."
+                              "  Interrupting scan.");
         set_report_scan_run_status (global_current_report,
                                     TASK_STATUS_INTERRUPTED);
         gvm_hosts_free (gvm_hosts);
@@ -4622,23 +4730,23 @@ run_task_setup (task_t task, config_t *config, target_t *target,
     return ret;
 
   if (*ssh_credential
-      && ((ret = check_available ("credential", *ssh_credential,
-                                  "get_credentials"))))
+      && ((ret = check_available (
+             "credential", *ssh_credential, "get_credentials"))))
     return ret;
 
   if (*smb_credential
-      && ((ret = check_available ("credential", *smb_credential,
-                                  "get_credentials"))))
+      && ((ret = check_available (
+             "credential", *smb_credential, "get_credentials"))))
     return ret;
 
   if (*esxi_credential
-      && ((ret = check_available ("credential", *esxi_credential,
-                                  "get_credentials"))))
+      && ((ret = check_available (
+             "credential", *esxi_credential, "get_credentials"))))
     return ret;
 
   if (*snmp_credential
-      && ((ret = check_available ("credential", *snmp_credential,
-                                  "get_credentials"))))
+      && ((ret = check_available (
+             "credential", *snmp_credential, "get_credentials"))))
     return ret;
 
   return 0;
@@ -4740,8 +4848,14 @@ run_slave_or_gmp_task (task_t task, int from, char **report_id,
   credential_t ssh_credential, smb_credential, esxi_credential, snmp_credential;
   port_list_t port_list;
 
-  ret = run_task_setup (task, &config, &target, &port_list, &ssh_credential,
-                        &smb_credential, &esxi_credential, &snmp_credential);
+  ret = run_task_setup (task,
+                        &config,
+                        &target,
+                        &port_list,
+                        &ssh_credential,
+                        &smb_credential,
+                        &esxi_credential,
+                        &snmp_credential);
   if (ret)
     return ret;
 
@@ -4759,8 +4873,8 @@ run_slave_or_gmp_task (task_t task, int from, char **report_id,
 
   /* Prepare the report. */
 
-  ret = run_task_prepare_report (task, report_id, from, run_status,
-                                 &last_stopped_report);
+  ret = run_task_prepare_report (
+    task, report_id, from, run_status, &last_stopped_report);
   if (ret)
     {
       set_task_run_status (task, run_status);
@@ -4803,8 +4917,9 @@ run_slave_or_gmp_task (task_t task, int from, char **report_id,
       break;
     case -1:
       /* Parent when error. */
-      set_task_interrupted (task, "Failed to fork task child."
-                                  "  Interrupting scan.");
+      set_task_interrupted (task,
+                            "Failed to fork task child."
+                            "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       global_current_report = (report_t) 0;
       return -9;
@@ -4834,27 +4949,37 @@ run_slave_or_gmp_task (task_t task, int from, char **report_id,
   free (uuid);
   proctitle_set (title);
 
-  switch (handle_slave_task (
-    task, target, ssh_credential, smb_credential, esxi_credential,
-    snmp_credential, last_stopped_report, connection, slave_id, slave_name))
+  switch (handle_slave_task (task,
+                             target,
+                             ssh_credential,
+                             smb_credential,
+                             esxi_credential,
+                             snmp_credential,
+                             last_stopped_report,
+                             connection,
+                             slave_id,
+                             slave_name))
     {
     case 0:
       break;
     default:
       assert (0);
     case 1:
-      set_task_interrupted (task, "Authentication with slave failed."
-                                  "  Interrupting scan.");
+      set_task_interrupted (task,
+                            "Authentication with slave failed."
+                            "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       exit (EXIT_FAILURE);
     case -1:
-      set_task_interrupted (task, "Failed to make UUID."
-                                  "  Interrupting scan.");
+      set_task_interrupted (task,
+                            "Failed to make UUID."
+                            "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       exit (EXIT_FAILURE);
     case -2:
-      set_task_interrupted (task, "Failed to get slave task name."
-                                  "  Interrupting scan.");
+      set_task_interrupted (task,
+                            "Failed to get slave task name."
+                            "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       exit (EXIT_FAILURE);
     }
@@ -4923,8 +5048,8 @@ run_gmp_task (task_t task, scanner_t scanner, int from, char **report_id)
 
   connection.tls = 1;
 
-  ret = run_slave_or_gmp_task (task, from, report_id, &connection, scanner_id,
-                               name);
+  ret = run_slave_or_gmp_task (
+    task, from, report_id, &connection, scanner_id, name);
 
   free (connection.host_string);
   free (connection.username);
@@ -4964,8 +5089,14 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
 
   /* Setup the task info required for the scan. */
 
-  ret = run_task_setup (task, &config, &target, &port_list, &ssh_credential,
-                        &smb_credential, &esxi_credential, &snmp_credential);
+  ret = run_task_setup (task,
+                        &config,
+                        &target,
+                        &port_list,
+                        &ssh_credential,
+                        &smb_credential,
+                        &esxi_credential,
+                        &snmp_credential);
   if (ret)
     return ret;
 
@@ -5005,8 +5136,8 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
 
   /* Prepare the report. */
 
-  ret = run_task_prepare_report (task, report_id, from, run_status,
-                                 &last_stopped_report);
+  ret = run_task_prepare_report (
+    task, report_id, from, run_status, &last_stopped_report);
   if (ret)
     {
       set_task_run_status (task, run_status);
@@ -5049,10 +5180,11 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
       break;
     case -1:
       /* Parent when error. */
-      g_warning ("%s: Failed to fork task child: %s", __FUNCTION__,
-                 strerror (errno));
-      set_task_interrupted (task, "Failed to fork task child."
-                                  "  Interrupting scan.");
+      g_warning (
+        "%s: Failed to fork task child: %s", __FUNCTION__, strerror (errno));
+      set_task_interrupted (task,
+                            "Failed to fork task child."
+                            "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       global_current_report = (report_t) 0;
       return -9;
@@ -5091,8 +5223,9 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
   if (send_to_server ("CLIENT <|> PREFERENCES <|>\n"))
     {
       g_warning ("%s: Failed to send OTP PREFERENCES", __FUNCTION__);
-      set_task_interrupted (task, "Failed to send OTP PREFERENCES."
-                                  "  Interrupting scan.");
+      set_task_interrupted (task,
+                            "Failed to send OTP PREFERENCES."
+                            "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       global_current_report = (report_t) 0;
       return -10;
@@ -5117,8 +5250,8 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
           if (snmp_credential)
             g_string_append (auth_plugins, "1.3.6.1.4.1.25623.1.0.105076;");
 
-          fail = sendf_to_server ("plugin_set <|> %s%s\n", auth_plugins->str,
-                                  plugins);
+          fail = sendf_to_server (
+            "plugin_set <|> %s%s\n", auth_plugins->str, plugins);
           g_string_free (auth_plugins, TRUE);
         }
     }
@@ -5127,8 +5260,9 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
   free (plugins);
   if (fail)
     {
-      set_task_interrupted (task, "Failed to send OTP plugin set."
-                                  "  Interrupting scan.");
+      set_task_interrupted (task,
+                            "Failed to send OTP plugin set."
+                            "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       global_current_report = (report_t) 0;
       return -10;
@@ -5138,8 +5272,9 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
 
   if (send_config_preferences (config, "SERVER_PREFS", NULL, NULL))
     {
-      set_task_interrupted (task, "Failed to send OTP SERVER PREFS."
-                                  "  Interrupting scan.");
+      set_task_interrupted (task,
+                            "Failed to send OTP SERVER PREFS."
+                            "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       global_current_report = (report_t) 0;
       return -10;
@@ -5147,8 +5282,9 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
 
   if (send_task_preferences (task))
     {
-      set_task_interrupted (task, "Failed to send OTP task preferences."
-                                  "  Interrupting scan.");
+      set_task_interrupted (task,
+                            "Failed to send OTP task preferences."
+                            "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       global_current_report = (report_t) 0;
       return -10;
@@ -5161,8 +5297,9 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
                        port_range ? port_range : "default"))
     {
       free (port_range);
-      set_task_interrupted (task, "Failed to send OTP port_range."
-                                  "  Interrupting scan.");
+      set_task_interrupted (task,
+                            "Failed to send OTP port_range."
+                            "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       global_current_report = (report_t) 0;
       return -10;
@@ -5175,8 +5312,9 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
   if (port && sendf_to_server ("auth_port_ssh <|> %s\n", port))
     {
       free (port);
-      set_task_interrupted (task, "Failed to send OTP auth_port_ssh."
-                                  "  Interrupting scan.");
+      set_task_interrupted (task,
+                            "Failed to send OTP auth_port_ssh."
+                            "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       global_current_report = (report_t) 0;
       return -10;
@@ -5190,13 +5328,14 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
   /* Send the plugins preferences. */
 
   preference_files = g_ptr_array_new ();
-  if (send_config_preferences (config, "PLUGINS_PREFS", files,
-                               preference_files))
+  if (send_config_preferences (
+        config, "PLUGINS_PREFS", files, preference_files))
     {
       g_ptr_array_free (preference_files, TRUE);
       slist_free (files);
-      set_task_interrupted (task, "Failed to send OTP PLUGINS_PREFS."
-                                  "  Interrupting scan.");
+      set_task_interrupted (task,
+                            "Failed to send OTP PLUGINS_PREFS."
+                            "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       global_current_report = (report_t) 0;
       return -10;
@@ -5209,8 +5348,9 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
       g_ptr_array_add (preference_files, NULL);
       array_free (preference_files);
       slist_free (files);
-      set_task_interrupted (task, "Failed to send OTP scanner preferences."
-                                  "  Interrupting scan.");
+      set_task_interrupted (task,
+                            "Failed to send OTP scanner preferences."
+                            "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       global_current_report = (report_t) 0;
       return -10;
@@ -5247,8 +5387,9 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
               g_ptr_array_add (preference_files, NULL);
               array_free (preference_files);
               slist_free (files);
-              set_task_interrupted (task, "Failed to send OTP SSH preferences."
-                                          "  Interrupting scan.");
+              set_task_interrupted (task,
+                                    "Failed to send OTP SSH preferences."
+                                    "  Interrupting scan.");
               set_report_scan_run_status (global_current_report, run_status);
               global_current_report = (report_t) 0;
               return -10;
@@ -5296,8 +5437,9 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
               g_ptr_array_add (preference_files, NULL);
               array_free (preference_files);
               slist_free (files);
-              set_task_interrupted (task, "Failed to send OTP SMB preferences."
-                                          "  Interrupting scan.");
+              set_task_interrupted (task,
+                                    "Failed to send OTP SMB preferences."
+                                    "  Interrupting scan.");
               set_report_scan_run_status (global_current_report, run_status);
               global_current_report = (report_t) 0;
               return -10;
@@ -5328,8 +5470,9 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
               g_ptr_array_add (preference_files, NULL);
               array_free (preference_files);
               slist_free (files);
-              set_task_interrupted (task, "Failed to send OTP EXSi preferences."
-                                          "  Interrupting scan.");
+              set_task_interrupted (task,
+                                    "Failed to send OTP EXSi preferences."
+                                    "  Interrupting scan.");
               set_report_scan_run_status (global_current_report, run_status);
               global_current_report = (report_t) 0;
               return -10;
@@ -5382,8 +5525,9 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
               g_ptr_array_add (preference_files, NULL);
               array_free (preference_files);
               slist_free (files);
-              set_task_interrupted (task, "Failed to send OTP SNMP preferences."
-                                          "  Interrupting scan.");
+              set_task_interrupted (task,
+                                    "Failed to send OTP SNMP preferences."
+                                    "  Interrupting scan.");
               set_report_scan_run_status (global_current_report, run_status);
               global_current_report = (report_t) 0;
               return -10;
@@ -5400,8 +5544,9 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
     {
       array_free (preference_files);
       slist_free (files);
-      set_task_interrupted (task, "Failed to send OTP alive test preferences."
-                                  "  Interrupting scan.");
+      set_task_interrupted (task,
+                            "Failed to send OTP alive test preferences."
+                            "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       global_current_report = (report_t) 0;
       return -10;
@@ -5416,8 +5561,9 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
       g_ptr_array_add (preference_files, NULL);
       array_free (preference_files);
       slist_free (files);
-      set_task_interrupted (task, "Failed to send OTP network_targets."
-                                  "  Interrupting scan.");
+      set_task_interrupted (task,
+                            "Failed to send OTP network_targets."
+                            "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       global_current_report = (report_t) 0;
       return -10;
@@ -5430,8 +5576,9 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
       free (hosts);
       array_free (preference_files);
       slist_free (files);
-      set_task_interrupted (task, "Failed to send OTP CLIENT."
-                                  "  Interrupting scan.");
+      set_task_interrupted (task,
+                            "Failed to send OTP CLIENT."
+                            "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       global_current_report = (report_t) 0;
       return -10;
@@ -5466,8 +5613,9 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
             array_free (preference_files);
             slist_free (files);
             g_warning ("%s: Failed to send an OTP file", __FUNCTION__);
-            set_task_interrupted (task, "Failed to send OTP file."
-                                        "  Interrupting scan.");
+            set_task_interrupted (task,
+                                  "Failed to send OTP file."
+                                  "  Interrupting scan.");
             set_report_scan_run_status (global_current_report, run_status);
             global_current_report = (report_t) 0;
             return -10;
@@ -5487,8 +5635,9 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
         {
           free (hosts);
           slist_free (files);
-          set_task_interrupted (task, "Failed to send an OTP task file."
-                                      "  Interrupting scan.");
+          set_task_interrupted (task,
+                                "Failed to send an OTP task file."
+                                "  Interrupting scan.");
           set_report_scan_run_status (global_current_report, run_status);
           global_current_report = (report_t) 0;
           return -10;
@@ -5503,13 +5652,14 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
   /* Send all the hosts to the Scanner.  When resuming a stopped task,
    * the hosts that have been completely scanned are excluded by being
    * included in exclude_hosts preference. */
-  fail = sendf_to_server ("CLIENT <|> LONG_ATTACK <|>\n%d\n%s\n",
-                          strlen (hosts), hosts);
+  fail = sendf_to_server (
+    "CLIENT <|> LONG_ATTACK <|>\n%d\n%s\n", strlen (hosts), hosts);
   free (hosts);
   if (fail)
     {
-      set_task_interrupted (task, "Failed to send OTP LONG_ATTACK."
-                                  "  Interrupting scan.");
+      set_task_interrupted (task,
+                            "Failed to send OTP LONG_ATTACK."
+                            "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       global_current_report = (report_t) 0;
       return -10;
@@ -6164,13 +6314,13 @@ get_system_report_types (const char *required_type, gchar ***start,
   gint exit_status;
 
   if (slave_id && strcmp (slave_id, "0"))
-    return get_slave_system_report_types (required_type, start, types,
-                                          slave_id);
+    return get_slave_system_report_types (
+      required_type, start, types, slave_id);
 
   g_debug ("   command: " COMMAND);
 
-  if ((g_spawn_command_line_sync (COMMAND, &astdout, &astderr, &exit_status,
-                                  &err)
+  if ((g_spawn_command_line_sync (
+         COMMAND, &astdout, &astderr, &exit_status, &err)
        == FALSE)
       || (WIFEXITED (exit_status) == 0) || WEXITSTATUS (exit_status))
     {
@@ -6260,8 +6410,8 @@ init_system_report_type_iterator (report_type_iterator_t *iterator,
   if (acl_user_may ("get_system_reports") == 0)
     return 99;
 
-  ret = get_system_report_types (type, &iterator->start, &iterator->current,
-                                 slave_id);
+  ret = get_system_report_types (
+    type, &iterator->start, &iterator->current, slave_id);
   if (ret == 0 || ret == 3)
     {
       iterator->current--;
@@ -6493,41 +6643,47 @@ manage_system_report (const char *name, const char *duration,
     }
 
   if (slave_id && strcmp (slave_id, "0"))
-    return slave_system_report (name, duration, start_time, end_time, slave_id,
-                                report);
+    return slave_system_report (
+      name, duration, start_time, end_time, slave_id, report);
 
   /* For simplicity, it's up to the command to do the base64 encoding. */
   if (start_time && strcmp (start_time, ""))
     {
       if (end_time && strcmp (end_time, ""))
         {
-          command = g_strdup_printf ("gvmcg %ld %ld %s", start_time_num,
-                                     end_time_num, name);
+          command = g_strdup_printf (
+            "gvmcg %ld %ld %s", start_time_num, end_time_num, name);
         }
       else if (duration && strcmp (duration, ""))
         {
-          command = g_strdup_printf ("gvmcg %ld %ld %s", start_time_num,
-                                     start_time_num + duration_num, name);
+          command = g_strdup_printf ("gvmcg %ld %ld %s",
+                                     start_time_num,
+                                     start_time_num + duration_num,
+                                     name);
         }
       else
         {
-          command = g_strdup_printf ("gvmcg %ld %ld %s", start_time_num,
-                                     start_time_num + DEFAULT_DURATION, name);
+          command = g_strdup_printf ("gvmcg %ld %ld %s",
+                                     start_time_num,
+                                     start_time_num + DEFAULT_DURATION,
+                                     name);
         }
     }
   else if (end_time && strcmp (end_time, ""))
     {
       if (duration && strcmp (duration, ""))
         {
-          command =
-            g_strdup_printf ("gvmcg %ld %ld %s", end_time_num - duration_num,
-                             end_time_num, name);
+          command = g_strdup_printf ("gvmcg %ld %ld %s",
+                                     end_time_num - duration_num,
+                                     end_time_num,
+                                     name);
         }
       else
         {
           command = g_strdup_printf ("gvmcg %ld %ld %s",
                                      end_time_num - DEFAULT_DURATION,
-                                     end_time_num, name);
+                                     end_time_num,
+                                     name);
         }
     }
   else
@@ -6544,8 +6700,8 @@ manage_system_report (const char *name, const char *duration,
 
   g_debug ("   command: %s", command);
 
-  if ((g_spawn_command_line_sync (command, &astdout, &astderr, &exit_status,
-                                  &err)
+  if ((g_spawn_command_line_sync (
+         command, &astdout, &astderr, &exit_status, &err)
        == FALSE)
       || (WIFEXITED (exit_status) == 0) || WEXITSTATUS (exit_status))
     {
@@ -6779,8 +6935,8 @@ scheduled_task_start (scheduled_task_t *scheduled_task,
 
         /* Parent.  Wait for child, to check return. */
 
-        snprintf (title, sizeof (title), "gvmd: scheduler: waiting for %i",
-                  pid);
+        snprintf (
+          title, sizeof (title), "gvmd: scheduler: waiting for %i", pid);
         proctitle_set (title);
 
         g_debug ("%s: %i fork_connectioned %i", __FUNCTION__, getpid (), pid);
@@ -6793,7 +6949,8 @@ scheduled_task_start (scheduled_task_t *scheduled_task,
               {
                 g_warning ("%s: Failed to get child exit,"
                            " so task '%s' may not have been scheduled",
-                           __FUNCTION__, scheduled_task->task_uuid);
+                           __FUNCTION__,
+                           scheduled_task->task_uuid);
                 scheduled_task_free (scheduled_task);
                 exit (EXIT_FAILURE);
               }
@@ -6802,7 +6959,8 @@ scheduled_task_start (scheduled_task_t *scheduled_task,
             g_warning ("%s: waitpid: %s", __FUNCTION__, strerror (errno));
             g_warning ("%s: As a result, task '%s' may not have been"
                        " scheduled",
-                       __FUNCTION__, scheduled_task->task_uuid);
+                       __FUNCTION__,
+                       scheduled_task->task_uuid);
             scheduled_task_free (scheduled_task);
             exit (EXIT_FAILURE);
           }
@@ -6869,7 +7027,9 @@ scheduled_task_start (scheduled_task_t *scheduled_task,
 
   /* Start the task. */
 
-  snprintf (title, sizeof (title), "gvmd: scheduler: starting %s",
+  snprintf (title,
+            sizeof (title),
+            "gvmd: scheduler: starting %s",
             scheduled_task->task_uuid);
   proctitle_set (title);
 
@@ -6885,8 +7045,8 @@ scheduled_task_start (scheduled_task_t *scheduled_task,
 
   if (gmp_resume_task_report_c (&connection, scheduled_task->task_uuid, NULL))
     {
-      if (gmp_start_task_report_c (&connection, scheduled_task->task_uuid,
-                                   NULL))
+      if (gmp_start_task_report_c (
+            &connection, scheduled_task->task_uuid, NULL))
         {
           g_warning ("%s: gmp_start_task and gmp_resume_task failed",
                      __FUNCTION__);
@@ -6943,7 +7103,9 @@ scheduled_task_stop (scheduled_task_t *scheduled_task,
 
   /* Stop the task. */
 
-  snprintf (title, sizeof (title), "gvmd: scheduler: stopping %s",
+  snprintf (title,
+            sizeof (title),
+            "gvmd: scheduler: stopping %s",
             scheduled_task->task_uuid);
   proctitle_set (title);
 
@@ -7062,7 +7224,8 @@ manage_schedule (manage_connection_forker_t fork_connection, gboolean run_tasks,
         icalendar = task_schedule_iterator_icalendar (&schedules);
         zone = task_schedule_iterator_timezone (&schedules);
 
-        g_debug ("%s: start due for %llu, setting next_time", __FUNCTION__,
+        g_debug ("%s: start due for %llu, setting next_time",
+                 __FUNCTION__,
                  task_schedule_iterator_task (&schedules));
         set_task_schedule_next_time (
           task_schedule_iterator_task (&schedules),
@@ -7076,7 +7239,8 @@ manage_schedule (manage_connection_forker_t fork_connection, gboolean run_tasks,
 
         if (timed_out)
           {
-            g_message (" %s: Task timed out: %s", __FUNCTION__,
+            g_message (" %s: Task timed out: %s",
+                       __FUNCTION__,
                        task_schedule_iterator_task_uuid (&schedules));
             continue;
           }
@@ -7123,8 +7287,8 @@ manage_schedule (manage_connection_forker_t fork_connection, gboolean run_tasks,
       starts = starts->next;
       g_slist_free_1 (head);
 
-      if (scheduled_task_start (scheduled_task, fork_connection,
-                                sigmask_current))
+      if (scheduled_task_start (
+            scheduled_task, fork_connection, sigmask_current))
         /* Error.  Reschedule and continue to next task. */
         reschedule_task (scheduled_task->task_uuid);
       scheduled_task_free (scheduled_task);
@@ -7142,8 +7306,8 @@ manage_schedule (manage_connection_forker_t fork_connection, gboolean run_tasks,
       stops = stops->next;
       g_slist_free_1 (head);
 
-      if (scheduled_task_stop (scheduled_task, fork_connection,
-                               sigmask_current))
+      if (scheduled_task_stop (
+            scheduled_task, fork_connection, sigmask_current))
         {
           /* Error.  Exit. */
           scheduled_task_free (scheduled_task);
@@ -7297,7 +7461,9 @@ get_report_format_files (const char *dir_name, GPtrArray **start)
   setlocale (LC_ALL, locale);
   if (n < 0)
     {
-      g_warning ("%s: failed to open dir %s: %s", __FUNCTION__, dir_name,
+      g_warning ("%s: failed to open dir %s: %s",
+                 __FUNCTION__,
+                 dir_name,
                  strerror (errno));
       return -1;
     }
@@ -7359,8 +7525,8 @@ init_report_format_file_iterator (file_iterator_t *iterator,
       owner_uuid = report_format_owner_uuid (report_format);
       if (owner_uuid == NULL)
         return -1;
-      dir_name = g_build_filename (GVMD_STATE_DIR, "report_formats", owner_uuid,
-                                   uuid, NULL);
+      dir_name = g_build_filename (
+        GVMD_STATE_DIR, "report_formats", owner_uuid, uuid, NULL);
       g_free (owner_uuid);
     }
 
@@ -7445,7 +7611,9 @@ file_iterator_content_64 (file_iterator_t *iterator)
     {
       if (error)
         {
-          g_debug ("%s: failed to read %s: %s", __FUNCTION__, path_name,
+          g_debug ("%s: failed to read %s: %s",
+                   __FUNCTION__,
+                   path_name,
                    error->message);
           g_error_free (error);
         }
@@ -7495,14 +7663,15 @@ parse_tags (const char *scanner_tags, gchar **tags, gchar **cvss_base)
         {
           /* Skip this tag. */
         }
-      else if (strncmp (*point,
-                        "cvss_base_vector=", strlen ("cvss_base_vector="))
+      else if (strncmp (
+                 *point, "cvss_base_vector=", strlen ("cvss_base_vector="))
                == 0)
         {
           if (*cvss_base == NULL)
-            *cvss_base = g_strdup_printf (
-              "%.1f", get_cvss_score_from_base_metrics (
-                        *point + strlen ("cvss_base_vector=")));
+            *cvss_base =
+              g_strdup_printf ("%.1f",
+                               get_cvss_score_from_base_metrics (
+                                 *point + strlen ("cvss_base_vector=")));
           if (first)
             first = FALSE;
           else
@@ -7624,11 +7793,11 @@ delete_slave_task (const gchar *host, int port, const gchar *username,
     goto fail_credential;
   if (gmp_delete_port_list_ext (&session, slave_port_list_uuid, del_opts))
     goto fail_credential;
-  if (gmp_delete_lsc_credential_ext (&session, slave_smb_credential_uuid,
-                                     del_opts))
+  if (gmp_delete_lsc_credential_ext (
+        &session, slave_smb_credential_uuid, del_opts))
     goto fail;
-  if (gmp_delete_lsc_credential_ext (&session, slave_ssh_credential_uuid,
-                                     del_opts))
+  if (gmp_delete_lsc_credential_ext (
+        &session, slave_ssh_credential_uuid, del_opts))
     goto fail;
 
   /* Cleanup. */
@@ -7808,14 +7977,23 @@ xsl_transform (gchar *stylesheet, gchar *xmlfile, gchar **param_names,
   g_free (cmd_full);
   /* --- */
 
-  if ((g_spawn_sync (NULL, cmd, NULL,           /* Environment. */
-                     G_SPAWN_SEARCH_PATH, NULL, /* Setup function. */
-                     NULL, &standard_out, &standard_err, &exit_status, NULL)
+  if ((g_spawn_sync (NULL,
+                     cmd,
+                     NULL, /* Environment. */
+                     G_SPAWN_SEARCH_PATH,
+                     NULL, /* Setup function. */
+                     NULL,
+                     &standard_out,
+                     &standard_err,
+                     &exit_status,
+                     NULL)
        == FALSE)
       || (WIFEXITED (exit_status) == 0) || WEXITSTATUS (exit_status))
     {
       g_debug ("%s: failed to transform the xml: %d (WIF %i, WEX %i)",
-               __FUNCTION__, exit_status, WIFEXITED (exit_status),
+               __FUNCTION__,
+               exit_status,
+               WIFEXITED (exit_status),
                WEXITSTATUS (exit_status));
       g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);
       g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
@@ -7889,7 +8067,8 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count, int preferences,
           while (next (&cert_refs_iterator))
             {
               g_string_append_printf (
-                cert_refs_str, "<cert_ref type=\"CERT-Bund\" id=\"%s\"/>",
+                cert_refs_str,
+                "<cert_ref type=\"CERT-Bund\" id=\"%s\"/>",
                 get_iterator_name (&cert_refs_iterator));
             }
           cleanup_iterator (&cert_refs_iterator);
@@ -7919,8 +8098,8 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count, int preferences,
                                   "<count>%i</count>",
                                   tag_count);
 
-          init_resource_tag_iterator (&tags, "nvt",
-                                      get_iterator_resource (nvts), 1, NULL, 1);
+          init_resource_tag_iterator (
+            &tags, "nvt", get_iterator_resource (nvts), 1, NULL, 1);
           while (next (&tags))
             {
               tag_name_esc =
@@ -7936,7 +8115,8 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count, int preferences,
                                       "<comment>%s</comment>"
                                       "</tag>",
                                       resource_tag_iterator_uuid (&tags),
-                                      tag_name_esc, tag_value_esc,
+                                      tag_name_esc,
+                                      tag_value_esc,
                                       tag_comment_esc);
               g_free (tag_name_esc);
               g_free (tag_value_esc);
@@ -7970,17 +8150,26 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count, int preferences,
         "<preference_count>%i</preference_count>"
         "<timeout>%s</timeout>"
         "<default_timeout>%s</default_timeout>",
-        oid, name_text,
+        oid,
+        name_text,
         get_iterator_creation_time (nvts) ? get_iterator_creation_time (nvts)
                                           : "",
         get_iterator_modification_time (nvts)
           ? get_iterator_modification_time (nvts)
           : "",
-        tags_str->str, nvt_iterator_category (nvts), family_text,
+        tags_str->str,
+        nvt_iterator_category (nvts),
+        family_text,
         nvt_iterator_cvss_base (nvts) ? nvt_iterator_cvss_base (nvts) : "",
-        nvt_iterator_qod (nvts), nvt_iterator_qod_type (nvts),
-        nvt_iterator_cve (nvts), nvt_iterator_bid (nvts), cert_refs_str->str,
-        xref_text, tag_text, pref_count, timeout ? timeout : "",
+        nvt_iterator_qod (nvts),
+        nvt_iterator_qod_type (nvts),
+        nvt_iterator_cve (nvts),
+        nvt_iterator_bid (nvts),
+        cert_refs_str->str,
+        xref_text,
+        tag_text,
+        pref_count,
+        timeout ? timeout : "",
         default_timeout ? default_timeout : "");
       g_free (family_text);
       g_free (xref_text);
@@ -8023,13 +8212,17 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count, int preferences,
         {
           msg = g_strdup_printf ("<nvt oid=\"%s\"><name>%s</name>"
                                  "<user_tags><count>%i</count></user_tags>%s",
-                                 oid, name_text, tag_count,
+                                 oid,
+                                 name_text,
+                                 tag_count,
                                  close_tag ? "</nvt>" : "");
         }
       else
         {
-          msg = g_strdup_printf ("<nvt oid=\"%s\"><name>%s</name>%s", oid,
-                                 name_text, close_tag ? "</nvt>" : "");
+          msg = g_strdup_printf ("<nvt oid=\"%s\"><name>%s</name>%s",
+                                 oid,
+                                 name_text,
+                                 close_tag ? "</nvt>" : "");
         }
     }
   g_free (name_text);
@@ -8052,14 +8245,16 @@ manage_scap_update_time ()
   /* Read in the contents. */
 
   error = NULL;
-  if (g_file_get_contents (SCAP_TIMESTAMP_FILENAME, &content, &content_size,
-                           &error)
+  if (g_file_get_contents (
+        SCAP_TIMESTAMP_FILENAME, &content, &content_size, &error)
       == FALSE)
     {
       if (error)
         {
-          g_debug ("%s: failed to read %s: %s", __FUNCTION__,
-                   SCAP_TIMESTAMP_FILENAME, error->message);
+          g_debug ("%s: failed to read %s: %s",
+                   __FUNCTION__,
+                   SCAP_TIMESTAMP_FILENAME,
+                   error->message);
           g_error_free (error);
         }
       return "";
@@ -8130,12 +8325,13 @@ manage_read_info (gchar *type, gchar *uid, gchar *name, gchar **result)
           init_nvt_iterator (&nvts, nvt, 0, NULL, NULL, 0, NULL);
 
           if (next (&nvts))
-            *result = get_nvti_xml (&nvts, 1, /* Include details. */
-                                    0,        /* Preference count. */
-                                    1,        /* Include preferences. */
-                                    NULL,     /* Timeout. */
-                                    0,        /* Config. */
-                                    1);       /* Close tag. */
+            *result = get_nvti_xml (&nvts,
+                                    1,    /* Include details. */
+                                    0,    /* Preference count. */
+                                    1,    /* Include preferences. */
+                                    NULL, /* Timeout. */
+                                    0,    /* Config. */
+                                    1);   /* Close tag. */
 
           cleanup_iterator (&nvts);
         }
@@ -8251,8 +8447,16 @@ gvm_sync_script_perform_selftest (const gchar *sync_script, gchar **result)
   gint script_exit;
   GError *error = NULL;
 
-  if (!g_spawn_sync (script_working_dir, argv, NULL, 0, NULL, NULL, &script_out,
-                     &script_err, &script_exit, &error))
+  if (!g_spawn_sync (script_working_dir,
+                     argv,
+                     NULL,
+                     0,
+                     NULL,
+                     NULL,
+                     &script_out,
+                     &script_err,
+                     &script_exit,
+                     &error))
     {
       if (*result != NULL)
         {
@@ -8325,8 +8529,16 @@ gvm_get_sync_script_identification (const gchar *sync_script,
 
   gchar **script_identification;
 
-  if (!g_spawn_sync (script_working_dir, argv, NULL, 0, NULL, NULL, &script_out,
-                     &script_err, &script_exit, &error))
+  if (!g_spawn_sync (script_working_dir,
+                     argv,
+                     NULL,
+                     0,
+                     NULL,
+                     NULL,
+                     &script_out,
+                     &script_err,
+                     &script_exit,
+                     &error))
     {
       g_warning ("Failed to execute %s: %s", sync_script, error->message);
 
@@ -8360,8 +8572,8 @@ gvm_get_sync_script_identification (const gchar *sync_script,
           && g_ascii_strncasecmp (script_identification[0], "SCAPSYNC", 7))
       || (feed_type == CERT_FEED
           && g_ascii_strncasecmp (script_identification[0], "CERTSYNC", 7))
-      || g_ascii_strncasecmp (script_identification[0],
-                              script_identification[5], 7))
+      || g_ascii_strncasecmp (
+           script_identification[0], script_identification[5], 7))
     {
       g_warning ("%s is not a feed synchronization script", sync_script);
 
@@ -8415,8 +8627,16 @@ gvm_get_sync_script_description (const gchar *sync_script, gchar **description)
   gint script_exit;
   GError *error = NULL;
 
-  if (!g_spawn_sync (script_working_dir, argv, NULL, 0, NULL, NULL, &script_out,
-                     &script_err, &script_exit, &error))
+  if (!g_spawn_sync (script_working_dir,
+                     argv,
+                     NULL,
+                     0,
+                     NULL,
+                     NULL,
+                     &script_out,
+                     &script_err,
+                     &script_exit,
+                     &error))
     {
       g_warning ("Failed to execute %s: %s", sync_script, error->message);
 
@@ -8480,8 +8700,16 @@ gvm_get_sync_script_feed_version (const gchar *sync_script,
   gint script_exit;
   GError *error = NULL;
 
-  if (!g_spawn_sync (script_working_dir, argv, NULL, 0, NULL, NULL, &script_out,
-                     &script_err, &script_exit, &error))
+  if (!g_spawn_sync (script_working_dir,
+                     argv,
+                     NULL,
+                     0,
+                     NULL,
+                     NULL,
+                     &script_out,
+                     &script_err,
+                     &script_exit,
+                     &error))
     {
       g_warning ("Failed to execute %s: %s", sync_script, error->message);
 
@@ -8546,13 +8774,14 @@ gvm_migrate_secinfo (int feed_type)
 
   lockfile_name = g_build_filename (g_get_tmp_dir (), lockfile_basename, NULL);
 
-  lockfile = open (lockfile_name, O_RDWR | O_CREAT | O_APPEND,
+  lockfile = open (lockfile_name,
+                   O_RDWR | O_CREAT | O_APPEND,
                    /* "-rw-r--r--" */
                    S_IWUSR | S_IRUSR | S_IROTH | S_IRGRP);
   if (lockfile == -1)
     {
-      g_warning ("Failed to open lock file '%s': %s", lockfile_name,
-                 strerror (errno));
+      g_warning (
+        "Failed to open lock file '%s': %s", lockfile_name, strerror (errno));
       g_free (lockfile_name);
       return -1;
     }
@@ -8562,15 +8791,16 @@ gvm_migrate_secinfo (int feed_type)
       if (errno == EWOULDBLOCK)
         {
           if (close (lockfile))
-            g_warning ("%s: failed to close lockfile: %s", __FUNCTION__,
+            g_warning ("%s: failed to close lockfile: %s",
+                       __FUNCTION__,
                        strerror (errno));
           g_free (lockfile_name);
           return 1;
         }
       g_debug ("%s: flock: %s", __FUNCTION__, strerror (errno));
       if (close (lockfile))
-        g_warning ("%s: failed to close lockfile: %s", __FUNCTION__,
-                   strerror (errno));
+        g_warning (
+          "%s: failed to close lockfile: %s", __FUNCTION__, strerror (errno));
       g_free (lockfile_name);
       return -1;
     }
@@ -8666,8 +8896,8 @@ manage_run_wizard (const gchar *wizard_name,
   g_free (file);
   if (get_error)
     {
-      g_warning ("%s: Failed to read wizard: %s", __FUNCTION__,
-                 get_error->message);
+      g_warning (
+        "%s: Failed to read wizard: %s", __FUNCTION__, get_error->message);
       g_error_free (get_error);
       return -1;
     }
@@ -8796,7 +9026,8 @@ manage_run_wizard (const gchar *wizard_name,
                           *command_error =
                             g_strdup_printf ("Value '%s' is not valid for"
                                              " parameter '%s'.",
-                                             pair->value, name);
+                                             pair->value,
+                                             name);
                           free_entity (entity);
                           g_string_free (params_xml, TRUE);
                           return 6;
@@ -8933,7 +9164,8 @@ manage_run_wizard (const gchar *wizard_name,
                        "</previous>"
                        "</wizard>\n",
                        params_xml->str ? params_xml->str : "",
-                       response ? response : "", extra ? extra : "")
+                       response ? response : "",
+                       extra ? extra : "")
               < 0)
             {
               fclose (xsl_file);
@@ -9138,7 +9370,8 @@ manage_run_wizard (const gchar *wizard_name,
                            "</previous>"
                            "</wizard>\n",
                            params_xml->str ? params_xml->str : "",
-                           response ? response : "", extra ? extra : "")
+                           response ? response : "",
+                           extra ? extra : "")
                   < 0)
                 {
                   fclose (xsl_file);
@@ -9156,8 +9389,8 @@ manage_run_wizard (const gchar *wizard_name,
               fflush (xml_file);
 
               g_free (extra);
-              extra = xsl_transform (extra_xsl_file_name, extra_xml_file_name,
-                                     NULL, NULL);
+              extra = xsl_transform (
+                extra_xsl_file_name, extra_xml_file_name, NULL, NULL);
               fclose (xsl_file);
               unlink (extra_xsl_file_name);
               fclose (xml_file);

--- a/src/manage.c
+++ b/src/manage.c
@@ -45,24 +45,32 @@
 #define _GNU_SOURCE
 
 #include "manage.h"
-#include "scanner.h"
+
+#include "comm.h"
 #include "manage_acl.h"
 #include "manage_sql.h"
-#include "manage_sql_secinfo.h"
 #include "manage_sql_nvts.h"
+#include "manage_sql_secinfo.h"
 #include "manage_sql_tickets.h"
-#include "comm.h"
+#include "scanner.h"
 #include "utils.h"
 
 #include <assert.h>
 #include <ctype.h>
-#include <errno.h>
 #include <dirent.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <glib.h>
 #include <gnutls/x509.h> /* for gnutls_x509_crt_... */
-#include <math.h>
+#include <gvm/base/cvss.h>
+#include <gvm/base/hosts.h>
+#include <gvm/base/proctitle.h>
+#include <gvm/gmp/gmp.h>
+#include <gvm/util/fileutils.h>
+#include <gvm/util/serverutils.h>
+#include <gvm/util/uuidutils.h>
 #include <locale.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -73,14 +81,6 @@
 #include <sys/wait.h>
 #include <time.h>
 #include <unistd.h>
-
-#include <gvm/base/cvss.h>
-#include <gvm/base/hosts.h>
-#include <gvm/base/proctitle.h>
-#include <gvm/util/fileutils.h>
-#include <gvm/util/serverutils.h>
-#include <gvm/util/uuidutils.h>
-#include <gvm/gmp/gmp.h>
 
 #undef G_LOG_DOMAIN
 /**
@@ -167,7 +167,6 @@ extern volatile int termination_signal;
  */
 static int schedule_timeout = SCHEDULE_TIMEOUT_DEFAULT;
 
-
 /* Certificate and key management. */
 
 /**
@@ -178,7 +177,7 @@ static int schedule_timeout = SCHEDULE_TIMEOUT_DEFAULT;
  * @return  The truncated certificate as a newly allocated string or NULL.
  */
 gchar *
-truncate_certificate (const gchar* certificate)
+truncate_certificate (const gchar *certificate)
 {
   GString *cert_buffer;
   gchar *current_pos, *cert_start, *cert_end;
@@ -190,12 +189,10 @@ truncate_certificate (const gchar* certificate)
     {
       cert_start = NULL;
       cert_end = NULL;
-      if (g_str_has_prefix (current_pos,
-                            "-----BEGIN CERTIFICATE-----"))
+      if (g_str_has_prefix (current_pos, "-----BEGIN CERTIFICATE-----"))
         {
           cert_start = current_pos;
-          cert_end = strstr (cert_start,
-                             "-----END CERTIFICATE-----");
+          cert_end = strstr (cert_start, "-----END CERTIFICATE-----");
           if (cert_end)
             cert_end += strlen ("-----END CERTIFICATE-----");
           else
@@ -205,19 +202,16 @@ truncate_certificate (const gchar* certificate)
                                  "-----BEGIN TRUSTED CERTIFICATE-----"))
         {
           cert_start = current_pos;
-          cert_end = strstr (cert_start,
-                             "-----END TRUSTED CERTIFICATE-----");
+          cert_end = strstr (cert_start, "-----END TRUSTED CERTIFICATE-----");
           if (cert_end)
             cert_end += strlen ("-----END TRUSTED CERTIFICATE-----");
           else
             done = TRUE;
         }
-      else if (g_str_has_prefix (current_pos,
-                                 "-----BEGIN PKCS7-----"))
+      else if (g_str_has_prefix (current_pos, "-----BEGIN PKCS7-----"))
         {
           cert_start = current_pos;
-          cert_end = strstr (cert_start,
-                             "-----END PKCS7-----");
+          cert_end = strstr (cert_start, "-----END PKCS7-----");
           if (cert_end)
             cert_end += strlen ("-----END PKCS7-----");
           else
@@ -243,7 +237,7 @@ truncate_certificate (const gchar* certificate)
  * @return  The truncated private key as a newly allocated string or NULL.
  */
 gchar *
-truncate_private_key (const gchar* private_key)
+truncate_private_key (const gchar *private_key)
 {
   gchar *key_start, *key_end;
   key_end = NULL;
@@ -307,9 +301,9 @@ truncate_private_key (const gchar* private_key)
  * @return 0 success, -1 error.
  */
 int
-get_certificate_info (const gchar* certificate,
-                      time_t* activation_time, time_t* expiration_time,
-                      gchar** fingerprint, gchar** issuer)
+get_certificate_info (const gchar *certificate, time_t *activation_time,
+                      time_t *expiration_time, gchar **fingerprint,
+                      gchar **issuer)
 {
   gchar *cert_truncated;
 
@@ -334,12 +328,12 @@ get_certificate_info (const gchar* certificate,
         {
           return -1;
         }
-      cert_datum.data = (unsigned char*) cert_truncated;
+      cert_datum.data = (unsigned char *) cert_truncated;
       cert_datum.size = strlen (cert_truncated);
 
       gnutls_x509_crt_init (&gnutls_cert);
-      err = gnutls_x509_crt_import (gnutls_cert, &cert_datum,
-                                    GNUTLS_X509_FMT_PEM);
+      err =
+        gnutls_x509_crt_import (gnutls_cert, &cert_datum, GNUTLS_X509_FMT_PEM);
       if (err)
         {
           g_free (cert_truncated);
@@ -348,14 +342,12 @@ get_certificate_info (const gchar* certificate,
 
       if (activation_time)
         {
-          *activation_time
-            = gnutls_x509_crt_get_activation_time (gnutls_cert);
+          *activation_time = gnutls_x509_crt_get_activation_time (gnutls_cert);
         }
 
       if (expiration_time)
         {
-          *expiration_time
-            = gnutls_x509_crt_get_expiration_time (gnutls_cert);
+          *expiration_time = gnutls_x509_crt_get_expiration_time (gnutls_cert);
         }
 
       if (fingerprint)
@@ -367,8 +359,8 @@ get_certificate_info (const gchar* certificate,
 
           string = g_string_new ("");
 
-          gnutls_x509_crt_get_fingerprint (gnutls_cert, GNUTLS_DIG_MD5,
-                                           buffer, &buffer_size);
+          gnutls_x509_crt_get_fingerprint (gnutls_cert, GNUTLS_DIG_MD5, buffer,
+                                           &buffer_size);
 
           for (i = 0; i < buffer_size; i++)
             {
@@ -442,7 +434,6 @@ certificate_time_status (time_t activates, time_t expires)
     return "valid";
 }
 
-
 /* Helpers. */
 
 /**
@@ -483,15 +474,14 @@ truncate_text (gchar *string, size_t max_len, gboolean xml, const char *suffix)
           //  move the offset to the start of that entity.
           ssize_t entity_start_offset = offset;
 
-          while (entity_start_offset >= 0 
-                 && string[entity_start_offset] != '&')
+          while (entity_start_offset >= 0 && string[entity_start_offset] != '&')
             {
-              entity_start_offset --;
+              entity_start_offset--;
             }
 
           if (entity_start_offset >= 0)
             {
-              char *entity_end = strchr(string + entity_start_offset, ';');
+              char *entity_end = strchr (string + entity_start_offset, ';');
               if (entity_end && (entity_end - string) >= offset)
                 offset = entity_start_offset;
             }
@@ -532,8 +522,7 @@ xml_escape_text_truncated (const char *string, size_t max_len,
       gchar *offset_next;
       ssize_t offset;
 
-      offset_next = g_utf8_find_next_char (string + max_len,
-                                           string + orig_len);
+      offset_next = g_utf8_find_next_char (string + max_len, string + orig_len);
       offset = offset_next - string;
       escaped = g_markup_escape_text (string, offset);
     }
@@ -548,7 +537,7 @@ xml_escape_text_truncated (const char *string, size_t max_len,
  * @param[in]  list  The list.
  */
 static void
-slist_free (GSList* list)
+slist_free (GSList *list)
 {
   GSList *head = list;
   while (list)
@@ -567,7 +556,7 @@ slist_free (GSList* list)
  * @return Plural name of type.
  */
 const char *
-type_name_plural (const char* type)
+type_name_plural (const char *type)
 {
   if (type == NULL)
     return "ERROR";
@@ -596,7 +585,7 @@ type_name_plural (const char* type)
  * @return Name of type.
  */
 const char *
-type_name (const char* type)
+type_name (const char *type)
 {
   if (type == NULL)
     return "ERROR";
@@ -625,10 +614,9 @@ type_name (const char* type)
  * @return Name of type.
  */
 int
-type_is_scap (const char* type)
+type_is_scap (const char *type)
 {
-  return (strcasecmp (type, "cpe") == 0)
-         || (strcasecmp (type, "cve") == 0)
+  return (strcasecmp (type, "cpe") == 0) || (strcasecmp (type, "cve") == 0)
          || (strcasecmp (type, "ovaldef") == 0);
 }
 
@@ -666,7 +654,6 @@ check_available (const gchar *type, resource_t resource,
   return -1;
 }
 
-
 /* Severity related functions. */
 
 /**
@@ -770,7 +757,7 @@ severity_in_level (double severity, const char *level)
         return severity >= 4 && severity < 7;
       else if (strcmp (level, "low") == 0)
         return severity > 0 && severity < 4;
-      else if (strcmp (level, "none") == 0  || strcmp (level, "log") == 0)
+      else if (strcmp (level, "none") == 0 || strcmp (level, "log") == 0)
         return severity == 0;
       else
         return 0;
@@ -804,7 +791,7 @@ severity_matches_ov (double severity, double ov_severity)
  *
  * @return the level as a static string
  */
-const char*
+const char *
 severity_to_level (double severity, int mode)
 {
   if (severity == SEVERITY_LOG)
@@ -830,8 +817,8 @@ severity_to_level (double severity, int mode)
     }
   else
     {
-      g_warning ("%s: Invalid severity score given: %f",
-                 __FUNCTION__, severity);
+      g_warning ("%s: Invalid severity score given: %f", __FUNCTION__,
+                 severity);
       return (NULL);
     }
 }
@@ -843,7 +830,7 @@ severity_to_level (double severity, int mode)
  *
  * @return the message type as a static string
  */
-const char*
+const char *
 severity_to_type (double severity)
 {
   if (severity == SEVERITY_LOG)
@@ -858,13 +845,12 @@ severity_to_type (double severity)
     return "Alarm";
   else
     {
-      g_warning ("%s: Invalid severity score given: %f",
-                 __FUNCTION__, severity);
+      g_warning ("%s: Invalid severity score given: %f", __FUNCTION__,
+                 severity);
       return (NULL);
     }
 }
 
-
 /* Credentials. */
 
 /**
@@ -872,7 +858,6 @@ severity_to_type (double severity)
  */
 credentials_t current_credentials;
 
-
 /* Reports. */
 
 /**
@@ -913,15 +898,13 @@ delete_reports (task_t task)
  * @return Filter term.
  */
 static gchar *
-report_results_filter_term (int first, int rows,
-                            int apply_overrides, int autofp, int min_qod)
+report_results_filter_term (int first, int rows, int apply_overrides,
+                            int autofp, int min_qod)
 {
   return g_strdup_printf ("first=%d rows=%d"
                           " apply_overrides=%d autofp=%d min_qod=%d",
-                          first, rows,
-                          apply_overrides, autofp, min_qod);
+                          first, rows, apply_overrides, autofp, min_qod);
 }
-
 
 /**
  * @brief Create a new basic get_data_t struct to get report results.
@@ -934,15 +917,15 @@ report_results_filter_term (int first, int rows,
  *
  * @return GET data struct.
  */
-get_data_t*
-report_results_get_data (int first, int rows,
-                         int apply_overrides, int autofp, int min_qod)
+get_data_t *
+report_results_get_data (int first, int rows, int apply_overrides, int autofp,
+                         int min_qod)
 {
-  get_data_t* get = g_malloc (sizeof (get_data_t));
+  get_data_t *get = g_malloc (sizeof (get_data_t));
   memset (get, 0, sizeof (get_data_t));
   get->type = g_strdup ("result");
-  get->filter = report_results_filter_term (first, rows,
-                                            apply_overrides, autofp, min_qod);
+  get->filter =
+    report_results_filter_term (first, rows, apply_overrides, autofp, min_qod);
 
   return get;
 }
@@ -964,10 +947,11 @@ severity_data_index (double severity)
 {
   int ret;
   if (severity >= 0.0)
-    ret = (int)(round (severity * SEVERITY_SUBDIVISIONS)) + ZERO_SEVERITY_INDEX;
+    ret =
+      (int) (round (severity * SEVERITY_SUBDIVISIONS)) + ZERO_SEVERITY_INDEX;
   else if (severity == SEVERITY_FP || severity == SEVERITY_DEBUG
            || severity == SEVERITY_ERROR)
-    ret = (int)(round (severity)) + ZERO_SEVERITY_INDEX;
+    ret = (int) (round (severity)) + ZERO_SEVERITY_INDEX;
   else
     ret = 0;
 
@@ -987,8 +971,8 @@ severity_data_value (int index)
   double ret;
   if (index <= ZERO_SEVERITY_INDEX && index > 0)
     ret = ((double) index) - ZERO_SEVERITY_INDEX;
-  else if (index <= (ZERO_SEVERITY_INDEX
-                     + (SEVERITY_SUBDIVISIONS * SEVERITY_MAX)))
+  else if (index
+           <= (ZERO_SEVERITY_INDEX + (SEVERITY_SUBDIVISIONS * SEVERITY_MAX)))
     ret = (((double) (index - ZERO_SEVERITY_INDEX)) / SEVERITY_SUBDIVISIONS);
   else
     ret = SEVERITY_MISSING;
@@ -1002,7 +986,7 @@ severity_data_value (int index)
  * @param[in] data  The data structure to initialize.
  */
 void
-init_severity_data (severity_data_t* data)
+init_severity_data (severity_data_t *data)
 {
   int max_i;
   max_i = ZERO_SEVERITY_INDEX + (SEVERITY_SUBDIVISIONS * SEVERITY_MAX);
@@ -1019,7 +1003,7 @@ init_severity_data (severity_data_t* data)
  * @param[in] data  The data structure to initialize.
  */
 void
-cleanup_severity_data (severity_data_t* data)
+cleanup_severity_data (severity_data_t *data)
 {
   g_free (data->counts);
 }
@@ -1031,7 +1015,7 @@ cleanup_severity_data (severity_data_t* data)
  * @param[in]   severity        The severity to add.
  */
 void
-severity_data_add (severity_data_t* severity_data, double severity)
+severity_data_add (severity_data_t *severity_data, double severity)
 {
   (severity_data->counts)[severity_data_index (severity)]++;
 
@@ -1042,14 +1026,15 @@ severity_data_add (severity_data_t* severity_data, double severity)
 }
 
 /**
- * @brief Add a multiple severity occurrences to the counts of a severity_data_t.
+ * @brief Add a multiple severity occurrences to the counts of a
+ * severity_data_t.
  *
  * @param[in]   severity_data   The severity count struct to add to.
  * @param[in]   severity        The severity to add.
  * @param[in]   count           The number of occurrences to add.
  */
 void
-severity_data_add_count (severity_data_t* severity_data, double severity,
+severity_data_add_count (severity_data_t *severity_data, double severity,
                          int count)
 {
   (severity_data->counts)[severity_data_index (severity)] += count;
@@ -1070,7 +1055,7 @@ severity_data_add_count (severity_data_t* severity_data, double severity,
  * @return     The total of severity counts in the specified range.
  */
 static int
-severity_data_range_count (const severity_data_t* severity_data,
+severity_data_range_count (const severity_data_t *severity_data,
                            double min_severity, double max_severity)
 {
   int i, i_max, count;
@@ -1078,9 +1063,7 @@ severity_data_range_count (const severity_data_t* severity_data,
   i_max = severity_data_index (max_severity);
   count = 0;
 
-  for (i = severity_data_index (min_severity);
-       i <= i_max;
-       i++)
+  for (i = severity_data_index (min_severity); i <= i_max; i++)
     {
       count += (severity_data->counts)[i];
     }
@@ -1102,68 +1085,46 @@ severity_data_range_count (const severity_data_t* severity_data,
  */
 void
 severity_data_level_counts (const severity_data_t *severity_data,
-                            const gchar *severity_class,
-                            int *errors, int *debugs, int *false_positives,
-                            int *logs, int *lows, int *mediums, int *highs)
+                            const gchar *severity_class, int *errors,
+                            int *debugs, int *false_positives, int *logs,
+                            int *lows, int *mediums, int *highs)
 {
   if (errors)
-    *errors
-      = severity_data_range_count (severity_data,
-                                   level_min_severity ("Error",
-                                                       severity_class),
-                                   level_max_severity ("Error",
-                                                       severity_class));
+    *errors = severity_data_range_count (
+      severity_data, level_min_severity ("Error", severity_class),
+      level_max_severity ("Error", severity_class));
 
   if (debugs)
-    *debugs
-      = severity_data_range_count (severity_data,
-                                   level_min_severity ("Debug",
-                                                       severity_class),
-                                   level_max_severity ("Debug",
-                                                       severity_class));
+    *debugs = severity_data_range_count (
+      severity_data, level_min_severity ("Debug", severity_class),
+      level_max_severity ("Debug", severity_class));
 
   if (false_positives)
-    *false_positives
-      = severity_data_range_count (severity_data,
-                                   level_min_severity ("False Positive",
-                                                       severity_class),
-                                   level_max_severity ("False Positive",
-                                                       severity_class));
+    *false_positives = severity_data_range_count (
+      severity_data, level_min_severity ("False Positive", severity_class),
+      level_max_severity ("False Positive", severity_class));
 
   if (logs)
-    *logs
-      = severity_data_range_count (severity_data,
-                                   level_min_severity ("Log",
-                                                       severity_class),
-                                   level_max_severity ("Log",
-                                                       severity_class));
+    *logs = severity_data_range_count (
+      severity_data, level_min_severity ("Log", severity_class),
+      level_max_severity ("Log", severity_class));
 
   if (lows)
-    *lows
-      = severity_data_range_count (severity_data,
-                                   level_min_severity ("low",
-                                                       severity_class),
-                                   level_max_severity ("low",
-                                                       severity_class));
+    *lows = severity_data_range_count (
+      severity_data, level_min_severity ("low", severity_class),
+      level_max_severity ("low", severity_class));
 
   if (mediums)
-    *mediums
-      = severity_data_range_count (severity_data,
-                                   level_min_severity ("medium",
-                                                       severity_class),
-                                   level_max_severity ("medium",
-                                                       severity_class));
+    *mediums = severity_data_range_count (
+      severity_data, level_min_severity ("medium", severity_class),
+      level_max_severity ("medium", severity_class));
 
   if (highs)
-    *highs
-      = severity_data_range_count (severity_data,
-                                   level_min_severity ("high",
-                                                       severity_class),
-                                   level_max_severity ("high",
-                                                       severity_class));
+    *highs = severity_data_range_count (
+      severity_data, level_min_severity ("high", severity_class),
+      level_max_severity ("high", severity_class));
 }
 
-
 /* Task globals. */
 
 /**
@@ -1176,7 +1137,6 @@ task_t current_scanner_task = (task_t) 0;
  */
 report_t global_current_report = (report_t) 0;
 
-
 /* Alerts. */
 
 /**
@@ -1220,23 +1180,23 @@ alert_report_data_reset (alert_report_data_t *data)
  *
  * @return The name of the condition (for example, "Always").
  */
-const char*
+const char *
 alert_condition_name (alert_condition_t condition)
 {
   switch (condition)
     {
-      case ALERT_CONDITION_ALWAYS:
-        return "Always";
-      case ALERT_CONDITION_FILTER_COUNT_AT_LEAST:
-        return "Filter count at least";
-      case ALERT_CONDITION_FILTER_COUNT_CHANGED:
-        return "Filter count changed";
-      case ALERT_CONDITION_SEVERITY_AT_LEAST:
-        return "Severity at least";
-      case ALERT_CONDITION_SEVERITY_CHANGED:
-        return "Severity changed";
-      default:
-        return "Internal Error";
+    case ALERT_CONDITION_ALWAYS:
+      return "Always";
+    case ALERT_CONDITION_FILTER_COUNT_AT_LEAST:
+      return "Filter count at least";
+    case ALERT_CONDITION_FILTER_COUNT_CHANGED:
+      return "Filter count changed";
+    case ALERT_CONDITION_SEVERITY_AT_LEAST:
+      return "Severity at least";
+    case ALERT_CONDITION_SEVERITY_CHANGED:
+      return "Severity changed";
+    default:
+      return "Internal Error";
     }
 }
 
@@ -1247,18 +1207,25 @@ alert_condition_name (alert_condition_t condition)
  *
  * @return The name of the event (for example, "Run status changed").
  */
-const char*
+const char *
 event_name (event_t event)
 {
   switch (event)
     {
-      case EVENT_TASK_RUN_STATUS_CHANGED: return "Task run status changed";
-      case EVENT_NEW_SECINFO:             return "New SecInfo arrived";
-      case EVENT_UPDATED_SECINFO:         return "Updated SecInfo arrived";
-      case EVENT_TICKET_RECEIVED:         return "Ticket received";
-      case EVENT_ASSIGNED_TICKET_CHANGED: return "Assigned ticket changed";
-      case EVENT_OWNED_TICKET_CHANGED:    return "Owned ticket changed";
-      default:                            return "Internal Error";
+    case EVENT_TASK_RUN_STATUS_CHANGED:
+      return "Task run status changed";
+    case EVENT_NEW_SECINFO:
+      return "New SecInfo arrived";
+    case EVENT_UPDATED_SECINFO:
+      return "Updated SecInfo arrived";
+    case EVENT_TICKET_RECEIVED:
+      return "Ticket received";
+    case EVENT_ASSIGNED_TICKET_CHANGED:
+      return "Assigned ticket changed";
+    case EVENT_OWNED_TICKET_CHANGED:
+      return "Owned ticket changed";
+    default:
+      return "Internal Error";
     }
 }
 
@@ -1270,45 +1237,42 @@ event_name (event_t event)
  *
  * @return Freshly allocated description of condition.
  */
-gchar*
-alert_condition_description (alert_condition_t condition,
-                             alert_t alert)
+gchar *
+alert_condition_description (alert_condition_t condition, alert_t alert)
 {
   switch (condition)
     {
-      case ALERT_CONDITION_ALWAYS:
-        return g_strdup ("Always");
-      case ALERT_CONDITION_FILTER_COUNT_AT_LEAST:
-        {
-          char *level;
-          gchar *ret;
+    case ALERT_CONDITION_ALWAYS:
+      return g_strdup ("Always");
+    case ALERT_CONDITION_FILTER_COUNT_AT_LEAST:
+      {
+        char *level;
+        gchar *ret;
 
-          level = alert_data (alert, "condition", "severity");
-          ret = g_strdup_printf ("Filter count at least %s",
-                                 level ? level : "0");
-          free (level);
-          return ret;
-        }
-      case ALERT_CONDITION_FILTER_COUNT_CHANGED:
-        return g_strdup ("Filter count changed");
-      case ALERT_CONDITION_SEVERITY_AT_LEAST:
-        {
-          char *level = alert_data (alert, "condition", "severity");
-          gchar *ret = g_strdup_printf ("Task severity is at least '%s'",
-                                        level);
-          free (level);
-          return ret;
-        }
-      case ALERT_CONDITION_SEVERITY_CHANGED:
-        {
-          char *direction;
-          direction = alert_data (alert, "condition", "direction");
-          gchar *ret = g_strdup_printf ("Task severity %s", direction);
-          free (direction);
-          return ret;
-        }
-      default:
-        return g_strdup ("Internal Error");
+        level = alert_data (alert, "condition", "severity");
+        ret = g_strdup_printf ("Filter count at least %s", level ? level : "0");
+        free (level);
+        return ret;
+      }
+    case ALERT_CONDITION_FILTER_COUNT_CHANGED:
+      return g_strdup ("Filter count changed");
+    case ALERT_CONDITION_SEVERITY_AT_LEAST:
+      {
+        char *level = alert_data (alert, "condition", "severity");
+        gchar *ret = g_strdup_printf ("Task severity is at least '%s'", level);
+        free (level);
+        return ret;
+      }
+    case ALERT_CONDITION_SEVERITY_CHANGED:
+      {
+        char *direction;
+        direction = alert_data (alert, "condition", "direction");
+        gchar *ret = g_strdup_printf ("Task severity %s", direction);
+        free (direction);
+        return ret;
+      }
+    default:
+      return g_strdup ("Internal Error");
     }
 }
 
@@ -1321,37 +1285,36 @@ alert_condition_description (alert_condition_t condition,
  *
  * @return Freshly allocated description of event.
  */
-gchar*
+gchar *
 event_description (event_t event, const void *event_data, const char *task_name)
 {
   switch (event)
     {
-      case EVENT_TASK_RUN_STATUS_CHANGED:
-        if (task_name)
-          return g_strdup_printf
-                  ("The security scan task '%s' changed status to '%s'",
-                   task_name,
-                   run_status_name ((task_status_t) event_data));
-        return g_strdup_printf ("Task status changed to '%s'",
-                                run_status_name ((task_status_t) event_data));
-        break;
-      case EVENT_NEW_SECINFO:
-        return g_strdup_printf ("New SecInfo arrived");
-        break;
-      case EVENT_UPDATED_SECINFO:
-        return g_strdup_printf ("Updated SecInfo arrived");
-        break;
-      case EVENT_TICKET_RECEIVED:
-        return g_strdup_printf ("Ticket received");
-        break;
-      case EVENT_ASSIGNED_TICKET_CHANGED:
-        return g_strdup_printf ("Assigned ticket changed");
-        break;
-      case EVENT_OWNED_TICKET_CHANGED:
-        return g_strdup_printf ("Owned ticket changed");
-        break;
-      default:
-        return g_strdup ("Internal Error");
+    case EVENT_TASK_RUN_STATUS_CHANGED:
+      if (task_name)
+        return g_strdup_printf (
+          "The security scan task '%s' changed status to '%s'", task_name,
+          run_status_name ((task_status_t) event_data));
+      return g_strdup_printf ("Task status changed to '%s'",
+                              run_status_name ((task_status_t) event_data));
+      break;
+    case EVENT_NEW_SECINFO:
+      return g_strdup_printf ("New SecInfo arrived");
+      break;
+    case EVENT_UPDATED_SECINFO:
+      return g_strdup_printf ("Updated SecInfo arrived");
+      break;
+    case EVENT_TICKET_RECEIVED:
+      return g_strdup_printf ("Ticket received");
+      break;
+    case EVENT_ASSIGNED_TICKET_CHANGED:
+      return g_strdup_printf ("Assigned ticket changed");
+      break;
+    case EVENT_OWNED_TICKET_CHANGED:
+      return g_strdup_printf ("Owned ticket changed");
+      break;
+    default:
+      return g_strdup ("Internal Error");
     }
 }
 
@@ -1362,24 +1325,37 @@ event_description (event_t event, const void *event_data, const char *task_name)
  *
  * @return The name of the method (for example, "Email" or "SNMP").
  */
-const char*
+const char *
 alert_method_name (alert_method_t method)
 {
   switch (method)
     {
-      case ALERT_METHOD_EMAIL:       return "Email";
-      case ALERT_METHOD_HTTP_GET:    return "HTTP Get";
-      case ALERT_METHOD_SCP:         return "SCP";
-      case ALERT_METHOD_SEND:        return "Send";
-      case ALERT_METHOD_SMB:         return "SMB";
-      case ALERT_METHOD_SNMP:        return "SNMP";
-      case ALERT_METHOD_SOURCEFIRE:  return "Sourcefire Connector";
-      case ALERT_METHOD_START_TASK:  return "Start Task";
-      case ALERT_METHOD_SYSLOG:      return "Syslog";
-      case ALERT_METHOD_TIPPINGPOINT:return "TippingPoint SMS";
-      case ALERT_METHOD_VERINICE:    return "verinice Connector";
-      case ALERT_METHOD_VFIRE:       return "Alemba vFire";
-      default:                       return "Internal Error";
+    case ALERT_METHOD_EMAIL:
+      return "Email";
+    case ALERT_METHOD_HTTP_GET:
+      return "HTTP Get";
+    case ALERT_METHOD_SCP:
+      return "SCP";
+    case ALERT_METHOD_SEND:
+      return "Send";
+    case ALERT_METHOD_SMB:
+      return "SMB";
+    case ALERT_METHOD_SNMP:
+      return "SNMP";
+    case ALERT_METHOD_SOURCEFIRE:
+      return "Sourcefire Connector";
+    case ALERT_METHOD_START_TASK:
+      return "Start Task";
+    case ALERT_METHOD_SYSLOG:
+      return "Syslog";
+    case ALERT_METHOD_TIPPINGPOINT:
+      return "TippingPoint SMS";
+    case ALERT_METHOD_VERINICE:
+      return "verinice Connector";
+    case ALERT_METHOD_VFIRE:
+      return "Alemba vFire";
+    default:
+      return "Internal Error";
     }
 }
 
@@ -1391,7 +1367,7 @@ alert_method_name (alert_method_t method)
  * @return The condition.
  */
 alert_condition_t
-alert_condition_from_name (const char* name)
+alert_condition_from_name (const char *name)
 {
   if (strcasecmp (name, "Always") == 0)
     return ALERT_CONDITION_ALWAYS;
@@ -1414,7 +1390,7 @@ alert_condition_from_name (const char* name)
  * @return The event.
  */
 event_t
-event_from_name (const char* name)
+event_from_name (const char *name)
 {
   if (strcasecmp (name, "Task run status changed") == 0)
     return EVENT_TASK_RUN_STATUS_CHANGED;
@@ -1439,7 +1415,7 @@ event_from_name (const char* name)
  * @return The method.
  */
 alert_method_t
-alert_method_from_name (const char* name)
+alert_method_from_name (const char *name)
 {
   if (strcasecmp (name, "Email") == 0)
     return ALERT_METHOD_EMAIL;
@@ -1468,7 +1444,6 @@ alert_method_from_name (const char* name)
   return ALERT_METHOD_ERROR;
 }
 
-
 /* General task facilities. */
 
 /**
@@ -1478,31 +1453,37 @@ alert_method_from_name (const char* name)
  *
  * @return The name of the status (for example, "Done" or "Running").
  */
-const char*
+const char *
 run_status_name (task_status_t status)
 {
   switch (status)
     {
-      case TASK_STATUS_DELETE_REQUESTED:
-      case TASK_STATUS_DELETE_WAITING:
-        return "Delete Requested";
-      case TASK_STATUS_DELETE_ULTIMATE_REQUESTED:
-      case TASK_STATUS_DELETE_ULTIMATE_WAITING:
-        return "Ultimate Delete Requested";
-      case TASK_STATUS_DONE:             return "Done";
-      case TASK_STATUS_NEW:              return "New";
+    case TASK_STATUS_DELETE_REQUESTED:
+    case TASK_STATUS_DELETE_WAITING:
+      return "Delete Requested";
+    case TASK_STATUS_DELETE_ULTIMATE_REQUESTED:
+    case TASK_STATUS_DELETE_ULTIMATE_WAITING:
+      return "Ultimate Delete Requested";
+    case TASK_STATUS_DONE:
+      return "Done";
+    case TASK_STATUS_NEW:
+      return "New";
 
-      case TASK_STATUS_REQUESTED:        return "Requested";
+    case TASK_STATUS_REQUESTED:
+      return "Requested";
 
-      case TASK_STATUS_RUNNING:          return "Running";
+    case TASK_STATUS_RUNNING:
+      return "Running";
 
-      case TASK_STATUS_STOP_REQUESTED_GIVEUP:
-      case TASK_STATUS_STOP_REQUESTED:
-      case TASK_STATUS_STOP_WAITING:
-        return "Stop Requested";
+    case TASK_STATUS_STOP_REQUESTED_GIVEUP:
+    case TASK_STATUS_STOP_REQUESTED:
+    case TASK_STATUS_STOP_WAITING:
+      return "Stop Requested";
 
-      case TASK_STATUS_STOPPED:          return "Stopped";
-      default:                           return "Interrupted";
+    case TASK_STATUS_STOPPED:
+      return "Stopped";
+    default:
+      return "Interrupted";
     }
 }
 
@@ -1513,33 +1494,41 @@ run_status_name (task_status_t status)
  *
  * @return The name of the status (for example, "Done" or "Running").
  */
-const char*
+const char *
 run_status_name_internal (task_status_t status)
 {
   switch (status)
     {
-      case TASK_STATUS_DELETE_REQUESTED: return "Delete Requested";
-      case TASK_STATUS_DELETE_ULTIMATE_REQUESTED:
-        return "Ultimate Delete Requested";
-      case TASK_STATUS_DELETE_ULTIMATE_WAITING:
-        return "Ultimate Delete Waiting";
-      case TASK_STATUS_DELETE_WAITING:   return "Delete Waiting";
-      case TASK_STATUS_DONE:             return "Done";
-      case TASK_STATUS_NEW:              return "New";
+    case TASK_STATUS_DELETE_REQUESTED:
+      return "Delete Requested";
+    case TASK_STATUS_DELETE_ULTIMATE_REQUESTED:
+      return "Ultimate Delete Requested";
+    case TASK_STATUS_DELETE_ULTIMATE_WAITING:
+      return "Ultimate Delete Waiting";
+    case TASK_STATUS_DELETE_WAITING:
+      return "Delete Waiting";
+    case TASK_STATUS_DONE:
+      return "Done";
+    case TASK_STATUS_NEW:
+      return "New";
 
-      case TASK_STATUS_REQUESTED:        return "Requested";
+    case TASK_STATUS_REQUESTED:
+      return "Requested";
 
-      case TASK_STATUS_RUNNING:          return "Running";
+    case TASK_STATUS_RUNNING:
+      return "Running";
 
-      case TASK_STATUS_STOP_REQUESTED_GIVEUP:
-      case TASK_STATUS_STOP_REQUESTED:
-        return "Stop Requested";
+    case TASK_STATUS_STOP_REQUESTED_GIVEUP:
+    case TASK_STATUS_STOP_REQUESTED:
+      return "Stop Requested";
 
-      case TASK_STATUS_STOP_WAITING:
-        return "Stop Waiting";
+    case TASK_STATUS_STOP_WAITING:
+      return "Stop Waiting";
 
-      case TASK_STATUS_STOPPED:          return "Stopped";
-      default:                           return "Interrupted";
+    case TASK_STATUS_STOPPED:
+      return "Stopped";
+    default:
+      return "Interrupted";
     }
 }
 
@@ -1551,16 +1540,16 @@ run_status_name_internal (task_status_t status)
  * @return List of files to send, (NULL if none), data has to be freed with
  *         g_free.
  */
-static GSList*
+static GSList *
 get_files_to_send (task_t task)
 {
   iterator_t files;
-  GSList* filelist = NULL;
+  GSList *filelist = NULL;
 
   init_task_file_iterator (&files, task, NULL);
   while (next (&files))
     {
-      const gchar* file_path = task_file_iterator_name (&files);
+      const gchar *file_path = task_file_iterator_name (&files);
       filelist = g_slist_append (filelist, g_strdup (file_path));
     }
   cleanup_iterator (&files);
@@ -1575,7 +1564,7 @@ get_files_to_send (task_t task)
  *
  * @return A string of semi-colon separated plugin IDS.
  */
-static gchar*
+static gchar *
 nvt_selector_plugins (config_t config)
 {
   GString *plugins;
@@ -1618,8 +1607,8 @@ nvt_selector_plugins (config_t config)
  *
  * @return Real value of the preference.
  */
-static gchar*
-preference_value (const char* name, const char* full_value)
+static gchar *
+preference_value (const char *name, const char *full_value)
 {
   char *bracket = strchr (name, '[');
   if (bracket)
@@ -1645,7 +1634,7 @@ preference_value (const char* name, const char* full_value)
  * @return 0 on success, -1 on failure.
  */
 static int
-send_config_preferences (config_t config, const char* section_name,
+send_config_preferences (config_t config, const char *section_name,
                          GSList *task_files, GPtrArray *pref_files)
 {
   iterator_t prefs;
@@ -1671,21 +1660,17 @@ send_config_preferences (config_t config, const char* section_name,
           return -1;
         }
 
-      value = preference_value (pref_name,
-                                otp_pref_iterator_value (&prefs));
+      value = preference_value (pref_name, otp_pref_iterator_value (&prefs));
 
       if (pref_files)
         {
           int type_start = -1, type_end = -1, count;
 
           /* LDAPsearch[entry]:Timeout value */
-          count = sscanf (pref_name, "%*[^[][%n%*[^]]%n]:", &type_start,
-                          &type_end);
-          if (count == 0
-              && type_start > 0
-              && type_end > 0
-              && (strncmp (pref_name + type_start,
-                           "file",
+          count =
+            sscanf (pref_name, "%*[^[][%n%*[^]]%n]:", &type_start, &type_end);
+          if (count == 0 && type_start > 0 && type_end > 0
+              && (strncmp (pref_name + type_start, "file",
                            type_end - type_start)
                   == 0))
             {
@@ -1794,8 +1779,7 @@ send_task_preferences (task_t task)
   g_free (value);
 
   value = task_preference_value (task, "max_hosts");
-  if (sendf_to_server ("max_hosts <|> %s\n",
-                       value ? value : MAX_HOSTS_DEFAULT))
+  if (sendf_to_server ("max_hosts <|> %s\n", value ? value : MAX_HOSTS_DEFAULT))
     {
       g_free (value);
       return -1;
@@ -1911,11 +1895,9 @@ finished_hosts_str (report_t stopped_report)
 
       if (end_time && strlen (end_time))
         {
-          char *new_str = str ?
-                           g_strdup_printf ("%s, %s", str,
-                                            host_iterator_host (&hosts))
-                           : g_strdup_printf ("%s",
-                                              host_iterator_host (&hosts));
+          char *new_str =
+            str ? g_strdup_printf ("%s, %s", str, host_iterator_host (&hosts))
+                : g_strdup_printf ("%s", host_iterator_host (&hosts));
           g_free (str);
           str = new_str;
         }
@@ -2016,7 +1998,7 @@ send_scanner_preferences (task_t task, target_t target, report_t stopped_report)
  * @return 0 on success, -1 on failure.
  */
 static int
-send_file (const char* name, const char* content)
+send_file (const char *name, const char *content)
 {
   size_t content_len = strlen (content);
 
@@ -2024,8 +2006,7 @@ send_file (const char* name, const char* content)
                        "name: %s\n"
                        "content: octet/stream\n"
                        "bytes: %i\n",
-                       name,
-                       content_len))
+                       name, content_len))
     return -1;
 
   if (sendn_to_server (content, content_len))
@@ -2043,7 +2024,7 @@ send_file (const char* name, const char* content)
  * @return 0 on success, -1 on failure.
  */
 static int
-send_task_file (task_t task, const char* file)
+send_task_file (task_t task, const char *file)
 {
   iterator_t files;
 
@@ -2060,8 +2041,7 @@ send_task_file (task_t task, const char* file)
                            "name: %s\n"
                            "content: octet/stream\n"
                            "bytes: %i\n",
-                           file,
-                           content_len))
+                           file, content_len))
         {
           g_free (content);
           cleanup_iterator (&files);
@@ -2099,44 +2079,38 @@ send_alive_test_preferences (target_t target)
 
   if (sendf_to_server ("Ping Host[checkbox]:Do a TCP ping <|> %s\n",
                        alive_test & ALIVE_TEST_TCP_ACK_SERVICE
-                       || alive_test & ALIVE_TEST_TCP_SYN_SERVICE
-                        ? "yes"
-                        : "no"))
+                           || alive_test & ALIVE_TEST_TCP_SYN_SERVICE
+                         ? "yes"
+                         : "no"))
     return -1;
 
   if (sendf_to_server ("Ping Host[checkbox]:TCP ping tries also TCP-SYN ping"
                        " <|> %s\n",
                        ((alive_test & ALIVE_TEST_TCP_SYN_SERVICE)
                         && (alive_test & ALIVE_TEST_TCP_ACK_SERVICE))
-                        ? "yes"
-                        : "no"))
+                         ? "yes"
+                         : "no"))
     return -1;
 
   if (sendf_to_server ("Ping Host[checkbox]:TCP ping tries only TCP-SYN ping"
                        " <|> %s\n",
                        ((alive_test & ALIVE_TEST_TCP_SYN_SERVICE)
                         && !(alive_test & ALIVE_TEST_TCP_ACK_SERVICE))
-                        ? "yes"
-                        : "no"))
+                         ? "yes"
+                         : "no"))
     return -1;
 
   if (sendf_to_server ("Ping Host[checkbox]:Do an ICMP ping <|> %s\n",
-                       (alive_test & ALIVE_TEST_ICMP)
-                        ? "yes"
-                        : "no"))
+                       (alive_test & ALIVE_TEST_ICMP) ? "yes" : "no"))
     return -1;
 
   if (sendf_to_server ("Ping Host[checkbox]:Use ARP <|> %s\n",
-                       (alive_test & ALIVE_TEST_ARP)
-                        ? "yes"
-                        : "no"))
+                       (alive_test & ALIVE_TEST_ARP) ? "yes" : "no"))
     return -1;
 
   if (sendf_to_server ("Ping Host[checkbox]:"
                        "Mark unrechable Hosts as dead (not scanning) <|> %s\n",
-                       (alive_test & ALIVE_TEST_CONSIDER_ALIVE)
-                        ? "no"
-                        : "yes"))
+                       (alive_test & ALIVE_TEST_CONSIDER_ALIVE) ? "no" : "yes"))
     return -1;
 
   if (alive_test == ALIVE_TEST_CONSIDER_ALIVE)
@@ -2151,11 +2125,11 @@ send_alive_test_preferences (target_t target)
 
 /** @todo g_convert back to ISO-8559-1 for scanner? */
 
-
 /* Slave tasks. */
 
 /* Defined in gmp.c. */
-void buffer_config_preference_xml (GString *, iterator_t *, config_t, int);
+void
+buffer_config_preference_xml (GString *, iterator_t *, config_t, int);
 
 /**
  * @brief Number of seconds to sleep between polls to slave.
@@ -2310,33 +2284,25 @@ slave_connect (gvm_connection_t *connection)
     ca_cert = manage_default_ca_cert ();
   else
     ca_cert = NULL;
-  connection->socket = gvm_server_open_verify
-                        (&connection->session,
-                         connection->host_string,
-                         connection->port,
-                         ca_cert ? ca_cert : connection->ca_cert,
-                         connection->pub_key,
-                         connection->priv_key,
-                         1);
+  connection->socket = gvm_server_open_verify (
+    &connection->session, connection->host_string, connection->port,
+    ca_cert ? ca_cert : connection->ca_cert, connection->pub_key,
+    connection->priv_key, 1);
   if (connection->socket == -1)
     {
-      g_warning ("%s: failed to open connection to %s on %i",
-                 __FUNCTION__,
-                 connection->host_string,
-                 connection->port);
+      g_warning ("%s: failed to open connection to %s on %i", __FUNCTION__,
+                 connection->host_string, connection->port);
       return -1;
     }
 
   {
     int optval;
     optval = 1;
-    if (setsockopt (connection->socket,
-                    SOL_SOCKET, SO_KEEPALIVE,
-                    &optval, sizeof (int)))
+    if (setsockopt (connection->socket, SOL_SOCKET, SO_KEEPALIVE, &optval,
+                    sizeof (int)))
       {
         g_warning ("%s: failed to set SO_KEEPALIVE on slave socket: %s",
-                   __FUNCTION__,
-                   strerror (errno));
+                   __FUNCTION__, strerror (errno));
         gvm_connection_close (connection);
         return -1;
       }
@@ -2381,7 +2347,7 @@ slave_sleep_connect (gvm_connection_t *connection, task_t task)
           return 3;
         }
       g_debug ("   %s: sleeping for %i", __FUNCTION__,
-              RUN_SLAVE_TASK_SLEEP_SECONDS);
+               RUN_SLAVE_TASK_SLEEP_SECONDS);
       gvm_sleep (RUN_SLAVE_TASK_SLEEP_SECONDS);
     }
   while (slave_connect (connection));
@@ -2411,7 +2377,8 @@ update_end_times (entity_t report)
         {
           char *text;
           text = entity_text (end);
-          while (*text && isspace (*text)) text++;
+          while (*text && isspace (*text))
+            text++;
           if (*text == '\0')
             break;
           set_task_end_time (current_scanner_task,
@@ -2441,16 +2408,16 @@ update_end_times (entity_t report)
             return -1;
 
           text = entity_text (time);
-          while (*text && isspace (*text)) text++;
+          while (*text && isspace (*text))
+            text++;
           if ((*text != '\0')
-              && (scan_host_end_time (global_current_report, entity_text (ip)) == 0))
+              && (scan_host_end_time (global_current_report, entity_text (ip))
+                  == 0))
             {
-              set_scan_host_end_time (global_current_report,
-                                      entity_text (ip),
+              set_scan_host_end_time (global_current_report, entity_text (ip),
                                       entity_text (time));
               if (manage_report_host_details (global_current_report,
-                                              entity_text (ip),
-                                              end))
+                                              entity_text (ip), end))
                 return -1;
             }
         }
@@ -2532,10 +2499,10 @@ get_tasks_last_report (entity_t get_tasks)
  * @return 0 success, 1 giveup.
  */
 static int
-setup_ids (gvm_connection_t *connection, task_t task,
-           entity_t get_tasks, gchar **slave_config_uuid,
-           gchar **slave_target_uuid, gchar **slave_port_list_uuid,
-           gchar **slave_ssh_credential_uuid, gchar **slave_smb_credential_uuid,
+setup_ids (gvm_connection_t *connection, task_t task, entity_t get_tasks,
+           gchar **slave_config_uuid, gchar **slave_target_uuid,
+           gchar **slave_port_list_uuid, gchar **slave_ssh_credential_uuid,
+           gchar **slave_smb_credential_uuid,
            gchar **slave_esxi_credential_uuid,
            gchar **slave_snmp_credential_uuid)
 {
@@ -2567,9 +2534,9 @@ setup_ids (gvm_connection_t *connection, task_t task,
           entity_t get_targets;
           int ret;
 
-          while ((ret = gmp_get_targets (&connection->session,
-                                         *slave_target_uuid, 0, 0,
-                                         &get_targets)))
+          while (
+            (ret = gmp_get_targets (&connection->session, *slave_target_uuid, 0,
+                                    0, &get_targets)))
             {
               if (ret == 404)
                 {
@@ -2592,28 +2559,28 @@ setup_ids (gvm_connection_t *connection, task_t task,
                 {
                   entity = entity_child (target, "port_list");
                   if (entity && entity_attribute (entity, "id"))
-                    *slave_port_list_uuid = g_strdup (entity_attribute
-                                                       (entity, "id"));
+                    *slave_port_list_uuid =
+                      g_strdup (entity_attribute (entity, "id"));
 
                   entity = entity_child (target, "ssh_credential");
                   if (entity && entity_attribute (entity, "id"))
-                    *slave_ssh_credential_uuid = g_strdup (entity_attribute
-                                                            (entity, "id"));
+                    *slave_ssh_credential_uuid =
+                      g_strdup (entity_attribute (entity, "id"));
 
                   entity = entity_child (target, "smb_credential");
                   if (entity && entity_attribute (entity, "id"))
-                    *slave_smb_credential_uuid = g_strdup (entity_attribute
-                                                            (entity, "id"));
+                    *slave_smb_credential_uuid =
+                      g_strdup (entity_attribute (entity, "id"));
 
                   entity = entity_child (target, "esxi_credential");
                   if (entity && entity_attribute (entity, "id"))
-                    *slave_esxi_credential_uuid = g_strdup (entity_attribute
-                                                             (entity, "id"));
+                    *slave_esxi_credential_uuid =
+                      g_strdup (entity_attribute (entity, "id"));
 
                   entity = entity_child (target, "snmp_credential");
                   if (entity && entity_attribute (entity, "id"))
-                    *slave_snmp_credential_uuid = g_strdup (entity_attribute
-                                                             (entity, "id"));
+                    *slave_snmp_credential_uuid =
+                      g_strdup (entity_attribute (entity, "id"));
                 }
               free_entity (get_targets);
             }
@@ -2662,8 +2629,7 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
              target_t target, credential_t target_ssh_credential,
              credential_t target_smb_credential,
              credential_t target_esxi_credential,
-             credential_t target_snmp_credential,
-             report_t last_stopped_report)
+             credential_t target_snmp_credential, report_t last_stopped_report)
 {
   const int ret_giveup = 3;
   int ret_fail, next_result;
@@ -2704,14 +2670,15 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
 
           /* Check if the task is running or complete on the slave. */
 
-          while ((ret = gmp_get_tasks (&connection->session, global_slave_task_uuid,
-                                       0, 0, &get_tasks)))
+          while (
+            (ret = gmp_get_tasks (&connection->session, global_slave_task_uuid,
+                                  0, 0, &get_tasks)))
             {
               if (ret == 404)
                 {
-                  /* Task missing.  Perhaps someone removed the task on the slave.
-                   * Clear all the report results and start the task from the
-                   * beginning. */
+                  /* Task missing.  Perhaps someone removed the task on the
+                   * slave. Clear all the report results and start the task from
+                   * the beginning. */
                   trim_report (last_stopped_report);
                   last_stopped_report = 0;
                   break;
@@ -2744,19 +2711,18 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
                   global_slave_report_uuid = get_tasks_last_report (get_tasks);
                   if (global_slave_report_uuid == NULL)
                     {
-                      g_warning ("%s: slave report %s missing UUID", __FUNCTION__,
-                                 global_slave_task_uuid);
+                      g_warning ("%s: slave report %s missing UUID",
+                                 __FUNCTION__, global_slave_task_uuid);
                       goto fail;
                     }
 
-                  setup_ids (connection, task,
-                             get_tasks, &global_slave_config_uuid,
-                             &global_slave_target_uuid,
-                             &global_slave_port_list_uuid,
-                             &global_slave_ssh_credential_uuid,
-                             &global_slave_smb_credential_uuid,
-                             &global_slave_esxi_credential_uuid,
-                             &global_slave_snmp_credential_uuid);
+                  setup_ids (
+                    connection, task, get_tasks, &global_slave_config_uuid,
+                    &global_slave_target_uuid, &global_slave_port_list_uuid,
+                    &global_slave_ssh_credential_uuid,
+                    &global_slave_smb_credential_uuid,
+                    &global_slave_esxi_credential_uuid,
+                    &global_slave_snmp_credential_uuid);
                 }
               else
                 {
@@ -2765,33 +2731,33 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
                                                   global_slave_task_uuid,
                                                   &global_slave_report_uuid))
                     {
-                      case 0:
-                        if (global_slave_report_uuid == NULL)
-                          goto fail;
-                        setup_ids (connection, task,
-                                   get_tasks, &global_slave_config_uuid,
-                                   &global_slave_target_uuid,
-                                   &global_slave_port_list_uuid,
-                                   &global_slave_ssh_credential_uuid,
-                                   &global_slave_smb_credential_uuid,
-                                   &global_slave_esxi_credential_uuid,
-                                   &global_slave_snmp_credential_uuid);
-                        set_task_run_status (task, TASK_STATUS_REQUESTED);
-                        break;
-                      case 1:
-                        /* The resume may have failed because the task slave changed or
-                         * because someone removed the task on the slave.  Clear all the
-                         * report results and start the task from the beginning.
-                         *
-                         * This and the if above both "leak" the resources on the slave,
-                         * because on the report these resources are replaced with the new
-                         * resources. */
-                        trim_report (last_stopped_report);
-                        last_stopped_report = 0;
-                        break;
-                      default:
-                        free (global_slave_task_uuid);
+                    case 0:
+                      if (global_slave_report_uuid == NULL)
                         goto fail;
+                      setup_ids (
+                        connection, task, get_tasks, &global_slave_config_uuid,
+                        &global_slave_target_uuid, &global_slave_port_list_uuid,
+                        &global_slave_ssh_credential_uuid,
+                        &global_slave_smb_credential_uuid,
+                        &global_slave_esxi_credential_uuid,
+                        &global_slave_snmp_credential_uuid);
+                      set_task_run_status (task, TASK_STATUS_REQUESTED);
+                      break;
+                    case 1:
+                      /* The resume may have failed because the task slave
+                       * changed or because someone removed the task on the
+                       * slave.  Clear all the report results and start the task
+                       * from the beginning.
+                       *
+                       * This and the if above both "leak" the resources on the
+                       * slave, because on the report these resources are
+                       * replaced with the new resources. */
+                      trim_report (last_stopped_report);
+                      last_stopped_report = 0;
+                      break;
+                    default:
+                      free (global_slave_task_uuid);
+                      goto fail;
                     }
                 }
             }
@@ -2804,8 +2770,7 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
 
       if (target_ssh_credential)
         {
-          init_credential_iterator_one (&credentials,
-                                            target_ssh_credential);
+          init_credential_iterator_one (&credentials, target_ssh_credential);
           if (next (&credentials))
             {
               int ret;
@@ -2817,8 +2782,7 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
               password = credential_iterator_password (&credentials);
               private_key = credential_iterator_private_key (&credentials);
 
-              if (user == NULL
-                  || (private_key == NULL && password == NULL))
+              if (user == NULL || (private_key == NULL && password == NULL))
                 {
                   cleanup_iterator (&credentials);
                   global_slave_ssh_credential_uuid = NULL;
@@ -2846,10 +2810,9 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
 
                   cleanup_iterator (&credentials);
 
-                  ret = gmp_create_lsc_credential_ext
-                         (&connection->session,
-                          opts,
-                          &global_slave_ssh_credential_uuid);
+                  ret = gmp_create_lsc_credential_ext (
+                    &connection->session, opts,
+                    &global_slave_ssh_credential_uuid);
 
                   g_free (user_copy);
                   g_free (password_copy);
@@ -2869,8 +2832,7 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
 
       if (target_smb_credential)
         {
-          init_credential_iterator_one (&credentials,
-                                        target_smb_credential);
+          init_credential_iterator_one (&credentials, target_smb_credential);
           if (next (&credentials))
             {
               int ret;
@@ -2903,10 +2865,9 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
 
                   cleanup_iterator (&credentials);
 
-                  ret = gmp_create_lsc_credential_ext
-                           (&connection->session,
-                            opts,
-                            &global_slave_smb_credential_uuid);
+                  ret = gmp_create_lsc_credential_ext (
+                    &connection->session, opts,
+                    &global_slave_smb_credential_uuid);
 
                   g_free (smb_name);
                   g_free (user_copy);
@@ -2926,8 +2887,7 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
 
       if (target_esxi_credential)
         {
-          init_credential_iterator_one (&credentials,
-                                        target_esxi_credential);
+          init_credential_iterator_one (&credentials, target_esxi_credential);
           if (next (&credentials))
             {
               int ret;
@@ -2960,10 +2920,9 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
 
                   cleanup_iterator (&credentials);
 
-                  ret = gmp_create_lsc_credential_ext
-                           (&connection->session,
-                            opts,
-                            &global_slave_esxi_credential_uuid);
+                  ret = gmp_create_lsc_credential_ext (
+                    &connection->session, opts,
+                    &global_slave_esxi_credential_uuid);
 
                   g_free (esxi_name);
                   g_free (user_copy);
@@ -2982,8 +2941,7 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
 
       if (target_snmp_credential)
         {
-          init_credential_iterator_one (&credentials,
-                                        target_snmp_credential);
+          init_credential_iterator_one (&credentials, target_snmp_credential);
           if (next (&credentials))
             {
               int ret;
@@ -2997,12 +2955,12 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
               community = credential_iterator_community (&credentials);
               user = credential_iterator_login (&credentials);
               password = credential_iterator_password (&credentials);
-              auth_algorithm
-                = credential_iterator_auth_algorithm (&credentials);
-              privacy_password
-                = credential_iterator_privacy_password (&credentials);
-              privacy_algorithm
-                = credential_iterator_privacy_algorithm (&credentials);
+              auth_algorithm =
+                credential_iterator_auth_algorithm (&credentials);
+              privacy_password =
+                credential_iterator_privacy_password (&credentials);
+              privacy_algorithm =
+                credential_iterator_privacy_algorithm (&credentials);
 
               if (password && strcmp (password, "")
                   && (auth_algorithm == NULL || strcmp (auth_algorithm, "")))
@@ -3017,8 +2975,7 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
               else if (((privacy_password && strcmp (privacy_password, ""))
                         || (privacy_algorithm
                             && strcmp (privacy_algorithm, "")))
-                       && (password == NULL
-                           || auth_algorithm == NULL
+                       && (password == NULL || auth_algorithm == NULL
                            || privacy_password == NULL
                            || privacy_algorithm == NULL))
                 {
@@ -3033,18 +2990,15 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
                 }
               else
                 {
-                  community_copy
-                      = g_strdup (community ? community : "");
-                  user_copy
-                      = g_strdup (user ? user : "");
-                  password_copy
-                      = g_strdup (password ? password : "");
-                  auth_algorithm_copy
-                      = g_strdup (auth_algorithm ? auth_algorithm : "");
-                  privacy_password_copy
-                      = g_strdup (privacy_password ? privacy_password : "");
-                  privacy_algorithm_copy
-                      = g_strdup (privacy_algorithm ? privacy_algorithm : "");
+                  community_copy = g_strdup (community ? community : "");
+                  user_copy = g_strdup (user ? user : "");
+                  password_copy = g_strdup (password ? password : "");
+                  auth_algorithm_copy =
+                    g_strdup (auth_algorithm ? auth_algorithm : "");
+                  privacy_password_copy =
+                    g_strdup (privacy_password ? privacy_password : "");
+                  privacy_algorithm_copy =
+                    g_strdup (privacy_algorithm ? privacy_algorithm : "");
 
                   opts = gmp_create_lsc_credential_opts_defaults;
                   snmp_name = g_strdup_printf ("%ssnmp", name);
@@ -3059,10 +3013,9 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
 
                   cleanup_iterator (&credentials);
 
-                  ret = gmp_create_lsc_credential_ext
-                           (&connection->session,
-                            opts,
-                            &global_slave_snmp_credential_uuid);
+                  ret = gmp_create_lsc_credential_ext (
+                    &connection->session, opts,
+                    &global_slave_snmp_credential_uuid);
 
                   g_free (snmp_name);
                   g_free (community_copy);
@@ -3113,10 +3066,9 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
           hosts = target_iterator_hosts (&targets);
           exclude_hosts = target_iterator_exclude_hosts (&targets);
           alive_tests = target_iterator_alive_tests (&targets);
-          reverse_lookup_only
-            = target_iterator_reverse_lookup_only (&targets);
-          reverse_lookup_unify
-            = target_iterator_reverse_lookup_unify (&targets);
+          reverse_lookup_only = target_iterator_reverse_lookup_only (&targets);
+          reverse_lookup_unify =
+            target_iterator_reverse_lookup_unify (&targets);
           if (hosts == NULL)
             {
               cleanup_iterator (&targets);
@@ -3147,10 +3099,10 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
           opts.port_range = port_range;
           opts.name = name;
           opts.comment = "Slave target created by Master";
-          opts.reverse_lookup_only
-            = reverse_lookup_only ? atoi (reverse_lookup_only) : 0;
-          opts.reverse_lookup_unify
-            = reverse_lookup_unify ? atoi (reverse_lookup_unify) : 0;
+          opts.reverse_lookup_only =
+            reverse_lookup_only ? atoi (reverse_lookup_only) : 0;
+          opts.reverse_lookup_unify =
+            reverse_lookup_unify ? atoi (reverse_lookup_unify) : 0;
 
           ret = gmp_create_target_ext (&connection->session, opts,
                                        &global_slave_target_uuid);
@@ -3162,9 +3114,8 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
             goto fail_credentials;
           if (ret)
             {
-              set_task_interrupted (task,
-                                    "Failed to create target on slave."
-                                    "  Interrupting scan.");
+              set_task_interrupted (task, "Failed to create target on slave."
+                                          "  Interrupting scan.");
               ret_fail = ret_giveup;
               goto fail_credentials;
             }
@@ -3199,8 +3150,7 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
           goto fail_credentials;
         }
 
-      g_debug ("   %s: slave target uuid: %s",
-               __FUNCTION__,
+      g_debug ("   %s: slave target uuid: %s", __FUNCTION__,
                global_slave_target_uuid);
 
       /* Create the config on the slave. */
@@ -3273,52 +3223,46 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
           }
         cleanup_iterator (&prefs);
 
-        if (gvm_server_sendf (&connection->session,
-                              "</preferences>"
-                              "<nvt_selectors>"))
+        if (gvm_server_sendf (&connection->session, "</preferences>"
+                                                    "<nvt_selectors>"))
           {
             cleanup_iterator (&prefs);
             goto fail_target;
           }
 
-        init_nvt_selector_iterator (&selectors,
-                                    NULL,
-                                    config,
+        init_nvt_selector_iterator (&selectors, NULL, config,
                                     NVT_SELECTOR_TYPE_ANY);
         while (next (&selectors))
           {
             int type = nvt_selector_iterator_type (&selectors);
-            if (gvm_server_sendf
-                 (&connection->session,
-                  "<nvt_selector>"
-                  "<name>%s</name>"
-                  "<include>%i</include>"
-                  "<type>%i</type>"
-                  "<family_or_nvt>%s</family_or_nvt>"
-                  "</nvt_selector>",
-                  nvt_selector_iterator_name (&selectors),
-                  nvt_selector_iterator_include (&selectors),
-                  type,
-                  (type == NVT_SELECTOR_TYPE_ALL
-                    ? ""
-                    : nvt_selector_iterator_nvt (&selectors))))
+            if (gvm_server_sendf (&connection->session,
+                                  "<nvt_selector>"
+                                  "<name>%s</name>"
+                                  "<include>%i</include>"
+                                  "<type>%i</type>"
+                                  "<family_or_nvt>%s</family_or_nvt>"
+                                  "</nvt_selector>",
+                                  nvt_selector_iterator_name (&selectors),
+                                  nvt_selector_iterator_include (&selectors),
+                                  type,
+                                  (type == NVT_SELECTOR_TYPE_ALL
+                                     ? ""
+                                     : nvt_selector_iterator_nvt (&selectors))))
               goto fail_target;
           }
         cleanup_iterator (&selectors);
 
-        if (gvm_server_sendf (&connection->session,
-                              "</nvt_selectors>"
-                              "</config>"
-                              "</get_configs_response>"
-                              "</create_config>")
+        if (gvm_server_sendf (&connection->session, "</nvt_selectors>"
+                                                    "</config>"
+                                                    "</get_configs_response>"
+                                                    "</create_config>")
             || (gmp_read_create_response (&connection->session,
                                           &global_slave_config_uuid)
                 != 201))
           goto fail_target;
       }
 
-      g_debug ("   %s: slave config uuid: %s",
-               __FUNCTION__,
+      g_debug ("   %s: slave config uuid: %s", __FUNCTION__,
                global_slave_config_uuid);
 
       /* Create the task on the slave. */
@@ -3339,9 +3283,7 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
         uuid_report = report_uuid (global_current_report);
         comment = g_strdup_printf ("Slave task for master task %s (%s)"
                                    " report %s.",
-                                   name_task,
-                                   uuid_task,
-                                   uuid_report);
+                                   name_task, uuid_task, uuid_report);
         opts.comment = comment;
         free (uuid_task);
         free (name_task);
@@ -3366,8 +3308,7 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
         opts.schedule_id = NULL;
         opts.slave_id = NULL;
 
-        ret = gmp_create_task_ext (&connection->session,
-                                   opts,
+        ret = gmp_create_task_ext (&connection->session, opts,
                                    &global_slave_task_uuid);
         g_free (comment);
         g_free (max_checks);
@@ -3380,14 +3321,14 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
 
       /* Start the task on the slave. */
 
-      if (gmp_start_task_report (&connection->session,
-                                 global_slave_task_uuid,
+      if (gmp_start_task_report (&connection->session, global_slave_task_uuid,
                                  &global_slave_report_uuid))
         goto fail_task;
       if (global_slave_report_uuid == NULL)
         goto fail_stop_task;
 
-      set_report_slave_task_uuid (global_current_report, global_slave_task_uuid);
+      set_report_slave_task_uuid (global_current_report,
+                                  global_slave_task_uuid);
     }
 
   /* Setup the current task for functions like set_task_run_status. */
@@ -3409,51 +3350,49 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
       run_status = task_run_status (task);
       switch (run_status)
         {
-          case TASK_STATUS_DELETE_REQUESTED:
-          case TASK_STATUS_DELETE_ULTIMATE_REQUESTED:
-          case TASK_STATUS_STOP_REQUESTED:
-            switch (gmp_stop_task (&connection->session,
-                                   global_slave_task_uuid))
-              {
-                case 0:
-                  break;
-                case 404:
-                  /* Resource Missing. */
-                  set_task_interrupted (task,
-                                        "Failed to find task on slave."
-                                        "  Interrupting scan.");
-                  goto giveup;
-                default:
-                  goto fail_stop_task;
-              }
-            if (run_status == TASK_STATUS_DELETE_REQUESTED)
-              set_task_run_status (current_scanner_task,
-                                   TASK_STATUS_DELETE_WAITING);
-            else if (run_status == TASK_STATUS_DELETE_ULTIMATE_REQUESTED)
-              set_task_run_status (current_scanner_task,
-                                   TASK_STATUS_DELETE_ULTIMATE_WAITING);
-            else
-              set_task_run_status (current_scanner_task,
-                                   TASK_STATUS_STOP_WAITING);
-            break;
-          case TASK_STATUS_STOP_REQUESTED_GIVEUP:
-            g_debug ("   %s: task stopped for giveup", __FUNCTION__);
-            set_task_run_status (current_scanner_task, TASK_STATUS_STOPPED);
-            goto giveup;
-            break;
-          case TASK_STATUS_STOPPED:
-            assert (0);
-            goto fail_stop_task;
-            break;
-          case TASK_STATUS_DELETE_WAITING:
-          case TASK_STATUS_DELETE_ULTIMATE_WAITING:
-          case TASK_STATUS_DONE:
-          case TASK_STATUS_NEW:
-          case TASK_STATUS_REQUESTED:
-          case TASK_STATUS_RUNNING:
-          case TASK_STATUS_STOP_WAITING:
-          case TASK_STATUS_INTERRUPTED:
-            break;
+        case TASK_STATUS_DELETE_REQUESTED:
+        case TASK_STATUS_DELETE_ULTIMATE_REQUESTED:
+        case TASK_STATUS_STOP_REQUESTED:
+          switch (gmp_stop_task (&connection->session, global_slave_task_uuid))
+            {
+            case 0:
+              break;
+            case 404:
+              /* Resource Missing. */
+              set_task_interrupted (task, "Failed to find task on slave."
+                                          "  Interrupting scan.");
+              goto giveup;
+            default:
+              goto fail_stop_task;
+            }
+          if (run_status == TASK_STATUS_DELETE_REQUESTED)
+            set_task_run_status (current_scanner_task,
+                                 TASK_STATUS_DELETE_WAITING);
+          else if (run_status == TASK_STATUS_DELETE_ULTIMATE_REQUESTED)
+            set_task_run_status (current_scanner_task,
+                                 TASK_STATUS_DELETE_ULTIMATE_WAITING);
+          else
+            set_task_run_status (current_scanner_task,
+                                 TASK_STATUS_STOP_WAITING);
+          break;
+        case TASK_STATUS_STOP_REQUESTED_GIVEUP:
+          g_debug ("   %s: task stopped for giveup", __FUNCTION__);
+          set_task_run_status (current_scanner_task, TASK_STATUS_STOPPED);
+          goto giveup;
+          break;
+        case TASK_STATUS_STOPPED:
+          assert (0);
+          goto fail_stop_task;
+          break;
+        case TASK_STATUS_DELETE_WAITING:
+        case TASK_STATUS_DELETE_ULTIMATE_WAITING:
+        case TASK_STATUS_DONE:
+        case TASK_STATUS_NEW:
+        case TASK_STATUS_REQUESTED:
+        case TASK_STATUS_RUNNING:
+        case TASK_STATUS_STOP_WAITING:
+        case TASK_STATUS_INTERRUPTED:
+          break;
         }
 
       ret = gmp_get_tasks (&connection->session, global_slave_task_uuid, 0, 0,
@@ -3461,9 +3400,8 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
       if (ret == 404)
         {
           /* Resource Missing. */
-          set_task_interrupted (task,
-                                "Task missing on slave."
-                                "  Interrupting scan.");
+          set_task_interrupted (task, "Task missing on slave."
+                                      "  Interrupting scan.");
           goto giveup;
         }
       else if (ret)
@@ -3478,14 +3416,12 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
       status = gmp_task_status (get_tasks);
       if (status == NULL)
         {
-          set_task_interrupted (task,
-                                "Error in slave task status."
-                                "  Interrupting scan.");
+          set_task_interrupted (task, "Error in slave task status."
+                                      "  Interrupting scan.");
           goto giveup;
         }
       status_done = (strcmp (status, "Done") == 0);
-      if ((strcmp (status, "Running") == 0)
-          || status_done)
+      if ((strcmp (status, "Running") == 0) || status_done)
         {
           int ret2 = 0;
           gmp_get_report_opts_t opts;
@@ -3503,30 +3439,29 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
           opts = gmp_get_report_opts_defaults;
           opts.report_id = global_slave_report_uuid;
           opts.format_id = "a994b278-1f62-11e1-96ac-406186ea4fc5";
-          opts.filter = g_strdup_printf
-                         ("first=%i rows=-1 levels=hmlgd apply_overrides=0"
-                          " min_qod=0 autofp=0 result_hosts_only=%i"
-                          " sort=created",
-                          next_result,
-                          status_done
-                           /* Request all the hosts to get their end times. */
-                           ? 0
-                           : 1);
+          opts.filter = g_strdup_printf (
+            "first=%i rows=-1 levels=hmlgd apply_overrides=0"
+            " min_qod=0 autofp=0 result_hosts_only=%i"
+            " sort=created",
+            next_result,
+            status_done
+              /* Request all the hosts to get their end times. */
+              ? 0
+              : 1);
 
           ret = gmp_get_report_ext (&connection->session, opts, &get_report);
           if (ret)
             {
               opts.format_id = "d5da9f67-8551-4e51-807b-b6a873d70e34";
-              ret2 = gmp_get_report_ext (&connection->session, opts,
-                                         &get_report);
+              ret2 =
+                gmp_get_report_ext (&connection->session, opts, &get_report);
             }
           g_free (opts.filter);
           if ((ret == 404) && (ret2 == 404))
             {
               /* Resource Missing. */
-              set_task_interrupted (task,
-                                    "Task report missing on slave."
-                                    "  Interrupting scan.");
+              set_task_interrupted (task, "Task report missing on slave."
+                                          "  Interrupting scan.");
               goto giveup;
             }
           if (ret && ret2)
@@ -3607,36 +3542,27 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
 
   current_scanner_task = (task_t) 0;
 
-  gmp_delete_task_ext (&connection->session,
-                       global_slave_task_uuid,
-                       del_opts);
+  gmp_delete_task_ext (&connection->session, global_slave_task_uuid, del_opts);
   set_report_slave_task_uuid (global_current_report, "");
-  gmp_delete_config_ext (&connection->session,
-                         global_slave_config_uuid,
+  gmp_delete_config_ext (&connection->session, global_slave_config_uuid,
                          del_opts);
-  gmp_delete_target_ext (&connection->session,
-                         global_slave_target_uuid,
+  gmp_delete_target_ext (&connection->session, global_slave_target_uuid,
                          del_opts);
-  gmp_delete_port_list_ext (&connection->session,
-                            global_slave_port_list_uuid,
+  gmp_delete_port_list_ext (&connection->session, global_slave_port_list_uuid,
                             del_opts);
   if (global_slave_ssh_credential_uuid)
     gmp_delete_lsc_credential_ext (&connection->session,
-                                   global_slave_ssh_credential_uuid,
-                                   del_opts);
+                                   global_slave_ssh_credential_uuid, del_opts);
   if (global_slave_smb_credential_uuid)
     gmp_delete_lsc_credential_ext (&connection->session,
-                                   global_slave_smb_credential_uuid,
-                                   del_opts);
+                                   global_slave_smb_credential_uuid, del_opts);
   if (global_slave_esxi_credential_uuid)
     gmp_delete_lsc_credential_ext (&connection->session,
-                                   global_slave_esxi_credential_uuid,
-                                   del_opts);
+                                   global_slave_esxi_credential_uuid, del_opts);
   if (global_slave_snmp_credential_uuid)
     gmp_delete_lsc_credential_ext (&connection->session,
-                                   global_slave_snmp_credential_uuid,
-                                   del_opts);
- succeed_stopped:
+                                   global_slave_snmp_credential_uuid, del_opts);
+succeed_stopped:
   free (global_slave_task_uuid);
   global_slave_task_uuid = NULL;
   free (global_slave_report_uuid);
@@ -3660,58 +3586,48 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
   g_debug ("   %s: succeed", __FUNCTION__);
   return 0;
 
- fail_stop_task:
-  gmp_stop_task (&connection->session,
-                 global_slave_task_uuid);
+fail_stop_task:
+  gmp_stop_task (&connection->session, global_slave_task_uuid);
   free (global_slave_report_uuid);
- fail_task:
-  gmp_delete_task_ext (&connection->session,
-                       global_slave_task_uuid,
-                       del_opts);
+fail_task:
+  gmp_delete_task_ext (&connection->session, global_slave_task_uuid, del_opts);
   set_report_slave_task_uuid (global_current_report, "");
   free (global_slave_task_uuid);
- fail_config:
-  gmp_delete_config_ext (&connection->session,
-                         global_slave_config_uuid,
+fail_config:
+  gmp_delete_config_ext (&connection->session, global_slave_config_uuid,
                          del_opts);
   free (global_slave_config_uuid);
- fail_target:
-  gmp_delete_target_ext (&connection->session,
-                         global_slave_target_uuid,
+fail_target:
+  gmp_delete_target_ext (&connection->session, global_slave_target_uuid,
                          del_opts);
   free (global_slave_target_uuid);
-  gmp_delete_port_list_ext (&connection->session,
-                            global_slave_port_list_uuid,
+  gmp_delete_port_list_ext (&connection->session, global_slave_port_list_uuid,
                             del_opts);
   free (global_slave_port_list_uuid);
- fail_credentials:
+fail_credentials:
   if (global_slave_snmp_credential_uuid)
     gmp_delete_lsc_credential_ext (&connection->session,
-                                   global_slave_snmp_credential_uuid,
-                                   del_opts);
+                                   global_slave_snmp_credential_uuid, del_opts);
   free (global_slave_snmp_credential_uuid);
   if (global_slave_esxi_credential_uuid)
     gmp_delete_lsc_credential_ext (&connection->session,
-                                   global_slave_esxi_credential_uuid,
-                                   del_opts);
+                                   global_slave_esxi_credential_uuid, del_opts);
   free (global_slave_esxi_credential_uuid);
   if (global_slave_smb_credential_uuid)
     gmp_delete_lsc_credential_ext (&connection->session,
-                                   global_slave_smb_credential_uuid,
-                                   del_opts);
+                                   global_slave_smb_credential_uuid, del_opts);
   free (global_slave_smb_credential_uuid);
   if (global_slave_ssh_credential_uuid)
     gmp_delete_lsc_credential_ext (&connection->session,
-                                   global_slave_ssh_credential_uuid,
-                                   del_opts);
+                                   global_slave_ssh_credential_uuid, del_opts);
   free (global_slave_ssh_credential_uuid);
- fail:
+fail:
   g_debug ("   %s: fail (%i)", __FUNCTION__, ret_fail);
   gvm_connection_close (connection);
   global_slave_connection = NULL;
   return ret_fail;
 
- giveup:
+giveup:
   g_debug ("   %s: giveup (%i)", __FUNCTION__, ret_giveup);
   gvm_connection_close (connection);
   global_slave_connection = NULL;
@@ -3741,10 +3657,8 @@ handle_slave_task (task_t task, target_t target,
                    credential_t target_smb_credential,
                    credential_t target_esxi_credential,
                    credential_t target_snmp_credential,
-                   report_t last_stopped_report,
-                   gvm_connection_t *connection,
-                   const gchar *slave_id,
-                   const gchar *slave_name)
+                   report_t last_stopped_report, gvm_connection_t *connection,
+                   const gchar *slave_id, const gchar *slave_name)
 {
   char *name, *uuid;
   int ret;
@@ -3758,7 +3672,8 @@ handle_slave_task (task_t task, target_t target,
 
   g_debug ("   Running slave task %llu", task);
 
-  // FIX permission checks  may the user still access the slave, target, port list etc?
+  // FIX permission checks  may the user still access the slave, target, port
+  // list etc?
 
   report_set_slave_uuid (global_current_report, slave_id);
   report_set_slave_name (global_current_report, slave_name);
@@ -3792,13 +3707,9 @@ handle_slave_task (task_t task, target_t target,
         /* Login failed. */
 
         port_string = g_strdup_printf ("%i", connection->port);
-        result = make_result (task,
-                              connection->host_string,
-                              "",
-                              port_string,
+        result = make_result (task, connection->host_string, "", port_string,
                               /* NVT: Global variable settings. */
-                              "1.3.6.1.4.1.25623.1.0.12288",
-                              "Error Message",
+                              "1.3.6.1.4.1.25623.1.0.12288", "Error Message",
                               "Authentication with the slave failed.");
         g_free (port_string);
         if (global_current_report)
@@ -3816,9 +3727,8 @@ handle_slave_task (task_t task, target_t target,
           {
             if (current_signal)
               {
-                g_debug ("%s: Received %s signal.",
-                         __FUNCTION__,
-                         sys_siglist[get_termination_signal()]);
+                g_debug ("%s: Received %s signal.", __FUNCTION__,
+                         sys_siglist[get_termination_signal ()]);
               }
             if (global_current_report)
               {
@@ -3836,9 +3746,8 @@ handle_slave_task (task_t task, target_t target,
     {
       if (get_termination_signal ())
         {
-          g_debug ("%s: Received %s signal.",
-                   __FUNCTION__,
-                   sys_siglist[get_termination_signal()]);
+          g_debug ("%s: Received %s signal.", __FUNCTION__,
+                   sys_siglist[get_termination_signal ()]);
           if (global_current_report)
             {
               set_report_scan_run_status (global_current_report,
@@ -3849,10 +3758,10 @@ handle_slave_task (task_t task, target_t target,
           return 0;
         }
 
-      ret = slave_setup (connection, slave_task_name,
-                         task, target, target_ssh_credential,
-                         target_smb_credential, target_esxi_credential,
-                         target_snmp_credential, last_stopped_report);
+      ret = slave_setup (connection, slave_task_name, task, target,
+                         target_ssh_credential, target_smb_credential,
+                         target_esxi_credential, target_snmp_credential,
+                         last_stopped_report);
       if (ret == 1)
         {
           ret = slave_sleep_connect (connection, task);
@@ -3870,7 +3779,6 @@ handle_slave_task (task_t task, target_t target,
   return 0;
 }
 
-
 /* OSP tasks. */
 
 /**
@@ -3934,7 +3842,8 @@ task_scanner_options (task_t task, target_t target)
           else if (!strcmp (type, "credential_up"))
             {
               g_warning ("OSP Parameter %s requires credentials of type"
-                         " username+password", name);
+                         " username+password",
+                         name);
               g_free (name);
               continue;
             }
@@ -4010,8 +3919,8 @@ delete_osp_scan (const char *report_id, const char *host, int port,
  */
 static int
 get_osp_scan_report (const char *scan_id, const char *host, int port,
-                     const char *ca_pub, const char *key_pub, const char
-                     *key_priv, int details, char **report_xml)
+                     const char *ca_pub, const char *key_pub,
+                     const char *key_priv, int details, char **report_xml)
 {
   osp_connection_t *connection;
   int progress;
@@ -4073,10 +3982,9 @@ handle_osp_scan (task_t task, report_t report, const char *scan_id)
                                           key_priv, 0, NULL);
       if (progress == -1)
         {
-          result_t result = make_osp_result
-                             (task, "", "", threat_message_type ("Error"),
-                              "Erroneous scan progress value", "", "",
-                              QOD_DEFAULT);
+          result_t result = make_osp_result (
+            task, "", "", threat_message_type ("Error"),
+            "Erroneous scan progress value", "", "", QOD_DEFAULT);
           report_add_result (report, result);
           rc = -1;
           break;
@@ -4093,10 +4001,9 @@ handle_osp_scan (task_t task, report_t report, const char *scan_id)
                                           key_priv, 1, &report_xml);
           if (progress != 100)
             {
-              result_t result = make_osp_result
-                                 (task, "", "", threat_message_type ("Error"),
-                                  "Erroneous scan progress value", "", "",
-                                  QOD_DEFAULT);
+              result_t result = make_osp_result (
+                task, "", "", threat_message_type ("Error"),
+                "Erroneous scan progress value", "", "", QOD_DEFAULT);
               report_add_result (report, result);
               rc = -1;
               break;
@@ -4196,8 +4103,8 @@ launch_osp_task (task_t task, target_t target, const char *scan_id,
     }
   target_str = target_hosts (target);
   ports_str = target_port_range (target);
-  ret = osp_start_scan (connection, target_str, ports_str, options, scan_id,
-                        error);
+  ret =
+    osp_start_scan (connection, target_str, ports_str, options, scan_id, error);
 
   g_hash_table_destroy (options);
   osp_connection_close (connection);
@@ -4234,23 +4141,20 @@ fork_osp_scan_handler (task_t task, target_t target)
 
   switch (fork ())
     {
-      case 0:
-        break;
-      case -1:
-        /* Parent, failed to fork. */
-        g_warning ("%s: Failed to fork: %s",
-                   __FUNCTION__,
-                   strerror (errno));
-        set_task_interrupted (task,
-                              "Error forking scan handler."
-                              "  Interrupting scan.");
-        set_report_scan_run_status (global_current_report,
-                                    TASK_STATUS_INTERRUPTED);
-        global_current_report = (report_t) 0;
-        return -9;
-      default:
-        /* Parent, successfully forked. */
-        return 0;
+    case 0:
+      break;
+    case -1:
+      /* Parent, failed to fork. */
+      g_warning ("%s: Failed to fork: %s", __FUNCTION__, strerror (errno));
+      set_task_interrupted (task, "Error forking scan handler."
+                                  "  Interrupting scan.");
+      set_report_scan_run_status (global_current_report,
+                                  TASK_STATUS_INTERRUPTED);
+      global_current_report = (report_t) 0;
+      return -9;
+    default:
+      /* Parent, successfully forked. */
+      return 0;
     }
 
   /* Child: Re-open DB after fork and periodically check scan progress.
@@ -4340,7 +4244,6 @@ run_osp_task (task_t task)
   return 0;
 }
 
-
 /* CVE tasks. */
 
 /**
@@ -4392,8 +4295,8 @@ cve_scan_host (task_t task, gvm_host_t *gvm_host)
 
           start_time = time (NULL);
           prognosis_report_host = 0;
-          init_host_prognosis_iterator (&prognosis, report_host, 0, -1,
-                                        NULL, NULL, 0, NULL);
+          init_host_prognosis_iterator (&prognosis, report_host, 0, -1, NULL,
+                                        NULL, 0, NULL);
           while (next (&prognosis))
             {
               const char *app, *cve;
@@ -4402,10 +4305,8 @@ cve_scan_host (task_t task, gvm_host_t *gvm_host)
               result_t result;
 
               if (global_current_report && (prognosis_report_host == 0))
-                prognosis_report_host = manage_report_host_add (global_current_report,
-                                                                ip,
-                                                                start_time,
-                                                                0);
+                prognosis_report_host = manage_report_host_add (
+                  global_current_report, ip, start_time, 0);
 
               severity = prognosis_iterator_cvss_double (&prognosis);
 
@@ -4413,20 +4314,15 @@ cve_scan_host (task_t task, gvm_host_t *gvm_host)
               cve = prognosis_iterator_cve (&prognosis);
               location = app_location (report_host, app);
 
-              desc = g_strdup_printf ("The host carries the product: %s\n"
-                                      "It is vulnerable according to: %s.\n"
-                                      "%s%s%s"
-                                      "\n"
-                                      "%s",
-                                      app,
-                                      cve,
-                                      location
-                                       ? "The product was found at: "
-                                       : "",
-                                      location ? location : "",
-                                      location ? ".\n" : "",
-                                      prognosis_iterator_description
-                                       (&prognosis));
+              desc = g_strdup_printf (
+                "The host carries the product: %s\n"
+                "It is vulnerable according to: %s.\n"
+                "%s%s%s"
+                "\n"
+                "%s",
+                app, cve, location ? "The product was found at: " : "",
+                location ? location : "", location ? ".\n" : "",
+                prognosis_iterator_description (&prognosis));
 
               g_debug ("%s: making result with severity %1.1f desc [%s]",
                        __FUNCTION__, severity, desc);
@@ -4437,19 +4333,21 @@ cve_scan_host (task_t task, gvm_host_t *gvm_host)
                 {
                   report_add_result (global_current_report, result);
 
-                  insert_report_host_detail (global_current_report, ip, "cve", cve,
-                                             "CVE Scanner", "App", app);
+                  insert_report_host_detail (global_current_report, ip, "cve",
+                                             cve, "CVE Scanner", "App", app);
 
                   if (location)
                     {
-                      insert_report_host_detail (global_current_report, ip, "cve", cve,
-                                                 "CVE Scanner", app, location);
-
-                      insert_report_host_detail (global_current_report, ip, "cve", cve,
-                                                 "CVE Scanner", "detected_at",
+                      insert_report_host_detail (global_current_report, ip,
+                                                 "cve", cve, "CVE Scanner", app,
                                                  location);
-                      insert_report_host_detail (global_current_report, ip, "cve", cve,
-                                                 "CVE Scanner", "detected_by",
+
+                      insert_report_host_detail (global_current_report, ip,
+                                                 "cve", cve, "CVE Scanner",
+                                                 "detected_at", location);
+                      insert_report_host_detail (global_current_report, ip,
+                                                 "cve", cve, "CVE Scanner",
+                                                 "detected_by",
                                                  /* Detected by itself. */
                                                  cve);
                     }
@@ -4505,24 +4403,21 @@ fork_cve_scan_handler (task_t task, target_t target)
   pid = fork ();
   switch (pid)
     {
-      case 0:
-        break;
-      case -1:
-        /* Parent, failed to fork. */
-        g_warning ("%s: Failed to fork: %s",
-                   __FUNCTION__,
-                   strerror (errno));
-        set_task_interrupted (task,
-                              "Error forking scan handler."
-                              "  Interrupting scan.");
-        set_report_scan_run_status (global_current_report,
-                                    TASK_STATUS_INTERRUPTED);
-        global_current_report = (report_t) 0;
-        return -9;
-      default:
-        /* Parent, successfully forked. */
-        g_debug ("%s: %i forked %i", __FUNCTION__, getpid (), pid);
-        return 0;
+    case 0:
+      break;
+    case -1:
+      /* Parent, failed to fork. */
+      g_warning ("%s: Failed to fork: %s", __FUNCTION__, strerror (errno));
+      set_task_interrupted (task, "Error forking scan handler."
+                                  "  Interrupting scan.");
+      set_report_scan_run_status (global_current_report,
+                                  TASK_STATUS_INTERRUPTED);
+      global_current_report = (report_t) 0;
+      return -9;
+    default:
+      /* Parent, successfully forked. */
+      g_debug ("%s: %i forked %i", __FUNCTION__, getpid (), pid);
+      return 0;
     }
 
   /* Child.
@@ -4543,10 +4438,10 @@ fork_cve_scan_handler (task_t task, target_t target)
   hosts = target_hosts (target);
   if (hosts == NULL)
     {
-      set_task_interrupted (task,
-                            "Error in target host list."
-                            "  Interrupting scan.");
-      set_report_scan_run_status (global_current_report, TASK_STATUS_INTERRUPTED);
+      set_task_interrupted (task, "Error in target host list."
+                                  "  Interrupting scan.");
+      set_report_scan_run_status (global_current_report,
+                                  TASK_STATUS_INTERRUPTED);
       exit (1);
     }
 
@@ -4561,10 +4456,10 @@ fork_cve_scan_handler (task_t task, target_t target)
   while ((gvm_host = gvm_hosts_next (gvm_hosts)))
     if (cve_scan_host (task, gvm_host))
       {
-        set_task_interrupted (task,
-                              "Failed to get nthlast report."
-                              "  Interrupting scan.");
-        set_report_scan_run_status (global_current_report, TASK_STATUS_INTERRUPTED);
+        set_task_interrupted (task, "Failed to get nthlast report."
+                                    "  Interrupting scan.");
+        set_report_scan_run_status (global_current_report,
+                                    TASK_STATUS_INTERRUPTED);
         gvm_hosts_free (gvm_hosts);
         exit (1);
       }
@@ -4618,7 +4513,6 @@ run_cve_task (task_t task)
   return 0;
 }
 
-
 /* OTP tasks. */
 
 /**
@@ -4728,26 +4622,22 @@ run_task_setup (task_t task, config_t *config, target_t *target,
     return ret;
 
   if (*ssh_credential
-      && ((ret = check_available ("credential",
-                                  *ssh_credential,
+      && ((ret = check_available ("credential", *ssh_credential,
                                   "get_credentials"))))
     return ret;
 
   if (*smb_credential
-      && ((ret = check_available ("credential",
-                                  *smb_credential,
+      && ((ret = check_available ("credential", *smb_credential,
                                   "get_credentials"))))
     return ret;
 
   if (*esxi_credential
-      && ((ret = check_available ("credential",
-                                  *esxi_credential,
+      && ((ret = check_available ("credential", *esxi_credential,
                                   "get_credentials"))))
     return ret;
 
   if (*snmp_credential
-      && ((ret = check_available ("credential",
-                                  *snmp_credential,
+      && ((ret = check_available ("credential", *snmp_credential,
                                   "get_credentials"))))
     return ret;
 
@@ -4783,7 +4673,8 @@ run_task_prepare_report (task_t task, char **report_id, int from,
         }
 
       global_current_report = *last_stopped_report;
-      if (report_id) *report_id = report_uuid (*last_stopped_report);
+      if (report_id)
+        *report_id = report_uuid (*last_stopped_report);
 
       /* Remove partial host information from the report. */
 
@@ -4795,7 +4686,8 @@ run_task_prepare_report (task_t task, char **report_id, int from,
 
       /* Clear the end times of the task and partial report. */
 
-      set_task_start_time_epoch (task, scan_start_time_epoch (global_current_report));
+      set_task_start_time_epoch (task,
+                                 scan_start_time_epoch (global_current_report));
       set_task_end_time (task, NULL);
       set_scan_end_time (*last_stopped_report, NULL);
     }
@@ -4836,8 +4728,7 @@ run_task_prepare_report (task_t task, char **report_id, int from,
  */
 static int
 run_slave_or_gmp_task (task_t task, int from, char **report_id,
-                       gvm_connection_t *connection,
-                       const gchar *slave_id,
+                       gvm_connection_t *connection, const gchar *slave_id,
                        const gchar *slave_name)
 {
   int ret, pid;
@@ -4904,29 +4795,26 @@ run_slave_or_gmp_task (task_t task, int from, char **report_id,
   pid = fork ();
   switch (pid)
     {
-      case 0:
-        /* Child.  Carry on starting the task, reopen the database (required
-         * after fork). */
-        reinit_manage_process ();
-        manage_session_init (current_credentials.uuid);
-        break;
-      case -1:
-        /* Parent when error. */
-        set_task_interrupted (task,
-                              "Failed to fork task child."
-                              "  Interrupting scan.");
-        set_report_scan_run_status (global_current_report, run_status);
-        global_current_report = (report_t) 0;
-        return -9;
-        break;
-      default:
-        g_debug ("%s: forked %i to run slave/gmp task",
-                 __FUNCTION__,
-                 pid);
-        /* Parent.  Return, in order to respond to client. */
-        global_current_report = (report_t) 0;
-        return 0;
-        break;
+    case 0:
+      /* Child.  Carry on starting the task, reopen the database (required
+       * after fork). */
+      reinit_manage_process ();
+      manage_session_init (current_credentials.uuid);
+      break;
+    case -1:
+      /* Parent when error. */
+      set_task_interrupted (task, "Failed to fork task child."
+                                  "  Interrupting scan.");
+      set_report_scan_run_status (global_current_report, run_status);
+      global_current_report = (report_t) 0;
+      return -9;
+      break;
+    default:
+      g_debug ("%s: forked %i to run slave/gmp task", __FUNCTION__, pid);
+      /* Parent.  Return, in order to respond to client. */
+      global_current_report = (report_t) 0;
+      return 0;
+      break;
     }
 
   /* Reset any running information. */
@@ -4942,39 +4830,33 @@ run_slave_or_gmp_task (task_t task, int from, char **report_id,
   }
 
   uuid = report_uuid (global_current_report);
-  snprintf (title, sizeof (title),
-            "gvmd: OTP: Handling slave scan %s",
-            uuid);
+  snprintf (title, sizeof (title), "gvmd: OTP: Handling slave scan %s", uuid);
   free (uuid);
   proctitle_set (title);
 
-  switch (handle_slave_task (task, target, ssh_credential, smb_credential,
-                             esxi_credential, snmp_credential,
-                             last_stopped_report, connection, slave_id,
-                             slave_name))
+  switch (handle_slave_task (
+    task, target, ssh_credential, smb_credential, esxi_credential,
+    snmp_credential, last_stopped_report, connection, slave_id, slave_name))
     {
-      case 0:
-        break;
-      default:
-        assert (0);
-      case 1:
-        set_task_interrupted (task,
-                              "Authentication with slave failed."
-                              "  Interrupting scan.");
-        set_report_scan_run_status (global_current_report, run_status);
-        exit (EXIT_FAILURE);
-      case -1:
-        set_task_interrupted (task,
-                              "Failed to make UUID."
-                              "  Interrupting scan.");
-        set_report_scan_run_status (global_current_report, run_status);
-        exit (EXIT_FAILURE);
-      case -2:
-        set_task_interrupted (task,
-                              "Failed to get slave task name."
-                              "  Interrupting scan.");
-        set_report_scan_run_status (global_current_report, run_status);
-        exit (EXIT_FAILURE);
+    case 0:
+      break;
+    default:
+      assert (0);
+    case 1:
+      set_task_interrupted (task, "Authentication with slave failed."
+                                  "  Interrupting scan.");
+      set_report_scan_run_status (global_current_report, run_status);
+      exit (EXIT_FAILURE);
+    case -1:
+      set_task_interrupted (task, "Failed to make UUID."
+                                  "  Interrupting scan.");
+      set_report_scan_run_status (global_current_report, run_status);
+      exit (EXIT_FAILURE);
+    case -2:
+      set_task_interrupted (task, "Failed to get slave task name."
+                                  "  Interrupting scan.");
+      set_report_scan_run_status (global_current_report, run_status);
+      exit (EXIT_FAILURE);
     }
   exit (EXIT_SUCCESS);
 }
@@ -5007,8 +4889,7 @@ run_gmp_task (task_t task, scanner_t scanner, int from, char **report_id)
       return -1;
     }
 
-  g_debug ("   %s: connection.host: %s", __FUNCTION__,
-           connection.host_string);
+  g_debug ("   %s: connection.host: %s", __FUNCTION__, connection.host_string);
 
   connection.port = scanner_port (scanner);
   if (connection.port == -1)
@@ -5097,12 +4978,12 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
 
   switch (scanner_setup (scanner))
     {
-      case 0:
-        break;
-      case 1:
-        return -7;
-      default:
-        return -5;
+    case 0:
+      break;
+    case 1:
+      return -7;
+    default:
+      return -5;
     }
 
   if (!openvas_scanner_connected ()
@@ -5160,29 +5041,27 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
   pid = fork ();
   switch (pid)
     {
-      case 0:
-        /* Child.  Carry on starting the task, reopen the database (required
-         * after fork). */
-        reinit_manage_process ();
-        manage_session_init (current_credentials.uuid);
-        break;
-      case -1:
-        /* Parent when error. */
-        g_warning ("%s: Failed to fork task child: %s",
-                   __FUNCTION__,
-                   strerror (errno));
-        set_task_interrupted (task,
-                              "Failed to fork task child."
-                              "  Interrupting scan.");
-        set_report_scan_run_status (global_current_report, run_status);
-        global_current_report = (report_t) 0;
-        return -9;
-        break;
-      default:
-        /* Parent.  Return, in order to respond to client. */
-        global_current_report = (report_t) 0;
-        return 0;
-        break;
+    case 0:
+      /* Child.  Carry on starting the task, reopen the database (required
+       * after fork). */
+      reinit_manage_process ();
+      manage_session_init (current_credentials.uuid);
+      break;
+    case -1:
+      /* Parent when error. */
+      g_warning ("%s: Failed to fork task child: %s", __FUNCTION__,
+                 strerror (errno));
+      set_task_interrupted (task, "Failed to fork task child."
+                                  "  Interrupting scan.");
+      set_report_scan_run_status (global_current_report, run_status);
+      global_current_report = (report_t) 0;
+      return -9;
+      break;
+    default:
+      /* Parent.  Return, in order to respond to client. */
+      global_current_report = (report_t) 0;
+      return 0;
+      break;
     }
 
   /* Reset any running information. */
@@ -5212,9 +5091,8 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
   if (send_to_server ("CLIENT <|> PREFERENCES <|>\n"))
     {
       g_warning ("%s: Failed to send OTP PREFERENCES", __FUNCTION__);
-      set_task_interrupted (task,
-                            "Failed to send OTP PREFERENCES."
-                            "  Interrupting scan.");
+      set_task_interrupted (task, "Failed to send OTP PREFERENCES."
+                                  "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       global_current_report = (report_t) 0;
       return -10;
@@ -5239,8 +5117,7 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
           if (snmp_credential)
             g_string_append (auth_plugins, "1.3.6.1.4.1.25623.1.0.105076;");
 
-          fail = sendf_to_server ("plugin_set <|> %s%s\n",
-                                  auth_plugins->str,
+          fail = sendf_to_server ("plugin_set <|> %s%s\n", auth_plugins->str,
                                   plugins);
           g_string_free (auth_plugins, TRUE);
         }
@@ -5250,9 +5127,8 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
   free (plugins);
   if (fail)
     {
-      set_task_interrupted (task,
-                            "Failed to send OTP plugin set."
-                            "  Interrupting scan.");
+      set_task_interrupted (task, "Failed to send OTP plugin set."
+                                  "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       global_current_report = (report_t) 0;
       return -10;
@@ -5262,9 +5138,8 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
 
   if (send_config_preferences (config, "SERVER_PREFS", NULL, NULL))
     {
-      set_task_interrupted (task,
-                            "Failed to send OTP SERVER PREFS."
-                            "  Interrupting scan.");
+      set_task_interrupted (task, "Failed to send OTP SERVER PREFS."
+                                  "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       global_current_report = (report_t) 0;
       return -10;
@@ -5272,9 +5147,8 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
 
   if (send_task_preferences (task))
     {
-      set_task_interrupted (task,
-                            "Failed to send OTP task preferences."
-                            "  Interrupting scan.");
+      set_task_interrupted (task, "Failed to send OTP task preferences."
+                                  "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       global_current_report = (report_t) 0;
       return -10;
@@ -5287,9 +5161,8 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
                        port_range ? port_range : "default"))
     {
       free (port_range);
-      set_task_interrupted (task,
-                            "Failed to send OTP port_range."
-                            "  Interrupting scan.");
+      set_task_interrupted (task, "Failed to send OTP port_range."
+                                  "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       global_current_report = (report_t) 0;
       return -10;
@@ -5302,9 +5175,8 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
   if (port && sendf_to_server ("auth_port_ssh <|> %s\n", port))
     {
       free (port);
-      set_task_interrupted (task,
-                            "Failed to send OTP auth_port_ssh."
-                            "  Interrupting scan.");
+      set_task_interrupted (task, "Failed to send OTP auth_port_ssh."
+                                  "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       global_current_report = (report_t) 0;
       return -10;
@@ -5318,13 +5190,13 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
   /* Send the plugins preferences. */
 
   preference_files = g_ptr_array_new ();
-  if (send_config_preferences (config, "PLUGINS_PREFS", files, preference_files))
+  if (send_config_preferences (config, "PLUGINS_PREFS", files,
+                               preference_files))
     {
       g_ptr_array_free (preference_files, TRUE);
       slist_free (files);
-      set_task_interrupted (task,
-                            "Failed to send OTP PLUGINS_PREFS."
-                            "  Interrupting scan.");
+      set_task_interrupted (task, "Failed to send OTP PLUGINS_PREFS."
+                                  "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       global_current_report = (report_t) 0;
       return -10;
@@ -5337,9 +5209,8 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
       g_ptr_array_add (preference_files, NULL);
       array_free (preference_files);
       slist_free (files);
-      set_task_interrupted (task,
-                            "Failed to send OTP scanner preferences."
-                            "  Interrupting scan.");
+      set_task_interrupted (task, "Failed to send OTP scanner preferences."
+                                  "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       global_current_report = (report_t) 0;
       return -10;
@@ -5361,24 +5232,23 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
                                " <|> %s\n",
                                user ? user : "")
               || (credential_iterator_private_key (&credentials)
-                   ? sendf_to_server ("SSH Authorization[password]:"
-                                      "SSH key passphrase:"
-                                      " <|> %s\n",
-                                      password ? password : "")
-                   : sendf_to_server ("SSH Authorization[password]:"
-                                      "SSH password (unsafe!):"
-                                      " <|> %s\n",
-                                      password ? password : "")))
+                    ? sendf_to_server ("SSH Authorization[password]:"
+                                       "SSH key passphrase:"
+                                       " <|> %s\n",
+                                       password ? password : "")
+                    : sendf_to_server ("SSH Authorization[password]:"
+                                       "SSH password (unsafe!):"
+                                       " <|> %s\n",
+                                       password ? password : "")))
 
             {
- fail:
+            fail:
               cleanup_iterator (&credentials);
               g_ptr_array_add (preference_files, NULL);
               array_free (preference_files);
               slist_free (files);
-              set_task_interrupted (task,
-                                    "Failed to send OTP SSH preferences."
-                                    "  Interrupting scan.");
+              set_task_interrupted (task, "Failed to send OTP SSH preferences."
+                                          "  Interrupting scan.");
               set_report_scan_run_status (global_current_report, run_status);
               global_current_report = (report_t) 0;
               return -10;
@@ -5391,10 +5261,10 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
                 goto fail;
 
               g_ptr_array_add (preference_files, (gpointer) file_uuid);
-              g_ptr_array_add
-               (preference_files,
-                (gpointer) g_strdup (credential_iterator_private_key
-                                      (&credentials)));
+              g_ptr_array_add (
+                preference_files,
+                (gpointer) g_strdup (
+                  credential_iterator_private_key (&credentials)));
 
               if (sendf_to_server ("SSH Authorization[file]:"
                                    "SSH private key:"
@@ -5426,9 +5296,8 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
               g_ptr_array_add (preference_files, NULL);
               array_free (preference_files);
               slist_free (files);
-              set_task_interrupted (task,
-                                    "Failed to send OTP SMB preferences."
-                                    "  Interrupting scan.");
+              set_task_interrupted (task, "Failed to send OTP SMB preferences."
+                                          "  Interrupting scan.");
               set_report_scan_run_status (global_current_report, run_status);
               global_current_report = (report_t) 0;
               return -10;
@@ -5450,17 +5319,17 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
           if (sendf_to_server ("ESXi Authorization[entry]:ESXi login name:"
                                " <|> %s\n",
                                user ? user : "")
-              || sendf_to_server ("ESXi Authorization[password]:ESXi login password:"
-                                  " <|> %s\n",
-                                  password ? password : ""))
+              || sendf_to_server (
+                   "ESXi Authorization[password]:ESXi login password:"
+                   " <|> %s\n",
+                   password ? password : ""))
             {
               cleanup_iterator (&credentials);
               g_ptr_array_add (preference_files, NULL);
               array_free (preference_files);
               slist_free (files);
-              set_task_interrupted (task,
-                                    "Failed to send OTP EXSi preferences."
-                                    "  Interrupting scan.");
+              set_task_interrupted (task, "Failed to send OTP EXSi preferences."
+                                          "  Interrupting scan.");
               set_report_scan_run_status (global_current_report, run_status);
               global_current_report = (report_t) 0;
               return -10;
@@ -5479,12 +5348,12 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
           const char *community = credential_iterator_community (&credentials);
           const char *user = credential_iterator_login (&credentials);
           const char *password = credential_iterator_password (&credentials);
-          const char *auth_algorithm
-            = credential_iterator_auth_algorithm (&credentials);
-          const char *privacy_password
-            = credential_iterator_privacy_password (&credentials);
-          const char *privacy_algorithm
-            = credential_iterator_privacy_algorithm (&credentials);
+          const char *auth_algorithm =
+            credential_iterator_auth_algorithm (&credentials);
+          const char *privacy_password =
+            credential_iterator_privacy_password (&credentials);
+          const char *privacy_algorithm =
+            credential_iterator_privacy_algorithm (&credentials);
 
           if (sendf_to_server ("SNMP Authorization[password]:SNMP Community:"
                                " <|> %s\n",
@@ -5513,9 +5382,8 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
               g_ptr_array_add (preference_files, NULL);
               array_free (preference_files);
               slist_free (files);
-              set_task_interrupted (task,
-                                    "Failed to send OTP SNMP preferences."
-                                    "  Interrupting scan.");
+              set_task_interrupted (task, "Failed to send OTP SNMP preferences."
+                                          "  Interrupting scan.");
               set_report_scan_run_status (global_current_report, run_status);
               global_current_report = (report_t) 0;
               return -10;
@@ -5532,9 +5400,8 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
     {
       array_free (preference_files);
       slist_free (files);
-      set_task_interrupted (task,
-                            "Failed to send OTP alive test preferences."
-                            "  Interrupting scan.");
+      set_task_interrupted (task, "Failed to send OTP alive test preferences."
+                                  "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       global_current_report = (report_t) 0;
       return -10;
@@ -5549,9 +5416,8 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
       g_ptr_array_add (preference_files, NULL);
       array_free (preference_files);
       slist_free (files);
-      set_task_interrupted (task,
-                            "Failed to send OTP network_targets."
-                            "  Interrupting scan.");
+      set_task_interrupted (task, "Failed to send OTP network_targets."
+                                  "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       global_current_report = (report_t) 0;
       return -10;
@@ -5564,9 +5430,8 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
       free (hosts);
       array_free (preference_files);
       slist_free (files);
-      set_task_interrupted (task,
-                            "Failed to send OTP CLIENT."
-                            "  Interrupting scan.");
+      set_task_interrupted (task, "Failed to send OTP CLIENT."
+                                  "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       global_current_report = (report_t) 0;
       return -10;
@@ -5601,9 +5466,8 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
             array_free (preference_files);
             slist_free (files);
             g_warning ("%s: Failed to send an OTP file", __FUNCTION__);
-            set_task_interrupted (task,
-                                  "Failed to send OTP file."
-                                  "  Interrupting scan.");
+            set_task_interrupted (task, "Failed to send OTP file."
+                                        "  Interrupting scan.");
             set_report_scan_run_status (global_current_report, run_status);
             global_current_report = (report_t) 0;
             return -10;
@@ -5623,9 +5487,8 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
         {
           free (hosts);
           slist_free (files);
-          set_task_interrupted (task,
-                                "Failed to send an OTP task file."
-                                "  Interrupting scan.");
+          set_task_interrupted (task, "Failed to send an OTP task file."
+                                      "  Interrupting scan.");
           set_report_scan_run_status (global_current_report, run_status);
           global_current_report = (report_t) 0;
           return -10;
@@ -5641,14 +5504,12 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
    * the hosts that have been completely scanned are excluded by being
    * included in exclude_hosts preference. */
   fail = sendf_to_server ("CLIENT <|> LONG_ATTACK <|>\n%d\n%s\n",
-                          strlen (hosts),
-                          hosts);
+                          strlen (hosts), hosts);
   free (hosts);
   if (fail)
     {
-      set_task_interrupted (task,
-                            "Failed to send OTP LONG_ATTACK."
-                            "  Interrupting scan.");
+      set_task_interrupted (task, "Failed to send OTP LONG_ATTACK."
+                                  "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, run_status);
       global_current_report = (report_t) 0;
       return -10;
@@ -5805,8 +5666,7 @@ stop_task_internal (task_t task)
   task_status_t run_status;
 
   run_status = task_run_status (task);
-  if (run_status == TASK_STATUS_REQUESTED
-      || run_status == TASK_STATUS_RUNNING)
+  if (run_status == TASK_STATUS_REQUESTED || run_status == TASK_STATUS_RUNNING)
     {
       if (current_scanner_task == task)
         {
@@ -5815,12 +5675,12 @@ stop_task_internal (task_t task)
           assert (scanner);
           switch (scanner_setup (scanner))
             {
-              case 0:
-                break;
-              case 1:
-                return -7;
-              default:
-                return -5;
+            case 0:
+              break;
+            case 1:
+              return -7;
+            default:
+              return -5;
             }
           if (!openvas_scanner_connected ()
               && (openvas_scanner_connect () || openvas_scanner_init (0)))
@@ -5985,50 +5845,50 @@ move_task (const char *task_id, const char *slave_id)
 
   switch (status)
     {
-      case TASK_STATUS_DELETE_REQUESTED:
-      case TASK_STATUS_DELETE_ULTIMATE_REQUESTED:
-      case TASK_STATUS_DELETE_WAITING:
-      case TASK_STATUS_DELETE_ULTIMATE_WAITING:
-      case TASK_STATUS_REQUESTED:
-        // Task cannot be stopped now
-        return 5;
-        break;
-      case TASK_STATUS_RUNNING:
-        if (task_scanner_type == SCANNER_TYPE_CVE)
-          return 6;
-        // Check permissions to stop and resume task
-        if (acl_user_has_access_uuid ("task", task_id, "stop_task", 0)
-            && acl_user_has_access_uuid ("task", task_id, "resume_task", 0))
-          {
-            // Stop the task, wait and resume after changes
-            stop_task_internal (task);
-            should_resume_task = 1;
+    case TASK_STATUS_DELETE_REQUESTED:
+    case TASK_STATUS_DELETE_ULTIMATE_REQUESTED:
+    case TASK_STATUS_DELETE_WAITING:
+    case TASK_STATUS_DELETE_ULTIMATE_WAITING:
+    case TASK_STATUS_REQUESTED:
+      // Task cannot be stopped now
+      return 5;
+      break;
+    case TASK_STATUS_RUNNING:
+      if (task_scanner_type == SCANNER_TYPE_CVE)
+        return 6;
+      // Check permissions to stop and resume task
+      if (acl_user_has_access_uuid ("task", task_id, "stop_task", 0)
+          && acl_user_has_access_uuid ("task", task_id, "resume_task", 0))
+        {
+          // Stop the task, wait and resume after changes
+          stop_task_internal (task);
+          should_resume_task = 1;
 
-            status = task_run_status (task);
-            while (status == TASK_STATUS_STOP_REQUESTED
-                   || status == TASK_STATUS_STOP_REQUESTED_GIVEUP
-                   || status == TASK_STATUS_STOP_WAITING)
-              {
-                sleep (5);
-                status = task_run_status (task);
-              }
-          }
-        else
-          return 98;
-        break;
-      case TASK_STATUS_STOP_REQUESTED:
-      case TASK_STATUS_STOP_REQUESTED_GIVEUP:
-      case TASK_STATUS_STOP_WAITING:
-        while (status == TASK_STATUS_STOP_REQUESTED
-                || status == TASK_STATUS_STOP_REQUESTED_GIVEUP
-                || status == TASK_STATUS_STOP_WAITING)
-          {
-            sleep (5);
-            status = task_run_status (task);
-          }
-        break;
-      default:
-        break;
+          status = task_run_status (task);
+          while (status == TASK_STATUS_STOP_REQUESTED
+                 || status == TASK_STATUS_STOP_REQUESTED_GIVEUP
+                 || status == TASK_STATUS_STOP_WAITING)
+            {
+              sleep (5);
+              status = task_run_status (task);
+            }
+        }
+      else
+        return 98;
+      break;
+    case TASK_STATUS_STOP_REQUESTED:
+    case TASK_STATUS_STOP_REQUESTED_GIVEUP:
+    case TASK_STATUS_STOP_WAITING:
+      while (status == TASK_STATUS_STOP_REQUESTED
+             || status == TASK_STATUS_STOP_REQUESTED_GIVEUP
+             || status == TASK_STATUS_STOP_WAITING)
+        {
+          sleep (5);
+          status = task_run_status (task);
+        }
+      break;
+    default:
+      break;
     }
 
   /* Update scanner. */
@@ -6050,7 +5910,6 @@ move_task (const char *task_id, const char *slave_id)
   return 0;
 }
 
-
 /* OTP Scanner messaging. */
 
 /**
@@ -6101,46 +5960,44 @@ manage_check_current_task ()
       run_status = task_run_status (current_scanner_task);
       switch (run_status)
         {
-          case TASK_STATUS_STOP_REQUESTED_GIVEUP:
-            /* This should only happen for slave tasks. */
-            assert (0);
-          case TASK_STATUS_STOP_REQUESTED:
-            if (send_to_server ("CLIENT <|> STOP_WHOLE_TEST <|> CLIENT\n"))
-              return -1;
-            set_task_run_status (current_scanner_task,
-                                 TASK_STATUS_STOP_WAITING);
-            return 1;
-            break;
-          case TASK_STATUS_DELETE_REQUESTED:
-            if (send_to_server ("CLIENT <|> STOP_WHOLE_TEST <|> CLIENT\n"))
-              return -1;
-            set_task_run_status (current_scanner_task,
-                                 TASK_STATUS_DELETE_WAITING);
-            return 1;
-            break;
-          case TASK_STATUS_DELETE_ULTIMATE_REQUESTED:
-            if (send_to_server ("CLIENT <|> STOP_WHOLE_TEST <|> CLIENT\n"))
-              return -1;
-            set_task_run_status (current_scanner_task,
-                                 TASK_STATUS_DELETE_ULTIMATE_WAITING);
-            return 1;
-            break;
-          case TASK_STATUS_DELETE_WAITING:
-          case TASK_STATUS_DELETE_ULTIMATE_WAITING:
-          case TASK_STATUS_DONE:
-          case TASK_STATUS_NEW:
-          case TASK_STATUS_REQUESTED:
-          case TASK_STATUS_RUNNING:
-          case TASK_STATUS_STOP_WAITING:
-          case TASK_STATUS_STOPPED:
-          case TASK_STATUS_INTERRUPTED:
-            break;
+        case TASK_STATUS_STOP_REQUESTED_GIVEUP:
+          /* This should only happen for slave tasks. */
+          assert (0);
+        case TASK_STATUS_STOP_REQUESTED:
+          if (send_to_server ("CLIENT <|> STOP_WHOLE_TEST <|> CLIENT\n"))
+            return -1;
+          set_task_run_status (current_scanner_task, TASK_STATUS_STOP_WAITING);
+          return 1;
+          break;
+        case TASK_STATUS_DELETE_REQUESTED:
+          if (send_to_server ("CLIENT <|> STOP_WHOLE_TEST <|> CLIENT\n"))
+            return -1;
+          set_task_run_status (current_scanner_task,
+                               TASK_STATUS_DELETE_WAITING);
+          return 1;
+          break;
+        case TASK_STATUS_DELETE_ULTIMATE_REQUESTED:
+          if (send_to_server ("CLIENT <|> STOP_WHOLE_TEST <|> CLIENT\n"))
+            return -1;
+          set_task_run_status (current_scanner_task,
+                               TASK_STATUS_DELETE_ULTIMATE_WAITING);
+          return 1;
+          break;
+        case TASK_STATUS_DELETE_WAITING:
+        case TASK_STATUS_DELETE_ULTIMATE_WAITING:
+        case TASK_STATUS_DONE:
+        case TASK_STATUS_NEW:
+        case TASK_STATUS_REQUESTED:
+        case TASK_STATUS_RUNNING:
+        case TASK_STATUS_STOP_WAITING:
+        case TASK_STATUS_STOPPED:
+        case TASK_STATUS_INTERRUPTED:
+          break;
         }
     }
   return 0;
 }
 
-
 /* Credentials. */
 
 /**
@@ -6150,8 +6007,8 @@ manage_check_current_task ()
  *
  * @return The written-out type name.
  */
-const char*
-credential_full_type (const char* abbreviation)
+const char *
+credential_full_type (const char *abbreviation)
 {
   if (abbreviation == NULL)
     return NULL;
@@ -6169,7 +6026,6 @@ credential_full_type (const char* abbreviation)
     return abbreviation;
 }
 
-
 /* System reports. */
 
 /**
@@ -6202,7 +6058,8 @@ get_slave_system_report_types (const char *required_type, gchar ***start,
     return 2;
 
   host = scanner_host (slave);
-  if (host == NULL) return -1;
+  if (host == NULL)
+    return -1;
 
   g_debug ("   %s: host: %s", __FUNCTION__, host);
 
@@ -6215,7 +6072,8 @@ get_slave_system_report_types (const char *required_type, gchar ***start,
 
   socket = gvm_server_open (&session, host, port);
   free (host);
-  if (socket == -1) return 4;
+  if (socket == -1)
+    return 4;
 
   g_debug ("   %s: connected", __FUNCTION__);
 
@@ -6238,8 +6096,8 @@ get_slave_system_report_types (const char *required_type, gchar ***start,
   gvm_server_close (socket, session);
 
   reports = get->entities;
-  end = *types = *start = g_malloc ((xml_count_entities (reports) + 1)
-                                    * sizeof (gchar*));
+  end = *types = *start =
+    g_malloc ((xml_count_entities (reports) + 1) * sizeof (gchar *));
   while ((report = first_entity (reports)))
     {
       if (strcmp (entity_name (report), "system_report") == 0)
@@ -6272,7 +6130,7 @@ get_slave_system_report_types (const char *required_type, gchar ***start,
 
   return 0;
 
- fail:
+fail:
   gvm_server_close (socket, session);
   return ret;
 }
@@ -6311,21 +6169,17 @@ get_system_report_types (const char *required_type, gchar ***start,
 
   g_debug ("   command: " COMMAND);
 
-  if ((g_spawn_command_line_sync (COMMAND,
-                                  &astdout,
-                                  &astderr,
-                                  &exit_status,
+  if ((g_spawn_command_line_sync (COMMAND, &astdout, &astderr, &exit_status,
                                   &err)
        == FALSE)
-      || (WIFEXITED (exit_status) == 0)
-      || WEXITSTATUS (exit_status))
+      || (WIFEXITED (exit_status) == 0) || WEXITSTATUS (exit_status))
     {
       g_debug ("%s: gvmcg failed with %d", __FUNCTION__, exit_status);
       g_debug ("%s: stdout: %s", __FUNCTION__, astdout);
       g_debug ("%s: stderr: %s", __FUNCTION__, astderr);
       g_free (astdout);
       g_free (astderr);
-      *start = *types = g_malloc0 (sizeof (gchar*) * 2);
+      *start = *types = g_malloc0 (sizeof (gchar *) * 2);
       (*start)[0] = g_strdup ("fallback Fallback Report");
       (*start)[0][strlen ("fallback")] = '\0';
       return 3;
@@ -6376,7 +6230,7 @@ get_system_report_types (const char *required_type, gchar ***start,
         }
     }
   else
-    *start = *types = g_malloc0 (sizeof (gchar*));
+    *start = *types = g_malloc0 (sizeof (gchar *));
 
   g_free (astdout);
   g_free (astderr);
@@ -6398,9 +6252,8 @@ get_system_report_types (const char *required_type, gchar ***start,
  *         99 permission denied, -1 on error.
  */
 int
-init_system_report_type_iterator (report_type_iterator_t* iterator,
-                                  const char* type,
-                                  const char* slave_id)
+init_system_report_type_iterator (report_type_iterator_t *iterator,
+                                  const char *type, const char *slave_id)
 {
   int ret;
 
@@ -6423,7 +6276,7 @@ init_system_report_type_iterator (report_type_iterator_t* iterator,
  * @param[in]  iterator  Iterator.
  */
 void
-cleanup_report_type_iterator (report_type_iterator_t* iterator)
+cleanup_report_type_iterator (report_type_iterator_t *iterator)
 {
   g_strfreev (iterator->start);
 }
@@ -6438,10 +6291,11 @@ cleanup_report_type_iterator (report_type_iterator_t* iterator)
  * @return TRUE if there was a next item, else FALSE.
  */
 gboolean
-next_report_type (report_type_iterator_t* iterator)
+next_report_type (report_type_iterator_t *iterator)
 {
   iterator->current++;
-  if (*iterator->current == NULL) return FALSE;
+  if (*iterator->current == NULL)
+    return FALSE;
   return TRUE;
 }
 
@@ -6452,10 +6306,10 @@ next_report_type (report_type_iterator_t* iterator)
  *
  * @return Name.
  */
-const char*
-report_type_iterator_name (report_type_iterator_t* iterator)
+const char *
+report_type_iterator_name (report_type_iterator_t *iterator)
 {
-  return (const char*) *iterator->current;
+  return (const char *) *iterator->current;
 }
 
 /**
@@ -6465,8 +6319,8 @@ report_type_iterator_name (report_type_iterator_t* iterator)
  *
  * @return Title.
  */
-const char*
-report_type_iterator_title (report_type_iterator_t* iterator)
+const char *
+report_type_iterator_title (report_type_iterator_t *iterator)
 {
   const char *name = *iterator->current;
   return name + strlen (name) + 1;
@@ -6508,7 +6362,8 @@ slave_system_report (const char *name, const char *duration,
     return 2;
 
   host = scanner_host (slave);
-  if (host == NULL) return -1;
+  if (host == NULL)
+    return -1;
 
   g_debug ("   %s: host: %s", __FUNCTION__, host);
 
@@ -6521,7 +6376,8 @@ slave_system_report (const char *name, const char *duration,
 
   socket = gvm_server_open (&session, host, port);
   free (host);
-  if (socket == -1) return 4;
+  if (socket == -1)
+    return 4;
 
   g_debug ("   %s: connected", __FUNCTION__);
 
@@ -6566,7 +6422,7 @@ slave_system_report (const char *name, const char *duration,
   g_warning ("   %s: error getting entity", __FUNCTION__);
   return 6;
 
- fail:
+fail:
   gvm_server_close (socket, session);
   return ret;
 }
@@ -6574,10 +6430,11 @@ slave_system_report (const char *name, const char *duration,
 /**
  * @brief Header for fallback system report.
  */
-#define FALLBACK_SYSTEM_REPORT_HEADER \
-"This is the most basic, fallback report.  The system can be configured to\n" \
-"produce more powerful reports.  Please contact your system administrator\n" \
-"for more information.\n\n"
+#define FALLBACK_SYSTEM_REPORT_HEADER                                          \
+  "This is the most basic, fallback report.  The system can be configured "    \
+  "to\n"                                                                       \
+  "produce more powerful reports.  Please contact your system administrator\n" \
+  "for more information.\n\n"
 
 /**
  * @brief Default duration for system reports.
@@ -6620,96 +6477,77 @@ manage_system_report (const char *name, const char *duration,
     {
       duration_num = atol (duration);
       if (duration_num == 0)
-        return manage_system_report ("blank", NULL, NULL, NULL,
-                                     NULL, report);
+        return manage_system_report ("blank", NULL, NULL, NULL, NULL, report);
     }
   if (start_time && strcmp (start_time, ""))
     {
       start_time_num = parse_iso_time (start_time);
       if (start_time_num == 0)
-        return manage_system_report ("blank", NULL, NULL, NULL,
-                                     NULL, report);
+        return manage_system_report ("blank", NULL, NULL, NULL, NULL, report);
     }
   if (end_time && strcmp (end_time, ""))
     {
       end_time_num = parse_iso_time (end_time);
       if (end_time_num == 0)
-        return manage_system_report ("blank", NULL, NULL, NULL,
-                                     NULL, report);
+        return manage_system_report ("blank", NULL, NULL, NULL, NULL, report);
     }
 
   if (slave_id && strcmp (slave_id, "0"))
-    return slave_system_report (name, duration, start_time, end_time,
-                                slave_id, report);
+    return slave_system_report (name, duration, start_time, end_time, slave_id,
+                                report);
 
   /* For simplicity, it's up to the command to do the base64 encoding. */
   if (start_time && strcmp (start_time, ""))
     {
       if (end_time && strcmp (end_time, ""))
         {
-          command = g_strdup_printf ("gvmcg %ld %ld %s",
-                                     start_time_num,
-                                     end_time_num,
-                                     name);
+          command = g_strdup_printf ("gvmcg %ld %ld %s", start_time_num,
+                                     end_time_num, name);
         }
       else if (duration && strcmp (duration, ""))
         {
-          command = g_strdup_printf ("gvmcg %ld %ld %s",
-                                     start_time_num,
-                                     start_time_num + duration_num,
-                                     name);
+          command = g_strdup_printf ("gvmcg %ld %ld %s", start_time_num,
+                                     start_time_num + duration_num, name);
         }
       else
         {
-          command = g_strdup_printf ("gvmcg %ld %ld %s",
-                                     start_time_num,
-                                     start_time_num + DEFAULT_DURATION,
-                                     name);
+          command = g_strdup_printf ("gvmcg %ld %ld %s", start_time_num,
+                                     start_time_num + DEFAULT_DURATION, name);
         }
     }
   else if (end_time && strcmp (end_time, ""))
     {
       if (duration && strcmp (duration, ""))
         {
-          command = g_strdup_printf ("gvmcg %ld %ld %s",
-                                     end_time_num - duration_num,
-                                     end_time_num,
-                                     name);
+          command =
+            g_strdup_printf ("gvmcg %ld %ld %s", end_time_num - duration_num,
+                             end_time_num, name);
         }
       else
         {
           command = g_strdup_printf ("gvmcg %ld %ld %s",
                                      end_time_num - DEFAULT_DURATION,
-                                     end_time_num,
-                                     name);
+                                     end_time_num, name);
         }
     }
   else
     {
       if (duration && strcmp (duration, ""))
         {
-          command = g_strdup_printf ("gvmcg %ld %s",
-                                     duration_num,
-                                     name);
+          command = g_strdup_printf ("gvmcg %ld %s", duration_num, name);
         }
       else
         {
-          command = g_strdup_printf ("gvmcg %ld %s",
-                                     DEFAULT_DURATION,
-                                     name);
+          command = g_strdup_printf ("gvmcg %ld %s", DEFAULT_DURATION, name);
         }
     }
 
   g_debug ("   command: %s", command);
 
-  if ((g_spawn_command_line_sync (command,
-                                  &astdout,
-                                  &astderr,
-                                  &exit_status,
+  if ((g_spawn_command_line_sync (command, &astdout, &astderr, &exit_status,
                                   &err)
        == FALSE)
-      || (WIFEXITED (exit_status) == 0)
-      || WEXITSTATUS (exit_status))
+      || (WIFEXITED (exit_status) == 0) || WEXITSTATUS (exit_status))
     {
       int ret;
       double load[3];
@@ -6730,24 +6568,18 @@ manage_system_report (const char *name, const char *duration,
       ret = getloadavg (load, 3);
       if (ret == 3)
         {
-          g_string_append_printf (buffer,
-                                  "Load average for past minute:     %.1f\n",
-                                  load[0]);
-          g_string_append_printf (buffer,
-                                  "Load average for past 5 minutes:  %.1f\n",
-                                  load[1]);
-          g_string_append_printf (buffer,
-                                  "Load average for past 15 minutes: %.1f\n",
-                                  load[2]);
+          g_string_append_printf (
+            buffer, "Load average for past minute:     %.1f\n", load[0]);
+          g_string_append_printf (
+            buffer, "Load average for past 5 minutes:  %.1f\n", load[1]);
+          g_string_append_printf (
+            buffer, "Load average for past 15 minutes: %.1f\n", load[2]);
         }
       else
         g_string_append (buffer, "Error getting load averages.\n");
 
       get_error = NULL;
-      g_file_get_contents ("/proc/meminfo",
-                           &output,
-                           &output_len,
-                           &get_error);
+      g_file_get_contents ("/proc/meminfo", &output, &output_len, &get_error);
       if (get_error)
         g_error_free (get_error);
       else
@@ -6770,15 +6602,13 @@ manage_system_report (const char *name, const char *duration,
       g_free (astdout);
       if (strcmp (name, "blank") == 0)
         return -1;
-      return manage_system_report ("blank", NULL, NULL, NULL,
-                                   NULL, report);
+      return manage_system_report ("blank", NULL, NULL, NULL, NULL, report);
     }
   else
     *report = astdout;
   return 0;
 }
 
-
 /* Scheduling. */
 
 /**
@@ -6792,7 +6622,7 @@ int authenticate_allow_all = 0;
  * @brief UUID of user whose scheduled task is to be started (in connection
  *        with authenticate_allow_all).
  */
-static gchar* schedule_user_uuid = NULL;
+static gchar *schedule_user_uuid = NULL;
 
 /**
  * @brief Ensure that any subsequent authentications succeed.
@@ -6810,7 +6640,7 @@ manage_auth_allow_all (int scheduled)
  *
  * @return UUID of user that scheduled the current task.
  */
-const gchar*
+const gchar *
 get_scheduled_user_uuid ()
 {
   return schedule_user_uuid;
@@ -6823,7 +6653,7 @@ get_scheduled_user_uuid ()
  * @param user_uuid UUID of user that scheduled the current task.
  */
 void
-set_scheduled_user_uuid (const gchar* user_uuid)
+set_scheduled_user_uuid (const gchar *user_uuid)
 {
   gchar *user_uuid_copy = user_uuid ? g_strdup (user_uuid) : NULL;
   g_free (schedule_user_uuid);
@@ -6835,9 +6665,9 @@ set_scheduled_user_uuid (const gchar* user_uuid)
  */
 typedef struct
 {
-  gchar *owner_uuid;   ///< UUID of owner.
-  gchar *owner_name;   ///< Name of owner.
-  gchar *task_uuid;    ///< UUID of task.
+  gchar *owner_uuid; ///< UUID of owner.
+  gchar *owner_name; ///< Name of owner.
+  gchar *task_uuid;  ///< UUID of task.
 } scheduled_task_t;
 
 /**
@@ -6850,8 +6680,8 @@ typedef struct
  * @return Scheduled task structure.
  */
 static scheduled_task_t *
-scheduled_task_new (const gchar* task_uuid, const gchar* owner_uuid,
-                    const gchar* owner_name)
+scheduled_task_new (const gchar *task_uuid, const gchar *owner_uuid,
+                    const gchar *owner_name)
 {
   scheduled_task_t *scheduled_task;
 
@@ -6904,26 +6734,26 @@ scheduled_task_start (scheduled_task_t *scheduled_task,
   pid = fork ();
   switch (pid)
     {
-      case 0:
-        /* Child.  Carry on to start the task, reopen the database (required
-         * after fork). */
+    case 0:
+      /* Child.  Carry on to start the task, reopen the database (required
+       * after fork). */
 
-        /* Restore the sigmask that was blanked for pselect. */
-        pthread_sigmask (SIG_SETMASK, sigmask_current, NULL);
+      /* Restore the sigmask that was blanked for pselect. */
+      pthread_sigmask (SIG_SETMASK, sigmask_current, NULL);
 
-        reinit_manage_process ();
-        manage_session_init (current_credentials.uuid);
-        break;
+      reinit_manage_process ();
+      manage_session_init (current_credentials.uuid);
+      break;
 
-      case -1:
-        /* Parent on error. */
-        g_warning ("%s: fork failed", __FUNCTION__);
-        return -1;
+    case -1:
+      /* Parent on error. */
+      g_warning ("%s: fork failed", __FUNCTION__);
+      return -1;
 
-      default:
-        /* Parent.  Continue to next task. */
-        g_debug ("%s: %i forked %i", __FUNCTION__, getpid (), pid);
-        return 0;
+    default:
+      /* Parent.  Continue to next task. */
+      g_debug ("%s: %i forked %i", __FUNCTION__, getpid (), pid);
+      return 0;
     }
 
   /* Run the callback to fork a child connected to the Manager. */
@@ -6931,126 +6761,115 @@ scheduled_task_start (scheduled_task_t *scheduled_task,
   pid = fork_connection (&connection, scheduled_task->owner_uuid);
   switch (pid)
     {
-      case 0:
-        /* Child.  Break, start task, exit. */
-        break;
+    case 0:
+      /* Child.  Break, start task, exit. */
+      break;
 
-      case -1:
-        /* Parent on error. */
-        g_warning ("%s: fork_connection failed", __FUNCTION__);
+    case -1:
+      /* Parent on error. */
+      g_warning ("%s: fork_connection failed", __FUNCTION__);
+      reschedule_task (scheduled_task->task_uuid);
+      scheduled_task_free (scheduled_task);
+      exit (EXIT_FAILURE);
+      break;
+
+    default:
+      {
+        int status;
+
+        /* Parent.  Wait for child, to check return. */
+
+        snprintf (title, sizeof (title), "gvmd: scheduler: waiting for %i",
+                  pid);
+        proctitle_set (title);
+
+        g_debug ("%s: %i fork_connectioned %i", __FUNCTION__, getpid (), pid);
+
+        if (signal (SIGCHLD, SIG_DFL) == SIG_ERR)
+          g_warning ("%s: failed to set SIGCHLD", __FUNCTION__);
+        while (waitpid (pid, &status, 0) < 0)
+          {
+            if (errno == ECHILD)
+              {
+                g_warning ("%s: Failed to get child exit,"
+                           " so task '%s' may not have been scheduled",
+                           __FUNCTION__, scheduled_task->task_uuid);
+                scheduled_task_free (scheduled_task);
+                exit (EXIT_FAILURE);
+              }
+            if (errno == EINTR)
+              continue;
+            g_warning ("%s: waitpid: %s", __FUNCTION__, strerror (errno));
+            g_warning ("%s: As a result, task '%s' may not have been"
+                       " scheduled",
+                       __FUNCTION__, scheduled_task->task_uuid);
+            scheduled_task_free (scheduled_task);
+            exit (EXIT_FAILURE);
+          }
+        if (WIFEXITED (status))
+          switch (WEXITSTATUS (status))
+            {
+            case EXIT_SUCCESS:
+              {
+                schedule_t schedule;
+                int periods;
+                const gchar *task_uuid;
+
+                /* Child succeeded, so task successfully started. */
+
+                task_uuid = scheduled_task->task_uuid;
+                schedule = task_schedule_uuid (task_uuid);
+                if (schedule && schedule_period (schedule) == 0
+                    && schedule_duration (schedule) == 0
+                    /* Check next time too, in case the user changed
+                     * the schedule after this task was added to the
+                     * "starts" list. */
+                    && task_schedule_next_time_uuid (task_uuid) == 0)
+                  /* A once-off schedule without a duration, remove
+                   * it from the task.  If it has a duration it
+                   * will be removed by manage_schedule via
+                   * clear_duration_schedules, after the duration. */
+                  set_task_schedule_uuid (task_uuid, 0, 0);
+                else if ((periods = task_schedule_periods_uuid (task_uuid)))
+                  {
+                    /* A task restricted to a certain number of
+                     * scheduled runs. */
+                    if (periods > 1)
+                      {
+                        set_task_schedule_periods (task_uuid, periods - 1);
+                      }
+                    else if (periods == 1 && schedule_duration (schedule) == 0)
+                      {
+                        /* Last run of a task restricted to a certain
+                         * number of scheduled runs. */
+                        set_task_schedule_uuid (task_uuid, 0, 1);
+                      }
+                    else if (periods == 1)
+                      /* Flag that the task has started, for
+                       * update_duration_schedule_periods. */
+                      set_task_schedule_next_time_uuid (task_uuid, 0);
+                  }
+              }
+              scheduled_task_free (scheduled_task);
+              exit (EXIT_SUCCESS);
+
+            case EXIT_FAILURE:
+            default:
+              break;
+            }
+
+        /* Child failed, reset task schedule time and exit. */
+
+        g_warning ("%s: child failed", __FUNCTION__);
         reschedule_task (scheduled_task->task_uuid);
         scheduled_task_free (scheduled_task);
         exit (EXIT_FAILURE);
-        break;
-
-      default:
-        {
-          int status;
-
-          /* Parent.  Wait for child, to check return. */
-
-          snprintf (title, sizeof (title),
-                    "gvmd: scheduler: waiting for %i",
-                    pid);
-          proctitle_set (title);
-
-          g_debug ("%s: %i fork_connectioned %i",
-                   __FUNCTION__, getpid (), pid);
-
-          if (signal (SIGCHLD, SIG_DFL) == SIG_ERR)
-            g_warning ("%s: failed to set SIGCHLD", __FUNCTION__);
-          while (waitpid (pid, &status, 0) < 0)
-            {
-              if (errno == ECHILD)
-                {
-                  g_warning ("%s: Failed to get child exit,"
-                             " so task '%s' may not have been scheduled",
-                             __FUNCTION__,
-                             scheduled_task->task_uuid);
-                  scheduled_task_free (scheduled_task);
-                  exit (EXIT_FAILURE);
-                }
-              if (errno == EINTR)
-                continue;
-              g_warning ("%s: waitpid: %s",
-                         __FUNCTION__,
-                         strerror (errno));
-              g_warning ("%s: As a result, task '%s' may not have been"
-                         " scheduled",
-                         __FUNCTION__,
-                         scheduled_task->task_uuid);
-              scheduled_task_free (scheduled_task);
-              exit (EXIT_FAILURE);
-            }
-          if (WIFEXITED (status))
-            switch (WEXITSTATUS (status))
-              {
-                case EXIT_SUCCESS:
-                  {
-                    schedule_t schedule;
-                    int periods;
-                    const gchar *task_uuid;
-
-                    /* Child succeeded, so task successfully started. */
-
-                    task_uuid = scheduled_task->task_uuid;
-                    schedule = task_schedule_uuid (task_uuid);
-                    if (schedule
-                        && schedule_period (schedule) == 0
-                        && schedule_duration (schedule) == 0
-                        /* Check next time too, in case the user changed
-                         * the schedule after this task was added to the
-                         * "starts" list. */
-                        && task_schedule_next_time_uuid (task_uuid) == 0)
-                      /* A once-off schedule without a duration, remove
-                       * it from the task.  If it has a duration it
-                       * will be removed by manage_schedule via
-                       * clear_duration_schedules, after the duration. */
-                      set_task_schedule_uuid (task_uuid, 0, 0);
-                    else if ((periods = task_schedule_periods_uuid
-                                         (task_uuid)))
-                      {
-                        /* A task restricted to a certain number of
-                         * scheduled runs. */
-                        if (periods > 1)
-                          {
-                            set_task_schedule_periods (task_uuid,
-                                                       periods - 1);
-                          }
-                        else if (periods == 1
-                                 && schedule_duration (schedule) == 0)
-                          {
-                            /* Last run of a task restricted to a certain
-                             * number of scheduled runs. */
-                            set_task_schedule_uuid (task_uuid, 0, 1);
-                          }
-                        else if (periods == 1)
-                          /* Flag that the task has started, for
-                           * update_duration_schedule_periods. */
-                          set_task_schedule_next_time_uuid (task_uuid, 0);
-                      }
-                  }
-                  scheduled_task_free (scheduled_task);
-                  exit (EXIT_SUCCESS);
-
-                case EXIT_FAILURE:
-                default:
-                  break;
-              }
-
-          /* Child failed, reset task schedule time and exit. */
-
-          g_warning ("%s: child failed", __FUNCTION__);
-          reschedule_task (scheduled_task->task_uuid);
-          scheduled_task_free (scheduled_task);
-          exit (EXIT_FAILURE);
-        }
+      }
     }
 
   /* Start the task. */
 
-  snprintf (title, sizeof (title),
-            "gvmd: scheduler: starting %s",
+  snprintf (title, sizeof (title), "gvmd: scheduler: starting %s",
             scheduled_task->task_uuid);
   proctitle_set (title);
 
@@ -7064,15 +6883,13 @@ scheduled_task_start (scheduled_task_t *scheduled_task,
       exit (EXIT_FAILURE);
     }
 
-  if (gmp_resume_task_report_c (&connection,
-                                scheduled_task->task_uuid,
-                                NULL))
+  if (gmp_resume_task_report_c (&connection, scheduled_task->task_uuid, NULL))
     {
-      if (gmp_start_task_report_c (&connection,
-                                   scheduled_task->task_uuid,
+      if (gmp_start_task_report_c (&connection, scheduled_task->task_uuid,
                                    NULL))
         {
-          g_warning ("%s: gmp_start_task and gmp_resume_task failed", __FUNCTION__);
+          g_warning ("%s: gmp_start_task and gmp_resume_task failed",
+                     __FUNCTION__);
           scheduled_task_free (scheduled_task);
           gvm_connection_free (&connection);
           exit (EXIT_FAILURE);
@@ -7110,24 +6927,23 @@ scheduled_task_stop (scheduled_task_t *scheduled_task,
 
   switch (fork_connection (&connection, scheduled_task->owner_uuid))
     {
-      case 0:
-        /* Child.  Break, stop task, exit. */
-        break;
+    case 0:
+      /* Child.  Break, stop task, exit. */
+      break;
 
-      case -1:
-        /* Parent on error. */
-        g_warning ("%s: stop fork failed", __FUNCTION__);
-        return -1;
+    case -1:
+      /* Parent on error. */
+      g_warning ("%s: stop fork failed", __FUNCTION__);
+      return -1;
 
-      default:
-        /* Parent.  Continue to next task. */
-        return 0;
+    default:
+      /* Parent.  Continue to next task. */
+      return 0;
     }
 
   /* Stop the task. */
 
-  snprintf (title, sizeof (title),
-            "gvmd: scheduler: stopping %s",
+  snprintf (title, sizeof (title), "gvmd: scheduler: stopping %s",
             scheduled_task->task_uuid);
   proctitle_set (title);
 
@@ -7162,8 +6978,7 @@ scheduled_task_stop (scheduled_task_t *scheduled_task,
  *                                    the NVTS.  Child does not return.
  */
 void
-manage_sync (sigset_t *sigmask_current,
-             int (*fork_update_nvt_cache) ())
+manage_sync (sigset_t *sigmask_current, int (*fork_update_nvt_cache) ())
 {
   manage_sync_nvts (fork_update_nvt_cache);
   manage_sync_scap (sigmask_current);
@@ -7184,8 +6999,7 @@ manage_sync (sigset_t *sigmask_current,
  * @return 0 success, 1 failed to get lock, -1 error.
  */
 int
-manage_schedule (manage_connection_forker_t fork_connection,
-                 gboolean run_tasks,
+manage_schedule (manage_connection_forker_t fork_connection, gboolean run_tasks,
                  sigset_t *sigmask_current)
 {
   iterator_t schedules;
@@ -7248,11 +7062,10 @@ manage_schedule (manage_connection_forker_t fork_connection,
         icalendar = task_schedule_iterator_icalendar (&schedules);
         zone = task_schedule_iterator_timezone (&schedules);
 
-        g_debug ("%s: start due for %llu, setting next_time",
-                 __FUNCTION__,
+        g_debug ("%s: start due for %llu, setting next_time", __FUNCTION__,
                  task_schedule_iterator_task (&schedules));
-        set_task_schedule_next_time
-         (task_schedule_iterator_task (&schedules),
+        set_task_schedule_next_time (
+          task_schedule_iterator_task (&schedules),
           icalendar_next_time_from_string (icalendar, zone, 0));
 
         /* Skip this task if it was already added to the starts list
@@ -7263,8 +7076,7 @@ manage_schedule (manage_connection_forker_t fork_connection,
 
         if (timed_out)
           {
-            g_message (" %s: Task timed out: %s",
-                       __FUNCTION__,
+            g_message (" %s: Task timed out: %s", __FUNCTION__,
                        task_schedule_iterator_task_uuid (&schedules));
             continue;
           }
@@ -7273,12 +7085,11 @@ manage_schedule (manage_connection_forker_t fork_connection,
 
         /* Add task UUID and owner name and UUID to the list. */
 
-        starts = g_slist_prepend
-                  (starts,
-                   scheduled_task_new
-                    (task_schedule_iterator_task_uuid (&schedules),
-                     task_schedule_iterator_owner_uuid (&schedules),
-                     task_schedule_iterator_owner_name (&schedules)));
+        starts = g_slist_prepend (
+          starts,
+          scheduled_task_new (task_schedule_iterator_task_uuid (&schedules),
+                              task_schedule_iterator_owner_uuid (&schedules),
+                              task_schedule_iterator_owner_name (&schedules)));
       }
     else if (task_schedule_iterator_stop_due (&schedules))
       {
@@ -7291,12 +7102,11 @@ manage_schedule (manage_connection_forker_t fork_connection,
 
         /* Add task UUID and owner name and UUID to the list. */
 
-        stops = g_slist_prepend
-                 (stops,
-                  scheduled_task_new
-                   (task_schedule_iterator_task_uuid (&schedules),
-                    task_schedule_iterator_owner_uuid (&schedules),
-                    task_schedule_iterator_owner_name (&schedules)));
+        stops = g_slist_prepend (
+          stops,
+          scheduled_task_new (task_schedule_iterator_task_uuid (&schedules),
+                              task_schedule_iterator_owner_uuid (&schedules),
+                              task_schedule_iterator_owner_name (&schedules)));
       }
   cleanup_task_schedule_iterator (&schedules);
 
@@ -7313,8 +7123,7 @@ manage_schedule (manage_connection_forker_t fork_connection,
       starts = starts->next;
       g_slist_free_1 (head);
 
-      if (scheduled_task_start (scheduled_task,
-                                fork_connection,
+      if (scheduled_task_start (scheduled_task, fork_connection,
                                 sigmask_current))
         /* Error.  Reschedule and continue to next task. */
         reschedule_task (scheduled_task->task_uuid);
@@ -7333,8 +7142,7 @@ manage_schedule (manage_connection_forker_t fork_connection,
       stops = stops->next;
       g_slist_free_1 (head);
 
-      if (scheduled_task_stop (scheduled_task,
-                               fork_connection,
+      if (scheduled_task_stop (scheduled_task, fork_connection,
                                sigmask_current))
         {
           /* Error.  Exit. */
@@ -7382,7 +7190,6 @@ set_schedule_timeout (int new_timeout)
     schedule_timeout = new_timeout;
 }
 
-
 /* Report formats. */
 
 /**
@@ -7397,22 +7204,22 @@ report_format_param_type_name (report_format_param_type_t type)
 {
   switch (type)
     {
-      case REPORT_FORMAT_PARAM_TYPE_BOOLEAN:
-        return "boolean";
-      case REPORT_FORMAT_PARAM_TYPE_INTEGER:
-        return "integer";
-      case REPORT_FORMAT_PARAM_TYPE_SELECTION:
-        return "selection";
-      case REPORT_FORMAT_PARAM_TYPE_STRING:
-        return "string";
-      case REPORT_FORMAT_PARAM_TYPE_TEXT:
-        return "text";
-      case REPORT_FORMAT_PARAM_TYPE_REPORT_FORMAT_LIST:
-        return "report_format_list";
-      default:
-        assert (0);
-      case REPORT_FORMAT_PARAM_TYPE_ERROR:
-        return "ERROR";
+    case REPORT_FORMAT_PARAM_TYPE_BOOLEAN:
+      return "boolean";
+    case REPORT_FORMAT_PARAM_TYPE_INTEGER:
+      return "integer";
+    case REPORT_FORMAT_PARAM_TYPE_SELECTION:
+      return "selection";
+    case REPORT_FORMAT_PARAM_TYPE_STRING:
+      return "string";
+    case REPORT_FORMAT_PARAM_TYPE_TEXT:
+      return "text";
+    case REPORT_FORMAT_PARAM_TYPE_REPORT_FORMAT_LIST:
+      return "report_format_list";
+    default:
+      assert (0);
+    case REPORT_FORMAT_PARAM_TYPE_ERROR:
+      return "ERROR";
     }
 }
 
@@ -7456,16 +7263,12 @@ backup_file_name (const char *name)
   if (length && (name[length - 1] == '~'))
     return 1;
 
-  if ((length > 3)
-      && (name[length - 4] == '.'))
-    return ((name[length - 3] == 'b')
-            && (name[length - 2] == 'a')
+  if ((length > 3) && (name[length - 4] == '.'))
+    return ((name[length - 3] == 'b') && (name[length - 2] == 'a')
             && (name[length - 1] == 'k'))
-           || ((name[length - 3] == 'B')
-               && (name[length - 2] == 'A')
+           || ((name[length - 3] == 'B') && (name[length - 2] == 'A')
                && (name[length - 1] == 'K'))
-           || ((name[length - 3] == 'C')
-               && (name[length - 2] == 'K')
+           || ((name[length - 3] == 'C') && (name[length - 2] == 'K')
                && (name[length - 1] == 'P'));
 
   return 0;
@@ -7494,9 +7297,7 @@ get_report_format_files (const char *dir_name, GPtrArray **start)
   setlocale (LC_ALL, locale);
   if (n < 0)
     {
-      g_warning ("%s: failed to open dir %s: %s",
-                 __FUNCTION__,
-                 dir_name,
+      g_warning ("%s: failed to open dir %s: %s", __FUNCTION__, dir_name,
                  strerror (errno));
       return -1;
     }
@@ -7527,10 +7328,7 @@ get_report_format_files (const char *dir_name, GPtrArray **start)
 gchar *
 predefined_report_format_dir (const gchar *uuid)
 {
-  return g_build_filename (GVMD_DATA_DIR,
-                           "report_formats",
-                           uuid,
-                           NULL);
+  return g_build_filename (GVMD_DATA_DIR, "report_formats", uuid, NULL);
 }
 
 /**
@@ -7543,7 +7341,7 @@ predefined_report_format_dir (const gchar *uuid)
  * @return 0 on success, -1 on error.
  */
 int
-init_report_format_file_iterator (file_iterator_t* iterator,
+init_report_format_file_iterator (file_iterator_t *iterator,
                                   report_format_t report_format)
 {
   gchar *dir_name, *uuid;
@@ -7561,11 +7359,8 @@ init_report_format_file_iterator (file_iterator_t* iterator,
       owner_uuid = report_format_owner_uuid (report_format);
       if (owner_uuid == NULL)
         return -1;
-      dir_name = g_build_filename (GVMD_STATE_DIR,
-                                   "report_formats",
-                                   owner_uuid,
-                                   uuid,
-                                   NULL);
+      dir_name = g_build_filename (GVMD_STATE_DIR, "report_formats", owner_uuid,
+                                   uuid, NULL);
       g_free (owner_uuid);
     }
 
@@ -7589,7 +7384,7 @@ init_report_format_file_iterator (file_iterator_t* iterator,
  * @param[in]  iterator  Iterator.
  */
 void
-cleanup_file_iterator (file_iterator_t* iterator)
+cleanup_file_iterator (file_iterator_t *iterator)
 {
   array_free (iterator->start);
   g_free (iterator->dir_name);
@@ -7605,10 +7400,11 @@ cleanup_file_iterator (file_iterator_t* iterator)
  * @return TRUE if there was a next item, else FALSE.
  */
 gboolean
-next_file (file_iterator_t* iterator)
+next_file (file_iterator_t *iterator)
 {
   iterator->current++;
-  if (*iterator->current == NULL) return FALSE;
+  if (*iterator->current == NULL)
+    return FALSE;
   return TRUE;
 }
 
@@ -7619,10 +7415,10 @@ next_file (file_iterator_t* iterator)
  *
  * @return File name.
  */
-const char*
-file_iterator_name (file_iterator_t* iterator)
+const char *
+file_iterator_name (file_iterator_t *iterator)
 {
-  return (const char*) *iterator->current;
+  return (const char *) *iterator->current;
 }
 
 /**
@@ -7632,30 +7428,25 @@ file_iterator_name (file_iterator_t* iterator)
  *
  * @return Freshly allocated file contents, in base64.
  */
-gchar*
-file_iterator_content_64 (file_iterator_t* iterator)
+gchar *
+file_iterator_content_64 (file_iterator_t *iterator)
 {
   gchar *path_name, *content;
   GError *error;
   gsize content_size;
 
-  path_name = g_build_filename (iterator->dir_name,
-                                (gchar*) *iterator->current,
-                                NULL);
+  path_name =
+    g_build_filename (iterator->dir_name, (gchar *) *iterator->current, NULL);
 
   /* Read in the contents. */
 
   error = NULL;
-  if (g_file_get_contents (path_name,
-                           &content,
-                           &content_size,
-                           &error)
-      == FALSE)
+  if (g_file_get_contents (path_name, &content, &content_size, &error) == FALSE)
     {
       if (error)
         {
-          g_debug ("%s: failed to read %s: %s",
-                   __FUNCTION__, path_name, error->message);
+          g_debug ("%s: failed to read %s: %s", __FUNCTION__, path_name,
+                   error->message);
           g_error_free (error);
         }
       g_free (path_name);
@@ -7668,7 +7459,7 @@ file_iterator_content_64 (file_iterator_t* iterator)
 
   if (content && (content_size > 0))
     {
-      gchar *base64 = g_base64_encode ((guchar*) content, content_size);
+      gchar *base64 = g_base64_encode ((guchar *) content, content_size);
       g_free (content);
       return base64;
     }
@@ -7676,7 +7467,6 @@ file_iterator_content_64 (file_iterator_t* iterator)
   return content;
 }
 
-
 /* Scanner Tags. */
 
 /**
@@ -7706,15 +7496,13 @@ parse_tags (const char *scanner_tags, gchar **tags, gchar **cvss_base)
           /* Skip this tag. */
         }
       else if (strncmp (*point,
-                        "cvss_base_vector=",
-                        strlen ("cvss_base_vector="))
+                        "cvss_base_vector=", strlen ("cvss_base_vector="))
                == 0)
         {
           if (*cvss_base == NULL)
-            *cvss_base = g_strdup_printf ("%.1f",
-                                          get_cvss_score_from_base_metrics
-                                           (*point
-                                            + strlen ("cvss_base_vector=")));
+            *cvss_base = g_strdup_printf (
+              "%.1f", get_cvss_score_from_base_metrics (
+                        *point + strlen ("cvss_base_vector=")));
           if (first)
             first = FALSE;
           else
@@ -7742,7 +7530,6 @@ parse_tags (const char *scanner_tags, gchar **tags, gchar **cvss_base)
   g_strfreev (split);
 }
 
-
 /* Slaves. */
 
 /**
@@ -7773,7 +7560,8 @@ delete_slave_task (const gchar *host, int port, const gchar *username,
   g_debug ("   %s: host: %s", __FUNCTION__, host);
 
   socket = gvm_server_open (&session, host, port);
-  if (socket == -1) return -1;
+  if (socket == -1)
+    return -1;
 
   g_debug ("   %s: connected", __FUNCTION__);
 
@@ -7850,19 +7638,19 @@ delete_slave_task (const gchar *host, int port, const gchar *username,
   gvm_server_close (socket, session);
   return 0;
 
- fail_config:
+fail_config:
   gmp_delete_config_ext (&session, slave_config_uuid, del_opts);
- fail_target:
+fail_target:
   gmp_delete_target_ext (&session, slave_target_uuid, del_opts);
   gmp_delete_port_list_ext (&session, slave_port_list_uuid, del_opts);
- fail_credential:
+fail_credential:
   gmp_delete_lsc_credential_ext (&session, slave_smb_credential_uuid, del_opts);
   gmp_delete_lsc_credential_ext (&session, slave_ssh_credential_uuid, del_opts);
- fail_free:
+fail_free:
   free_entity (get_targets);
- fail_free_task:
+fail_free_task:
   free_entity (get_tasks);
- fail:
+fail:
   gvm_server_close (socket, session);
   return -1;
 }
@@ -7995,7 +7783,7 @@ xsl_transform (gchar *stylesheet, gchar *xmlfile, gchar **param_names,
     while (param_names[param_idx] && param_values[param_idx])
       param_idx++;
 
-  cmd = (gchar **)g_malloc ((4 + param_idx * 3) * sizeof (gchar *));
+  cmd = (gchar **) g_malloc ((4 + param_idx * 3) * sizeof (gchar *));
 
   i = 0;
   cmd[i++] = "xsltproc";
@@ -8014,32 +7802,20 @@ xsl_transform (gchar *stylesheet, gchar *xmlfile, gchar **param_names,
   cmd[i++] = xmlfile;
   cmd[i] = NULL;
 
-
   /* DEBUG: display the final command line. */
   cmd_full = g_strjoinv (" ", cmd);
-  g_debug ("%s: Spawning in parent dir: %s",
-           __FUNCTION__, cmd_full);
+  g_debug ("%s: Spawning in parent dir: %s", __FUNCTION__, cmd_full);
   g_free (cmd_full);
   /* --- */
 
-  if ((g_spawn_sync (NULL,
-                     cmd,
-                     NULL,                  /* Environment. */
-                     G_SPAWN_SEARCH_PATH,
-                     NULL,                  /* Setup function. */
-                     NULL,
-                     &standard_out,
-                     &standard_err,
-                     &exit_status,
-                     NULL)
+  if ((g_spawn_sync (NULL, cmd, NULL,           /* Environment. */
+                     G_SPAWN_SEARCH_PATH, NULL, /* Setup function. */
+                     NULL, &standard_out, &standard_err, &exit_status, NULL)
        == FALSE)
-      || (WIFEXITED (exit_status) == 0)
-      || WEXITSTATUS (exit_status))
+      || (WIFEXITED (exit_status) == 0) || WEXITSTATUS (exit_status))
     {
       g_debug ("%s: failed to transform the xml: %d (WIF %i, WEX %i)",
-               __FUNCTION__,
-               exit_status,
-               WIFEXITED (exit_status),
+               __FUNCTION__, exit_status, WIFEXITED (exit_status),
                WEXITSTATUS (exit_status));
       g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);
       g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
@@ -8066,11 +7842,9 @@ xsl_transform (gchar *stylesheet, gchar *xmlfile, gchar **param_names,
  *
  * @param  x  Prefix for names in snippet.
  */
-#define DEF(x)                                                    \
-      const char* x = nvt_iterator_ ## x (nvts);                  \
-      gchar* x ## _text = x                                       \
-                          ? g_markup_escape_text (x, -1)          \
-                          : g_strdup ("");
+#define DEF(x)                             \
+  const char *x = nvt_iterator_##x (nvts); \
+  gchar *x##_text = x ? g_markup_escape_text (x, -1) : g_strdup ("");
 
 /**
  * @brief Create and return XML description for an NVT.
@@ -8086,17 +7860,14 @@ xsl_transform (gchar *stylesheet, gchar *xmlfile, gchar **param_names,
  * @return A dynamically allocated string containing the XML description.
  */
 gchar *
-get_nvti_xml (iterator_t *nvts, int details, int pref_count,
-              int preferences, const char *timeout, config_t config,
-              int close_tag)
+get_nvti_xml (iterator_t *nvts, int details, int pref_count, int preferences,
+              const char *timeout, config_t config, int close_tag)
 {
-  const char* oid = nvt_iterator_oid (nvts);
-  const char* name = nvt_iterator_name (nvts);
+  const char *oid = nvt_iterator_oid (nvts);
+  const char *name = nvt_iterator_name (nvts);
   gchar *msg, *name_text;
 
-  name_text = name
-               ? g_markup_escape_text (name, strlen (name))
-               : g_strdup ("");
+  name_text = name ? g_markup_escape_text (name, strlen (name)) : g_strdup ("");
   if (details)
     {
       int tag_count;
@@ -8112,15 +7883,15 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count,
 #undef DEF
 
       cert_refs_str = g_string_new ("");
-      if (manage_cert_loaded())
+      if (manage_cert_loaded ())
         {
           init_nvt_cert_bund_adv_iterator (&cert_refs_iterator, oid, 0, 0);
           while (next (&cert_refs_iterator))
             {
-              g_string_append_printf (cert_refs_str,
-                                      "<cert_ref type=\"CERT-Bund\" id=\"%s\"/>",
-                                      get_iterator_name (&cert_refs_iterator));
-          }
+              g_string_append_printf (
+                cert_refs_str, "<cert_ref type=\"CERT-Bund\" id=\"%s\"/>",
+                get_iterator_name (&cert_refs_iterator));
+            }
           cleanup_iterator (&cert_refs_iterator);
 
           init_nvt_dfn_cert_adv_iterator (&cert_refs_iterator, oid, 0, 0);
@@ -8129,18 +7900,17 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count,
               g_string_append_printf (cert_refs_str,
                                       "<cert_ref type=\"DFN-CERT\" id=\"%s\"/>",
                                       get_iterator_name (&cert_refs_iterator));
-          }
+            }
           cleanup_iterator (&cert_refs_iterator);
         }
       else
         {
-          g_string_append (cert_refs_str, "<warning>database not available</warning>");
+          g_string_append (cert_refs_str,
+                           "<warning>database not available</warning>");
         }
 
       tags_str = g_string_new ("");
-      tag_count = resource_tag_count ("nvt",
-                                      get_iterator_resource (nvts),
-                                      1);
+      tag_count = resource_tag_count ("nvt", get_iterator_resource (nvts), 1);
 
       if (tag_count)
         {
@@ -8150,19 +7920,15 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count,
                                   tag_count);
 
           init_resource_tag_iterator (&tags, "nvt",
-                                      get_iterator_resource (nvts),
-                                      1, NULL, 1);
+                                      get_iterator_resource (nvts), 1, NULL, 1);
           while (next (&tags))
             {
-              tag_name_esc = g_markup_escape_text (resource_tag_iterator_name
-                                                    (&tags),
-                                                  -1);
-              tag_value_esc = g_markup_escape_text (resource_tag_iterator_value
-                                                      (&tags),
-                                                    -1);
-              tag_comment_esc = g_markup_escape_text (resource_tag_iterator_comment
-                                                        (&tags),
-                                                      -1);
+              tag_name_esc =
+                g_markup_escape_text (resource_tag_iterator_name (&tags), -1);
+              tag_value_esc =
+                g_markup_escape_text (resource_tag_iterator_value (&tags), -1);
+              tag_comment_esc = g_markup_escape_text (
+                resource_tag_iterator_comment (&tags), -1);
               g_string_append_printf (tags_str,
                                       "<tag id=\"%s\">"
                                       "<name>%s</name>"
@@ -8170,70 +7936,57 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count,
                                       "<comment>%s</comment>"
                                       "</tag>",
                                       resource_tag_iterator_uuid (&tags),
-                                      tag_name_esc,
-                                      tag_value_esc,
+                                      tag_name_esc, tag_value_esc,
                                       tag_comment_esc);
               g_free (tag_name_esc);
               g_free (tag_value_esc);
               g_free (tag_comment_esc);
             }
           cleanup_iterator (&tags);
-          g_string_append_printf (tags_str,
-                                  "</user_tags>");
+          g_string_append_printf (tags_str, "</user_tags>");
         }
 
       buffer = g_string_new ("");
 
-      g_string_append_printf (buffer,
-                              "<nvt oid=\"%s\">"
-                              "<name>%s</name>"
-                              "<creation_time>%s</creation_time>"
-                              "<modification_time>%s</modification_time>"
-                              "%s" // user_tags
-                              "<category>%d</category>"
-                              "<family>%s</family>"
-                              "<cvss_base>%s</cvss_base>"
-                              "<qod>"
-                              "<value>%s</value>"
-                              "<type>%s</type>"
-                              "</qod>"
-                              "<cve_id>%s</cve_id>"
-                              "<bugtraq_id>%s</bugtraq_id>"
-                              "<cert_refs>%s</cert_refs>"
-                              "<xrefs>%s</xrefs>"
-                              "<tags>%s</tags>"
-                              "<preference_count>%i</preference_count>"
-                              "<timeout>%s</timeout>"
-                              "<default_timeout>%s</default_timeout>",
-                              oid,
-                              name_text,
-                              get_iterator_creation_time (nvts)
-                               ? get_iterator_creation_time (nvts)
-                               : "",
-                              get_iterator_modification_time (nvts)
-                               ? get_iterator_modification_time (nvts)
-                               : "",
-                              tags_str->str,
-                              nvt_iterator_category (nvts),
-                              family_text,
-                              nvt_iterator_cvss_base (nvts)
-                               ? nvt_iterator_cvss_base (nvts)
-                               : "",
-                              nvt_iterator_qod (nvts),
-                              nvt_iterator_qod_type (nvts),
-                              nvt_iterator_cve (nvts),
-                              nvt_iterator_bid (nvts),
-                              cert_refs_str->str,
-                              xref_text,
-                              tag_text,
-                              pref_count,
-                              timeout ? timeout : "",
-                              default_timeout ? default_timeout : "");
+      g_string_append_printf (
+        buffer,
+        "<nvt oid=\"%s\">"
+        "<name>%s</name>"
+        "<creation_time>%s</creation_time>"
+        "<modification_time>%s</modification_time>"
+        "%s" // user_tags
+        "<category>%d</category>"
+        "<family>%s</family>"
+        "<cvss_base>%s</cvss_base>"
+        "<qod>"
+        "<value>%s</value>"
+        "<type>%s</type>"
+        "</qod>"
+        "<cve_id>%s</cve_id>"
+        "<bugtraq_id>%s</bugtraq_id>"
+        "<cert_refs>%s</cert_refs>"
+        "<xrefs>%s</xrefs>"
+        "<tags>%s</tags>"
+        "<preference_count>%i</preference_count>"
+        "<timeout>%s</timeout>"
+        "<default_timeout>%s</default_timeout>",
+        oid, name_text,
+        get_iterator_creation_time (nvts) ? get_iterator_creation_time (nvts)
+                                          : "",
+        get_iterator_modification_time (nvts)
+          ? get_iterator_modification_time (nvts)
+          : "",
+        tags_str->str, nvt_iterator_category (nvts), family_text,
+        nvt_iterator_cvss_base (nvts) ? nvt_iterator_cvss_base (nvts) : "",
+        nvt_iterator_qod (nvts), nvt_iterator_qod_type (nvts),
+        nvt_iterator_cve (nvts), nvt_iterator_bid (nvts), cert_refs_str->str,
+        xref_text, tag_text, pref_count, timeout ? timeout : "",
+        default_timeout ? default_timeout : "");
       g_free (family_text);
       g_free (xref_text);
       g_free (tag_text);
-      g_string_free(cert_refs_str, 1);
-      g_string_free(tags_str, 1);
+      g_string_free (cert_refs_str, 1);
+      g_string_free (tags_str, 1);
 
       if (preferences)
         {
@@ -8264,25 +8017,19 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count,
   else
     {
       int tag_count;
-      tag_count = resource_tag_count ("nvt",
-                                      get_iterator_resource (nvts),
-                                      1);
+      tag_count = resource_tag_count ("nvt", get_iterator_resource (nvts), 1);
 
       if (tag_count)
         {
-          msg = g_strdup_printf
-                 ("<nvt oid=\"%s\"><name>%s</name>"
-                  "<user_tags><count>%i</count></user_tags>%s",
-                  oid, name_text,
-                  tag_count,
-                  close_tag ? "</nvt>" : "");
+          msg = g_strdup_printf ("<nvt oid=\"%s\"><name>%s</name>"
+                                 "<user_tags><count>%i</count></user_tags>%s",
+                                 oid, name_text, tag_count,
+                                 close_tag ? "</nvt>" : "");
         }
       else
         {
-          msg = g_strdup_printf
-                 ("<nvt oid=\"%s\"><name>%s</name>%s",
-                  oid, name_text,
-                  close_tag ? "</nvt>" : "");
+          msg = g_strdup_printf ("<nvt oid=\"%s\"><name>%s</name>%s", oid,
+                                 name_text, close_tag ? "</nvt>" : "");
         }
     }
   g_free (name_text);
@@ -8305,16 +8052,14 @@ manage_scap_update_time ()
   /* Read in the contents. */
 
   error = NULL;
-  if (g_file_get_contents (SCAP_TIMESTAMP_FILENAME,
-                           &content,
-                           &content_size,
+  if (g_file_get_contents (SCAP_TIMESTAMP_FILENAME, &content, &content_size,
                            &error)
       == FALSE)
     {
       if (error)
         {
-          g_debug ("%s: failed to read %s: %s",
-                   __FUNCTION__, SCAP_TIMESTAMP_FILENAME, error->message);
+          g_debug ("%s: failed to read %s: %s", __FUNCTION__,
+                   SCAP_TIMESTAMP_FILENAME, error->message);
           g_error_free (error);
         }
       return "";
@@ -8345,8 +8090,8 @@ int
 manage_read_info (gchar *type, gchar *uid, gchar *name, gchar **result)
 {
   gchar *fname;
-  gchar *pnames[2] = { "refname", NULL };
-  gchar *pvalues[2] = { name, NULL };
+  gchar *pnames[2] = {"refname", NULL};
+  gchar *pvalues[2] = {name, NULL};
 
   assert (result != NULL);
   *result = NULL;
@@ -8385,13 +8130,12 @@ manage_read_info (gchar *type, gchar *uid, gchar *name, gchar **result)
           init_nvt_iterator (&nvts, nvt, 0, NULL, NULL, 0, NULL);
 
           if (next (&nvts))
-            *result = get_nvti_xml (&nvts,
-                                    1,    /* Include details. */
-                                    0,    /* Preference count. */
-                                    1,    /* Include preferences. */
-                                    NULL, /* Timeout. */
-                                    0,    /* Config. */
-                                    1);   /* Close tag. */
+            *result = get_nvti_xml (&nvts, 1, /* Include details. */
+                                    0,        /* Preference count. */
+                                    1,        /* Include preferences. */
+                                    NULL,     /* Timeout. */
+                                    0,        /* Config. */
+                                    1);       /* Close tag. */
 
           cleanup_iterator (&nvts);
         }
@@ -8402,8 +8146,8 @@ manage_read_info (gchar *type, gchar *uid, gchar *name, gchar **result)
       if (fname)
         {
           gchar *ovaldef;
-          ovaldef = xsl_transform (OVALDEF_GETBYNAME_XSL, fname,
-                                   pnames, pvalues);
+          ovaldef =
+            xsl_transform (OVALDEF_GETBYNAME_XSL, fname, pnames, pvalues);
           g_free (fname);
           if (ovaldef)
             *result = ovaldef;
@@ -8415,8 +8159,8 @@ manage_read_info (gchar *type, gchar *uid, gchar *name, gchar **result)
       if (fname)
         {
           gchar *adv;
-          adv = xsl_transform (CERT_BUND_ADV_GETBYNAME_XSL, fname,
-                               pnames, pvalues);
+          adv =
+            xsl_transform (CERT_BUND_ADV_GETBYNAME_XSL, fname, pnames, pvalues);
           g_free (fname);
           if (adv)
             *result = adv;
@@ -8428,8 +8172,8 @@ manage_read_info (gchar *type, gchar *uid, gchar *name, gchar **result)
       if (fname)
         {
           gchar *adv;
-          adv = xsl_transform (DFN_CERT_ADV_GETBYNAME_XSL, fname,
-                               pnames, pvalues);
+          adv =
+            xsl_transform (DFN_CERT_ADV_GETBYNAME_XSL, fname, pnames, pvalues);
           g_free (fname);
           if (adv)
             *result = adv;
@@ -8442,7 +8186,6 @@ manage_read_info (gchar *type, gchar *uid, gchar *name, gchar **result)
   return 1;
 }
 
-
 /* Users. */
 
 /**
@@ -8454,7 +8197,7 @@ manage_read_info (gchar *type, gchar *uid, gchar *name, gchar **result)
  * @return 0 if the username is valid, 1 if not.
  */
 int
-validate_username (const gchar * name)
+validate_username (const gchar *name)
 {
   if (g_regex_match_simple ("^[[:alnum:]-_.]+$", name, 0, 0))
     return 0;
@@ -8462,7 +8205,6 @@ validate_username (const gchar * name)
     return 1;
 }
 
-
 /* Resource aggregates. */
 
 /**
@@ -8478,7 +8220,6 @@ sort_data_free (sort_data_t *sort_data)
   g_free (sort_data);
 }
 
-
 /* Feeds. */
 
 /**
@@ -8493,8 +8234,7 @@ sort_data_free (sort_data_t *sort_data)
  * @return TRUE if the selftest was successful, or FALSE if an error occurred.
  */
 gboolean
-gvm_sync_script_perform_selftest (const gchar * sync_script,
-                                  gchar ** result)
+gvm_sync_script_perform_selftest (const gchar *sync_script, gchar **result)
 {
   g_assert (sync_script);
   g_assert_cmpstr (*result, ==, NULL);
@@ -8511,15 +8251,14 @@ gvm_sync_script_perform_selftest (const gchar * sync_script,
   gint script_exit;
   GError *error = NULL;
 
-  if (!g_spawn_sync
-      (script_working_dir, argv, NULL, 0, NULL, NULL, &script_out, &script_err,
-       &script_exit, &error))
+  if (!g_spawn_sync (script_working_dir, argv, NULL, 0, NULL, NULL, &script_out,
+                     &script_err, &script_exit, &error))
     {
       if (*result != NULL)
         {
-          *result =
-            g_strdup_printf ("Failed to execute synchronization " "script: %s",
-                             error->message);
+          *result = g_strdup_printf ("Failed to execute synchronization "
+                                     "script: %s",
+                                     error->message);
         }
 
       g_free (script_working_dir);
@@ -8565,9 +8304,8 @@ gvm_sync_script_perform_selftest (const gchar * sync_script,
  *         error occurred.
  */
 gboolean
-gvm_get_sync_script_identification (const gchar * sync_script,
-                                    gchar ** identification,
-                                    int feed_type)
+gvm_get_sync_script_identification (const gchar *sync_script,
+                                    gchar **identification, int feed_type)
 {
   g_assert (sync_script);
   if (identification)
@@ -8587,9 +8325,8 @@ gvm_get_sync_script_identification (const gchar * sync_script,
 
   gchar **script_identification;
 
-  if (!g_spawn_sync
-        (script_working_dir, argv, NULL, 0, NULL, NULL, &script_out, &script_err,
-         &script_exit, &error))
+  if (!g_spawn_sync (script_working_dir, argv, NULL, 0, NULL, NULL, &script_out,
+                     &script_err, &script_exit, &error))
     {
       g_warning ("Failed to execute %s: %s", sync_script, error->message);
 
@@ -8623,7 +8360,8 @@ gvm_get_sync_script_identification (const gchar * sync_script,
           && g_ascii_strncasecmp (script_identification[0], "SCAPSYNC", 7))
       || (feed_type == CERT_FEED
           && g_ascii_strncasecmp (script_identification[0], "CERTSYNC", 7))
-      || g_ascii_strncasecmp (script_identification[0], script_identification[5], 7))
+      || g_ascii_strncasecmp (script_identification[0],
+                              script_identification[5], 7))
     {
       g_warning ("%s is not a feed synchronization script", sync_script);
 
@@ -8660,8 +8398,7 @@ gvm_get_sync_script_identification (const gchar * sync_script,
  *         occurred.
  */
 gboolean
-gvm_get_sync_script_description (const gchar * sync_script,
-                                 gchar ** description)
+gvm_get_sync_script_description (const gchar *sync_script, gchar **description)
 {
   g_assert (sync_script);
   g_assert_cmpstr (*description, ==, NULL);
@@ -8678,9 +8415,8 @@ gvm_get_sync_script_description (const gchar * sync_script,
   gint script_exit;
   GError *error = NULL;
 
-  if (!g_spawn_sync
-      (script_working_dir, argv, NULL, 0, NULL, NULL, &script_out, &script_err,
-       &script_exit, &error))
+  if (!g_spawn_sync (script_working_dir, argv, NULL, 0, NULL, NULL, &script_out,
+                     &script_err, &script_exit, &error))
     {
       g_warning ("Failed to execute %s: %s", sync_script, error->message);
 
@@ -8726,8 +8462,8 @@ gvm_get_sync_script_description (const gchar * sync_script,
  *         occurred.
  */
 gboolean
-gvm_get_sync_script_feed_version (const gchar * sync_script,
-                                  gchar ** feed_version)
+gvm_get_sync_script_feed_version (const gchar *sync_script,
+                                  gchar **feed_version)
 {
   g_assert (sync_script);
   g_assert_cmpstr (*feed_version, ==, NULL);
@@ -8744,9 +8480,8 @@ gvm_get_sync_script_feed_version (const gchar * sync_script,
   gint script_exit;
   GError *error = NULL;
 
-  if (!g_spawn_sync
-        (script_working_dir, argv, NULL, 0, NULL, NULL, &script_out, &script_err,
-         &script_exit, &error))
+  if (!g_spawn_sync (script_working_dir, argv, NULL, 0, NULL, NULL, &script_out,
+                     &script_err, &script_exit, &error))
     {
       g_warning ("Failed to execute %s: %s", sync_script, error->message);
 
@@ -8822,21 +8557,19 @@ gvm_migrate_secinfo (int feed_type)
       return -1;
     }
 
-  if (flock (lockfile, LOCK_EX | LOCK_NB))  /* Exclusive, Non blocking. */
+  if (flock (lockfile, LOCK_EX | LOCK_NB)) /* Exclusive, Non blocking. */
     {
       if (errno == EWOULDBLOCK)
         {
           if (close (lockfile))
-            g_warning ("%s: failed to close lockfile: %s",
-                       __FUNCTION__,
+            g_warning ("%s: failed to close lockfile: %s", __FUNCTION__,
                        strerror (errno));
           g_free (lockfile_name);
           return 1;
         }
       g_debug ("%s: flock: %s", __FUNCTION__, strerror (errno));
       if (close (lockfile))
-        g_warning ("%s: failed to close lockfile: %s",
-                   __FUNCTION__,
+        g_warning ("%s: failed to close lockfile: %s", __FUNCTION__,
                    strerror (errno));
       g_free (lockfile_name);
       return -1;
@@ -8861,7 +8594,6 @@ gvm_migrate_secinfo (int feed_type)
   return ret;
 }
 
-
 /* Wizards. */
 
 /**
@@ -8888,14 +8620,10 @@ gvm_migrate_secinfo (int feed_type)
  */
 int
 manage_run_wizard (const gchar *wizard_name,
-                   int (*run_command) (void*, gchar*, gchar**),
-                   void *run_command_data,
-                   array_t *params,
-                   int read_only,
-                   const char *mode,
-                   gchar **command_error,
-                   gchar **command_error_code,
-                   gchar **ret_response)
+                   int (*run_command) (void *, gchar *, gchar **),
+                   void *run_command_data, array_t *params, int read_only,
+                   const char *mode, gchar **command_error,
+                   gchar **command_error_code, gchar **ret_response)
 {
   GString *params_xml;
   gchar *file, *file_name, *response, *extra, *extra_wrapped, *wizard;
@@ -8922,29 +8650,23 @@ manage_run_wizard (const gchar *wizard_name,
     *ret_response = NULL;
 
   point = wizard_name;
-  while (*point && (isalnum (*point) || *point == '_')) point++;
+  while (*point && (isalnum (*point) || *point == '_'))
+    point++;
   if (*point)
     return 1;
 
   /* Read wizard from file. */
 
   file_name = g_strdup_printf ("%s.xml", wizard_name);
-  file = g_build_filename (GVMD_DATA_DIR,
-                           "wizards",
-                           file_name,
-                           NULL);
+  file = g_build_filename (GVMD_DATA_DIR, "wizards", file_name, NULL);
   g_free (file_name);
 
   get_error = NULL;
-  g_file_get_contents (file,
-                       &wizard,
-                       &wizard_len,
-                       &get_error);
+  g_file_get_contents (file, &wizard, &wizard_len, &get_error);
   g_free (file);
   if (get_error)
     {
-      g_warning ("%s: Failed to read wizard: %s",
-                 __FUNCTION__,
+      g_warning ("%s: Failed to read wizard: %s", __FUNCTION__,
                  get_error->message);
       g_error_free (get_error);
       return -1;
@@ -9028,8 +8750,7 @@ manage_run_wizard (const gchar *wizard_name,
           if ((name_entity == NULL)
               || (strcmp (entity_text (name_entity), "") == 0))
             {
-              g_warning ("%s: Wizard PARAM missing NAME",
-                         __FUNCTION__);
+              g_warning ("%s: Wizard PARAM missing NAME", __FUNCTION__);
               free_entity (entity);
               return -1;
             }
@@ -9040,8 +8761,7 @@ manage_run_wizard (const gchar *wizard_name,
           if ((regex_entity == NULL)
               || (strcmp (entity_text (regex_entity), "") == 0))
             {
-              g_warning ("%s: Wizard PARAM missing REGEX",
-                         __FUNCTION__);
+              g_warning ("%s: Wizard PARAM missing REGEX", __FUNCTION__);
               free_entity (entity);
               return -1;
             }
@@ -9049,9 +8769,9 @@ manage_run_wizard (const gchar *wizard_name,
             regex = entity_text (regex_entity);
 
           optional_entity = entity_child (param_def, "optional");
-          optional = (optional_entity
-                      && strcmp (entity_text (optional_entity), "")
-                      && strcmp (entity_text (optional_entity), "0"));
+          optional =
+            (optional_entity && strcmp (entity_text (optional_entity), "")
+             && strcmp (entity_text (optional_entity), "0"));
 
           if (params)
             {
@@ -9060,13 +8780,12 @@ manage_run_wizard (const gchar *wizard_name,
                 {
                   name_value_t *pair;
 
-                  pair = (name_value_t*) g_ptr_array_index (params, index);
+                  pair = (name_value_t *) g_ptr_array_index (params, index);
 
                   if (pair == NULL)
                     continue;
 
-                  if ((pair->name)
-                      && (pair->value)
+                  if ((pair->name) && (pair->value)
                       && (strcmp (pair->name, name) == 0))
                     {
                       index = 0; // end loop;
@@ -9074,10 +8793,10 @@ manage_run_wizard (const gchar *wizard_name,
 
                       if (g_regex_match_simple (regex, pair->value, 0, 0) == 0)
                         {
-                          *command_error
-                            = g_strdup_printf ("Value '%s' is not valid for"
-                                              " parameter '%s'.",
-                                              pair->value, name);
+                          *command_error =
+                            g_strdup_printf ("Value '%s' is not valid for"
+                                             " parameter '%s'.",
+                                             pair->value, name);
                           free_entity (entity);
                           g_string_free (params_xml, TRUE);
                           return 6;
@@ -9094,8 +8813,6 @@ manage_run_wizard (const gchar *wizard_name,
               free_entity (entity);
               return 6;
             }
-
-
         }
       param_defs = next_entities (param_defs);
     }
@@ -9108,7 +8825,7 @@ manage_run_wizard (const gchar *wizard_name,
         {
           name_value_t *pair;
 
-          pair = (name_value_t*) g_ptr_array_index (params, index);
+          pair = (name_value_t *) g_ptr_array_index (params, index);
           xml_string_append (params_xml,
                              "<param>"
                              "<name>%s</name>"
@@ -9142,8 +8859,7 @@ manage_run_wizard (const gchar *wizard_name,
           command = entity_child (step, "command");
           if (command == NULL)
             {
-              g_warning ("%s: Wizard STEP missing COMMAND",
-                         __FUNCTION__);
+              g_warning ("%s: Wizard STEP missing COMMAND", __FUNCTION__);
               free_entity (entity);
               g_free (response);
               g_free (extra);
@@ -9156,8 +8872,7 @@ manage_run_wizard (const gchar *wizard_name,
           xsl_fd = mkstemp (xsl_file_name);
           if (xsl_fd == -1)
             {
-              g_warning ("%s: Wizard XSL file create failed",
-                         __FUNCTION__);
+              g_warning ("%s: Wizard XSL file create failed", __FUNCTION__);
               free_entity (entity);
               g_free (response);
               g_free (extra);
@@ -9168,8 +8883,7 @@ manage_run_wizard (const gchar *wizard_name,
           xsl_file = fdopen (xsl_fd, "w");
           if (xsl_file == NULL)
             {
-              g_warning ("%s: Wizard XSL file open failed",
-                         __FUNCTION__);
+              g_warning ("%s: Wizard XSL file open failed", __FUNCTION__);
               close (xsl_fd);
               free_entity (entity);
               g_free (response);
@@ -9186,8 +8900,7 @@ manage_run_wizard (const gchar *wizard_name,
           xml_fd = mkstemp (xml_file_name);
           if (xml_fd == -1)
             {
-              g_warning ("%s: Wizard XML file create failed",
-                         __FUNCTION__);
+              g_warning ("%s: Wizard XML file create failed", __FUNCTION__);
               fclose (xsl_file);
               unlink (xsl_file_name);
               free_entity (entity);
@@ -9200,8 +8913,7 @@ manage_run_wizard (const gchar *wizard_name,
           xml_file = fdopen (xml_fd, "w");
           if (xml_file == NULL)
             {
-              g_warning ("%s: Wizard XML file open failed",
-                         __FUNCTION__);
+              g_warning ("%s: Wizard XML file open failed", __FUNCTION__);
               fclose (xsl_file);
               unlink (xsl_file_name);
               close (xml_fd);
@@ -9221,8 +8933,7 @@ manage_run_wizard (const gchar *wizard_name,
                        "</previous>"
                        "</wizard>\n",
                        params_xml->str ? params_xml->str : "",
-                       response ? response : "",
-                       extra ? extra : "")
+                       response ? response : "", extra ? extra : "")
               < 0)
             {
               fclose (xsl_file);
@@ -9230,8 +8941,7 @@ manage_run_wizard (const gchar *wizard_name,
               fclose (xml_file);
               unlink (xml_file_name);
               free_entity (entity);
-              g_warning ("%s: Wizard failed to write XML",
-                         __FUNCTION__);
+              g_warning ("%s: Wizard failed to write XML", __FUNCTION__);
               g_free (response);
               g_free (extra);
               g_string_free (params_xml, TRUE);
@@ -9242,16 +8952,14 @@ manage_run_wizard (const gchar *wizard_name,
 
           /* Combine XSL and XML to get the GMP command. */
 
-          gmp = xsl_transform (xsl_file_name, xml_file_name, NULL,
-                               NULL);
+          gmp = xsl_transform (xsl_file_name, xml_file_name, NULL, NULL);
           fclose (xsl_file);
           unlink (xsl_file_name);
           fclose (xml_file);
           unlink (xml_file_name);
           if (gmp == NULL)
             {
-              g_warning ("%s: Wizard XSL transform failed",
-                         __FUNCTION__);
+              g_warning ("%s: Wizard XSL transform failed", __FUNCTION__);
               free_entity (entity);
               g_free (response);
               g_free (extra);
@@ -9329,8 +9037,7 @@ manage_run_wizard (const gchar *wizard_name,
                 }
 
               status = entity_attribute (response_entity, "status");
-              if ((status == NULL)
-                  || (strlen (status) == 0)
+              if ((status == NULL) || (strlen (status) == 0)
                   || (status[0] != '2'))
                 {
                   g_debug ("response was %s", response);
@@ -9367,7 +9074,7 @@ manage_run_wizard (const gchar *wizard_name,
               if (xsl_fd == -1)
                 {
                   g_warning ("%s: Wizard extra_data XSL file create failed",
-                            __FUNCTION__);
+                             __FUNCTION__);
                   free_entity (entity);
                   g_free (response);
                   g_free (extra);
@@ -9379,7 +9086,7 @@ manage_run_wizard (const gchar *wizard_name,
               if (xsl_file == NULL)
                 {
                   g_warning ("%s: Wizard extra_data XSL file open failed",
-                            __FUNCTION__);
+                             __FUNCTION__);
                   close (xsl_fd);
                   free_entity (entity);
                   g_free (response);
@@ -9396,8 +9103,7 @@ manage_run_wizard (const gchar *wizard_name,
               xml_fd = mkstemp (extra_xml_file_name);
               if (xml_fd == -1)
                 {
-                  g_warning ("%s: Wizard XML file create failed",
-                            __FUNCTION__);
+                  g_warning ("%s: Wizard XML file create failed", __FUNCTION__);
                   fclose (xsl_file);
                   unlink (xsl_file_name);
                   free_entity (entity);
@@ -9410,8 +9116,7 @@ manage_run_wizard (const gchar *wizard_name,
               xml_file = fdopen (xml_fd, "w");
               if (xml_file == NULL)
                 {
-                  g_warning ("%s: Wizard XML file open failed",
-                            __FUNCTION__);
+                  g_warning ("%s: Wizard XML file open failed", __FUNCTION__);
                   fclose (xsl_file);
                   unlink (xsl_file_name);
                   close (xml_fd);
@@ -9433,8 +9138,7 @@ manage_run_wizard (const gchar *wizard_name,
                            "</previous>"
                            "</wizard>\n",
                            params_xml->str ? params_xml->str : "",
-                           response ? response : "",
-                           extra ? extra : "")
+                           response ? response : "", extra ? extra : "")
                   < 0)
                 {
                   fclose (xsl_file);
@@ -9442,8 +9146,7 @@ manage_run_wizard (const gchar *wizard_name,
                   fclose (xml_file);
                   unlink (extra_xml_file_name);
                   free_entity (entity);
-                  g_warning ("%s: Wizard failed to write XML",
-                            __FUNCTION__);
+                  g_warning ("%s: Wizard failed to write XML", __FUNCTION__);
                   g_free (response);
                   g_free (extra);
                   g_string_free (params_xml, TRUE);
@@ -9465,8 +9168,7 @@ manage_run_wizard (const gchar *wizard_name,
     }
 
   if (extra)
-    extra_wrapped = g_strdup_printf ("<extra_data>%s</extra_data>",
-                                     extra);
+    extra_wrapped = g_strdup_printf ("<extra_data>%s</extra_data>", extra);
   else
     extra_wrapped = NULL;
   g_free (extra);
@@ -9524,7 +9226,6 @@ get_termination_signal ()
   return termination_signal;
 }
 
-
 /* Resources. */
 
 /**

--- a/src/manage.h
+++ b/src/manage.h
@@ -27,33 +27,28 @@
 
 #include "iterator.h"
 
-#include <stdio.h>
 #include <glib.h>
 #include <gnutls/gnutls.h>
-
 #include <gvm/base/array.h>       /* for array_t */
 #include <gvm/base/credentials.h> /* for credentials_t */
-#include <gvm/base/nvti.h>        /* for nvti_t */
 #include <gvm/base/networking.h>  /* for port_protocol_t */
-#include <gvm/util/serverutils.h> /* for gvm_connection_t */
-#include <gvm/util/authutils.h>   /* for auth_method_t */
+#include <gvm/base/nvti.h>        /* for nvti_t */
 #include <gvm/osp/osp.h>          /* for osp_connection_t */
-
+#include <gvm/util/authutils.h>   /* for auth_method_t */
+#include <gvm/util/serverutils.h> /* for gvm_connection_t */
+#include <stdio.h>
 
 /**
  * @brief Flag with all Glib log levels.
  */
-#define ALL_LOG_LEVELS  (G_LOG_LEVEL_MASK       \
-                         | G_LOG_FLAG_FATAL     \
-                         | G_LOG_FLAG_RECURSION)
+#define ALL_LOG_LEVELS \
+  (G_LOG_LEVEL_MASK | G_LOG_FLAG_FATAL | G_LOG_FLAG_RECURSION)
 
 /**
  * @brief Defines g_info for glib versions older than 2.40.
  */
 #ifndef g_info
-#define g_info(...)  g_log (G_LOG_DOMAIN,         \
-                            G_LOG_LEVEL_INFO,     \
-                            __VA_ARGS__)
+#define g_info(...) g_log (G_LOG_DOMAIN, G_LOG_LEVEL_INFO, __VA_ARGS__)
 #endif /* g_info not defined */
 
 /**
@@ -61,28 +56,27 @@
  */
 typedef struct
 {
-  gchar *name;    ///< Name.
-  gchar *value;   ///< Param value.
+  gchar *name;  ///< Name.
+  gchar *value; ///< Param value.
 } name_value_t;
 
 /**
  * @brief Fork helper function type.
  */
-typedef int (*manage_connection_forker_t) (gvm_connection_t * conn,
-                                           const gchar* uuid);
+typedef int (*manage_connection_forker_t) (gvm_connection_t *conn,
+                                           const gchar *uuid);
 
 int
-init_manage (GSList*, int, const gchar *, int, int, int, int,
+init_manage (GSList *, int, const gchar *, int, int, int, int,
              manage_connection_forker_t, int);
 
 int
 init_manage_helper (GSList *, const gchar *, int);
 
 void
-init_manage_process (int, const gchar*);
+init_manage_process (int, const gchar *);
 
-void
-cleanup_manage_process (gboolean);
+void cleanup_manage_process (gboolean);
 
 void
 manage_cleanup_process_error (int);
@@ -90,7 +84,6 @@ manage_cleanup_process_error (int);
 void
 manage_reset_currents ();
 
-
 /* Commands. */
 
 /**
@@ -98,8 +91,8 @@ manage_reset_currents ();
  */
 typedef struct
 {
-  gchar *name;     ///< Command name.
-  gchar *summary;  ///< Summary of command.
+  gchar *name;    ///< Command name.
+  gchar *summary; ///< Summary of command.
 } command_t;
 
 /**
@@ -107,33 +100,28 @@ typedef struct
  */
 extern command_t gmp_commands[];
 
-
 /* Certificate and key management. */
 
-gchar*
-truncate_certificate (const gchar*);
-
-gchar*
-truncate_private_key (const gchar*);
-
-int
-get_certificate_info (const gchar*, time_t*, time_t*, gchar**, gchar**);
+gchar *
+truncate_certificate (const gchar *);
 
 gchar *
-certificate_iso_time (time_t);
+truncate_private_key (const gchar *);
 
-const gchar *
-certificate_time_status (time_t, time_t);
+int
+get_certificate_info (const gchar *, time_t *, time_t *, gchar **, gchar **);
 
-
+gchar *certificate_iso_time (time_t);
+
+const gchar *certificate_time_status (time_t, time_t);
+
 /* Credentials. */
 
 extern credentials_t current_credentials;
 
 int
-authenticate (credentials_t*);
+authenticate (credentials_t *);
 
-
 /* Database. */
 
 int
@@ -167,7 +155,7 @@ char *
 manage_port_name (int, const char *);
 
 int
-manage_migrate (GSList*, const gchar*);
+manage_migrate (GSList *, const gchar *);
 
 int
 manage_encrypt_all_credentials (GSList *, const gchar *);
@@ -181,10 +169,8 @@ manage_session_set_timezone (const char *);
 void
 manage_transaction_start ();
 
-void
-manage_transaction_stop (gboolean);
+void manage_transaction_stop (gboolean);
 
-
 /* Task structures. */
 
 extern short scanner_active;
@@ -195,9 +181,9 @@ extern short scanner_active;
  */
 typedef struct
 {
-  unsigned int number;       ///< Port number.
-  port_protocol_t protocol;  ///< Port protocol (TCP, UDP, ...).
-  char* string;              ///< Original string describing port.
+  unsigned int number;      ///< Port number.
+  port_protocol_t protocol; ///< Port protocol (TCP, UDP, ...).
+  char *string;             ///< Original string describing port.
 } port_t;
 
 /** @todo Should be in otp.c/h. */
@@ -206,13 +192,12 @@ typedef struct
  */
 typedef struct
 {
-  char* host;           ///< Host message describes.
-  char* hostname;       ///< Hostname message describes.
-  port_t port;          ///< The port.
-  char* description;    ///< Description of the message.
-  char* oid;            ///< NVT identifier.
+  char *host;        ///< Host message describes.
+  char *hostname;    ///< Hostname message describes.
+  port_t port;       ///< The port.
+  char *description; ///< Description of the message.
+  char *oid;         ///< NVT identifier.
 } message_t;
-
 
 /**
  * @brief Task statuses, also used as scan/report statuses.
@@ -224,11 +209,11 @@ typedef enum
 {
   TASK_STATUS_DELETE_REQUESTED = 0,
   TASK_STATUS_DONE = 1,
-  TASK_STATUS_NEW  = 2,
+  TASK_STATUS_NEW = 2,
   TASK_STATUS_REQUESTED = 3,
-  TASK_STATUS_RUNNING   = 4,
-  TASK_STATUS_STOP_REQUESTED   = 10,
-  TASK_STATUS_STOP_WAITING     = 11,
+  TASK_STATUS_RUNNING = 4,
+  TASK_STATUS_STOP_REQUESTED = 10,
+  TASK_STATUS_STOP_WAITING = 11,
   TASK_STATUS_STOPPED = 12,
   TASK_STATUS_INTERRUPTED = 13,
   TASK_STATUS_DELETE_ULTIMATE_REQUESTED = 14,
@@ -246,7 +231,6 @@ typedef enum
  * Maximum value for number of reports to keep on auto_delete
  */
 #define AUTO_DELETE_KEEP_MAX 1200
-
 
 /**
  * @brief Alive tests.
@@ -307,7 +291,6 @@ typedef long long int scanner_t;
 typedef long long int setting_t;
 typedef long long int user_t;
 
-
 /* GMP GET. */
 
 /**
@@ -325,48 +308,48 @@ typedef long long int user_t;
  */
 typedef struct
 {
-  int details;         ///< Boolean.  Whether to include full details.
-  char *filt_id;       ///< Filter ID.  Overrides "filter".
-  char *filter;        ///< Filter term.
-  char *filter_replace; ///< Column to replace in filter.
-  char *filter_replacement; ///< Filter term to replace the one in filt_id.
-  char *id;            ///< ID of single item to get.
-  int trash;           ///< Boolean.  Whether to return from trashcan.
-  gchar *type;         ///< Type of resource.
-  gchar *subtype;      ///< Subtype, or NULL.
-  int ignore_max_rows_per_page; ///< Whether to ignore the Max Rows Per Page setting.
+  int details;                  ///< Boolean.  Whether to include full details.
+  char *filt_id;                ///< Filter ID.  Overrides "filter".
+  char *filter;                 ///< Filter term.
+  char *filter_replace;         ///< Column to replace in filter.
+  char *filter_replacement;     ///< Filter term to replace the one in filt_id.
+  char *id;                     ///< ID of single item to get.
+  int trash;                    ///< Boolean.  Whether to return from trashcan.
+  gchar *type;                  ///< Type of resource.
+  gchar *subtype;               ///< Subtype, or NULL.
+  int ignore_max_rows_per_page; ///< Whether to ignore the Max Rows Per Page
+                                ///< setting.
   int ignore_pagination; ///< Whether to ignore the pagination (first and max).
-  int minimal;         ///< Whether to respond with minimal information.
+  int minimal;           ///< Whether to respond with minimal information.
 } get_data_t;
 
 void
-get_data_reset (get_data_t*);
+get_data_reset (get_data_t *);
 
 resource_t
-get_iterator_resource (iterator_t*);
+get_iterator_resource (iterator_t *);
 
-const char*
-get_iterator_uuid (iterator_t*);
+const char *
+get_iterator_uuid (iterator_t *);
 
-const char*
-get_iterator_name (iterator_t*);
+const char *
+get_iterator_name (iterator_t *);
 
-const char*
-get_iterator_comment (iterator_t*);
+const char *
+get_iterator_comment (iterator_t *);
 
-const char*
-get_iterator_creation_time (iterator_t*);
+const char *
+get_iterator_creation_time (iterator_t *);
 
-const char*
-get_iterator_modification_time (iterator_t*);
+const char *
+get_iterator_modification_time (iterator_t *);
 
-const char*
-get_iterator_owner_name (iterator_t*);
+const char *
+get_iterator_owner_name (iterator_t *);
 
 user_t
-get_iterator_owner (iterator_t*);
+get_iterator_owner (iterator_t *);
 
-
 /* Resources. */
 
 int
@@ -385,31 +368,31 @@ int
 trash_id_exists (const char *, const char *);
 
 gboolean
-find_resource (const char*, const char*, resource_t*);
+find_resource (const char *, const char *, resource_t *);
 
 const char *
-type_name_plural (const char*);
+type_name_plural (const char *);
 
 const char *
-type_name (const char*);
+type_name (const char *);
 
 int
-type_is_scap (const char*);
+type_is_scap (const char *);
 
 int
 delete_resource (const char *, const char *, int);
 
-
 /* Events and Alerts. */
 
 /**
  * @brief Data about a report sent by an alert.
  */
-typedef struct {
-  gchar *local_filename;          ///< Path to the local report file.
-  gchar *remote_filename;         ///< Path or filename to send to / as.
-  gchar *content_type;            ///< The MIME content type of the report.
-  gchar *report_format_name;      ///< Name of the report format used.
+typedef struct
+{
+  gchar *local_filename;     ///< Path to the local report file.
+  gchar *remote_filename;    ///< Path or filename to send to / as.
+  gchar *content_type;       ///< The MIME content type of the report.
+  gchar *report_format_name; ///< Name of the report format used.
 } alert_report_data_t;
 
 void
@@ -422,103 +405,103 @@ alert_report_data_reset (alert_report_data_t *);
  * @brief Default format string for alert email, when including report.
  */
 #define ALERT_MESSAGE_INCLUDE                                                 \
- "Task '$n': $e\n"                                                            \
- "\n"                                                                         \
- "After the event $e,\n"                                                      \
- "the following condition was met: $c\n"                                      \
- "\n"                                                                         \
- "This email escalation is configured to apply report format '$r'.\n"         \
- "Full details and other report formats are available on the scan engine.\n"  \
- "\n"                                                                         \
- "$t"                                                                         \
- "\n"                                                                         \
- "$i"                                                                         \
- "\n"                                                                         \
- "\n"                                                                         \
- "Note:\n"                                                                    \
- "This email was sent to you as a configured security scan escalation.\n"     \
- "Please contact your local system administrator if you think you\n"          \
- "should not have received it.\n"
+  "Task '$n': $e\n"                                                           \
+  "\n"                                                                        \
+  "After the event $e,\n"                                                     \
+  "the following condition was met: $c\n"                                     \
+  "\n"                                                                        \
+  "This email escalation is configured to apply report format '$r'.\n"        \
+  "Full details and other report formats are available on the scan engine.\n" \
+  "\n"                                                                        \
+  "$t"                                                                        \
+  "\n"                                                                        \
+  "$i"                                                                        \
+  "\n"                                                                        \
+  "\n"                                                                        \
+  "Note:\n"                                                                   \
+  "This email was sent to you as a configured security scan escalation.\n"    \
+  "Please contact your local system administrator if you think you\n"         \
+  "should not have received it.\n"
 
 /**
  * @brief Default format string for SecInfo alert email, when including report.
  */
 #define SECINFO_ALERT_MESSAGE_INCLUDE                                         \
- "Task '$n': $e\n"                                                            \
- "\n"                                                                         \
- "After the event $e,\n"                                                      \
- "the following condition was met: $c\n"                                      \
- "\n"                                                                         \
- "This email escalation is configured to apply report format '$r'.\n"         \
- "Full details and other report formats are available on the scan engine.\n"  \
- "\n"                                                                         \
- "$t"                                                                         \
- "\n"                                                                         \
- "$i"                                                                         \
- "\n"                                                                         \
- "\n"                                                                         \
- "Note:\n"                                                                    \
- "This email was sent to you as a configured security scan escalation.\n"     \
- "Please contact your local system administrator if you think you\n"          \
- "should not have received it.\n"
+  "Task '$n': $e\n"                                                           \
+  "\n"                                                                        \
+  "After the event $e,\n"                                                     \
+  "the following condition was met: $c\n"                                     \
+  "\n"                                                                        \
+  "This email escalation is configured to apply report format '$r'.\n"        \
+  "Full details and other report formats are available on the scan engine.\n" \
+  "\n"                                                                        \
+  "$t"                                                                        \
+  "\n"                                                                        \
+  "$i"                                                                        \
+  "\n"                                                                        \
+  "\n"                                                                        \
+  "Note:\n"                                                                   \
+  "This email was sent to you as a configured security scan escalation.\n"    \
+  "Please contact your local system administrator if you think you\n"         \
+  "should not have received it.\n"
 
 /**
  * @brief Default format string for alert email, when attaching report.
  */
 #define ALERT_MESSAGE_ATTACH                                                  \
- "Task '$n': $e\n"                                                            \
- "\n"                                                                         \
- "After the event $e,\n"                                                      \
- "the following condition was met: $c\n"                                      \
- "\n"                                                                         \
- "This email escalation is configured to attach report format '$r'.\n"        \
- "Full details and other report formats are available on the scan engine.\n"  \
- "\n"                                                                         \
- "$t"                                                                         \
- "\n"                                                                         \
- "Note:\n"                                                                    \
- "This email was sent to you as a configured security scan escalation.\n"     \
- "Please contact your local system administrator if you think you\n"          \
- "should not have received it.\n"
+  "Task '$n': $e\n"                                                           \
+  "\n"                                                                        \
+  "After the event $e,\n"                                                     \
+  "the following condition was met: $c\n"                                     \
+  "\n"                                                                        \
+  "This email escalation is configured to attach report format '$r'.\n"       \
+  "Full details and other report formats are available on the scan engine.\n" \
+  "\n"                                                                        \
+  "$t"                                                                        \
+  "\n"                                                                        \
+  "Note:\n"                                                                   \
+  "This email was sent to you as a configured security scan escalation.\n"    \
+  "Please contact your local system administrator if you think you\n"         \
+  "should not have received it.\n"
 
 /**
  * @brief Default format string for SecInfo alert email, when attaching report.
  */
 #define SECINFO_ALERT_MESSAGE_ATTACH                                          \
- "Task '$n': $e\n"                                                            \
- "\n"                                                                         \
- "After the event $e,\n"                                                      \
- "the following condition was met: $c\n"                                      \
- "\n"                                                                         \
- "This email escalation is configured to attach report format '$r'.\n"        \
- "Full details and other report formats are available on the scan engine.\n"  \
- "\n"                                                                         \
- "$t"                                                                         \
- "\n"                                                                         \
- "Note:\n"                                                                    \
- "This email was sent to you as a configured security scan escalation.\n"     \
- "Please contact your local system administrator if you think you\n"          \
- "should not have received it.\n"
+  "Task '$n': $e\n"                                                           \
+  "\n"                                                                        \
+  "After the event $e,\n"                                                     \
+  "the following condition was met: $c\n"                                     \
+  "\n"                                                                        \
+  "This email escalation is configured to attach report format '$r'.\n"       \
+  "Full details and other report formats are available on the scan engine.\n" \
+  "\n"                                                                        \
+  "$t"                                                                        \
+  "\n"                                                                        \
+  "Note:\n"                                                                   \
+  "This email was sent to you as a configured security scan escalation.\n"    \
+  "Please contact your local system administrator if you think you\n"         \
+  "should not have received it.\n"
 
 /**
  * @brief Default description format string for vFire alert.
  */
 #define ALERT_VFIRE_CALL_DESCRIPTION                                          \
- "GVM Task '$n': $e\n"                                                        \
- "\n"                                                                         \
- "After the event $e,\n"                                                      \
- "the following condition was met: $c\n"                                      \
- "\n"                                                                         \
- "This ticket includes reports in the following format(s):\n"                 \
- "$r.\n"                                                                      \
- "Full details and other report formats are available on the scan engine.\n"  \
- "\n"                                                                         \
- "$t"                                                                         \
- "\n"                                                                         \
- "Note:\n"                                                                    \
- "This ticket was created automatically as a security scan escalation.\n"     \
- "Please contact your local system administrator if you think it\n"           \
- "was created or assigned erroneously.\n"
+  "GVM Task '$n': $e\n"                                                       \
+  "\n"                                                                        \
+  "After the event $e,\n"                                                     \
+  "the following condition was met: $c\n"                                     \
+  "\n"                                                                        \
+  "This ticket includes reports in the following format(s):\n"                \
+  "$r.\n"                                                                     \
+  "Full details and other report formats are available on the scan engine.\n" \
+  "\n"                                                                        \
+  "$t"                                                                        \
+  "\n"                                                                        \
+  "Note:\n"                                                                   \
+  "This ticket was created automatically as a security scan escalation.\n"    \
+  "Please contact your local system administrator if you think it\n"          \
+  "was created or assigned erroneously.\n"
 
 /**
  * @brief Types of task events.
@@ -571,130 +554,120 @@ int
 manage_check_alerts (GSList *, const gchar *);
 
 int
-create_alert (const char*, const char*, const char*, const char*, event_t,
-              GPtrArray*, alert_condition_t, GPtrArray*, alert_method_t,
-              GPtrArray*, alert_t*);
+create_alert (const char *, const char *, const char *, const char *, event_t,
+              GPtrArray *, alert_condition_t, GPtrArray *, alert_method_t,
+              GPtrArray *, alert_t *);
 
 int
-copy_alert (const char*, const char*, const char*, alert_t*);
+copy_alert (const char *, const char *, const char *, alert_t *);
 
 int
-modify_alert (const char*, const char*, const char*, const char*,
-              const char*, event_t, GPtrArray*, alert_condition_t, GPtrArray*,
-              alert_method_t, GPtrArray*);
+modify_alert (const char *, const char *, const char *, const char *,
+              const char *, event_t, GPtrArray *, alert_condition_t,
+              GPtrArray *, alert_method_t, GPtrArray *);
 
 int
 delete_alert (const char *, int);
 
-char *
-alert_uuid (alert_t);
+char *alert_uuid (alert_t);
 
 gboolean
 find_alert_with_permission (const char *, alert_t *, const char *);
 
 int
-manage_alert (const char *, const char *, event_t, const void*, gchar **);
+manage_alert (const char *, const char *, event_t, const void *, gchar **);
 
 int
 manage_test_alert (const char *, gchar **);
 
-int
-alert_in_use (alert_t);
+int alert_in_use (alert_t);
 
-int
-trash_alert_in_use (alert_t);
+int trash_alert_in_use (alert_t);
 
-int
-alert_writable (alert_t);
+int alert_writable (alert_t);
 
-int
-trash_alert_writable (alert_t);
+int trash_alert_writable (alert_t);
 
 int
 alert_count (const get_data_t *);
 
 int
-init_alert_iterator (iterator_t*, const get_data_t*);
+init_alert_iterator (iterator_t *, const get_data_t *);
 
 int
-alert_iterator_event (iterator_t*);
+alert_iterator_event (iterator_t *);
 
 int
-alert_iterator_condition (iterator_t*);
+alert_iterator_condition (iterator_t *);
 
 int
-alert_iterator_method (iterator_t*);
+alert_iterator_method (iterator_t *);
 
 char *
-alert_iterator_filter_uuid (iterator_t*);
+alert_iterator_filter_uuid (iterator_t *);
 
 char *
-alert_iterator_filter_name (iterator_t*);
+alert_iterator_filter_name (iterator_t *);
 
 int
-alert_iterator_filter_trash (iterator_t*);
+alert_iterator_filter_trash (iterator_t *);
 
 int
-alert_iterator_filter_readable (iterator_t*);
+alert_iterator_filter_readable (iterator_t *);
 
 int
-alert_iterator_active (iterator_t*);
+alert_iterator_active (iterator_t *);
 
-const char*
-alert_condition_name (alert_condition_t);
+const char *alert_condition_name (alert_condition_t);
 
-gchar*
-alert_condition_description (alert_condition_t, alert_t);
+gchar *alert_condition_description (alert_condition_t, alert_t);
 
-const char*
-event_name (event_t);
+const char *event_name (event_t);
 
-gchar*
+gchar *
 event_description (event_t, const void *, const char *);
 
-const char*
-alert_method_name (alert_method_t);
+const char *alert_method_name (alert_method_t);
 
 alert_condition_t
-alert_condition_from_name (const char*);
+alert_condition_from_name (const char *);
 
 event_t
-event_from_name (const char*);
+event_from_name (const char *);
 
 alert_method_t
-alert_method_from_name (const char*);
+alert_method_from_name (const char *);
 
 void
 init_alert_data_iterator (iterator_t *, alert_t, int, const char *);
 
-const char*
-alert_data_iterator_name (iterator_t*);
+const char *
+alert_data_iterator_name (iterator_t *);
 
-const char*
-alert_data_iterator_data (iterator_t*);
+const char *
+alert_data_iterator_data (iterator_t *);
 
 void
-init_alert_task_iterator (iterator_t*, alert_t, int);
+init_alert_task_iterator (iterator_t *, alert_t, int);
 
-const char*
-alert_task_iterator_name (iterator_t*);
+const char *
+alert_task_iterator_name (iterator_t *);
 
-const char*
-alert_task_iterator_uuid (iterator_t*);
+const char *
+alert_task_iterator_uuid (iterator_t *);
 
 int
-alert_task_iterator_readable (iterator_t*);
+alert_task_iterator_readable (iterator_t *);
 
 void
-init_task_alert_iterator (iterator_t*, task_t);
+init_task_alert_iterator (iterator_t *, task_t);
 
-const char*
-task_alert_iterator_uuid (iterator_t*);
+const char *
+task_alert_iterator_uuid (iterator_t *);
 
-const char*
-task_alert_iterator_name (iterator_t*);
+const char *
+task_alert_iterator_name (iterator_t *);
 
-
 /* Task global variables and preprocessor variables. */
 
 /**
@@ -704,29 +677,28 @@ extern task_t current_scanner_task;
 
 extern report_t global_current_report;
 
-
 /* Task code specific to the representation of tasks. */
 
 unsigned int
 task_count (const get_data_t *);
 
 int
-init_task_iterator (iterator_t*, const get_data_t *);
+init_task_iterator (iterator_t *, const get_data_t *);
 
 task_status_t
-task_iterator_run_status (iterator_t*);
+task_iterator_run_status (iterator_t *);
 
 const char *
-task_iterator_run_status_name (iterator_t*);
+task_iterator_run_status_name (iterator_t *);
 
 int
-task_iterator_total_reports (iterator_t*);
+task_iterator_total_reports (iterator_t *);
 
 int
 task_iterator_finished_reports (iterator_t *);
 
 const char *
-task_iterator_first_report (iterator_t*);
+task_iterator_first_report (iterator_t *);
 
 const char *
 task_iterator_last_report (iterator_t *);
@@ -743,119 +715,90 @@ task_iterator_scanner (iterator_t *);
 int
 task_uuid (task_t, char **);
 
-int
-task_in_trash (task_t);
+int task_in_trash (task_t);
 
 int
 task_in_trash_id (const gchar *);
 
-int
-task_in_use (task_t);
+int task_in_use (task_t);
 
-int
-trash_task_in_use (task_t);
+int trash_task_in_use (task_t);
 
-int
-task_writable (task_t);
+int task_writable (task_t);
 
-int
-task_alterable (task_t);
+int task_alterable (task_t);
 
-int
-trash_task_writable (task_t);
+int trash_task_writable (task_t);
 
-int
-task_average_scan_duration (task_t);
+int task_average_scan_duration (task_t);
 
-char*
-task_owner_name (task_t);
+char *task_owner_name (task_t);
 
-char*
-task_name (task_t);
+char *task_name (task_t);
 
-char*
-task_comment (task_t);
+char *task_comment (task_t);
 
-char*
-task_hosts_ordering (task_t);
+char *task_hosts_ordering (task_t);
 
-scanner_t
-task_scanner (task_t);
+scanner_t task_scanner (task_t);
 
-int
-task_scanner_in_trash (task_t);
+int task_scanner_in_trash (task_t);
 
-config_t
-task_config (task_t);
+config_t task_config (task_t);
 
-char*
-task_config_uuid (task_t);
+char *task_config_uuid (task_t);
 
-char*
-task_config_name (task_t);
+char *task_config_name (task_t);
 
-int
-task_config_in_trash (task_t);
+int task_config_in_trash (task_t);
 
-void
-set_task_config (task_t, config_t);
+void set_task_config (task_t, config_t);
 
-target_t
-task_target (task_t);
+target_t task_target (task_t);
 
-int
-task_target_in_trash (task_t);
+int task_target_in_trash (task_t);
 
-void
-set_task_target (task_t, target_t);
+void set_task_target (task_t, target_t);
 
 void
 set_task_hosts_ordering (task_t, const char *);
 
-void
-set_task_scanner (task_t, scanner_t);
+void set_task_scanner (task_t, scanner_t);
 
-char*
-task_description (task_t);
+char *task_description (task_t);
 
 void
-set_task_description (task_t, char*, gsize);
+set_task_description (task_t, char *, gsize);
 
-task_status_t
-task_run_status (task_t);
+task_status_t task_run_status (task_t);
 
-void
-set_task_run_status (task_t, task_status_t);
+void set_task_run_status (task_t, task_status_t);
 
 int
 task_result_count (task_t, int);
 
-report_t
-task_running_report (task_t);
+report_t task_running_report (task_t);
 
-int
-task_upload_progress (task_t);
+int task_upload_progress (task_t);
 
 void
 set_task_start_time_epoch (task_t, int);
 
 void
-set_task_start_time_otp (task_t, char*);
+set_task_start_time_otp (task_t, char *);
 
 void
-set_task_end_time (task_t task, char* time);
+set_task_end_time (task_t task, char *time);
 
-void
-set_task_end_time_epoch (task_t, time_t);
+void set_task_end_time_epoch (task_t, time_t);
 
-void
-add_task_alert (task_t, alert_t);
+void add_task_alert (task_t, alert_t);
 
 void
 set_task_alterable (task_t, int);
 
 int
-set_task_groups (task_t, array_t*, gchar**);
+set_task_groups (task_t, array_t *, gchar **);
 
 int
 set_task_schedule (task_t, schedule_t, int);
@@ -866,11 +809,10 @@ set_task_schedule_periods (const gchar *, int);
 int
 set_task_schedule_periods_id (task_t, int);
 
-unsigned int
-task_report_count (task_t);
+unsigned int task_report_count (task_t);
 
 int
-task_last_report (task_t, report_t*);
+task_last_report (task_t, report_t *);
 
 const char *
 task_iterator_trend_counts (iterator_t *, int, int, int, double, int, int, int,
@@ -879,74 +821,61 @@ task_iterator_trend_counts (iterator_t *, int, int, int, double, int, int, int,
 const char *
 task_trend (task_t, int, int);
 
-int
-task_schedule_periods (task_t);
+int task_schedule_periods (task_t);
 
 int
 task_schedule_periods_uuid (const gchar *);
 
-schedule_t
-task_schedule (task_t);
+schedule_t task_schedule (task_t);
 
 schedule_t
 task_schedule_uuid (const gchar *);
 
-int
-task_schedule_in_trash (task_t);
+int task_schedule_in_trash (task_t);
 
 time_t
 task_schedule_next_time_uuid (const gchar *);
 
-int
-task_schedule_next_time (task_t);
+int task_schedule_next_time (task_t);
 
 char *
 task_severity (task_t, int, int, int);
 
-int
-task_debugs_size (task_t);
+int task_debugs_size (task_t);
 
-int
-task_holes_size (task_t);
+int task_holes_size (task_t);
 
-int
-task_infos_size (task_t);
+int task_infos_size (task_t);
 
-int
-task_logs_size (task_t);
+int task_logs_size (task_t);
 
-int
-task_warnings_size (task_t);
+int task_warnings_size (task_t);
 
-int
-task_false_positive_size (task_t);
+int task_false_positive_size (task_t);
 
 task_t
-make_task (char*, char*, int, int);
+make_task (char *, char *, int, int);
 
-void
-make_task_complete (task_t);
+void make_task_complete (task_t);
 
 int
-copy_task (const char*, const char*, const char *, int, task_t*);
+copy_task (const char *, const char *, const char *, int, task_t *);
 
 void
 set_task_name (task_t, const char *);
 
 gboolean
-find_task_with_permission (const char*, task_t*, const char *);
+find_task_with_permission (const char *, task_t *, const char *);
 
 gboolean
-find_trash_task_with_permission (const char*, task_t*, const char *);
+find_trash_task_with_permission (const char *, task_t *, const char *);
 
-void
-reset_task (task_t);
+void reset_task (task_t);
 
 int
-set_task_parameter (task_t, const char*, char*);
+set_task_parameter (task_t, const char *, char *);
 
-char*
-task_observers (task_t);
+char *task_observers (task_t);
 
 int
 set_task_observers (task_t, const gchar *);
@@ -955,7 +884,7 @@ int
 request_delete_task_uuid (const char *, int);
 
 int
-request_delete_task (task_t*);
+request_delete_task (task_t *);
 
 int
 delete_task (task_t, int);
@@ -965,16 +894,16 @@ int
 delete_task_lock (task_t, int);
 
 void
-append_to_task_comment (task_t, const char*, int);
+append_to_task_comment (task_t, const char *, int);
 
 void
-add_task_description_line (task_t, const char*, size_t);
+add_task_description_line (task_t, const char *, size_t);
 
 void
-set_scan_ports (report_t, const char*, unsigned int, unsigned int);
+set_scan_ports (report_t, const char *, unsigned int, unsigned int);
 
 void
-append_task_open_port (task_t task, const char *, const char*);
+append_task_open_port (task_t task, const char *, const char *);
 
 int
 manage_task_update_file (const gchar *, const char *, const void *);
@@ -985,31 +914,30 @@ manage_task_remove_file (const gchar *, const char *);
 int
 modify_task (const gchar *, const gchar *, const gchar *, const gchar *,
              const gchar *, const gchar *, const gchar *, array_t *,
-             const gchar *, array_t *, const gchar *, const gchar *,
-             array_t *, const gchar *, gchar **, gchar **);
+             const gchar *, array_t *, const gchar *, const gchar *, array_t *,
+             const gchar *, gchar **, gchar **);
 
 void
-init_config_file_iterator (iterator_t*, const char*, const char*);
+init_config_file_iterator (iterator_t *, const char *, const char *);
 
-const char*
-config_file_iterator_content (iterator_t*);
+const char *
+config_file_iterator_content (iterator_t *);
 
 int
-config_file_iterator_length (iterator_t*);
+config_file_iterator_length (iterator_t *);
 
 void
-init_config_task_iterator (iterator_t*, config_t, int);
+init_config_task_iterator (iterator_t *, config_t, int);
 
-const char*
-config_task_iterator_name (iterator_t*);
+const char *
+config_task_iterator_name (iterator_t *);
 
-const char*
-config_task_iterator_uuid (iterator_t*);
+const char *
+config_task_iterator_uuid (iterator_t *);
 
 int
-config_task_iterator_readable (iterator_t*);
+config_task_iterator_readable (iterator_t *);
 
-
 /* General severity related facilities. */
 
 int
@@ -1018,10 +946,10 @@ severity_in_level (double, const char *);
 int
 severity_matches_ov (double, double);
 
-const char*
+const char *
 severity_to_level (double, int);
 
-const char*
+const char *
 severity_to_type (double);
 
 /**
@@ -1029,38 +957,36 @@ severity_to_type (double);
  */
 typedef struct
 {
-  int* counts;       ///< Counts.
-  int total;         ///< Total.
-  double max;        ///< Max.
+  int *counts; ///< Counts.
+  int total;   ///< Total.
+  double max;  ///< Max.
 } severity_data_t;
 
 double
 severity_data_value (int);
 
 void
-init_severity_data (severity_data_t*);
+init_severity_data (severity_data_t *);
 
 void
-cleanup_severity_data (severity_data_t*);
+cleanup_severity_data (severity_data_t *);
 
 void
-severity_data_add (severity_data_t*, double);
+severity_data_add (severity_data_t *, double);
 
 void
-severity_data_add_count (severity_data_t*, double, int);
+severity_data_add_count (severity_data_t *, double, int);
 
 void
-severity_data_level_counts (const severity_data_t*, const gchar*,
-                            int*, int*, int*, int*, int*, int*, int*);
+severity_data_level_counts (const severity_data_t *, const gchar *, int *,
+                            int *, int *, int *, int *, int *, int *);
 
-
 /* General task facilities. */
 
-const char*
-run_status_name (task_status_t);
+const char *run_status_name (task_status_t);
 
 int
-start_task (const char *, char**);
+start_task (const char *, char **);
 
 int
 stop_task (const char *);
@@ -1069,9 +995,8 @@ int
 resume_task (const char *, char **);
 
 int
-move_task (const char*, const char*);
+move_task (const char *, const char *);
 
-
 /* Access control. */
 
 int
@@ -1086,31 +1011,30 @@ user_can_super_everyone (const char *);
 extern int
 user_has_super (const char *, user_t);
 
-
 /* Results. */
 
 /**
  * @brief SQL list of LSC families.
  */
-#define LSC_FAMILY_LIST                  \
-  "'AIX Local Security Checks',"         \
-  " 'CentOS Local Security Checks',"     \
-  " 'Debian Local Security Checks',"     \
-  " 'Fedora Local Security Checks',"     \
-  " 'FreeBSD Local Security Checks',"    \
-  " 'Gentoo Local Security Checks',"     \
-  " 'HP-UX Local Security Checks',"      \
-  " 'Mac OS X Local Security Checks',"   \
-  " 'Mandrake Local Security Checks',"   \
-  " 'Red Hat Local Security Checks',"    \
-  " 'Solaris Local Security Checks',"    \
-  " 'SuSE Local Security Checks',"       \
-  " 'Ubuntu Local Security Checks',"     \
-  " 'Windows : Microsoft Bulletins',"    \
+#define LSC_FAMILY_LIST                \
+  "'AIX Local Security Checks',"       \
+  " 'CentOS Local Security Checks',"   \
+  " 'Debian Local Security Checks',"   \
+  " 'Fedora Local Security Checks',"   \
+  " 'FreeBSD Local Security Checks',"  \
+  " 'Gentoo Local Security Checks',"   \
+  " 'HP-UX Local Security Checks',"    \
+  " 'Mac OS X Local Security Checks'," \
+  " 'Mandrake Local Security Checks'," \
+  " 'Red Hat Local Security Checks',"  \
+  " 'Solaris Local Security Checks',"  \
+  " 'SuSE Local Security Checks',"     \
+  " 'Ubuntu Local Security Checks',"   \
+  " 'Windows : Microsoft Bulletins',"  \
   " 'Privilege escalation'"
 
 gboolean
-find_result_with_permission (const char*, result_t*, const char *);
+find_result_with_permission (const char *, result_t *, const char *);
 
 int
 result_uuid (result_t, char **);
@@ -1147,13 +1071,12 @@ reports_clear_count_cache_for_override (override_t, int);
 
 void
 init_report_counts_build_iterator (iterator_t *, report_t, int, int,
-                                   const char*);
+                                   const char *);
 
 double
 report_severity (report_t, int, int);
 
-int
-report_host_count (report_t);
+int report_host_count (report_t);
 
 int
 report_result_host_count (report_t, int);
@@ -1168,31 +1091,31 @@ int
 qod_from_type (const char *);
 
 result_t
-make_result (task_t, const char*, const char*, const char*, const char*,
-             const char*, const char*);
+make_result (task_t, const char *, const char *, const char *, const char *,
+             const char *, const char *);
 
 result_t
-make_osp_result (task_t, const char*, const char*, const char*, const char*,
+make_osp_result (task_t, const char *, const char *, const char *, const char *,
                  const char *, const char *, int);
 
 result_t
-make_cve_result (task_t, const char*, const char*, double, const char*);
+make_cve_result (task_t, const char *, const char *, double, const char *);
 
 /**
  * @brief A CREATE_REPORT result.
  */
 typedef struct
 {
-  char *description;       ///< Description of NVT.
-  char *host;              ///< Host.
-  char *hostname;          ///< Hostname.
-  char *nvt_oid;           ///< OID of NVT.
-  char *scan_nvt_version;  ///< Version of NVT used at scan time.
-  char *port;              ///< Port.
-  char *qod;               ///< QoD (quality of detection).
-  char *qod_type;          ///< QoD type.
-  char *severity;          ///< Severity score.
-  char *threat;            ///< Threat.
+  char *description;      ///< Description of NVT.
+  char *host;             ///< Host.
+  char *hostname;         ///< Hostname.
+  char *nvt_oid;          ///< OID of NVT.
+  char *scan_nvt_version; ///< Version of NVT used at scan time.
+  char *port;             ///< Port.
+  char *qod;              ///< QoD (quality of detection).
+  char *qod_type;         ///< QoD type.
+  char *severity;         ///< Severity score.
+  char *threat;           ///< Threat.
 } create_report_result_t;
 
 /**
@@ -1200,12 +1123,12 @@ typedef struct
  */
 typedef struct
 {
-  char *ip;           ///< IP.
-  char *name;         ///< Detail name.
-  char *source_desc;  ///< Source description.
-  char *source_name;  ///< Source name.
-  char *source_type;  ///< Source type.
-  char *value;        ///< Detail value.
+  char *ip;          ///< IP.
+  char *name;        ///< Detail name.
+  char *source_desc; ///< Source description.
+  char *source_name; ///< Source name.
+  char *source_type; ///< Source type.
+  char *value;       ///< Detail value.
 } host_detail_t;
 
 void
@@ -1218,31 +1141,26 @@ insert_report_host_detail (report_t, const char *, const char *, const char *,
 int
 manage_report_host_detail (report_t, const char *, const char *);
 
-void
-hosts_set_identifiers (report_t);
+void hosts_set_identifiers (report_t);
 
 void
-hosts_set_max_severity (report_t, int*, int*);
+hosts_set_max_severity (report_t, int *, int *);
 
 void
 hosts_set_details (report_t report);
 
-void
-clear_duration_schedules (task_t);
+void clear_duration_schedules (task_t);
 
-void
-update_duration_schedule_periods (task_t);
+void update_duration_schedule_periods (task_t);
 
 int
-create_report (array_t*, const char *, const char *, const char *, const char *,
-               const char *, const char *, array_t*, array_t*, array_t*,
-               char **);
+create_report (array_t *, const char *, const char *, const char *,
+               const char *, const char *, const char *, array_t *, array_t *,
+               array_t *, char **);
 
-void
-report_add_result (report_t, result_t);
+void report_add_result (report_t, result_t);
 
-char*
-report_uuid (report_t);
+char *report_uuid (report_t);
 
 void
 report_set_slave_uuid (report_t, const gchar *);
@@ -1268,78 +1186,73 @@ report_set_source_iface (report_t, const gchar *);
 int
 task_last_resumable_report (task_t, report_t *);
 
-gchar*
-task_second_last_report_id (task_t);
+gchar *task_second_last_report_id (task_t);
 
-gchar*
-report_path_task_uuid (gchar*);
+gchar *
+report_path_task_uuid (gchar *);
 
 gboolean
-report_task (report_t, task_t*);
+report_task (report_t, task_t *);
 
-char *
-report_slave_task_uuid (report_t);
-
-int
-report_scan_result_count (report_t, const char*, const char*, int, const char*,
-                          const char*, int, int, int*);
+char *report_slave_task_uuid (report_t);
 
 int
-report_counts (const char*, int*, int*, int*, int*, int*, int*, double*,
+report_scan_result_count (report_t, const char *, const char *, int,
+                          const char *, const char *, int, int, int *);
+
+int
+report_counts (const char *, int *, int *, int *, int *, int *, int *, double *,
                int, int, int);
 
 int
-report_counts_id (report_t, int*, int*, int*, int*, int*, int*, double*,
-                  const get_data_t*, const char*);
+report_counts_id (report_t, int *, int *, int *, int *, int *, int *, double *,
+                  const get_data_t *, const char *);
 
 int
-report_counts_id_no_filt (report_t, int*, int*, int*, int*, int*, int*,
-                          double*, const get_data_t*, const char*);
+report_counts_id_no_filt (report_t, int *, int *, int *, int *, int *, int *,
+                          double *, const get_data_t *, const char *);
 
-get_data_t*
+get_data_t *
 report_results_get_data (int, int, int, int, int);
 
-int
-scan_start_time_epoch (report_t);
+int scan_start_time_epoch (report_t);
 
-char*
+char *
 scan_start_time_uuid (const char *);
 
-char*
+char *
 scan_end_time_uuid (const char *);
 
 void
-set_scan_start_time_otp (report_t, const char*);
+set_scan_start_time_otp (report_t, const char *);
+
+void set_scan_start_time_epoch (report_t, time_t);
 
 void
-set_scan_start_time_epoch (report_t, time_t);
+set_scan_end_time (report_t, const char *);
 
 void
-set_scan_end_time (report_t, const char*);
+set_scan_end_time_otp (report_t, const char *);
+
+void set_scan_end_time_epoch (report_t, time_t);
 
 void
-set_scan_end_time_otp (report_t, const char*);
-
-void
-set_scan_end_time_epoch (report_t, time_t);
-
-void
-set_scan_host_start_time_otp (report_t, const char*, const char*);
+set_scan_host_start_time_otp (report_t, const char *, const char *);
 
 int
-scan_host_end_time (report_t, const char*);
+scan_host_end_time (report_t, const char *);
 
 void
-set_scan_host_end_time (report_t, const char*, const char*);
+set_scan_host_end_time (report_t, const char *, const char *);
 
 void
-set_scan_host_end_time_otp (report_t, const char*, const char*);
+set_scan_host_end_time_otp (report_t, const char *, const char *);
 
 int
-report_timestamp (const char*, gchar**);
+report_timestamp (const char *, gchar **);
 
 int
-modify_report (const char*, const char*);
+modify_report (const char *, const char *);
 
 int
 delete_report (const char *, int);
@@ -1348,186 +1261,179 @@ int
 report_count (const get_data_t *);
 
 int
-init_report_iterator (iterator_t*, const get_data_t *);
+init_report_iterator (iterator_t *, const get_data_t *);
 
 void
-init_report_iterator_task (iterator_t*, task_t);
+init_report_iterator_task (iterator_t *, task_t);
 
 void
-init_report_errors_iterator (iterator_t*, report_t);
+init_report_errors_iterator (iterator_t *, report_t);
 
-const char*
-report_iterator_uuid (iterator_t*);
-
-int
-result_count (const get_data_t *, report_t, const char*);
+const char *
+report_iterator_uuid (iterator_t *);
 
 int
-init_result_get_iterator (iterator_t*, const get_data_t *, report_t,
-                          const char*, const gchar *);
+result_count (const get_data_t *, report_t, const char *);
+
+int
+init_result_get_iterator (iterator_t *, const get_data_t *, report_t,
+                          const char *, const gchar *);
 
 gboolean
-next_report (iterator_t*, report_t*);
+next_report (iterator_t *, report_t *);
 
 result_t
-result_iterator_result (iterator_t*);
+result_iterator_result (iterator_t *);
 
-const char*
-result_iterator_host (iterator_t*);
+const char *
+result_iterator_host (iterator_t *);
 
-const char*
-result_iterator_port (iterator_t*);
+const char *
+result_iterator_port (iterator_t *);
 
-const char*
-result_iterator_nvt_oid (iterator_t*);
+const char *
+result_iterator_nvt_oid (iterator_t *);
 
-const char*
+const char *
 result_iterator_nvt_name (iterator_t *);
 
-const char*
+const char *
 result_iterator_nvt_family (iterator_t *);
 
-const char*
+const char *
 result_iterator_nvt_cvss_base (iterator_t *);
 
-const char*
+const char *
 result_iterator_nvt_cve (iterator_t *);
 
-const char*
+const char *
 result_iterator_nvt_bid (iterator_t *);
 
-const char*
+const char *
 result_iterator_nvt_xref (iterator_t *);
 
-const char*
+const char *
 result_iterator_nvt_tag (iterator_t *);
 
-const char*
-result_iterator_descr (iterator_t*);
+const char *
+result_iterator_descr (iterator_t *);
 
 task_t
-result_iterator_task (iterator_t*);
+result_iterator_task (iterator_t *);
 
 report_t
-result_iterator_report (iterator_t*);
+result_iterator_report (iterator_t *);
 
-const char*
-result_iterator_scan_nvt_version (iterator_t*);
+const char *
+result_iterator_scan_nvt_version (iterator_t *);
 
-const char*
-result_iterator_original_severity (iterator_t*);
+const char *
+result_iterator_original_severity (iterator_t *);
 
 double
 result_iterator_severity_double (iterator_t *);
 
-const char*
-result_iterator_original_level (iterator_t*);
+const char *
+result_iterator_original_level (iterator_t *);
 
-const char*
-result_iterator_level (iterator_t*);
+const char *
+result_iterator_level (iterator_t *);
 
-const char*
-result_iterator_solution_type (iterator_t*);
+const char *
+result_iterator_solution_type (iterator_t *);
 
-const char*
-result_iterator_qod (iterator_t*);
+const char *
+result_iterator_qod (iterator_t *);
 
-const char*
-result_iterator_qod_type (iterator_t*);
+const char *
+result_iterator_qod_type (iterator_t *);
 
-const char*
-result_iterator_hostname (iterator_t*);
+const char *
+result_iterator_hostname (iterator_t *);
 
-const char*
-result_iterator_date (iterator_t*);
+const char *
+result_iterator_date (iterator_t *);
 
-const char*
-result_iterator_detected_by_oid (iterator_t*);
+const char *
+result_iterator_detected_by_oid (iterator_t *);
 
-const char*
-result_iterator_asset_host_id (iterator_t*);
-
-int
-result_iterator_may_have_notes (iterator_t*);
+const char *
+result_iterator_asset_host_id (iterator_t *);
 
 int
-result_iterator_may_have_overrides (iterator_t*);
+result_iterator_may_have_notes (iterator_t *);
 
 int
-result_iterator_may_have_tickets (iterator_t*);
+result_iterator_may_have_overrides (iterator_t *);
 
 int
-result_iterator_has_cert_bunds (iterator_t*);
+result_iterator_may_have_tickets (iterator_t *);
 
 int
-result_iterator_has_dfn_certs (iterator_t*);
+result_iterator_has_cert_bunds (iterator_t *);
+
+int
+result_iterator_has_dfn_certs (iterator_t *);
 
 void
-init_report_host_iterator (iterator_t*, report_t, const char *, report_host_t);
+init_report_host_iterator (iterator_t *, report_t, const char *, report_host_t);
 
-const char*
-host_iterator_host (iterator_t*);
+const char *
+host_iterator_host (iterator_t *);
 
-const char*
-host_iterator_start_time (iterator_t*);
+const char *
+host_iterator_start_time (iterator_t *);
 
-const char*
-host_iterator_end_time (iterator_t*);
-
-int
-host_iterator_current_port (iterator_t*);
+const char *
+host_iterator_end_time (iterator_t *);
 
 int
-host_iterator_max_port (iterator_t*);
+host_iterator_current_port (iterator_t *);
 
 int
-collate_message_type (void* data, int, const void*, int, const void*);
+host_iterator_max_port (iterator_t *);
 
-void
-trim_partial_report (report_t);
+int
+collate_message_type (void *data, int, const void *, int, const void *);
+
+void trim_partial_report (report_t);
 
 int
 report_progress (report_t, task_t, gchar **);
 
 gchar *
-manage_report (report_t, report_t, const get_data_t *, report_format_t,
-               int, int, const char *,
-               gsize *, gchar **, gchar **, gchar **, gchar **, gchar **);
+manage_report (report_t, report_t, const get_data_t *, report_format_t, int,
+               int, const char *, gsize *, gchar **, gchar **, gchar **,
+               gchar **, gchar **);
 
 int
-manage_send_report (report_t, report_t, report_format_t, const get_data_t *,
-                    int, int, int, int, int,
-                    gboolean (*) (const char *,
-                                  int (*) (const char*, void*),
-                                  void*),
-                    int (*) (const char *, void*), void *, const char *,
-                    const char *, const char *, int, const char *,
-                    const char *, int, int, const gchar *);
+manage_send_report (
+  report_t, report_t, report_format_t, const get_data_t *, int, int, int, int,
+  int, gboolean (*) (const char *, int (*) (const char *, void *), void *),
+  int (*) (const char *, void *), void *, const char *, const char *,
+  const char *, int, const char *, const char *, int, int, const gchar *);
 
-
-
 /* Reports. */
 
 gchar *
 app_location (report_host_t, const gchar *);
 
 void
-init_host_prognosis_iterator (iterator_t*, report_host_t, int, int,
+init_host_prognosis_iterator (iterator_t *, report_host_t, int, int,
                               const char *, const char *, int, const char *);
 
 double
-prognosis_iterator_cvss_double (iterator_t*);
+prognosis_iterator_cvss_double (iterator_t *);
 
-const char*
-prognosis_iterator_cpe (iterator_t*);
+const char *
+prognosis_iterator_cpe (iterator_t *);
 
-const char*
-prognosis_iterator_cve (iterator_t*);
+const char *
+prognosis_iterator_cve (iterator_t *);
 
-const char*
-prognosis_iterator_description (iterator_t*);
+const char *
+prognosis_iterator_description (iterator_t *);
 
-
 /* Targets. */
 
 /**
@@ -1571,164 +1477,149 @@ gboolean
 find_target_with_permission (const char *, target_t *, const char *);
 
 int
-create_target (const char*, const char*, const char*, const char*, const char*,
-               const char *, const char*, credential_t, const char*,
-               credential_t, credential_t, credential_t, const char *,
-               const char *, const char *, target_t*);
+create_target (const char *, const char *, const char *, const char *,
+               const char *, const char *, const char *, credential_t,
+               const char *, credential_t, credential_t, credential_t,
+               const char *, const char *, const char *, target_t *);
 
 int
-copy_target (const char*, const char*, const char *, target_t*);
+copy_target (const char *, const char *, const char *, target_t *);
 
 int
-modify_target (const char*, const char*, const char*, const char*, const char*,
-               const char*, const char*, const char*, const char*, const char*,
-               const char*, const char *, const char*, const char*);
+modify_target (const char *, const char *, const char *, const char *,
+               const char *, const char *, const char *, const char *,
+               const char *, const char *, const char *, const char *,
+               const char *, const char *);
 
 int
-delete_target (const char*, int);
+delete_target (const char *, int);
 
 int
 target_count (const get_data_t *);
 
 void
-init_user_target_iterator (iterator_t*, target_t);
+init_user_target_iterator (iterator_t *, target_t);
 
 void
-init_target_iterator_one (iterator_t*, target_t);
+init_target_iterator_one (iterator_t *, target_t);
 
 int
-init_target_iterator (iterator_t*, const get_data_t *);
+init_target_iterator (iterator_t *, const get_data_t *);
 
-const char*
-target_iterator_hosts (iterator_t*);
+const char *
+target_iterator_hosts (iterator_t *);
 
-const char*
-target_iterator_exclude_hosts (iterator_t*);
+const char *
+target_iterator_exclude_hosts (iterator_t *);
 
-const char*
-target_iterator_reverse_lookup_only (iterator_t*);
+const char *
+target_iterator_reverse_lookup_only (iterator_t *);
 
-const char*
-target_iterator_reverse_lookup_unify (iterator_t*);
+const char *
+target_iterator_reverse_lookup_unify (iterator_t *);
 
-const char*
-target_iterator_comment (iterator_t*);
-
-int
-target_iterator_ssh_credential (iterator_t*);
-
-const char*
-target_iterator_ssh_port (iterator_t*);
+const char *
+target_iterator_comment (iterator_t *);
 
 int
-target_iterator_smb_credential (iterator_t*);
+target_iterator_ssh_credential (iterator_t *);
+
+const char *
+target_iterator_ssh_port (iterator_t *);
 
 int
-target_iterator_esxi_credential (iterator_t*);
+target_iterator_smb_credential (iterator_t *);
 
 int
-target_iterator_snmp_credential (iterator_t*);
+target_iterator_esxi_credential (iterator_t *);
 
 int
-target_iterator_ssh_trash (iterator_t*);
+target_iterator_snmp_credential (iterator_t *);
 
 int
-target_iterator_smb_trash (iterator_t*);
+target_iterator_ssh_trash (iterator_t *);
 
 int
-target_iterator_esxi_trash (iterator_t*);
+target_iterator_smb_trash (iterator_t *);
 
 int
-target_iterator_snmp_trash (iterator_t*);
-
-const char*
-target_iterator_port_list_uuid (iterator_t*);
-
-const char*
-target_iterator_port_list_name (iterator_t*);
+target_iterator_esxi_trash (iterator_t *);
 
 int
-target_iterator_port_list_trash (iterator_t*);
+target_iterator_snmp_trash (iterator_t *);
 
-const char*
-target_iterator_alive_tests (iterator_t*);
+const char *
+target_iterator_port_list_uuid (iterator_t *);
 
-char*
-target_uuid (target_t);
-
-char*
-trash_target_uuid (target_t);
-
-char*
-target_name (target_t);
-
-char*
-trash_target_name (target_t);
+const char *
+target_iterator_port_list_name (iterator_t *);
 
 int
-trash_target_readable (target_t);
+target_iterator_port_list_trash (iterator_t *);
 
-char*
-target_hosts (target_t);
+const char *
+target_iterator_alive_tests (iterator_t *);
 
-char*
-target_exclude_hosts (target_t);
+char *target_uuid (target_t);
 
-char*
-target_reverse_lookup_only (target_t);
+char *trash_target_uuid (target_t);
 
-char*
-target_reverse_lookup_unify (target_t);
+char *target_name (target_t);
 
-char*
-target_port_range (target_t);
+char *trash_target_name (target_t);
 
-char*
-target_ssh_port (target_t);
+int trash_target_readable (target_t);
 
-int
-target_in_use (target_t);
+char *target_hosts (target_t);
 
-int
-trash_target_in_use (target_t);
+char *target_exclude_hosts (target_t);
 
-int
-target_writable (target_t);
+char *target_reverse_lookup_only (target_t);
 
-int
-trash_target_writable (target_t);
+char *target_reverse_lookup_unify (target_t);
 
-char*
+char *target_port_range (target_t);
+
+char *target_ssh_port (target_t);
+
+int target_in_use (target_t);
+
+int trash_target_in_use (target_t);
+
+int target_writable (target_t);
+
+int trash_target_writable (target_t);
+
+char *
 target_ssh_credential_name (const char *);
 
 void
-init_target_task_iterator (iterator_t*, target_t);
+init_target_task_iterator (iterator_t *, target_t);
 
-const char*
-target_task_iterator_name (iterator_t*);
+const char *
+target_task_iterator_name (iterator_t *);
 
-const char*
-target_task_iterator_uuid (iterator_t*);
+const char *
+target_task_iterator_uuid (iterator_t *);
 
 int
-target_task_iterator_readable (iterator_t*);
+target_task_iterator_readable (iterator_t *);
 
 credential_t
-target_credential (target_t, const char*);
+target_credential (target_t, const char *);
 
 credential_t
-trash_target_credential (target_t, const char*);
+trash_target_credential (target_t, const char *);
 
 int
-trash_target_credential_location (target_t, const char*);
+trash_target_credential_location (target_t, const char *);
 
 int
-target_login_port (target_t, const char*);
+target_login_port (target_t, const char *);
 
 int
-trash_target_login_port (target_t, const char*);
+trash_target_login_port (target_t, const char *);
 
-
 /* Configs. */
 
 /**
@@ -1736,14 +1627,14 @@ trash_target_login_port (target_t, const char*);
  */
 typedef struct
 {
-  char *name;      ///< Name of preference.
-  char *type;      ///< Type of preference (radio, password, ...).
-  char *value;     ///< Value of preference.
-  char *nvt_name;  ///< Name of NVT preference affects.
-  char *nvt_oid;   ///< OID of NVT preference affects.
-  array_t *alts;   ///< Array of gchar's.  Alternate values for radio type.
+  char *name;          ///< Name of preference.
+  char *type;          ///< Type of preference (radio, password, ...).
+  char *value;         ///< Value of preference.
+  char *nvt_name;      ///< Name of NVT preference affects.
+  char *nvt_oid;       ///< OID of NVT preference affects.
+  array_t *alts;       ///< Array of gchar's.  Alternate values for radio type.
   char *default_value; ///< Default value of preference.
-  char *hr_name;   ///< Extended, more human-readable name used by OSP.
+  char *hr_name;       ///< Extended, more human-readable name used by OSP.
 } preference_t;
 
 /**
@@ -1751,226 +1642,212 @@ typedef struct
  */
 typedef struct
 {
-  char *name;           ///< Name of NVT selector.
-  char *type;           ///< Name of NVT selector.
-  int include;          ///< Whether family/NVT is included or excluded.
-  char *family_or_nvt;  ///< Family or NVT that this selector selects.
+  char *name;          ///< Name of NVT selector.
+  char *type;          ///< Name of NVT selector.
+  int include;         ///< Whether family/NVT is included or excluded.
+  char *family_or_nvt; ///< Family or NVT that this selector selects.
 } nvt_selector_t;
 
 int
-create_config (const char*, const char*, const array_t*, const array_t*,
-               const char*, config_t*, char**);
+create_config (const char *, const char *, const array_t *, const array_t *,
+               const char *, config_t *, char **);
 
 int
-create_config_from_scanner (const char*, const char *, const char *,
-                            char **);
+create_config_from_scanner (const char *, const char *, const char *, char **);
 
 int
-copy_config (const char*, const char*, const char *, config_t*);
+copy_config (const char *, const char *, const char *, config_t *);
 
 int
-delete_config (const char*, int);
+delete_config (const char *, int);
 
 int
 sync_config (const char *);
 
 gboolean
-find_config_with_permission (const char*, config_t*, const char *);
+find_config_with_permission (const char *, config_t *, const char *);
 
-char *
-config_uuid (config_t);
+char *config_uuid (config_t);
 
-int
-config_type (config_t);
+int config_type (config_t);
 
 char *
 config_nvt_timeout (config_t, const char *);
 
 void
-init_user_config_iterator (iterator_t*, config_t, int, int, const char*);
+init_user_config_iterator (iterator_t *, config_t, int, int, const char *);
 
 int
-init_config_iterator (iterator_t*, const get_data_t*);
+init_config_iterator (iterator_t *, const get_data_t *);
 
-const char*
-config_iterator_nvt_selector (iterator_t*);
-
-int
-config_iterator_nvt_count (iterator_t*);
+const char *
+config_iterator_nvt_selector (iterator_t *);
 
 int
-config_iterator_family_count (iterator_t*);
+config_iterator_nvt_count (iterator_t *);
 
 int
-config_iterator_nvts_growing (iterator_t*);
+config_iterator_family_count (iterator_t *);
 
 int
-config_iterator_type (iterator_t*);
+config_iterator_nvts_growing (iterator_t *);
 
 int
-config_iterator_families_growing (iterator_t*);
+config_iterator_type (iterator_t *);
+
+int
+config_iterator_families_growing (iterator_t *);
 
 scanner_t
-config_iterator_scanner (iterator_t*);
+config_iterator_scanner (iterator_t *);
 
 int
-config_iterator_scanner_trash (iterator_t*);
+config_iterator_scanner_trash (iterator_t *);
 
-char*
-config_nvt_selector (config_t);
+char *config_nvt_selector (config_t);
 
-int
-config_in_use (config_t);
+int config_in_use (config_t);
 
-int
-config_writable (config_t);
+int config_writable (config_t);
 
 int
 config_count (const get_data_t *);
 
-int
-trash_config_in_use (config_t);
+int trash_config_in_use (config_t);
 
-int
-trash_config_writable (config_t);
+int trash_config_writable (config_t);
 
 int
 trash_config_readable_uuid (const gchar *);
 
-int
-config_families_growing (config_t);
+int config_families_growing (config_t);
 
-int
-config_nvts_growing (config_t);
+int config_nvts_growing (config_t);
 
-int
-create_task_check_config_scanner (config_t, scanner_t);
+int create_task_check_config_scanner (config_t, scanner_t);
 
 int
 modify_task_check_config_scanner (task_t, const char *, const char *);
 
 int
-manage_set_config_preference (const gchar *, const char*, const char*,
-                              const char*);
+manage_set_config_preference (const gchar *, const char *, const char *,
+                              const char *);
 
 void
 init_preference_iterator (iterator_t *, config_t);
 
-const char*
+const char *
 preference_iterator_name (iterator_t *);
 
-const char*
+const char *
 preference_iterator_value (iterator_t *);
 
-const char*
+const char *
 preference_iterator_type (iterator_t *);
 
-const char*
+const char *
 preference_iterator_default (iterator_t *);
 
-const char*
+const char *
 preference_iterator_hr_name (iterator_t *);
 
 int
-manage_set_config (const gchar *, const char*, const char *, const char *);
+manage_set_config (const gchar *, const char *, const char *, const char *);
 
 int
-manage_set_config_nvts (const gchar *, const char*, GPtrArray*);
+manage_set_config_nvts (const gchar *, const char *, GPtrArray *);
 
 int
-manage_set_config_families (const gchar *, GPtrArray*, GPtrArray*, GPtrArray*,
-                            int);
+manage_set_config_families (const gchar *, GPtrArray *, GPtrArray *,
+                            GPtrArray *, int);
 
 void
-init_config_timeout_iterator (iterator_t*, config_t);
+init_config_timeout_iterator (iterator_t *, config_t);
 
-const char*
+const char *
 config_timeout_iterator_oid (iterator_t *);
 
-const char*
+const char *
 config_timeout_iterator_nvt_name (iterator_t *);
 
-const char*
+const char *
 config_timeout_iterator_value (iterator_t *);
 
-
-
 /* NVT's. */
 
-char *
-manage_nvt_name (nvt_t);
+char *manage_nvt_name (nvt_t);
 
 char *
 nvt_oid (const char *);
 
-char*
+char *
 nvts_feed_version ();
 
 void
-set_nvts_feed_version (const char*);
+set_nvts_feed_version (const char *);
 
 gboolean
-find_nvt (const char*, nvt_t*);
+find_nvt (const char *, nvt_t *);
 
 int
-init_nvt_info_iterator (iterator_t*, get_data_t*, const char*);
+init_nvt_info_iterator (iterator_t *, get_data_t *, const char *);
 
 int
 nvt_info_count (const get_data_t *);
 
 void
-init_nvt_iterator (iterator_t*, nvt_t, config_t, const char*, const char*, int,
-                   const char*);
+init_nvt_iterator (iterator_t *, nvt_t, config_t, const char *, const char *,
+                   int, const char *);
 
 void
-init_cve_nvt_iterator (iterator_t*, const char *, int, const char*);
+init_cve_nvt_iterator (iterator_t *, const char *, int, const char *);
 
-const char*
-nvt_iterator_oid (iterator_t*);
+const char *
+nvt_iterator_oid (iterator_t *);
 
-const char*
-nvt_iterator_version (iterator_t*);
+const char *
+nvt_iterator_version (iterator_t *);
 
-const char*
-nvt_iterator_name (iterator_t*);
+const char *
+nvt_iterator_name (iterator_t *);
 
-const char*
-nvt_iterator_description (iterator_t*);
+const char *
+nvt_iterator_description (iterator_t *);
 
-const char*
-nvt_iterator_copyright (iterator_t*);
+const char *
+nvt_iterator_copyright (iterator_t *);
 
-const char*
-nvt_iterator_cve (iterator_t*);
+const char *
+nvt_iterator_cve (iterator_t *);
 
-const char*
-nvt_iterator_bid (iterator_t*);
+const char *
+nvt_iterator_bid (iterator_t *);
 
-const char*
-nvt_iterator_xref (iterator_t*);
+const char *
+nvt_iterator_xref (iterator_t *);
 
-const char*
-nvt_iterator_tag (iterator_t*);
+const char *
+nvt_iterator_tag (iterator_t *);
 
 int
-nvt_iterator_category (iterator_t*);
+nvt_iterator_category (iterator_t *);
 
-const char*
-nvt_iterator_family (iterator_t*);
+const char *
+nvt_iterator_family (iterator_t *);
 
-const char*
-nvt_iterator_cvss_base (iterator_t*);
+const char *
+nvt_iterator_cvss_base (iterator_t *);
 
-const char*
-nvt_iterator_qod (iterator_t*);
+const char *
+nvt_iterator_qod (iterator_t *);
 
-const char*
-nvt_iterator_qod_type ( iterator_t *iterator );
+const char *
+nvt_iterator_qod_type (iterator_t *iterator);
 
-const char*
-nvt_iterator_solution_type (iterator_t*);
+const char *
+nvt_iterator_solution_type (iterator_t *);
 
-char*
+char *
 nvt_default_timeout (const char *);
 
 int
@@ -1979,7 +1856,6 @@ family_nvt_count (const char *);
 void
 manage_complete_nvt_cache_update (GList *, GList *);
 
-
 /* NVT selectors. */
 
 /**
@@ -2003,72 +1879,71 @@ manage_complete_nvt_cache_update (GList *, GList *);
 #define NVT_SELECTOR_TYPE_ANY 999
 
 void
-init_family_iterator (iterator_t*, int, const char*, int);
+init_family_iterator (iterator_t *, int, const char *, int);
 
-const char*
-family_iterator_name (iterator_t*);
+const char *
+family_iterator_name (iterator_t *);
 
 int
 nvt_selector_family_growing (const char *, const char *, int);
 
 int
-nvt_selector_family_count (const char*, int);
+nvt_selector_family_count (const char *, int);
 
 int
 nvt_selector_nvt_count (const char *, const char *, int);
 
 void
-init_nvt_selector_iterator (iterator_t*, const char*, config_t, int);
+init_nvt_selector_iterator (iterator_t *, const char *, config_t, int);
 
-const char*
-nvt_selector_iterator_nvt (iterator_t*);
+const char *
+nvt_selector_iterator_nvt (iterator_t *);
 
-const char*
-nvt_selector_iterator_name (iterator_t*);
-
-int
-nvt_selector_iterator_include (iterator_t*);
+const char *
+nvt_selector_iterator_name (iterator_t *);
 
 int
-nvt_selector_iterator_type (iterator_t*);
+nvt_selector_iterator_include (iterator_t *);
 
-
+int
+nvt_selector_iterator_type (iterator_t *);
+
 /* NVT preferences. */
 
 void
-manage_nvt_preference_add (const char*, const char*);
+manage_nvt_preference_add (const char *, const char *);
 
 void
 manage_nvt_preferences_enable ();
 
 void
-init_nvt_preference_iterator (iterator_t*, const char*);
+init_nvt_preference_iterator (iterator_t *, const char *);
 
-const char*
-nvt_preference_iterator_name (iterator_t*);
+const char *
+nvt_preference_iterator_name (iterator_t *);
 
-const char*
-nvt_preference_iterator_value (iterator_t*);
+const char *
+nvt_preference_iterator_value (iterator_t *);
 
-char*
-nvt_preference_iterator_config_value (iterator_t*, config_t);
+char *
+nvt_preference_iterator_config_value (iterator_t *, config_t);
 
-char*
-nvt_preference_iterator_real_name (iterator_t*);
+char *
+nvt_preference_iterator_real_name (iterator_t *);
 
-char*
-nvt_preference_iterator_type (iterator_t*);
+char *
+nvt_preference_iterator_type (iterator_t *);
 
-char*
-nvt_preference_iterator_nvt (iterator_t*);
+char *
+nvt_preference_iterator_nvt (iterator_t *);
 
 int
 nvt_preference_count (const char *);
 
-gchar*
-get_nvti_xml (iterator_t*, int, int, int, const char*, config_t, int);
+gchar *
+get_nvti_xml (iterator_t *, int, int, int, const char *, config_t, int);
 
-char*
+char *
 task_preference_value (task_t, const char *);
 
 int
@@ -2077,22 +1952,21 @@ set_task_preferences (task_t, array_t *);
 void
 init_task_group_iterator (iterator_t *, task_t);
 
-const char*
-task_group_iterator_name (iterator_t*);
+const char *
+task_group_iterator_name (iterator_t *);
 
-const char*
-task_group_iterator_uuid (iterator_t*);
+const char *
+task_group_iterator_uuid (iterator_t *);
 
 void
 init_task_role_iterator (iterator_t *, task_t);
 
-const char*
-task_role_iterator_name (iterator_t*);
+const char *
+task_role_iterator_name (iterator_t *);
 
-const char*
-task_role_iterator_uuid (iterator_t*);
+const char *
+task_role_iterator_uuid (iterator_t *);
 
-
 /* Credentials. */
 
 /**
@@ -2100,33 +1974,32 @@ task_role_iterator_uuid (iterator_t*);
  */
 typedef enum
 {
-  CREDENTIAL_FORMAT_NONE = 0,   /// normal XML output
-  CREDENTIAL_FORMAT_KEY = 1,    /// public key
-  CREDENTIAL_FORMAT_RPM = 2,    /// RPM package
-  CREDENTIAL_FORMAT_DEB = 3,    /// DEB package
-  CREDENTIAL_FORMAT_EXE = 4,    /// EXE installer
-  CREDENTIAL_FORMAT_PEM = 5,    /// Certificate PEM
-  CREDENTIAL_FORMAT_ERROR = -1  /// Error / Invalid format
+  CREDENTIAL_FORMAT_NONE = 0,  /// normal XML output
+  CREDENTIAL_FORMAT_KEY = 1,   /// public key
+  CREDENTIAL_FORMAT_RPM = 2,   /// RPM package
+  CREDENTIAL_FORMAT_DEB = 3,   /// DEB package
+  CREDENTIAL_FORMAT_EXE = 4,   /// EXE installer
+  CREDENTIAL_FORMAT_PEM = 5,   /// Certificate PEM
+  CREDENTIAL_FORMAT_ERROR = -1 /// Error / Invalid format
 } credential_format_t;
 
 gboolean
-find_credential_with_permission (const char*, credential_t*, const char*);
+find_credential_with_permission (const char *, credential_t *, const char *);
 
 int
-create_credential (const char*, const char*, const char*, const char*,
-                   const char*, const char*, const char*, const char*,
-                   const char*, const char*, const char*, const char*,
-                   const char*, credential_t*);
+create_credential (const char *, const char *, const char *, const char *,
+                   const char *, const char *, const char *, const char *,
+                   const char *, const char *, const char *, const char *,
+                   const char *, credential_t *);
 
 int
-copy_credential (const char*, const char*, const char*,
-                 credential_t*);
+copy_credential (const char *, const char *, const char *, credential_t *);
 
 int
-modify_credential (const char*, const char*, const char*, const char*,
-                   const char*, const char*, const char*, const char*,
-                   const char*, const char*, const char*, const char*,
-                   const char*);
+modify_credential (const char *, const char *, const char *, const char *,
+                   const char *, const char *, const char *, const char *,
+                   const char *, const char *, const char *, const char *,
+                   const char *);
 
 int
 delete_credential (const char *, int);
@@ -2141,216 +2014,197 @@ void
 set_credential_public_key (credential_t, const char *);
 
 void
-init_credential_iterator_one (iterator_t*, credential_t);
+init_credential_iterator_one (iterator_t *, credential_t);
 
 int
-init_credential_iterator (iterator_t*, const get_data_t *);
+init_credential_iterator (iterator_t *, const get_data_t *);
 
-const char*
-credential_iterator_login (iterator_t*);
+const char *
+credential_iterator_login (iterator_t *);
 
-const char*
-credential_iterator_auth_algorithm (iterator_t*);
+const char *
+credential_iterator_auth_algorithm (iterator_t *);
 
-const char*
-credential_iterator_privacy_algorithm (iterator_t*);
+const char *
+credential_iterator_privacy_algorithm (iterator_t *);
 
-const char*
-credential_iterator_password (iterator_t*);
+const char *
+credential_iterator_password (iterator_t *);
 
-const char*
-credential_iterator_community (iterator_t*);
+const char *
+credential_iterator_community (iterator_t *);
 
-const char*
-credential_iterator_privacy_password (iterator_t*);
+const char *
+credential_iterator_privacy_password (iterator_t *);
 
-const char*
-credential_iterator_public_key (iterator_t*);
+const char *
+credential_iterator_public_key (iterator_t *);
 
-const char*
-credential_iterator_private_key (iterator_t*);
+const char *
+credential_iterator_private_key (iterator_t *);
 
-const char*
-credential_iterator_type (iterator_t*);
+const char *
+credential_iterator_type (iterator_t *);
 
 int
-credential_iterator_allow_insecure (iterator_t*);
+credential_iterator_allow_insecure (iterator_t *);
 
-const char*
-credential_full_type (const char*);
+const char *
+credential_full_type (const char *);
 
-char*
-credential_iterator_rpm (iterator_t*);
+char *
+credential_iterator_rpm (iterator_t *);
 
-char*
-credential_iterator_deb (iterator_t*);
+char *
+credential_iterator_deb (iterator_t *);
 
-char*
-credential_iterator_exe (iterator_t*);
+char *
+credential_iterator_exe (iterator_t *);
 
-const char*
-credential_iterator_certificate (iterator_t*);
+const char *
+credential_iterator_certificate (iterator_t *);
 
 gboolean
-credential_iterator_format_available (iterator_t*, credential_format_t);
+credential_iterator_format_available (iterator_t *, credential_format_t);
 
 gchar *
-credential_iterator_formats_xml (iterator_t* iterator);
+credential_iterator_formats_xml (iterator_t *iterator);
 
-char*
-credential_uuid (credential_t);
+char *credential_uuid (credential_t);
 
-char*
-trash_credential_uuid (credential_t);
+char *trash_credential_uuid (credential_t);
 
-char*
-credential_name (credential_t);
+char *credential_name (credential_t);
 
-char*
-trash_credential_name (credential_t);
+char *trash_credential_name (credential_t);
 
-char*
-credential_type (credential_t);
+char *credential_type (credential_t);
 
 void
-init_credential_target_iterator (iterator_t*, credential_t, int);
+init_credential_target_iterator (iterator_t *, credential_t, int);
 
-const char*
-credential_target_iterator_uuid (iterator_t*);
+const char *
+credential_target_iterator_uuid (iterator_t *);
 
-const char*
-credential_target_iterator_name (iterator_t*);
+const char *
+credential_target_iterator_name (iterator_t *);
 
 int
-credential_target_iterator_readable (iterator_t*);
+credential_target_iterator_readable (iterator_t *);
 
 void
-init_credential_scanner_iterator (iterator_t*, credential_t, int);
+init_credential_scanner_iterator (iterator_t *, credential_t, int);
 
-const char*
-credential_scanner_iterator_uuid (iterator_t*);
+const char *
+credential_scanner_iterator_uuid (iterator_t *);
 
-const char*
-credential_scanner_iterator_name (iterator_t*);
-
-int
-credential_scanner_iterator_readable (iterator_t*);
+const char *
+credential_scanner_iterator_name (iterator_t *);
 
 int
-trash_credential_in_use (credential_t);
+credential_scanner_iterator_readable (iterator_t *);
 
-int
-credential_in_use (credential_t);
+int trash_credential_in_use (credential_t);
 
-int
-trash_credential_writable (credential_t);
+int credential_in_use (credential_t);
 
-int
-credential_writable (credential_t);
+int trash_credential_writable (credential_t);
 
-int
-trash_credential_readable (credential_t);
+int credential_writable (credential_t);
 
-gchar*
-credential_value (credential_t, const char*);
+int trash_credential_readable (credential_t);
 
-gchar*
-credential_encrypted_value (credential_t, const char*);
+gchar *
+credential_value (credential_t, const char *);
 
+gchar *
+credential_encrypted_value (credential_t, const char *);
 
-
 /* Agents. */
 
 int
-create_agent (const char*, const char*, const char*, const char*, const char*,
-              const char*, const char*, agent_t*);
+create_agent (const char *, const char *, const char *, const char *,
+              const char *, const char *, const char *, agent_t *);
 
 int
-copy_agent (const char*, const char*, const char *, agent_t *);
+copy_agent (const char *, const char *, const char *, agent_t *);
 
 int
-modify_agent (const char*, const char*, const char*);
+modify_agent (const char *, const char *, const char *);
 
 int
 delete_agent (const char *, int);
 
-int
-agent_in_use (agent_t);
+int agent_in_use (agent_t);
 
-int
-trash_agent_in_use (agent_t);
+int trash_agent_in_use (agent_t);
 
-int
-trash_agent_writable (agent_t);
+int trash_agent_writable (agent_t);
 
-int
-agent_writable (agent_t);
+int agent_writable (agent_t);
 
 int
 verify_agent (const char *);
 
-char *
-agent_uuid (agent_t);
+char *agent_uuid (agent_t);
 
 int
 agent_count (const get_data_t *);
 
 int
-init_agent_iterator (iterator_t*, const get_data_t *);
+init_agent_iterator (iterator_t *, const get_data_t *);
 
-const char*
-agent_iterator_installer_64 (iterator_t*);
+const char *
+agent_iterator_installer_64 (iterator_t *);
 
-const char*
-agent_iterator_installer_filename (iterator_t*);
+const char *
+agent_iterator_installer_filename (iterator_t *);
 
-const char*
-agent_iterator_trust (iterator_t*);
+const char *
+agent_iterator_trust (iterator_t *);
 
 time_t
-agent_iterator_trust_time (iterator_t*);
+agent_iterator_trust_time (iterator_t *);
 
-const char*
-agent_iterator_howto_install (iterator_t*);
+const char *
+agent_iterator_howto_install (iterator_t *);
 
-const char*
-agent_iterator_howto_use (iterator_t*);
+const char *
+agent_iterator_howto_use (iterator_t *);
 
-
 /* Assets. */
 
 char *
 result_host_asset_id (const char *, result_t);
 
-char*
-host_uuid (resource_t);
+char *host_uuid (resource_t);
 
 host_t
 host_notice (const char *, const char *, const char *, const char *,
              const char *, int, int);
 
 void
-init_host_identifier_iterator (iterator_t*, host_t, int, const char*);
+init_host_identifier_iterator (iterator_t *, host_t, int, const char *);
 
-const char*
+const char *
 host_identifier_iterator_value (iterator_t *);
 
-const char*
+const char *
 host_identifier_iterator_source_type (iterator_t *);
 
-const char*
+const char *
 host_identifier_iterator_source_id (iterator_t *);
 
-const char*
+const char *
 host_identifier_iterator_source_data (iterator_t *);
 
 int
 host_identifier_iterator_source_orphan (iterator_t *);
 
-const char*
+const char *
 host_identifier_iterator_os_id (iterator_t *);
 
-const char*
+const char *
 host_identifier_iterator_os_title (iterator_t *);
 
 int
@@ -2362,7 +2216,7 @@ asset_iterator_writable (iterator_t *);
 int
 asset_iterator_in_use (iterator_t *);
 
-const char*
+const char *
 asset_host_iterator_severity (iterator_t *);
 
 int
@@ -2371,19 +2225,19 @@ asset_host_count (const get_data_t *);
 int
 init_asset_os_iterator (iterator_t *, const get_data_t *);
 
-const char*
+const char *
 asset_os_iterator_title (iterator_t *);
 
 int
 asset_os_iterator_installs (iterator_t *);
 
-const char*
+const char *
 asset_os_iterator_latest_severity (iterator_t *);
 
-const char*
+const char *
 asset_os_iterator_highest_severity (iterator_t *);
 
-const char*
+const char *
 asset_os_iterator_average_severity (iterator_t *);
 
 int
@@ -2395,22 +2249,22 @@ total_asset_count (const get_data_t *);
 void
 init_os_host_iterator (iterator_t *, resource_t);
 
-const char*
+const char *
 os_host_iterator_severity (iterator_t *);
 
 void
 init_host_detail_iterator (iterator_t *, resource_t);
 
-const char*
+const char *
 host_detail_iterator_name (iterator_t *);
 
-const char*
+const char *
 host_detail_iterator_value (iterator_t *);
 
-const char*
+const char *
 host_detail_iterator_source_type (iterator_t *);
 
-const char*
+const char *
 host_detail_iterator_source_id (iterator_t *);
 
 int
@@ -2423,20 +2277,20 @@ int
 create_asset_report (const char *, const char *);
 
 int
-create_asset_host (const char *, const char *, resource_t* );
+create_asset_host (const char *, const char *, resource_t *);
 
-
 /* Notes. */
 
 gboolean
-find_note_with_permission (const char*, note_t*, const char *);
+find_note_with_permission (const char *, note_t *, const char *);
 
 int
-create_note (const char*, const char*, const char*, const char*, const char*,
-             const char*, const char*, task_t, result_t, note_t*);
+create_note (const char *, const char *, const char *, const char *,
+             const char *, const char *, const char *, task_t, result_t,
+             note_t *);
 
 int
-copy_note (const char*, note_t*);
+copy_note (const char *, note_t *);
 
 int
 delete_note (const char *, int);
@@ -2453,66 +2307,65 @@ int
 note_count (const get_data_t *, nvt_t, result_t, task_t);
 
 int
-init_note_iterator (iterator_t*, const get_data_t*, nvt_t, result_t, task_t);
+init_note_iterator (iterator_t *, const get_data_t *, nvt_t, result_t, task_t);
 
-const char*
-note_iterator_nvt_oid (iterator_t*);
-
-time_t
-note_iterator_creation_time (iterator_t*);
+const char *
+note_iterator_nvt_oid (iterator_t *);
 
 time_t
-note_iterator_modification_time (iterator_t*);
+note_iterator_creation_time (iterator_t *);
 
-const char*
-note_iterator_text (iterator_t*);
+time_t
+note_iterator_modification_time (iterator_t *);
 
-const char*
-note_iterator_hosts (iterator_t*);
+const char *
+note_iterator_text (iterator_t *);
 
-const char*
-note_iterator_port (iterator_t*);
+const char *
+note_iterator_hosts (iterator_t *);
 
-const char*
-note_iterator_threat (iterator_t*);
+const char *
+note_iterator_port (iterator_t *);
+
+const char *
+note_iterator_threat (iterator_t *);
 
 task_t
-note_iterator_task (iterator_t*);
+note_iterator_task (iterator_t *);
 
 result_t
-note_iterator_result (iterator_t*);
+note_iterator_result (iterator_t *);
 
 time_t
-note_iterator_end_time (iterator_t*);
+note_iterator_end_time (iterator_t *);
 
 int
-note_iterator_active (iterator_t*);
+note_iterator_active (iterator_t *);
 
-const char*
+const char *
 note_iterator_nvt_name (iterator_t *);
 
 const char *
 note_iterator_nvt_type (iterator_t *);
 
-const char*
+const char *
 note_iterator_severity (iterator_t *);
 
-
 /* Overrides. */
 
 gboolean
-find_override_with_permission (const char*, override_t*, const char *);
+find_override_with_permission (const char *, override_t *, const char *);
 
 int
-create_override (const char*, const char*, const char*, const char*,
-                 const char*, const char*, const char*, const char*,
-                 const char*, task_t, result_t, override_t*);
+create_override (const char *, const char *, const char *, const char *,
+                 const char *, const char *, const char *, const char *,
+                 const char *, task_t, result_t, override_t *);
 
 int
 override_uuid (override_t, char **);
 
 int
-copy_override (const char*, override_t*);
+copy_override (const char *, override_t *);
 
 int
 delete_override (const char *, int);
@@ -2526,58 +2379,57 @@ int
 override_count (const get_data_t *, nvt_t, result_t, task_t);
 
 int
-init_override_iterator (iterator_t*, const get_data_t*, nvt_t, result_t,
+init_override_iterator (iterator_t *, const get_data_t *, nvt_t, result_t,
                         task_t);
 
-const char*
-override_iterator_nvt_oid (iterator_t*);
+const char *
+override_iterator_nvt_oid (iterator_t *);
 
 time_t
-override_iterator_creation_time (iterator_t*);
+override_iterator_creation_time (iterator_t *);
 
 time_t
-override_iterator_modification_time (iterator_t*);
+override_iterator_modification_time (iterator_t *);
 
-const char*
-override_iterator_text (iterator_t*);
+const char *
+override_iterator_text (iterator_t *);
 
-const char*
-override_iterator_hosts (iterator_t*);
+const char *
+override_iterator_hosts (iterator_t *);
 
-const char*
-override_iterator_port (iterator_t*);
+const char *
+override_iterator_port (iterator_t *);
 
-const char*
-override_iterator_threat (iterator_t*);
+const char *
+override_iterator_threat (iterator_t *);
 
-const char*
-override_iterator_new_threat (iterator_t*);
+const char *
+override_iterator_new_threat (iterator_t *);
 
 task_t
-override_iterator_task (iterator_t*);
+override_iterator_task (iterator_t *);
 
 result_t
-override_iterator_result (iterator_t*);
+override_iterator_result (iterator_t *);
 
 time_t
-override_iterator_end_time (iterator_t*);
+override_iterator_end_time (iterator_t *);
 
 int
-override_iterator_active (iterator_t*);
+override_iterator_active (iterator_t *);
 
-const char*
+const char *
 override_iterator_nvt_name (iterator_t *);
 
 const char *
 override_iterator_nvt_type (iterator_t *);
 
-const char*
+const char *
 override_iterator_severity (iterator_t *);
 
-const char*
+const char *
 override_iterator_new_severity (iterator_t *);
 
-
 /* Scanner messaging. */
 
 int
@@ -2589,7 +2441,6 @@ acknowledge_feed_version_info ();
 int
 manage_check_current_task ();
 
-
 /* System reports. */
 
 /**
@@ -2597,25 +2448,25 @@ manage_check_current_task ();
  */
 typedef struct
 {
-  gchar **start;        ///< First type.
-  gchar **current;      ///< Current type.
+  gchar **start;   ///< First type.
+  gchar **current; ///< Current type.
 } report_type_iterator_t;
 
 int
-init_system_report_type_iterator (report_type_iterator_t*, const char*,
-                                  const char*);
+init_system_report_type_iterator (report_type_iterator_t *, const char *,
+                                  const char *);
 
 void
-cleanup_report_type_iterator (report_type_iterator_t*);
+cleanup_report_type_iterator (report_type_iterator_t *);
 
 gboolean
-next_report_type (report_type_iterator_t*);
+next_report_type (report_type_iterator_t *);
 
-const char*
-report_type_iterator_name (report_type_iterator_t*);
+const char *
+report_type_iterator_name (report_type_iterator_t *);
 
-const char*
-report_type_iterator_title (report_type_iterator_t*);
+const char *
+report_type_iterator_title (report_type_iterator_t *);
 
 int
 manage_system_report (const char *, const char *, const char *, const char *,
@@ -2641,14 +2492,14 @@ int
 manage_get_scanners (GSList *, const gchar *);
 
 int
-create_scanner (const char*, const char *, const char *, const char *,
+create_scanner (const char *, const char *, const char *, const char *,
                 const char *, scanner_t *, const char *, const char *);
 
 int
-copy_scanner (const char*, const char*, const char *, scanner_t *);
+copy_scanner (const char *, const char *, const char *, scanner_t *);
 
 int
-modify_scanner (const char*, const char*, const char*, const char *,
+modify_scanner (const char *, const char *, const char *, const char *,
                 const char *, const char *, const char *, const char *);
 
 int
@@ -2657,116 +2508,99 @@ delete_scanner (const char *, int);
 gboolean
 find_scanner_with_permission (const char *, scanner_t *, const char *);
 
-int
-scanner_in_use (scanner_t);
+int scanner_in_use (scanner_t);
 
-int
-trash_scanner_readable (scanner_t);
+int trash_scanner_readable (scanner_t);
 
-int
-trash_scanner_in_use (scanner_t);
+int trash_scanner_in_use (scanner_t);
 
-int
-trash_scanner_writable (scanner_t);
+int trash_scanner_writable (scanner_t);
 
-int
-scanner_writable (scanner_t);
+int scanner_writable (scanner_t);
 
 const char *
 scanner_uuid_default ();
 
-char *
-scanner_host (scanner_t);
+char *scanner_host (scanner_t);
 
-int
-scanner_port (scanner_t);
+int scanner_port (scanner_t);
 
-int
-scanner_type (scanner_t);
+int scanner_type (scanner_t);
 
-char *
-scanner_ca_pub (scanner_t);
+char *scanner_ca_pub (scanner_t);
 
-char *
-scanner_key_pub (scanner_t);
+char *scanner_key_pub (scanner_t);
 
-char *
-scanner_key_priv (scanner_t);
+char *scanner_key_priv (scanner_t);
 
-char*
-scanner_login (scanner_t);
+char *scanner_login (scanner_t);
 
-char*
-scanner_password (scanner_t);
+char *scanner_password (scanner_t);
 
 int
 scanner_count (const get_data_t *);
 
 int
-init_scanner_iterator (iterator_t*, const get_data_t *);
+init_scanner_iterator (iterator_t *, const get_data_t *);
 
-const char*
-scanner_iterator_host (iterator_t*);
-
-int
-scanner_iterator_port (iterator_t*);
+const char *
+scanner_iterator_host (iterator_t *);
 
 int
-scanner_iterator_type (iterator_t*);
+scanner_iterator_port (iterator_t *);
 
-const char*
+int
+scanner_iterator_type (iterator_t *);
+
+const char *
 scanner_iterator_credential_name (iterator_t *);
 
 credential_t
 scanner_iterator_credential (iterator_t *);
 
 int
-scanner_iterator_credential_trash (iterator_t*);
+scanner_iterator_credential_trash (iterator_t *);
 
-const char*
+const char *
 scanner_iterator_ca_pub (iterator_t *);
 
-const char*
+const char *
 scanner_iterator_key_pub (iterator_t *);
 
-const char*
+const char *
 scanner_iterator_credential_type (iterator_t *);
 
 void
-init_scanner_config_iterator (iterator_t*, scanner_t);
+init_scanner_config_iterator (iterator_t *, scanner_t);
 
-const char*
+const char *
 scanner_config_iterator_uuid (iterator_t *);
 
-const char*
+const char *
 scanner_config_iterator_name (iterator_t *);
 
 int
 scanner_config_iterator_readable (iterator_t *);
 
 void
-init_scanner_task_iterator (iterator_t*, scanner_t);
+init_scanner_task_iterator (iterator_t *, scanner_t);
 
-const char*
+const char *
 scanner_task_iterator_uuid (iterator_t *);
 
-const char*
+const char *
 scanner_task_iterator_name (iterator_t *);
 
 int
 scanner_task_iterator_readable (iterator_t *);
 
-char *
-scanner_name (scanner_t);
+char *scanner_name (scanner_t);
 
-char *
-scanner_uuid (scanner_t);
+char *scanner_uuid (scanner_t);
 
-char *
-trash_scanner_name (scanner_t);
+char *trash_scanner_name (scanner_t);
 
-char *
-trash_scanner_uuid (scanner_t);
+char *trash_scanner_uuid (scanner_t);
 
 int
 osp_get_version_from_iterator (iterator_t *, char **, char **, char **, char **,
@@ -2775,8 +2609,7 @@ osp_get_version_from_iterator (iterator_t *, char **, char **, char **, char **,
 int
 osp_get_details_from_iterator (iterator_t *, char **, GSList **);
 
-osp_connection_t *
-osp_scanner_connect (scanner_t);
+osp_connection_t *osp_scanner_connect (scanner_t);
 
 int
 verify_scanner (const char *, char **);
@@ -2800,54 +2633,48 @@ verify_scanner (const char *, char **);
 #define SCHEDULE_TIMEOUT_DEFAULT 60
 
 gboolean
-find_schedule_with_permission (const char*, schedule_t*, const char*);
+find_schedule_with_permission (const char *, schedule_t *, const char *);
 
 int
-create_schedule (const char *, const char*, const char *,
-                 time_t, time_t, time_t, const char *, time_t, const char*,
-                 schedule_t *, gchar**);
+create_schedule (const char *, const char *, const char *, time_t, time_t,
+                 time_t, const char *, time_t, const char *, schedule_t *,
+                 gchar **);
 
 int
-copy_schedule (const char*, const char*, const char *, schedule_t *);
+copy_schedule (const char *, const char *, const char *, schedule_t *);
 
 int
-delete_schedule (const char*, int);
+delete_schedule (const char *, int);
 
 void
 manage_auth_allow_all (int);
 
-const gchar*
+const gchar *
 get_scheduled_user_uuid ();
 
 void
-set_scheduled_user_uuid (const gchar* uuid);
+set_scheduled_user_uuid (const gchar *uuid);
 
 void
 manage_sync (sigset_t *, int (*fork_update_nvt_cache) ());
 
 int
-manage_schedule (manage_connection_forker_t,
-                 gboolean,
-                 sigset_t *);
+manage_schedule (manage_connection_forker_t, gboolean, sigset_t *);
 
-char *
-schedule_uuid (schedule_t);
+char *schedule_uuid (schedule_t);
 
-char *
-schedule_name (schedule_t);
+char *schedule_name (schedule_t);
 
-int
-schedule_duration (schedule_t);
+int schedule_duration (schedule_t);
 
-int
-schedule_period (schedule_t);
+int schedule_period (schedule_t);
 
 int
 schedule_info (schedule_t, int, time_t *, time_t *, int *, int *, int *,
                gchar **, gchar **);
 
 int
-init_schedule_iterator (iterator_t*, const get_data_t *);
+init_schedule_iterator (iterator_t *, const get_data_t *);
 
 time_t
 schedule_iterator_first_time (iterator_t *);
@@ -2870,49 +2697,43 @@ schedule_iterator_byday (iterator_t *);
 gchar *
 schedule_iterator_byday_string (iterator_t *);
 
-const char*
+const char *
 schedule_iterator_timezone (iterator_t *);
 
 time_t
 schedule_iterator_initial_offset (iterator_t *);
 
-const char*
+const char *
 schedule_iterator_icalendar (iterator_t *);
 
-int
-trash_schedule_in_use (schedule_t);
+int trash_schedule_in_use (schedule_t);
 
-int
-schedule_in_use (schedule_t);
+int schedule_in_use (schedule_t);
 
-int
-trash_schedule_writable (schedule_t);
+int trash_schedule_writable (schedule_t);
 
-int
-trash_schedule_readable (schedule_t);
+int trash_schedule_readable (schedule_t);
 
-int
-schedule_writable (schedule_t);
+int schedule_writable (schedule_t);
 
 int
 schedule_count (const get_data_t *);
 
 void
-init_schedule_task_iterator (iterator_t*, schedule_t);
+init_schedule_task_iterator (iterator_t *, schedule_t);
 
-const char*
+const char *
 schedule_task_iterator_uuid (iterator_t *);
 
-const char*
+const char *
 schedule_task_iterator_name (iterator_t *);
 
 int
-schedule_task_iterator_readable (iterator_t*);
+schedule_task_iterator_readable (iterator_t *);
 
 int
-modify_schedule (const char *, const char*, const char *, const char*,
-                 time_t, time_t, time_t,
-                 const char *, time_t, const char *, gchar **);
+modify_schedule (const char *, const char *, const char *, const char *, time_t,
+                 time_t, time_t, const char *, time_t, const char *, gchar **);
 
 int
 get_schedule_timeout ();
@@ -2920,11 +2741,10 @@ get_schedule_timeout ();
 void
 set_schedule_timeout (int);
 
-
 /* Report Formats. */
 
 gboolean
-find_report_format_with_permission (const char*, report_format_t*,
+find_report_format_with_permission (const char *, report_format_t *,
                                     const char *);
 
 /**
@@ -2932,12 +2752,12 @@ find_report_format_with_permission (const char*, report_format_t*,
  */
 typedef struct
 {
-  gchar *fallback;  ///< Fallback value.
-  gchar *name;      ///< Name.
-  gchar *type;      ///< Type (boolean, string, integer, ...).
-  gchar *type_max;  ///< Maximum value for integer type.
-  gchar *type_min;  ///< Minimum value for integer type.
-  gchar *value;     ///< Value of param.
+  gchar *fallback; ///< Fallback value.
+  gchar *name;     ///< Name.
+  gchar *type;     ///< Type (boolean, string, integer, ...).
+  gchar *type_max; ///< Maximum value for integer type.
+  gchar *type_min; ///< Minimum value for integer type.
+  gchar *value;    ///< Value of param.
 } create_report_format_param_t;
 
 int
@@ -2946,7 +2766,7 @@ create_report_format (const char *, const char *, const char *, const char *,
                       array_t *, const char *, report_format_t *);
 
 int
-copy_report_format (const char *, const char *, report_format_t*);
+copy_report_format (const char *, const char *, report_format_t *);
 
 int
 modify_report_format (const char *, const char *, const char *, const char *,
@@ -2958,114 +2778,100 @@ delete_report_format (const char *, int);
 int
 verify_report_format (const char *);
 
-char *
-report_format_uuid (report_format_t);
+char *report_format_uuid (report_format_t);
 
-char *
-report_format_owner_uuid (report_format_t);
+char *report_format_owner_uuid (report_format_t);
 
-char *
-report_format_name (report_format_t);
+char *report_format_name (report_format_t);
 
-char *
-report_format_content_type (report_format_t);
+char *report_format_content_type (report_format_t);
 
-char *
-report_format_extension (report_format_t);
+char *report_format_extension (report_format_t);
 
-int
-report_format_global (report_format_t);
+int report_format_global (report_format_t);
 
-int
-trash_report_format_global (report_format_t);
+int trash_report_format_global (report_format_t);
 
-int
-report_format_predefined (report_format_t);
+int report_format_predefined (report_format_t);
 
-int
-report_format_active (report_format_t);
+int report_format_active (report_format_t);
 
-int
-report_format_trust (report_format_t);
+int report_format_trust (report_format_t);
 
-int
-report_format_in_use (report_format_t);
+int report_format_in_use (report_format_t);
 
-int
-trash_report_format_in_use (report_format_t);
+int trash_report_format_in_use (report_format_t);
 
-int
-trash_report_format_writable (report_format_t);
+int trash_report_format_writable (report_format_t);
 
-int
-report_format_writable (report_format_t);
+int report_format_writable (report_format_t);
 
 int
 report_format_count (const get_data_t *);
 
 int
-init_report_format_iterator (iterator_t*, const get_data_t *);
+init_report_format_iterator (iterator_t *, const get_data_t *);
 
-const char*
+const char *
 report_format_iterator_extension (iterator_t *);
 
-const char*
+const char *
 report_format_iterator_content_type (iterator_t *);
 
-const char*
+const char *
 report_format_iterator_description (iterator_t *);
 
 int
 report_format_iterator_active (iterator_t *);
 
-const char*
+const char *
 report_format_iterator_signature (iterator_t *);
 
-const char*
+const char *
 report_format_iterator_trust (iterator_t *);
 
-const char*
+const char *
 report_format_iterator_summary (iterator_t *);
 
 time_t
 report_format_iterator_trust_time (iterator_t *);
 
 void
-init_report_format_alert_iterator (iterator_t*, report_format_t);
+init_report_format_alert_iterator (iterator_t *, report_format_t);
 
-const char*
-report_format_alert_iterator_name (iterator_t*);
+const char *
+report_format_alert_iterator_name (iterator_t *);
 
-const char*
-report_format_alert_iterator_uuid (iterator_t*);
+const char *
+report_format_alert_iterator_uuid (iterator_t *);
 
 int
-report_format_alert_iterator_readable (iterator_t*);
+report_format_alert_iterator_readable (iterator_t *);
 
 /**
  * @brief A report format file iterator.
  */
 typedef struct
 {
-  GPtrArray *start;    ///< Array of files.
-  gpointer *current;   ///< Current file.
-  gchar *dir_name;     ///< Dir holding files.
+  GPtrArray *start;  ///< Array of files.
+  gpointer *current; ///< Current file.
+  gchar *dir_name;   ///< Dir holding files.
 } file_iterator_t;
 
 int
-init_report_format_file_iterator (file_iterator_t*, report_format_t);
+init_report_format_file_iterator (file_iterator_t *, report_format_t);
 
 void
-cleanup_file_iterator (file_iterator_t*);
+cleanup_file_iterator (file_iterator_t *);
 
 gboolean
-next_file (file_iterator_t*);
+next_file (file_iterator_t *);
 
-const char*
-file_iterator_name (file_iterator_t*);
+const char *
+file_iterator_name (file_iterator_t *);
 
-gchar*
-file_iterator_content_64 (file_iterator_t*);
+gchar *
+file_iterator_content_64 (file_iterator_t *);
 
 /**
  * @brief Report format param types.
@@ -3084,26 +2890,25 @@ typedef enum
   REPORT_FORMAT_PARAM_TYPE_ERROR = 100
 } report_format_param_type_t;
 
-const char *
-report_format_param_type_name (report_format_param_type_t);
+const char *report_format_param_type_name (report_format_param_type_t);
 
 report_format_param_type_t
 report_format_param_type_from_name (const char *);
 
 void
-init_report_format_param_iterator (iterator_t*, report_format_t, int,
-                                   int, const char*);
+init_report_format_param_iterator (iterator_t *, report_format_t, int, int,
+                                   const char *);
 
 report_format_param_t
-report_format_param_iterator_param (iterator_t*);
+report_format_param_iterator_param (iterator_t *);
 
-const char*
+const char *
 report_format_param_iterator_name (iterator_t *);
 
-const char*
+const char *
 report_format_param_iterator_value (iterator_t *);
 
-const char*
+const char *
 report_format_param_iterator_type_name (iterator_t *);
 
 report_format_param_type_t
@@ -3115,17 +2920,16 @@ report_format_param_iterator_type_min (iterator_t *);
 long long int
 report_format_param_iterator_type_max (iterator_t *);
 
-const char*
+const char *
 report_format_param_iterator_fallback (iterator_t *);
 
 void
-init_param_option_iterator (iterator_t*, report_format_param_t, int,
+init_param_option_iterator (iterator_t *, report_format_param_t, int,
                             const char *);
 
-const char*
+const char *
 param_option_iterator_value (iterator_t *);
 
-
 /* Groups. */
 
 int
@@ -3140,31 +2944,24 @@ create_group (const char *, const char *, const char *, int, group_t *);
 int
 delete_group (const char *, int);
 
-char*
-group_uuid (group_t);
+char *group_uuid (group_t);
 
-gchar *
-group_users (group_t);
+gchar *group_users (group_t);
 
-int
-trash_group_in_use (group_t);
+int trash_group_in_use (group_t);
 
-int
-group_in_use (group_t);
+int group_in_use (group_t);
 
-int
-trash_group_writable (group_t);
+int trash_group_writable (group_t);
+
+int group_writable (group_t);
 
 int
-group_writable (group_t);
-
-int
-group_count (const get_data_t*);
+group_count (const get_data_t *);
 
 int
 modify_group (const char *, const char *, const char *, const char *);
 
-
 /* Permissions. */
 
 int
@@ -3172,67 +2969,62 @@ create_permission (const char *, const char *, const char *, const char *,
                    const char *, const char *, permission_t *);
 
 int
-copy_permission (const char*, const char *, permission_t *);
+copy_permission (const char *, const char *, permission_t *);
 
-char*
-permission_uuid (permission_t);
+char *permission_uuid (permission_t);
 
 int
 permission_is_admin (const char *);
 
-int
-permission_in_use (permission_t);
+int permission_in_use (permission_t);
 
-int
-trash_permission_in_use (permission_t);
+int trash_permission_in_use (permission_t);
 
-int
-permission_writable (permission_t);
+int permission_writable (permission_t);
 
-int
-trash_permission_writable (permission_t);
+int trash_permission_writable (permission_t);
 
 int
 permission_count (const get_data_t *);
 
 int
-init_permission_iterator (iterator_t*, const get_data_t *);
+init_permission_iterator (iterator_t *, const get_data_t *);
 
-const char*
-permission_iterator_resource_type (iterator_t*);
+const char *
+permission_iterator_resource_type (iterator_t *);
 
-const char*
-permission_iterator_resource_uuid (iterator_t*);
+const char *
+permission_iterator_resource_uuid (iterator_t *);
 
-const char*
-permission_iterator_resource_name (iterator_t*);
-
-int
-permission_iterator_resource_in_trash (iterator_t*);
+const char *
+permission_iterator_resource_name (iterator_t *);
 
 int
-permission_iterator_resource_orphan (iterator_t*);
+permission_iterator_resource_in_trash (iterator_t *);
 
 int
-permission_iterator_resource_readable (iterator_t*);
-
-const char*
-permission_iterator_subject_type (iterator_t*);
-
-const char*
-permission_iterator_subject_uuid (iterator_t*);
-
-const char*
-permission_iterator_subject_name (iterator_t*);
+permission_iterator_resource_orphan (iterator_t *);
 
 int
-permission_iterator_subject_in_trash (iterator_t*);
+permission_iterator_resource_readable (iterator_t *);
+
+const char *
+permission_iterator_subject_type (iterator_t *);
+
+const char *
+permission_iterator_subject_uuid (iterator_t *);
+
+const char *
+permission_iterator_subject_name (iterator_t *);
 
 int
-permission_iterator_subject_readable (iterator_t*);
+permission_iterator_subject_in_trash (iterator_t *);
 
 int
-delete_permission (const char*, int);
+permission_iterator_subject_readable (iterator_t *);
+
+int
+delete_permission (const char *, int);
 
 int
 modify_permission (const char *, const char *, const char *, const char *,
@@ -3241,39 +3033,37 @@ modify_permission (const char *, const char *, const char *, const char *,
 /* Permission caching */
 
 void
-delete_permissions_cache_for_resource (const char*, resource_t);
+delete_permissions_cache_for_resource (const char *, resource_t);
 
-void
-delete_permissions_cache_for_user (user_t);
+void delete_permissions_cache_for_user (user_t);
 
-
 /* Port lists. */
 
 gboolean
-find_port_list (const char*, port_list_t*);
+find_port_list (const char *, port_list_t *);
 
 gboolean
 find_port_list_with_permission (const char *, port_list_t *, const char *);
 
 gboolean
-find_port_range (const char*, port_list_t*);
+find_port_range (const char *, port_list_t *);
 
 int
-create_port_list (const char*, const char*, const char*, const char*,
-                  array_t *, port_list_t*);
+create_port_list (const char *, const char *, const char *, const char *,
+                  array_t *, port_list_t *);
 
 int
-copy_port_list (const char*, const char*, const char*, port_list_t*);
+copy_port_list (const char *, const char *, const char *, port_list_t *);
 
 int
-modify_port_list (const char*, const char*, const char*);
+modify_port_list (const char *, const char *, const char *);
 
 int
 create_port_range (const char *, const char *, const char *, const char *,
                    const char *, port_range_t *);
 
 int
-delete_port_list (const char*, int);
+delete_port_list (const char *, int);
 
 int
 delete_port_range (const char *, int);
@@ -3282,34 +3072,28 @@ int
 port_list_count (const get_data_t *);
 
 int
-init_port_list_iterator (iterator_t*, const get_data_t *);
+init_port_list_iterator (iterator_t *, const get_data_t *);
 
 int
-port_list_iterator_count_all (iterator_t*);
+port_list_iterator_count_all (iterator_t *);
 
 int
-port_list_iterator_count_tcp (iterator_t*);
+port_list_iterator_count_tcp (iterator_t *);
 
 int
-port_list_iterator_count_udp (iterator_t*);
+port_list_iterator_count_udp (iterator_t *);
 
-char*
-port_list_uuid (port_list_t);
+char *port_list_uuid (port_list_t);
 
-char*
-port_range_uuid (port_range_t);
+char *port_range_uuid (port_range_t);
 
-int
-port_list_in_use (port_list_t);
+int port_list_in_use (port_list_t);
 
-int
-trash_port_list_in_use (port_list_t);
+int trash_port_list_in_use (port_list_t);
 
-int
-trash_port_list_writable (port_list_t);
+int trash_port_list_writable (port_list_t);
 
-int
-port_list_writable (port_list_t);
+int port_list_writable (port_list_t);
 
 #if 0
 int
@@ -3320,36 +3104,35 @@ int
 trash_port_list_readable_uuid (const gchar *);
 
 void
-init_port_range_iterator (iterator_t*, port_range_t, int, int, const char*);
+init_port_range_iterator (iterator_t *, port_range_t, int, int, const char *);
 
-const char*
-port_range_iterator_uuid (iterator_t*);
+const char *
+port_range_iterator_uuid (iterator_t *);
 
-const char*
-port_range_iterator_comment (iterator_t*);
+const char *
+port_range_iterator_comment (iterator_t *);
 
-const char*
-port_range_iterator_start (iterator_t*);
+const char *
+port_range_iterator_start (iterator_t *);
 
-const char*
-port_range_iterator_end (iterator_t*);
+const char *
+port_range_iterator_end (iterator_t *);
 
-const char*
-port_range_iterator_type (iterator_t*);
+const char *
+port_range_iterator_type (iterator_t *);
 
 void
-init_port_list_target_iterator (iterator_t*, port_list_t, int);
+init_port_list_target_iterator (iterator_t *, port_list_t, int);
 
-const char*
-port_list_target_iterator_uuid (iterator_t*);
+const char *
+port_list_target_iterator_uuid (iterator_t *);
 
-const char*
-port_list_target_iterator_name (iterator_t*);
+const char *
+port_list_target_iterator_name (iterator_t *);
 
 int
-port_list_target_iterator_readable (iterator_t*);
+port_list_target_iterator_readable (iterator_t *);
 
-
 /* Roles. */
 
 int
@@ -3364,31 +3147,24 @@ create_role (const char *, const char *, const char *, role_t *);
 int
 delete_role (const char *, int);
 
-char*
-role_uuid (role_t);
+char *role_uuid (role_t);
 
-gchar *
-role_users (role_t);
+gchar *role_users (role_t);
 
-int
-trash_role_in_use (role_t);
+int trash_role_in_use (role_t);
 
-int
-role_in_use (role_t);
+int role_in_use (role_t);
 
-int
-trash_role_writable (role_t);
+int trash_role_writable (role_t);
+
+int role_writable (role_t);
 
 int
-role_writable (role_t);
-
-int
-role_count (const get_data_t*);
+role_count (const get_data_t *);
 
 int
 modify_role (const char *, const char *, const char *, const char *);
 
-
 /* Filter Utilities. */
 
 /**
@@ -3420,14 +3196,14 @@ typedef enum
  */
 struct keyword
 {
-  gchar *column;                 ///< The column prefix, or NULL.
-  int equal;                     ///< Whether the keyword is like "=example".
-  int integer_value;             ///< Integer value of the keyword.
-  double double_value;           ///< Floating point value of the keyword.
-  int quoted;                    ///< Whether the keyword was quoted.
-  gchar *string;                 ///< The keyword string, outer quotes removed.
-  keyword_type_t type;           ///< Type of keyword.
-  keyword_relation_t relation;   ///< The relation.
+  gchar *column;               ///< The column prefix, or NULL.
+  int equal;                   ///< Whether the keyword is like "=example".
+  int integer_value;           ///< Integer value of the keyword.
+  double double_value;         ///< Floating point value of the keyword.
+  int quoted;                  ///< Whether the keyword was quoted.
+  gchar *string;               ///< The keyword string, outer quotes removed.
+  keyword_type_t type;         ///< Type of keyword.
+  keyword_relation_t relation; ///< The relation.
 };
 
 /**
@@ -3438,34 +3214,30 @@ typedef struct keyword keyword_t;
 int
 keyword_special (keyword_t *);
 
-const char *
-keyword_relation_symbol (keyword_relation_t);
+const char *keyword_relation_symbol (keyword_relation_t);
 
 void
-filter_free (array_t*);
+filter_free (array_t *);
 
 array_t *
-split_filter (const gchar*);
+split_filter (const gchar *);
 
-
 /* Filters. */
 
 gboolean
-find_filter (const char*, filter_t*);
+find_filter (const char *, filter_t *);
 
 gboolean
-find_filter_with_permission (const char*, filter_t*, const char*);
+find_filter_with_permission (const char *, filter_t *, const char *);
 
-char*
-filter_uuid (filter_t);
+char *filter_uuid (filter_t);
 
-char*
-filter_name (filter_t);
+char *filter_name (filter_t);
 
-gchar*
+gchar *
 filter_term (const char *);
 
-gchar*
+gchar *
 filter_term_value (const char *, const char *);
 
 int
@@ -3478,60 +3250,56 @@ int
 filter_term_min_qod (const char *);
 
 int
-create_filter (const char*, const char*, const char*, const char*, filter_t*);
+create_filter (const char *, const char *, const char *, const char *,
+               filter_t *);
 
 int
-copy_filter (const char*, const char*, const char*, filter_t*);
+copy_filter (const char *, const char *, const char *, filter_t *);
 
 int
 delete_filter (const char *, int);
 
-int
-trash_filter_in_use (filter_t);
+int trash_filter_in_use (filter_t);
+
+int filter_in_use (filter_t);
+
+int trash_filter_writable (filter_t);
+
+int filter_writable (filter_t);
 
 int
-filter_in_use (filter_t);
+filter_count (const get_data_t *);
 
 int
-trash_filter_writable (filter_t);
+init_filter_iterator (iterator_t *, const get_data_t *);
 
-int
-filter_writable (filter_t);
+const char *
+filter_iterator_type (iterator_t *);
 
-int
-filter_count (const get_data_t*);
-
-int
-init_filter_iterator (iterator_t*, const get_data_t*);
-
-const char*
-filter_iterator_type (iterator_t*);
-
-const char*
-filter_iterator_term (iterator_t*);
+const char *
+filter_iterator_term (iterator_t *);
 
 void
-init_filter_alert_iterator (iterator_t*, filter_t);
+init_filter_alert_iterator (iterator_t *, filter_t);
 
-const char*
-filter_alert_iterator_name (iterator_t*);
+const char *
+filter_alert_iterator_name (iterator_t *);
 
-const char*
-filter_alert_iterator_uuid (iterator_t*);
-
-int
-filter_alert_iterator_readable (iterator_t*);
+const char *
+filter_alert_iterator_uuid (iterator_t *);
 
 int
-modify_filter (const char*, const char*, const char*, const char*, const char*);
+filter_alert_iterator_readable (iterator_t *);
 
-
+int
+modify_filter (const char *, const char *, const char *, const char *,
+               const char *);
+
 /* Schema. */
 
 int
 manage_schema (gchar *, gchar **, gsize *, gchar **, gchar **);
 
-
 /* Trashcan. */
 
 int
@@ -3540,13 +3308,11 @@ manage_restore (const char *);
 int
 manage_empty_trashcan ();
 
-
 /* Scanner tags. */
 
 void
 parse_tags (const char *, gchar **, gchar **);
 
-
 /* SecInfo */
 
 int
@@ -3569,66 +3335,66 @@ void
 init_cpe_cve_iterator (iterator_t *, const char *, int, const char *);
 
 int
-init_cpe_info_iterator (iterator_t*, get_data_t*, const char*);
+init_cpe_info_iterator (iterator_t *, get_data_t *, const char *);
 
 int
 cpe_info_count (const get_data_t *get);
 
-const char*
-cpe_info_iterator_title (iterator_t*);
+const char *
+cpe_info_iterator_title (iterator_t *);
 
-const char*
-cpe_info_iterator_status (iterator_t*);
+const char *
+cpe_info_iterator_status (iterator_t *);
 
-const char*
-cpe_info_iterator_max_cvss (iterator_t*);
+const char *
+cpe_info_iterator_max_cvss (iterator_t *);
 
-const char*
-cpe_info_iterator_deprecated_by_id (iterator_t*);
+const char *
+cpe_info_iterator_deprecated_by_id (iterator_t *);
 
-const char*
-cpe_info_iterator_cve_refs (iterator_t*);
+const char *
+cpe_info_iterator_cve_refs (iterator_t *);
 
-const char*
-cpe_info_iterator_nvd_id (iterator_t*);
+const char *
+cpe_info_iterator_nvd_id (iterator_t *);
 
 /* CVE. */
 
-const char*
-cve_iterator_name (iterator_t*);
+const char *
+cve_iterator_name (iterator_t *);
 
-const char*
-cve_iterator_cvss (iterator_t*);
+const char *
+cve_iterator_cvss (iterator_t *);
 
-const char*
-cve_info_iterator_cvss (iterator_t*);
+const char *
+cve_info_iterator_cvss (iterator_t *);
 
-const char*
-cve_info_iterator_vector (iterator_t*);
+const char *
+cve_info_iterator_vector (iterator_t *);
 
-const char*
-cve_info_iterator_complexity (iterator_t*);
+const char *
+cve_info_iterator_complexity (iterator_t *);
 
-const char*
-cve_info_iterator_authentication (iterator_t*);
+const char *
+cve_info_iterator_authentication (iterator_t *);
 
-const char*
-cve_info_iterator_confidentiality_impact (iterator_t*);
+const char *
+cve_info_iterator_confidentiality_impact (iterator_t *);
 
-const char*
-cve_info_iterator_integrity_impact (iterator_t*);
+const char *
+cve_info_iterator_integrity_impact (iterator_t *);
 
-const char*
-cve_info_iterator_availability_impact (iterator_t*);
+const char *
+cve_info_iterator_availability_impact (iterator_t *);
 
-const char*
-cve_info_iterator_description (iterator_t*);
+const char *
+cve_info_iterator_description (iterator_t *);
 
-const char*
-cve_info_iterator_products (iterator_t*);
+const char *
+cve_info_iterator_products (iterator_t *);
 
 int
-init_cve_info_iterator (iterator_t*, get_data_t*, const char*);
+init_cve_info_iterator (iterator_t *, get_data_t *, const char *);
 
 int
 cve_info_count (const get_data_t *get);
@@ -3638,37 +3404,37 @@ cve_cvss_base (const gchar *);
 
 /* OVAL definitions */
 int
-init_ovaldef_info_iterator (iterator_t*, get_data_t*, const char*);
+init_ovaldef_info_iterator (iterator_t *, get_data_t *, const char *);
 
 int
 ovaldef_info_count (const get_data_t *get);
 
-const char*
-ovaldef_info_iterator_version (iterator_t*);
+const char *
+ovaldef_info_iterator_version (iterator_t *);
 
-const char*
-ovaldef_info_iterator_deprecated (iterator_t*);
+const char *
+ovaldef_info_iterator_deprecated (iterator_t *);
 
-const char*
-ovaldef_info_iterator_class (iterator_t*);
+const char *
+ovaldef_info_iterator_class (iterator_t *);
 
-const char*
-ovaldef_info_iterator_title (iterator_t*);
+const char *
+ovaldef_info_iterator_title (iterator_t *);
 
-const char*
-ovaldef_info_iterator_description (iterator_t*);
+const char *
+ovaldef_info_iterator_description (iterator_t *);
 
-const char*
-ovaldef_info_iterator_file (iterator_t*);
+const char *
+ovaldef_info_iterator_file (iterator_t *);
 
-const char*
-ovaldef_info_iterator_status (iterator_t*);
+const char *
+ovaldef_info_iterator_status (iterator_t *);
 
-const char*
-ovaldef_info_iterator_max_cvss (iterator_t*);
+const char *
+ovaldef_info_iterator_max_cvss (iterator_t *);
 
-const char*
-ovaldef_info_iterator_cve_refs (iterator_t*);
+const char *
+ovaldef_info_iterator_cve_refs (iterator_t *);
 
 char *
 ovaldef_severity (const char *);
@@ -3689,54 +3455,54 @@ manage_cert_loaded ();
 /* CERT-Bund */
 
 int
-init_cert_bund_adv_info_iterator (iterator_t*, get_data_t*, const char*);
+init_cert_bund_adv_info_iterator (iterator_t *, get_data_t *, const char *);
 
 int
 cert_bund_adv_info_count (const get_data_t *get);
 
-const char*
-cert_bund_adv_info_iterator_title (iterator_t*);
+const char *
+cert_bund_adv_info_iterator_title (iterator_t *);
 
-const char*
-cert_bund_adv_info_iterator_summary (iterator_t*);
+const char *
+cert_bund_adv_info_iterator_summary (iterator_t *);
 
-const char*
-cert_bund_adv_info_iterator_cve_refs (iterator_t*);
+const char *
+cert_bund_adv_info_iterator_cve_refs (iterator_t *);
 
-const char*
-cert_bund_adv_info_iterator_max_cvss (iterator_t*);
-
-void
-init_cve_cert_bund_adv_iterator (iterator_t*, const char*, int, const char*);
+const char *
+cert_bund_adv_info_iterator_max_cvss (iterator_t *);
 
 void
-init_nvt_cert_bund_adv_iterator (iterator_t*, const char*, int, const char*);
+init_cve_cert_bund_adv_iterator (iterator_t *, const char *, int, const char *);
+
+void
+init_nvt_cert_bund_adv_iterator (iterator_t *, const char *, int, const char *);
 
 /* DFN-CERT */
 
 int
-init_dfn_cert_adv_info_iterator (iterator_t*, get_data_t*, const char*);
+init_dfn_cert_adv_info_iterator (iterator_t *, get_data_t *, const char *);
 
 int
 dfn_cert_adv_info_count (const get_data_t *get);
 
-const char*
-dfn_cert_adv_info_iterator_title (iterator_t*);
+const char *
+dfn_cert_adv_info_iterator_title (iterator_t *);
 
-const char*
-dfn_cert_adv_info_iterator_summary (iterator_t*);
+const char *
+dfn_cert_adv_info_iterator_summary (iterator_t *);
 
-const char*
-dfn_cert_adv_info_iterator_cve_refs (iterator_t*);
+const char *
+dfn_cert_adv_info_iterator_cve_refs (iterator_t *);
 
-const char*
-dfn_cert_adv_info_iterator_max_cvss (iterator_t*);
-
-void
-init_cve_dfn_cert_adv_iterator (iterator_t*, const char*, int, const char*);
+const char *
+dfn_cert_adv_info_iterator_max_cvss (iterator_t *);
 
 void
-init_nvt_dfn_cert_adv_iterator (iterator_t*, const char*, int, const char*);
+init_cve_dfn_cert_adv_iterator (iterator_t *, const char *, int, const char *);
+
+void
+init_nvt_dfn_cert_adv_iterator (iterator_t *, const char *, int, const char *);
 
 /* All SecInfo Data */
 
@@ -3747,24 +3513,23 @@ int
 total_info_count (const get_data_t *, int);
 
 int
-init_all_info_iterator (iterator_t*, get_data_t*, const char*);
+init_all_info_iterator (iterator_t *, get_data_t *, const char *);
 
-const char*
-all_info_iterator_type (iterator_t*);
+const char *
+all_info_iterator_type (iterator_t *);
 
-const char*
-all_info_iterator_extra (iterator_t*);
+const char *
+all_info_iterator_extra (iterator_t *);
 
-const char*
-all_info_iterator_severity (iterator_t*);
+const char *
+all_info_iterator_severity (iterator_t *);
 
 void
-init_ovaldi_file_iterator (iterator_t*);
+init_ovaldi_file_iterator (iterator_t *);
 
-const char*
-ovaldi_file_iterator_name (iterator_t*);
+const char *
+ovaldi_file_iterator_name (iterator_t *);
 
-
 /* Settings. */
 
 int
@@ -3786,28 +3551,28 @@ void
 init_setting_iterator (iterator_t *, const char *, const char *, int, int, int,
                        const char *);
 
-const char*
-setting_iterator_uuid (iterator_t*);
+const char *
+setting_iterator_uuid (iterator_t *);
 
-const char*
-setting_iterator_name (iterator_t*);
+const char *
+setting_iterator_name (iterator_t *);
 
-const char*
-setting_iterator_comment (iterator_t*);
+const char *
+setting_iterator_comment (iterator_t *);
 
-const char*
-setting_iterator_value (iterator_t*);
+const char *
+setting_iterator_value (iterator_t *);
 
 int
 modify_setting (const gchar *, const gchar *, const gchar *, gchar **);
 
 int
-manage_modify_setting (GSList *, const gchar *, const gchar *, const gchar *, const char *);
+manage_modify_setting (GSList *, const gchar *, const gchar *, const gchar *,
+                       const char *);
 
 char *
 manage_default_ca_cert ();
 
-
 /* Users. */
 
 gboolean
@@ -3829,11 +3594,9 @@ manage_report_host_add (report_t, const char *, time_t, time_t);
 int
 report_host_noticeable (report_t, const gchar *);
 
-void
-report_host_set_end_time (report_host_t, time_t);
+void report_host_set_end_time (report_host_t, time_t);
 
-gchar*
-host_routes_xml (host_t);
+gchar *host_routes_xml (host_t);
 
 int
 manage_set_password (GSList *, const gchar *, const gchar *, const gchar *);
@@ -3851,129 +3614,124 @@ int
 manage_scanner_set_default ();
 
 int
-copy_user (const char*, const char*, const char*, user_t*);
+copy_user (const char *, const char *, const char *, user_t *);
 
 gchar *
 keyfile_to_auth_conf_settings_xml (const gchar *);
 
 int
-init_user_iterator (iterator_t*, const get_data_t*);
+init_user_iterator (iterator_t *, const get_data_t *);
 
-const char*
-user_iterator_role (iterator_t*);
+const char *
+user_iterator_role (iterator_t *);
 
-const char*
-user_iterator_method (iterator_t*);
+const char *
+user_iterator_method (iterator_t *);
 
-const char*
-user_iterator_hosts (iterator_t*);
-
-int
-user_iterator_hosts_allow (iterator_t*);
-
-const char*
-user_iterator_ifaces (iterator_t*);
+const char *
+user_iterator_hosts (iterator_t *);
 
 int
-user_iterator_ifaces_allow (iterator_t*);
+user_iterator_hosts_allow (iterator_t *);
+
+const char *
+user_iterator_ifaces (iterator_t *);
+
+int
+user_iterator_ifaces_allow (iterator_t *);
 
 void
 init_user_group_iterator (iterator_t *, user_t);
 
-const char*
-user_group_iterator_uuid (iterator_t*);
+const char *
+user_group_iterator_uuid (iterator_t *);
 
-const char*
-user_group_iterator_name (iterator_t*);
+const char *
+user_group_iterator_name (iterator_t *);
 
 int
-user_group_iterator_readable (iterator_t*);
+user_group_iterator_readable (iterator_t *);
 
 void
 init_user_role_iterator (iterator_t *, user_t);
 
-const char*
-user_role_iterator_uuid (iterator_t*);
+const char *
+user_role_iterator_uuid (iterator_t *);
 
-const char*
-user_role_iterator_name (iterator_t*);
-
-int
-user_role_iterator_readable (iterator_t*);
+const char *
+user_role_iterator_name (iterator_t *);
 
 int
-create_user (const gchar *, const gchar *, const gchar *, const gchar *,
-             int, const gchar *, int, const array_t *, array_t *, gchar **,
+user_role_iterator_readable (iterator_t *);
+
+int
+create_user (const gchar *, const gchar *, const gchar *, const gchar *, int,
+             const gchar *, int, const array_t *, array_t *, gchar **,
              array_t *, gchar **, gchar **, user_t *, int);
 
 int
-delete_user (const char *, const char *, int, int, const char*, const char*);
+delete_user (const char *, const char *, int, int, const char *, const char *);
 
 int
 modify_user (const gchar *, gchar **, const gchar *, const gchar *,
-             const gchar*, const gchar *, int, const gchar *, int,
+             const gchar *, const gchar *, int, const gchar *, int,
              const array_t *, array_t *, gchar **, array_t *, gchar **,
              gchar **);
 
-int
-user_in_use (user_t);
+int user_in_use (user_t);
+
+int trash_user_in_use (user_t);
+
+int user_writable (user_t);
+
+int trash_user_writable (user_t);
 
 int
-trash_user_in_use (user_t);
+user_count (const get_data_t *);
 
-int
-user_writable (user_t);
-
-int
-trash_user_writable (user_t);
-
-int
-user_count (const get_data_t*);
-
-gchar*
+gchar *
 user_name (const char *);
 
-char*
-user_uuid (user_t);
+char *user_uuid (user_t);
 
-gchar*
+gchar *
 user_ifaces (const char *);
 
 int
 user_ifaces_allow (const char *);
 
-gchar*
+gchar *
 user_hosts (const char *);
 
 int
 user_hosts_allow (const char *);
 
 int
-init_vuln_iterator (iterator_t*, const get_data_t*);
+init_vuln_iterator (iterator_t *, const get_data_t *);
 
 int
-vuln_iterator_results (iterator_t*);
+vuln_iterator_results (iterator_t *);
 
-const char*
-vuln_iterator_oldest (iterator_t*);
+const char *
+vuln_iterator_oldest (iterator_t *);
 
-const char*
-vuln_iterator_newest (iterator_t*);
+const char *
+vuln_iterator_newest (iterator_t *);
 
-const char*
-vuln_iterator_type (iterator_t*);
+const char *
+vuln_iterator_type (iterator_t *);
 
 int
-vuln_iterator_hosts (iterator_t*);
+vuln_iterator_hosts (iterator_t *);
 
 double
-vuln_iterator_severity (iterator_t*);
+vuln_iterator_severity (iterator_t *);
 
 int
-vuln_iterator_qod (iterator_t*);
+vuln_iterator_qod (iterator_t *);
 
 int
-vuln_count (const get_data_t*);
+vuln_count (const get_data_t *);
 
 void
 manage_get_ldap_info (int *, gchar **, gchar **, int *, gchar **);
@@ -3987,145 +3745,138 @@ manage_get_radius_info (int *, char **, char **);
 void
 manage_set_radius_info (int, gchar *, gchar *);
 
-
 /* Tags */
 
-char*
-tag_uuid (target_t);
+char *tag_uuid (target_t);
 
 int
-copy_tag (const char*, const char*, const char*, tag_t*);
+copy_tag (const char *, const char *, const char *, tag_t *);
 
 int
-create_tag (const char *, const char *, const char *, const char *,
-            array_t *, const char *, const char *, tag_t *, gchar **);
+create_tag (const char *, const char *, const char *, const char *, array_t *,
+            const char *, const char *, tag_t *, gchar **);
 
 int
 delete_tag (const char *, int);
 
 int
 modify_tag (const char *, const char *, const char *, const char *,
-            const char *, array_t *, const char *, const char *, const char*,
+            const char *, array_t *, const char *, const char *, const char *,
             gchar **);
 
 int
-init_tag_iterator (iterator_t*, const get_data_t*);
+init_tag_iterator (iterator_t *, const get_data_t *);
 
 int
 tag_count (const get_data_t *get);
 
-const char*
-tag_iterator_resource_type (iterator_t*);
+const char *
+tag_iterator_resource_type (iterator_t *);
 
 int
-tag_iterator_active (iterator_t*);
+tag_iterator_active (iterator_t *);
 
-const char*
-tag_iterator_value (iterator_t*);
+const char *
+tag_iterator_value (iterator_t *);
 
 int
-tag_iterator_resources (iterator_t*);
+tag_iterator_resources (iterator_t *);
 
 resource_t
-tag_resource_iterator_id (iterator_t*);
+tag_resource_iterator_id (iterator_t *);
 
-const char*
-tag_resource_iterator_uuid (iterator_t*);
-
-int
-tag_resource_iterator_location (iterator_t*);
-
-const char*
-tag_resource_iterator_name (iterator_t*);
+const char *
+tag_resource_iterator_uuid (iterator_t *);
 
 int
-tag_resource_iterator_readable (iterator_t*);
+tag_resource_iterator_location (iterator_t *);
+
+const char *
+tag_resource_iterator_name (iterator_t *);
 
 int
-init_tag_name_iterator (iterator_t*, const get_data_t*);
-
-const char*
-tag_name_iterator_name (iterator_t*);
+tag_resource_iterator_readable (iterator_t *);
 
 int
-init_resource_tag_iterator (iterator_t*, const char*, resource_t, int,
-                            const char*, int);
+init_tag_name_iterator (iterator_t *, const get_data_t *);
 
-const char*
-resource_tag_iterator_uuid (iterator_t*);
-
-const char*
-resource_tag_iterator_name (iterator_t*);
-
-const char*
-resource_tag_iterator_value (iterator_t*);
-
-const char*
-resource_tag_iterator_comment (iterator_t*);
+const char *
+tag_name_iterator_name (iterator_t *);
 
 int
-resource_tag_exists (const char*, resource_t, int);
+init_resource_tag_iterator (iterator_t *, const char *, resource_t, int,
+                            const char *, int);
+
+const char *
+resource_tag_iterator_uuid (iterator_t *);
+
+const char *
+resource_tag_iterator_name (iterator_t *);
+
+const char *
+resource_tag_iterator_value (iterator_t *);
+
+const char *
+resource_tag_iterator_comment (iterator_t *);
 
 int
-resource_tag_count (const char*, resource_t, int);
+resource_tag_exists (const char *, resource_t, int);
 
 int
-tag_in_use (tag_t);
+resource_tag_count (const char *, resource_t, int);
 
-int
-trash_tag_in_use (tag_t);
+int tag_in_use (tag_t);
 
-int
-tag_writable (tag_t);
+int trash_tag_in_use (tag_t);
 
-int
-trash_tag_writable (tag_t);
+int tag_writable (tag_t);
 
-
+int trash_tag_writable (tag_t);
+
 /* Resource aggregates */
 
 /**
  * @brief Sort data for aggregates commands.
  */
-typedef struct {
-  gchar *field;  ///< The field to sort by.
-  gchar *stat;   ///< The statistic to sort by.
-  int order;     ///< The sort order.
+typedef struct
+{
+  gchar *field; ///< The field to sort by.
+  gchar *stat;  ///< The statistic to sort by.
+  int order;    ///< The sort order.
 } sort_data_t;
 
 void
-sort_data_free (sort_data_t*);
+sort_data_free (sort_data_t *);
 
 int
-init_aggregate_iterator (iterator_t*, const char *, const get_data_t *, int,
-                         GArray *, const char *, const char*, GArray*, GArray*,
-                         int, int, const char *, const char *);
+init_aggregate_iterator (iterator_t *, const char *, const get_data_t *, int,
+                         GArray *, const char *, const char *, GArray *,
+                         GArray *, int, int, const char *, const char *);
 
 int
-aggregate_iterator_count (iterator_t*);
+aggregate_iterator_count (iterator_t *);
 
 double
-aggregate_iterator_min (iterator_t*, int);
+aggregate_iterator_min (iterator_t *, int);
 
 double
-aggregate_iterator_max (iterator_t*, int);
+aggregate_iterator_max (iterator_t *, int);
 
 double
-aggregate_iterator_mean (iterator_t*, int);
+aggregate_iterator_mean (iterator_t *, int);
 
 double
-aggregate_iterator_sum (iterator_t*, int);
+aggregate_iterator_sum (iterator_t *, int);
 
-const char*
-aggregate_iterator_text (iterator_t*, int, int);
+const char *
+aggregate_iterator_text (iterator_t *, int, int);
 
-const char*
-aggregate_iterator_value (iterator_t*);
+const char *
+aggregate_iterator_value (iterator_t *);
 
-const char*
-aggregate_iterator_subgroup_value (iterator_t*);
+const char *
+aggregate_iterator_subgroup_value (iterator_t *);
 
-
 /* Feeds. */
 
 #define NVT_FEED 1
@@ -4147,39 +3898,34 @@ gvm_get_sync_script_description (const gchar *, gchar **);
 gboolean
 gvm_get_sync_script_feed_version (const gchar *, gchar **);
 
-
 /* Wizards. */
 
 int
-manage_run_wizard (const gchar *, int (*) (void*, gchar*, gchar**),
-                   void *, array_t *, int, const char*,
-                   gchar **, gchar **, gchar **);
+manage_run_wizard (const gchar *, int (*) (void *, gchar *, gchar **), void *,
+                   array_t *, int, const char *, gchar **, gchar **, gchar **);
 
-
 /* Helpers. */
 
 gchar *
 xml_escape_text_truncated (const char *, size_t, const char *);
 
 int
-column_is_timestamp (const char*);
+column_is_timestamp (const char *);
 
-char*
+char *
 type_columns (const char *);
 
-char*
+char *
 type_trash_columns (const char *);
 
 gboolean
 manage_migrate_needs_timezone (GSList *, const gchar *);
 
-
 /* Optimize. */
 
 int
 manage_optimize (GSList *, const gchar *, const gchar *);
 
-
 /* Signal management */
 
 int

--- a/src/manage.h
+++ b/src/manage.h
@@ -67,8 +67,15 @@ typedef int (*manage_connection_forker_t) (gvm_connection_t *conn,
                                            const gchar *uuid);
 
 int
-init_manage (GSList *, int, const gchar *, int, int, int, int,
-             manage_connection_forker_t, int);
+init_manage (GSList *,
+             int,
+             const gchar *,
+             int,
+             int,
+             int,
+             int,
+             manage_connection_forker_t,
+             int);
 
 int
 init_manage_helper (GSList *, const gchar *, int);
@@ -554,17 +561,33 @@ int
 manage_check_alerts (GSList *, const gchar *);
 
 int
-create_alert (const char *, const char *, const char *, const char *, event_t,
-              GPtrArray *, alert_condition_t, GPtrArray *, alert_method_t,
-              GPtrArray *, alert_t *);
+create_alert (const char *,
+              const char *,
+              const char *,
+              const char *,
+              event_t,
+              GPtrArray *,
+              alert_condition_t,
+              GPtrArray *,
+              alert_method_t,
+              GPtrArray *,
+              alert_t *);
 
 int
 copy_alert (const char *, const char *, const char *, alert_t *);
 
 int
-modify_alert (const char *, const char *, const char *, const char *,
-              const char *, event_t, GPtrArray *, alert_condition_t,
-              GPtrArray *, alert_method_t, GPtrArray *);
+modify_alert (const char *,
+              const char *,
+              const char *,
+              const char *,
+              const char *,
+              event_t,
+              GPtrArray *,
+              alert_condition_t,
+              GPtrArray *,
+              alert_method_t,
+              GPtrArray *);
 
 int
 delete_alert (const char *, int);
@@ -815,7 +838,14 @@ int
 task_last_report (task_t, report_t *);
 
 const char *
-task_iterator_trend_counts (iterator_t *, int, int, int, double, int, int, int,
+task_iterator_trend_counts (iterator_t *,
+                            int,
+                            int,
+                            int,
+                            double,
+                            int,
+                            int,
+                            int,
                             double);
 
 const char *
@@ -912,10 +942,22 @@ int
 manage_task_remove_file (const gchar *, const char *);
 
 int
-modify_task (const gchar *, const gchar *, const gchar *, const gchar *,
-             const gchar *, const gchar *, const gchar *, array_t *,
-             const gchar *, array_t *, const gchar *, const gchar *, array_t *,
-             const gchar *, gchar **, gchar **);
+modify_task (const gchar *,
+             const gchar *,
+             const gchar *,
+             const gchar *,
+             const gchar *,
+             const gchar *,
+             const gchar *,
+             array_t *,
+             const gchar *,
+             array_t *,
+             const gchar *,
+             const gchar *,
+             array_t *,
+             const gchar *,
+             gchar **,
+             gchar **);
 
 void
 init_config_file_iterator (iterator_t *, const char *, const char *);
@@ -978,8 +1020,15 @@ void
 severity_data_add_count (severity_data_t *, double, int);
 
 void
-severity_data_level_counts (const severity_data_t *, const gchar *, int *,
-                            int *, int *, int *, int *, int *, int *);
+severity_data_level_counts (const severity_data_t *,
+                            const gchar *,
+                            int *,
+                            int *,
+                            int *,
+                            int *,
+                            int *,
+                            int *,
+                            int *);
 
 /* General task facilities. */
 
@@ -1040,8 +1089,14 @@ int
 result_uuid (result_t, char **);
 
 int
-result_detection_reference (result_t, report_t, const char *, const char *,
-                            char **, char **, char **, char **);
+result_detection_reference (result_t,
+                            report_t,
+                            const char *,
+                            const char *,
+                            char **,
+                            char **,
+                            char **,
+                            char **);
 
 /* Reports. */
 
@@ -1070,7 +1125,10 @@ void
 reports_clear_count_cache_for_override (override_t, int);
 
 void
-init_report_counts_build_iterator (iterator_t *, report_t, int, int,
+init_report_counts_build_iterator (iterator_t *,
+                                   report_t,
+                                   int,
+                                   int,
                                    const char *);
 
 double
@@ -1091,12 +1149,23 @@ int
 qod_from_type (const char *);
 
 result_t
-make_result (task_t, const char *, const char *, const char *, const char *,
-             const char *, const char *);
+make_result (task_t,
+             const char *,
+             const char *,
+             const char *,
+             const char *,
+             const char *,
+             const char *);
 
 result_t
-make_osp_result (task_t, const char *, const char *, const char *, const char *,
-                 const char *, const char *, int);
+make_osp_result (task_t,
+                 const char *,
+                 const char *,
+                 const char *,
+                 const char *,
+                 const char *,
+                 const char *,
+                 int);
 
 result_t
 make_cve_result (task_t, const char *, const char *, double, const char *);
@@ -1135,8 +1204,13 @@ void
 host_detail_free (host_detail_t *);
 
 void
-insert_report_host_detail (report_t, const char *, const char *, const char *,
-                           const char *, const char *, const char *);
+insert_report_host_detail (report_t,
+                           const char *,
+                           const char *,
+                           const char *,
+                           const char *,
+                           const char *,
+                           const char *);
 
 int
 manage_report_host_detail (report_t, const char *, const char *);
@@ -1154,9 +1228,17 @@ void clear_duration_schedules (task_t);
 void update_duration_schedule_periods (task_t);
 
 int
-create_report (array_t *, const char *, const char *, const char *,
-               const char *, const char *, const char *, array_t *, array_t *,
-               array_t *, char **);
+create_report (array_t *,
+               const char *,
+               const char *,
+               const char *,
+               const char *,
+               const char *,
+               const char *,
+               array_t *,
+               array_t *,
+               array_t *,
+               char **);
 
 void report_add_result (report_t, result_t);
 
@@ -1197,20 +1279,52 @@ report_task (report_t, task_t *);
 char *report_slave_task_uuid (report_t);
 
 int
-report_scan_result_count (report_t, const char *, const char *, int,
-                          const char *, const char *, int, int, int *);
+report_scan_result_count (report_t,
+                          const char *,
+                          const char *,
+                          int,
+                          const char *,
+                          const char *,
+                          int,
+                          int,
+                          int *);
 
 int
-report_counts (const char *, int *, int *, int *, int *, int *, int *, double *,
-               int, int, int);
+report_counts (const char *,
+               int *,
+               int *,
+               int *,
+               int *,
+               int *,
+               int *,
+               double *,
+               int,
+               int,
+               int);
 
 int
-report_counts_id (report_t, int *, int *, int *, int *, int *, int *, double *,
-                  const get_data_t *, const char *);
+report_counts_id (report_t,
+                  int *,
+                  int *,
+                  int *,
+                  int *,
+                  int *,
+                  int *,
+                  double *,
+                  const get_data_t *,
+                  const char *);
 
 int
-report_counts_id_no_filt (report_t, int *, int *, int *, int *, int *, int *,
-                          double *, const get_data_t *, const char *);
+report_counts_id_no_filt (report_t,
+                          int *,
+                          int *,
+                          int *,
+                          int *,
+                          int *,
+                          int *,
+                          double *,
+                          const get_data_t *,
+                          const char *);
 
 get_data_t *
 report_results_get_data (int, int, int, int, int);
@@ -1276,8 +1390,11 @@ int
 result_count (const get_data_t *, report_t, const char *);
 
 int
-init_result_get_iterator (iterator_t *, const get_data_t *, report_t,
-                          const char *, const gchar *);
+init_result_get_iterator (iterator_t *,
+                          const get_data_t *,
+                          report_t,
+                          const char *,
+                          const gchar *);
 
 gboolean
 next_report (iterator_t *, report_t *);
@@ -1402,16 +1519,44 @@ int
 report_progress (report_t, task_t, gchar **);
 
 gchar *
-manage_report (report_t, report_t, const get_data_t *, report_format_t, int,
-               int, const char *, gsize *, gchar **, gchar **, gchar **,
-               gchar **, gchar **);
+manage_report (report_t,
+               report_t,
+               const get_data_t *,
+               report_format_t,
+               int,
+               int,
+               const char *,
+               gsize *,
+               gchar **,
+               gchar **,
+               gchar **,
+               gchar **,
+               gchar **);
 
 int
-manage_send_report (
-  report_t, report_t, report_format_t, const get_data_t *, int, int, int, int,
-  int, gboolean (*) (const char *, int (*) (const char *, void *), void *),
-  int (*) (const char *, void *), void *, const char *, const char *,
-  const char *, int, const char *, const char *, int, int, const gchar *);
+manage_send_report (report_t,
+                    report_t,
+                    report_format_t,
+                    const get_data_t *,
+                    int,
+                    int,
+                    int,
+                    int,
+                    int,
+                    gboolean (*) (const char *,
+                                  int (*) (const char *, void *),
+                                  void *),
+                    int (*) (const char *, void *),
+                    void *,
+                    const char *,
+                    const char *,
+                    const char *,
+                    int,
+                    const char *,
+                    const char *,
+                    int,
+                    int,
+                    const gchar *);
 
 /* Reports. */
 
@@ -1419,8 +1564,14 @@ gchar *
 app_location (report_host_t, const gchar *);
 
 void
-init_host_prognosis_iterator (iterator_t *, report_host_t, int, int,
-                              const char *, const char *, int, const char *);
+init_host_prognosis_iterator (iterator_t *,
+                              report_host_t,
+                              int,
+                              int,
+                              const char *,
+                              const char *,
+                              int,
+                              const char *);
 
 double
 prognosis_iterator_cvss_double (iterator_t *);
@@ -1460,9 +1611,22 @@ void
 manage_filter_controls (const gchar *, int *, int *, gchar **, int *);
 
 void
-manage_report_filter_controls (const gchar *, int *, int *, gchar **, int *,
-                               int *, gchar **, gchar **, gchar **, gchar **,
-                               int *, int *, int *, int *, int *, gchar **);
+manage_report_filter_controls (const gchar *,
+                               int *,
+                               int *,
+                               gchar **,
+                               int *,
+                               int *,
+                               gchar **,
+                               gchar **,
+                               gchar **,
+                               gchar **,
+                               int *,
+                               int *,
+                               int *,
+                               int *,
+                               int *,
+                               gchar **);
 
 gchar *
 manage_clean_filter (const gchar *);
@@ -1477,19 +1641,41 @@ gboolean
 find_target_with_permission (const char *, target_t *, const char *);
 
 int
-create_target (const char *, const char *, const char *, const char *,
-               const char *, const char *, const char *, credential_t,
-               const char *, credential_t, credential_t, credential_t,
-               const char *, const char *, const char *, target_t *);
+create_target (const char *,
+               const char *,
+               const char *,
+               const char *,
+               const char *,
+               const char *,
+               const char *,
+               credential_t,
+               const char *,
+               credential_t,
+               credential_t,
+               credential_t,
+               const char *,
+               const char *,
+               const char *,
+               target_t *);
 
 int
 copy_target (const char *, const char *, const char *, target_t *);
 
 int
-modify_target (const char *, const char *, const char *, const char *,
-               const char *, const char *, const char *, const char *,
-               const char *, const char *, const char *, const char *,
-               const char *, const char *);
+modify_target (const char *,
+               const char *,
+               const char *,
+               const char *,
+               const char *,
+               const char *,
+               const char *,
+               const char *,
+               const char *,
+               const char *,
+               const char *,
+               const char *,
+               const char *,
+               const char *);
 
 int
 delete_target (const char *, int);
@@ -1649,8 +1835,13 @@ typedef struct
 } nvt_selector_t;
 
 int
-create_config (const char *, const char *, const array_t *, const array_t *,
-               const char *, config_t *, char **);
+create_config (const char *,
+               const char *,
+               const array_t *,
+               const array_t *,
+               const char *,
+               config_t *,
+               char **);
 
 int
 create_config_from_scanner (const char *, const char *, const char *, char **);
@@ -1730,7 +1921,9 @@ int
 modify_task_check_config_scanner (task_t, const char *, const char *);
 
 int
-manage_set_config_preference (const gchar *, const char *, const char *,
+manage_set_config_preference (const gchar *,
+                              const char *,
+                              const char *,
                               const char *);
 
 void
@@ -1758,8 +1951,11 @@ int
 manage_set_config_nvts (const gchar *, const char *, GPtrArray *);
 
 int
-manage_set_config_families (const gchar *, GPtrArray *, GPtrArray *,
-                            GPtrArray *, int);
+manage_set_config_families (const gchar *,
+                            GPtrArray *,
+                            GPtrArray *,
+                            GPtrArray *,
+                            int);
 
 void
 init_config_timeout_iterator (iterator_t *, config_t);
@@ -1796,8 +1992,13 @@ int
 nvt_info_count (const get_data_t *);
 
 void
-init_nvt_iterator (iterator_t *, nvt_t, config_t, const char *, const char *,
-                   int, const char *);
+init_nvt_iterator (iterator_t *,
+                   nvt_t,
+                   config_t,
+                   const char *,
+                   const char *,
+                   int,
+                   const char *);
 
 void
 init_cve_nvt_iterator (iterator_t *, const char *, int, const char *);
@@ -1987,18 +2188,37 @@ gboolean
 find_credential_with_permission (const char *, credential_t *, const char *);
 
 int
-create_credential (const char *, const char *, const char *, const char *,
-                   const char *, const char *, const char *, const char *,
-                   const char *, const char *, const char *, const char *,
-                   const char *, credential_t *);
+create_credential (const char *,
+                   const char *,
+                   const char *,
+                   const char *,
+                   const char *,
+                   const char *,
+                   const char *,
+                   const char *,
+                   const char *,
+                   const char *,
+                   const char *,
+                   const char *,
+                   const char *,
+                   credential_t *);
 
 int
 copy_credential (const char *, const char *, const char *, credential_t *);
 
 int
-modify_credential (const char *, const char *, const char *, const char *,
-                   const char *, const char *, const char *, const char *,
-                   const char *, const char *, const char *, const char *,
+modify_credential (const char *,
+                   const char *,
+                   const char *,
+                   const char *,
+                   const char *,
+                   const char *,
+                   const char *,
+                   const char *,
+                   const char *,
+                   const char *,
+                   const char *,
+                   const char *,
                    const char *);
 
 int
@@ -2123,8 +2343,14 @@ credential_encrypted_value (credential_t, const char *);
 /* Agents. */
 
 int
-create_agent (const char *, const char *, const char *, const char *,
-              const char *, const char *, const char *, agent_t *);
+create_agent (const char *,
+              const char *,
+              const char *,
+              const char *,
+              const char *,
+              const char *,
+              const char *,
+              agent_t *);
 
 int
 copy_agent (const char *, const char *, const char *, agent_t *);
@@ -2180,8 +2406,13 @@ result_host_asset_id (const char *, result_t);
 char *host_uuid (resource_t);
 
 host_t
-host_notice (const char *, const char *, const char *, const char *,
-             const char *, int, int);
+host_notice (const char *,
+             const char *,
+             const char *,
+             const char *,
+             const char *,
+             int,
+             int);
 
 void
 init_host_identifier_iterator (iterator_t *, host_t, int, const char *);
@@ -2285,8 +2516,15 @@ gboolean
 find_note_with_permission (const char *, note_t *, const char *);
 
 int
-create_note (const char *, const char *, const char *, const char *,
-             const char *, const char *, const char *, task_t, result_t,
+create_note (const char *,
+             const char *,
+             const char *,
+             const char *,
+             const char *,
+             const char *,
+             const char *,
+             task_t,
+             result_t,
              note_t *);
 
 int
@@ -2299,9 +2537,16 @@ int
 note_uuid (note_t, char **);
 
 int
-modify_note (const gchar *, const char *, const char *, const char *,
-             const char *, const char *, const char *, const char *,
-             const gchar *, const gchar *);
+modify_note (const gchar *,
+             const char *,
+             const char *,
+             const char *,
+             const char *,
+             const char *,
+             const char *,
+             const char *,
+             const gchar *,
+             const gchar *);
 
 int
 note_count (const get_data_t *, nvt_t, result_t, task_t);
@@ -2357,9 +2602,18 @@ gboolean
 find_override_with_permission (const char *, override_t *, const char *);
 
 int
-create_override (const char *, const char *, const char *, const char *,
-                 const char *, const char *, const char *, const char *,
-                 const char *, task_t, result_t, override_t *);
+create_override (const char *,
+                 const char *,
+                 const char *,
+                 const char *,
+                 const char *,
+                 const char *,
+                 const char *,
+                 const char *,
+                 const char *,
+                 task_t,
+                 result_t,
+                 override_t *);
 
 int
 override_uuid (override_t, char **);
@@ -2371,15 +2625,27 @@ int
 delete_override (const char *, int);
 
 int
-modify_override (const gchar *, const char *, const char *, const char *,
-                 const char *, const char *, const char *, const char *,
-                 const char *, const char *, const gchar *, const gchar *);
+modify_override (const gchar *,
+                 const char *,
+                 const char *,
+                 const char *,
+                 const char *,
+                 const char *,
+                 const char *,
+                 const char *,
+                 const char *,
+                 const char *,
+                 const gchar *,
+                 const gchar *);
 
 int
 override_count (const get_data_t *, nvt_t, result_t, task_t);
 
 int
-init_override_iterator (iterator_t *, const get_data_t *, nvt_t, result_t,
+init_override_iterator (iterator_t *,
+                        const get_data_t *,
+                        nvt_t,
+                        result_t,
                         task_t);
 
 const char *
@@ -2453,7 +2719,8 @@ typedef struct
 } report_type_iterator_t;
 
 int
-init_system_report_type_iterator (report_type_iterator_t *, const char *,
+init_system_report_type_iterator (report_type_iterator_t *,
+                                  const char *,
                                   const char *);
 
 void
@@ -2469,18 +2736,35 @@ const char *
 report_type_iterator_title (report_type_iterator_t *);
 
 int
-manage_system_report (const char *, const char *, const char *, const char *,
-                      const char *, char **);
+manage_system_report (const char *,
+                      const char *,
+                      const char *,
+                      const char *,
+                      const char *,
+                      char **);
 
 int
-manage_create_scanner (GSList *, const char *, const char *, const char *,
-                       const char *, const char *, const char *, const char *,
+manage_create_scanner (GSList *,
+                       const char *,
+                       const char *,
+                       const char *,
+                       const char *,
+                       const char *,
+                       const char *,
+                       const char *,
                        const char *);
 
 int
-manage_modify_scanner (GSList *, const gchar *, const char *, const char *,
-                       const char *, const char *, const char *, const char *,
-                       const char *, const char *);
+manage_modify_scanner (GSList *,
+                       const gchar *,
+                       const char *,
+                       const char *,
+                       const char *,
+                       const char *,
+                       const char *,
+                       const char *,
+                       const char *,
+                       const char *);
 
 int
 manage_delete_scanner (GSList *, const gchar *, const gchar *);
@@ -2492,15 +2776,27 @@ int
 manage_get_scanners (GSList *, const gchar *);
 
 int
-create_scanner (const char *, const char *, const char *, const char *,
-                const char *, scanner_t *, const char *, const char *);
+create_scanner (const char *,
+                const char *,
+                const char *,
+                const char *,
+                const char *,
+                scanner_t *,
+                const char *,
+                const char *);
 
 int
 copy_scanner (const char *, const char *, const char *, scanner_t *);
 
 int
-modify_scanner (const char *, const char *, const char *, const char *,
-                const char *, const char *, const char *, const char *);
+modify_scanner (const char *,
+                const char *,
+                const char *,
+                const char *,
+                const char *,
+                const char *,
+                const char *,
+                const char *);
 
 int
 delete_scanner (const char *, int);
@@ -2603,8 +2899,13 @@ char *trash_scanner_name (scanner_t);
 char *trash_scanner_uuid (scanner_t);
 
 int
-osp_get_version_from_iterator (iterator_t *, char **, char **, char **, char **,
-                               char **, char **);
+osp_get_version_from_iterator (iterator_t *,
+                               char **,
+                               char **,
+                               char **,
+                               char **,
+                               char **,
+                               char **);
 
 int
 osp_get_details_from_iterator (iterator_t *, char **, GSList **);
@@ -2636,8 +2937,16 @@ gboolean
 find_schedule_with_permission (const char *, schedule_t *, const char *);
 
 int
-create_schedule (const char *, const char *, const char *, time_t, time_t,
-                 time_t, const char *, time_t, const char *, schedule_t *,
+create_schedule (const char *,
+                 const char *,
+                 const char *,
+                 time_t,
+                 time_t,
+                 time_t,
+                 const char *,
+                 time_t,
+                 const char *,
+                 schedule_t *,
                  gchar **);
 
 int
@@ -2670,8 +2979,15 @@ int schedule_duration (schedule_t);
 int schedule_period (schedule_t);
 
 int
-schedule_info (schedule_t, int, time_t *, time_t *, int *, int *, int *,
-               gchar **, gchar **);
+schedule_info (schedule_t,
+               int,
+               time_t *,
+               time_t *,
+               int *,
+               int *,
+               int *,
+               gchar **,
+               gchar **);
 
 int
 init_schedule_iterator (iterator_t *, const get_data_t *);
@@ -2732,8 +3048,17 @@ int
 schedule_task_iterator_readable (iterator_t *);
 
 int
-modify_schedule (const char *, const char *, const char *, const char *, time_t,
-                 time_t, time_t, const char *, time_t, const char *, gchar **);
+modify_schedule (const char *,
+                 const char *,
+                 const char *,
+                 const char *,
+                 time_t,
+                 time_t,
+                 time_t,
+                 const char *,
+                 time_t,
+                 const char *,
+                 gchar **);
 
 int
 get_schedule_timeout ();
@@ -2744,7 +3069,8 @@ set_schedule_timeout (int);
 /* Report Formats. */
 
 gboolean
-find_report_format_with_permission (const char *, report_format_t *,
+find_report_format_with_permission (const char *,
+                                    report_format_t *,
                                     const char *);
 
 /**
@@ -2761,16 +3087,30 @@ typedef struct
 } create_report_format_param_t;
 
 int
-create_report_format (const char *, const char *, const char *, const char *,
-                      const char *, const char *, int, array_t *, array_t *,
-                      array_t *, const char *, report_format_t *);
+create_report_format (const char *,
+                      const char *,
+                      const char *,
+                      const char *,
+                      const char *,
+                      const char *,
+                      int,
+                      array_t *,
+                      array_t *,
+                      array_t *,
+                      const char *,
+                      report_format_t *);
 
 int
 copy_report_format (const char *, const char *, report_format_t *);
 
 int
-modify_report_format (const char *, const char *, const char *, const char *,
-                      const char *, const char *, const char *);
+modify_report_format (const char *,
+                      const char *,
+                      const char *,
+                      const char *,
+                      const char *,
+                      const char *,
+                      const char *);
 
 int
 delete_report_format (const char *, int);
@@ -2896,7 +3236,10 @@ report_format_param_type_t
 report_format_param_type_from_name (const char *);
 
 void
-init_report_format_param_iterator (iterator_t *, report_format_t, int, int,
+init_report_format_param_iterator (iterator_t *,
+                                   report_format_t,
+                                   int,
+                                   int,
                                    const char *);
 
 report_format_param_t
@@ -2924,7 +3267,9 @@ const char *
 report_format_param_iterator_fallback (iterator_t *);
 
 void
-init_param_option_iterator (iterator_t *, report_format_param_t, int,
+init_param_option_iterator (iterator_t *,
+                            report_format_param_t,
+                            int,
                             const char *);
 
 const char *
@@ -2965,8 +3310,13 @@ modify_group (const char *, const char *, const char *, const char *);
 /* Permissions. */
 
 int
-create_permission (const char *, const char *, const char *, const char *,
-                   const char *, const char *, permission_t *);
+create_permission (const char *,
+                   const char *,
+                   const char *,
+                   const char *,
+                   const char *,
+                   const char *,
+                   permission_t *);
 
 int
 copy_permission (const char *, const char *, permission_t *);
@@ -3027,8 +3377,13 @@ int
 delete_permission (const char *, int);
 
 int
-modify_permission (const char *, const char *, const char *, const char *,
-                   const char *, const char *, const char *);
+modify_permission (const char *,
+                   const char *,
+                   const char *,
+                   const char *,
+                   const char *,
+                   const char *,
+                   const char *);
 
 /* Permission caching */
 
@@ -3049,8 +3404,12 @@ gboolean
 find_port_range (const char *, port_list_t *);
 
 int
-create_port_list (const char *, const char *, const char *, const char *,
-                  array_t *, port_list_t *);
+create_port_list (const char *,
+                  const char *,
+                  const char *,
+                  const char *,
+                  array_t *,
+                  port_list_t *);
 
 int
 copy_port_list (const char *, const char *, const char *, port_list_t *);
@@ -3059,8 +3418,12 @@ int
 modify_port_list (const char *, const char *, const char *);
 
 int
-create_port_range (const char *, const char *, const char *, const char *,
-                   const char *, port_range_t *);
+create_port_range (const char *,
+                   const char *,
+                   const char *,
+                   const char *,
+                   const char *,
+                   port_range_t *);
 
 int
 delete_port_list (const char *, int);
@@ -3250,7 +3613,10 @@ int
 filter_term_min_qod (const char *);
 
 int
-create_filter (const char *, const char *, const char *, const char *,
+create_filter (const char *,
+               const char *,
+               const char *,
+               const char *,
                filter_t *);
 
 int
@@ -3292,7 +3658,10 @@ int
 filter_alert_iterator_readable (iterator_t *);
 
 int
-modify_filter (const char *, const char *, const char *, const char *,
+modify_filter (const char *,
+               const char *,
+               const char *,
+               const char *,
                const char *);
 
 /* Schema. */
@@ -3548,7 +3917,12 @@ const char *
 setting_severity ();
 
 void
-init_setting_iterator (iterator_t *, const char *, const char *, int, int, int,
+init_setting_iterator (iterator_t *,
+                       const char *,
+                       const char *,
+                       int,
+                       int,
+                       int,
                        const char *);
 
 const char *
@@ -3567,7 +3941,10 @@ int
 modify_setting (const gchar *, const gchar *, const gchar *, gchar **);
 
 int
-manage_modify_setting (GSList *, const gchar *, const gchar *, const gchar *,
+manage_modify_setting (GSList *,
+                       const gchar *,
+                       const gchar *,
+                       const gchar *,
                        const char *);
 
 char *
@@ -3579,7 +3956,10 @@ gboolean
 find_user_by_name_with_permission (const char *, user_t *, const char *);
 
 int
-manage_create_user (GSList *, const gchar *, const gchar *, const gchar *,
+manage_create_user (GSList *,
+                    const gchar *,
+                    const gchar *,
+                    const gchar *,
                     const gchar *);
 
 int
@@ -3665,17 +4045,40 @@ int
 user_role_iterator_readable (iterator_t *);
 
 int
-create_user (const gchar *, const gchar *, const gchar *, const gchar *, int,
-             const gchar *, int, const array_t *, array_t *, gchar **,
-             array_t *, gchar **, gchar **, user_t *, int);
+create_user (const gchar *,
+             const gchar *,
+             const gchar *,
+             const gchar *,
+             int,
+             const gchar *,
+             int,
+             const array_t *,
+             array_t *,
+             gchar **,
+             array_t *,
+             gchar **,
+             gchar **,
+             user_t *,
+             int);
 
 int
 delete_user (const char *, const char *, int, int, const char *, const char *);
 
 int
-modify_user (const gchar *, gchar **, const gchar *, const gchar *,
-             const gchar *, const gchar *, int, const gchar *, int,
-             const array_t *, array_t *, gchar **, array_t *, gchar **,
+modify_user (const gchar *,
+             gchar **,
+             const gchar *,
+             const gchar *,
+             const gchar *,
+             const gchar *,
+             int,
+             const gchar *,
+             int,
+             const array_t *,
+             array_t *,
+             gchar **,
+             array_t *,
+             gchar **,
              gchar **);
 
 int user_in_use (user_t);
@@ -3753,15 +4156,29 @@ int
 copy_tag (const char *, const char *, const char *, tag_t *);
 
 int
-create_tag (const char *, const char *, const char *, const char *, array_t *,
-            const char *, const char *, tag_t *, gchar **);
+create_tag (const char *,
+            const char *,
+            const char *,
+            const char *,
+            array_t *,
+            const char *,
+            const char *,
+            tag_t *,
+            gchar **);
 
 int
 delete_tag (const char *, int);
 
 int
-modify_tag (const char *, const char *, const char *, const char *,
-            const char *, array_t *, const char *, const char *, const char *,
+modify_tag (const char *,
+            const char *,
+            const char *,
+            const char *,
+            const char *,
+            array_t *,
+            const char *,
+            const char *,
+            const char *,
             gchar **);
 
 int
@@ -3804,8 +4221,12 @@ const char *
 tag_name_iterator_name (iterator_t *);
 
 int
-init_resource_tag_iterator (iterator_t *, const char *, resource_t, int,
-                            const char *, int);
+init_resource_tag_iterator (iterator_t *,
+                            const char *,
+                            resource_t,
+                            int,
+                            const char *,
+                            int);
 
 const char *
 resource_tag_iterator_uuid (iterator_t *);
@@ -3849,9 +4270,19 @@ void
 sort_data_free (sort_data_t *);
 
 int
-init_aggregate_iterator (iterator_t *, const char *, const get_data_t *, int,
-                         GArray *, const char *, const char *, GArray *,
-                         GArray *, int, int, const char *, const char *);
+init_aggregate_iterator (iterator_t *,
+                         const char *,
+                         const get_data_t *,
+                         int,
+                         GArray *,
+                         const char *,
+                         const char *,
+                         GArray *,
+                         GArray *,
+                         int,
+                         int,
+                         const char *,
+                         const char *);
 
 int
 aggregate_iterator_count (iterator_t *);
@@ -3901,8 +4332,15 @@ gvm_get_sync_script_feed_version (const gchar *, gchar **);
 /* Wizards. */
 
 int
-manage_run_wizard (const gchar *, int (*) (void *, gchar *, gchar **), void *,
-                   array_t *, int, const char *, gchar **, gchar **, gchar **);
+manage_run_wizard (const gchar *,
+                   int (*) (void *, gchar *, gchar **),
+                   void *,
+                   array_t *,
+                   int,
+                   const char *,
+                   gchar **,
+                   gchar **,
+                   gchar **);
 
 /* Helpers. */
 

--- a/src/manage_acl.c
+++ b/src/manage_acl.c
@@ -27,6 +27,7 @@
  */
 
 #include "manage_acl.h"
+
 #include "manage_sql.h"
 #include "sql.h"
 
@@ -59,19 +60,14 @@ acl_user_may (const char *operation)
     /* Allow the dummy user in init_manage to do anything. */
     return 1;
 
-  if (sql_int ("SELECT user_can_everything ('%s');",
-               current_credentials.uuid))
+  if (sql_int ("SELECT user_can_everything ('%s');", current_credentials.uuid))
     return 1;
 
   quoted_operation = sql_quote (operation);
 
-  ret = sql_int (ACL_USER_MAY ("0"),
-                 current_credentials.uuid,
-                 current_credentials.uuid,
-                 current_credentials.uuid,
-                 quoted_operation,
-                 quoted_operation,
-                 quoted_operation,
+  ret = sql_int (ACL_USER_MAY ("0"), current_credentials.uuid,
+                 current_credentials.uuid, current_credentials.uuid,
+                 quoted_operation, quoted_operation, quoted_operation,
                  quoted_operation);
 
   g_free (quoted_operation);
@@ -91,18 +87,19 @@ acl_role_can_super_everyone (const char *role_id)
 {
   gchar *quoted_role_id;
   quoted_role_id = sql_quote (role_id);
-  if (sql_int (" SELECT EXISTS (SELECT * FROM permissions"
-               "                WHERE name = 'Super'"
-               /*                    Super on everyone. */
-               "                AND (resource = 0)"
-               "                AND subject_location"
-               "                    = " G_STRINGIFY (LOCATION_TABLE)
-               "                AND (subject_type = 'role'"
-               "                     AND subject"
-               "                         = (SELECT id"
-               "                            FROM roles"
-               "                            WHERE uuid = '%s')));",
-               role_id))
+  if (sql_int (
+        " SELECT EXISTS (SELECT * FROM permissions"
+        "                WHERE name = 'Super'"
+        /*                    Super on everyone. */
+        "                AND (resource = 0)"
+        "                AND subject_location"
+        "                    = " G_STRINGIFY (
+          LOCATION_TABLE) "                AND (subject_type = 'role'"
+                          "                     AND subject"
+                          "                         = (SELECT id"
+                          "                            FROM roles"
+                          "                            WHERE uuid = '%s')));",
+        role_id))
     {
       g_free (quoted_role_id);
       return 1;
@@ -124,37 +121,42 @@ acl_user_can_super_everyone (const char *uuid)
   gchar *quoted_uuid;
 
   quoted_uuid = sql_quote (uuid);
-  if (sql_int (" SELECT EXISTS (SELECT * FROM permissions"
-               "                WHERE name = 'Super'"
-               /*                    Super on everyone. */
-               "                AND (resource = 0)"
-               "                AND subject_location"
-               "                    = " G_STRINGIFY (LOCATION_TABLE)
-               "                AND ((subject_type = 'user'"
-               "                      AND subject"
-               "                          = (SELECT id FROM users"
-               "                             WHERE users.uuid = '%s'))"
-               "                     OR (subject_type = 'group'"
-               "                         AND subject"
-               "                             IN (SELECT DISTINCT \"group\""
-               "                                 FROM group_users"
-               "                                 WHERE \"user\""
-               "                                       = (SELECT id"
-               "                                          FROM users"
-               "                                          WHERE users.uuid"
-               "                                                = '%s')))"
-               "                     OR (subject_type = 'role'"
-               "                         AND subject"
-               "                             IN (SELECT DISTINCT role"
-               "                                 FROM role_users"
-               "                                 WHERE \"user\""
-               "                                       = (SELECT id"
-               "                                          FROM users"
-               "                                          WHERE users.uuid"
-               "                                                = '%s')))));",
-               quoted_uuid,
-               quoted_uuid,
-               quoted_uuid))
+  if (
+    sql_int (
+      " SELECT EXISTS (SELECT * FROM permissions"
+      "                WHERE name = 'Super'"
+      /*                    Super on everyone. */
+      "                AND (resource = 0)"
+      "                AND subject_location"
+      "                    = " G_STRINGIFY (
+        LOCATION_TABLE) "                AND ((subject_type = 'user'"
+                        "                      AND subject"
+                        "                          = (SELECT id FROM users"
+                        "                             WHERE users.uuid = '%s'))"
+                        "                     OR (subject_type = 'group'"
+                        "                         AND subject"
+                        "                             IN (SELECT DISTINCT "
+                        "\"group\""
+                        "                                 FROM group_users"
+                        "                                 WHERE \"user\""
+                        "                                       = (SELECT id"
+                        "                                          FROM users"
+                        "                                          WHERE "
+                        "users.uuid"
+                        "                                                = "
+                        "'%s')))"
+                        "                     OR (subject_type = 'role'"
+                        "                         AND subject"
+                        "                             IN (SELECT DISTINCT role"
+                        "                                 FROM role_users"
+                        "                                 WHERE \"user\""
+                        "                                       = (SELECT id"
+                        "                                          FROM users"
+                        "                                          WHERE "
+                        "users.uuid"
+                        "                                                = "
+                        "'%s')))));",
+      quoted_uuid, quoted_uuid, quoted_uuid))
     {
       g_free (quoted_uuid);
       return 1;
@@ -177,34 +179,33 @@ acl_user_can_everything (const char *user_id)
   int ret;
 
   quoted_user_id = sql_quote (user_id);
-  ret = sql_int ("SELECT count(*) > 0 FROM permissions"
-                 " WHERE resource = 0"
-                 " AND subject_location"
-                 "     = " G_STRINGIFY (LOCATION_TABLE)
-                 " AND ((subject_type = 'user'"
-                 "       AND subject"
-                 "           = (SELECT id FROM users"
-                 "              WHERE users.uuid = '%s'))"
-                 "      OR (subject_type = 'group'"
-                 "          AND subject"
-                 "              IN (SELECT DISTINCT \"group\""
-                 "                  FROM group_users"
-                 "                  WHERE \"user\" = (SELECT id"
-                 "                                    FROM users"
-                 "                                    WHERE users.uuid"
-                 "                                          = '%s')))"
-                 "      OR (subject_type = 'role'"
-                 "          AND subject"
-                 "              IN (SELECT DISTINCT role"
-                 "                  FROM role_users"
-                 "                  WHERE \"user\" = (SELECT id"
-                 "                                    FROM users"
-                 "                                    WHERE users.uuid"
-                 "                                          = '%s'))))"
-                 " AND name = 'Everything';",
-                 quoted_user_id,
-                 quoted_user_id,
-                 quoted_user_id);
+  ret = sql_int (
+    "SELECT count(*) > 0 FROM permissions"
+    " WHERE resource = 0"
+    " AND subject_location"
+    "     = " G_STRINGIFY (
+      LOCATION_TABLE) " AND ((subject_type = 'user'"
+                      "       AND subject"
+                      "           = (SELECT id FROM users"
+                      "              WHERE users.uuid = '%s'))"
+                      "      OR (subject_type = 'group'"
+                      "          AND subject"
+                      "              IN (SELECT DISTINCT \"group\""
+                      "                  FROM group_users"
+                      "                  WHERE \"user\" = (SELECT id"
+                      "                                    FROM users"
+                      "                                    WHERE users.uuid"
+                      "                                          = '%s')))"
+                      "      OR (subject_type = 'role'"
+                      "          AND subject"
+                      "              IN (SELECT DISTINCT role"
+                      "                  FROM role_users"
+                      "                  WHERE \"user\" = (SELECT id"
+                      "                                    FROM users"
+                      "                                    WHERE users.uuid"
+                      "                                          = '%s'))))"
+                      " AND name = 'Everything';",
+    quoted_user_id, quoted_user_id, quoted_user_id);
   g_free (quoted_user_id);
   return ret;
 }
@@ -223,55 +224,58 @@ acl_user_has_super (const char *super_user_id, user_t other_user)
   gchar *quoted_super_user_id;
 
   quoted_super_user_id = sql_quote (super_user_id);
-  if (sql_int (" SELECT EXISTS (SELECT * FROM permissions"
-               "                WHERE name = 'Super'"
-               /*                    Super on everyone. */
-               "                AND ((resource = 0)"
-               /*                    Super on other_user. */
-               "                     OR ((resource_type = 'user')"
-               "                         AND (resource = %llu))"
-               /*                    Super on other_user's role. */
-               "                     OR ((resource_type = 'role')"
-               "                         AND (resource"
-               "                              IN (SELECT DISTINCT role"
-               "                                  FROM role_users"
-               "                                  WHERE \"user\" = %llu)))"
-               /*                    Super on other_user's group. */
-               "                     OR ((resource_type = 'group')"
-               "                         AND (resource"
-               "                              IN (SELECT DISTINCT \"group\""
-               "                                  FROM group_users"
-               "                                  WHERE \"user\" = %llu))))"
-               "                AND subject_location"
-               "                    = " G_STRINGIFY (LOCATION_TABLE)
-               "                AND ((subject_type = 'user'"
-               "                      AND subject"
-               "                          = (SELECT id FROM users"
-               "                             WHERE users.uuid = '%s'))"
-               "                     OR (subject_type = 'group'"
-               "                         AND subject"
-               "                             IN (SELECT DISTINCT \"group\""
-               "                                 FROM group_users"
-               "                                 WHERE \"user\""
-               "                                       = (SELECT id"
-               "                                          FROM users"
-               "                                          WHERE users.uuid"
-               "                                                = '%s')))"
-               "                     OR (subject_type = 'role'"
-               "                         AND subject"
-               "                             IN (SELECT DISTINCT role"
-               "                                 FROM role_users"
-               "                                 WHERE \"user\""
-               "                                       = (SELECT id"
-               "                                          FROM users"
-               "                                          WHERE users.uuid"
-               "                                                = '%s')))));",
-               other_user,
-               other_user,
-               other_user,
-               super_user_id,
-               super_user_id,
-               super_user_id))
+  if (
+    sql_int (
+      " SELECT EXISTS (SELECT * FROM permissions"
+      "                WHERE name = 'Super'"
+      /*                    Super on everyone. */
+      "                AND ((resource = 0)"
+      /*                    Super on other_user. */
+      "                     OR ((resource_type = 'user')"
+      "                         AND (resource = %llu))"
+      /*                    Super on other_user's role. */
+      "                     OR ((resource_type = 'role')"
+      "                         AND (resource"
+      "                              IN (SELECT DISTINCT role"
+      "                                  FROM role_users"
+      "                                  WHERE \"user\" = %llu)))"
+      /*                    Super on other_user's group. */
+      "                     OR ((resource_type = 'group')"
+      "                         AND (resource"
+      "                              IN (SELECT DISTINCT \"group\""
+      "                                  FROM group_users"
+      "                                  WHERE \"user\" = %llu))))"
+      "                AND subject_location"
+      "                    = " G_STRINGIFY (
+        LOCATION_TABLE) "                AND ((subject_type = 'user'"
+                        "                      AND subject"
+                        "                          = (SELECT id FROM users"
+                        "                             WHERE users.uuid = '%s'))"
+                        "                     OR (subject_type = 'group'"
+                        "                         AND subject"
+                        "                             IN (SELECT DISTINCT "
+                        "\"group\""
+                        "                                 FROM group_users"
+                        "                                 WHERE \"user\""
+                        "                                       = (SELECT id"
+                        "                                          FROM users"
+                        "                                          WHERE "
+                        "users.uuid"
+                        "                                                = "
+                        "'%s')))"
+                        "                     OR (subject_type = 'role'"
+                        "                         AND subject"
+                        "                             IN (SELECT DISTINCT role"
+                        "                                 FROM role_users"
+                        "                                 WHERE \"user\""
+                        "                                       = (SELECT id"
+                        "                                          FROM users"
+                        "                                          WHERE "
+                        "users.uuid"
+                        "                                                = "
+                        "'%s')))));",
+      other_user, other_user, other_user, super_user_id, super_user_id,
+      super_user_id))
     {
       g_free (quoted_super_user_id);
       return 1;
@@ -380,57 +384,61 @@ acl_user_is_user (const char *uuid)
  *
  * @param[in]  format  Value format specifier.
  */
-#define ACL_SUPER_CLAUSE(format)                                          \
-  "                name = 'Super'"                                        \
-  /*                    Super on everyone. */                             \
-  "                AND ((resource = 0)"                                   \
-  /*                    Super on other_user. */                           \
-  "                     OR ((resource_type = 'user')"                     \
-  "                         AND (resource = (SELECT %ss%s.owner"          \
-  "                                          FROM %ss%s"                  \
-  "                                          WHERE %s = " format ")))"    \
-  /*                    Super on other_user's role. */                    \
-  "                     OR ((resource_type = 'role')"                     \
-  "                         AND (resource"                                \
-  "                              IN (SELECT DISTINCT role"                \
-  "                                  FROM role_users"                     \
-  "                                  WHERE \"user\""                      \
-  "                                        = (SELECT %ss%s.owner"         \
-  "                                           FROM %ss%s"                 \
-  "                                           WHERE %s"                   \
-  "                                                 = " format "))))"     \
-  /*                    Super on other_user's group. */                   \
-  "                     OR ((resource_type = 'group')"                    \
-  "                         AND (resource"                                \
-  "                              IN (SELECT DISTINCT \"group\""           \
-  "                                  FROM group_users"                    \
-  "                                  WHERE \"user\""                      \
-  "                                        = (SELECT %ss%s.owner"         \
-  "                                           FROM %ss%s"                 \
-  "                                           WHERE %s = " format ")))))" \
-  "                AND subject_location = " G_STRINGIFY (LOCATION_TABLE)  \
-  "                AND ((subject_type = 'user'"                           \
-  "                      AND subject"                                     \
-  "                          = (SELECT id FROM users"                     \
-  "                             WHERE users.uuid = '%s'))"                \
-  "                     OR (subject_type = 'group'"                       \
-  "                         AND subject"                                  \
-  "                             IN (SELECT DISTINCT \"group\""            \
-  "                                 FROM group_users"                     \
-  "                                 WHERE \"user\""                       \
-  "                                       = (SELECT id"                   \
-  "                                          FROM users"                  \
-  "                                          WHERE users.uuid"            \
-  "                                                = '%s')))"             \
-  "                     OR (subject_type = 'role'"                        \
-  "                         AND subject"                                  \
-  "                             IN (SELECT DISTINCT role"                 \
-  "                                 FROM role_users"                      \
-  "                                 WHERE \"user\""                       \
-  "                                       = (SELECT id"                   \
-  "                                          FROM users"                  \
-  "                                          WHERE users.uuid"            \
-  "                                                = '%s'))))"
+#define ACL_SUPER_CLAUSE(format)                                               \
+  "                name = 'Super'" /*                    Super on everyone. */ \
+  "                AND ((resource = 0)" /*                    Super on         \
+                                           other_user. */                      \
+  "                     OR ((resource_type = 'user')"                          \
+  "                         AND (resource = (SELECT %ss%s.owner"               \
+  "                                          FROM %ss%s"                       \
+  "                                          WHERE %s = " format               \
+  ")))" /*                    Super on other_user's role. */                   \
+  "                     OR ((resource_type = 'role')"                          \
+  "                         AND (resource"                                     \
+  "                              IN (SELECT DISTINCT role"                     \
+  "                                  FROM role_users"                          \
+  "                                  WHERE \"user\""                           \
+  "                                        = (SELECT %ss%s.owner"              \
+  "                                           FROM %ss%s"                      \
+  "                                           WHERE %s"                        \
+  "                                                 = " format                 \
+  "))))" /*                    Super on other_user's group. */                 \
+  "                     OR ((resource_type = 'group')"                         \
+  "                         AND (resource"                                     \
+  "                              IN (SELECT DISTINCT \"group\""                \
+  "                                  FROM group_users"                         \
+  "                                  WHERE \"user\""                           \
+  "                                        = (SELECT %ss%s.owner"              \
+  "                                           FROM %ss%s"                      \
+  "                                           WHERE %s = " format ")))))"      \
+  "                AND subject_location = " G_STRINGIFY (                      \
+    LOCATION_TABLE) "                AND ((subject_type = 'user'"              \
+                    "                      AND subject"                        \
+                    "                          = (SELECT id FROM users"        \
+                    "                             WHERE users.uuid = '%s'))"   \
+                    "                     OR (subject_type = 'group'"          \
+                    "                         AND subject"                     \
+                    "                             IN (SELECT DISTINCT "        \
+                    "\"group\""                                                \
+                    "                                 FROM group_users"        \
+                    "                                 WHERE \"user\""          \
+                    "                                       = (SELECT id"      \
+                    "                                          FROM users"     \
+                    "                                          WHERE "         \
+                    "users.uuid"                                               \
+                    "                                                = "       \
+                    "'%s')))"                                                  \
+                    "                     OR (subject_type = 'role'"           \
+                    "                         AND subject"                     \
+                    "                             IN (SELECT DISTINCT role"    \
+                    "                                 FROM role_users"         \
+                    "                                 WHERE \"user\""          \
+                    "                                       = (SELECT id"      \
+                    "                                          FROM users"     \
+                    "                                          WHERE "         \
+                    "users.uuid"                                               \
+                    "                                                = "       \
+                    "'%s'))))"
 
 /**
  * @brief Super clause arguments.
@@ -441,28 +449,14 @@ acl_user_is_user (const char *uuid)
  * @param[in]  user_id  UUID of user.
  * @param[in]  trash    Whether to search trash.
  */
-#define ACL_SUPER_CLAUSE_ARGS(type, field, value, user_id, trash) \
-  type,                                                       \
-  trash ? (strcasecmp (type, "task") ? "_trash" : "") : "",   \
-  type,                                                       \
-  trash ? (strcasecmp (type, "task") ? "_trash" : "") : "",   \
-  field,                                                      \
-  value,                                                      \
-  type,                                                       \
-  trash ? (strcasecmp (type, "task") ? "_trash" : "") : "",   \
-  type,                                                       \
-  trash ? (strcasecmp (type, "task") ? "_trash" : "") : "",   \
-  field,                                                      \
-  value,                                                      \
-  type,                                                       \
-  trash ? (strcasecmp (type, "task") ? "_trash" : "") : "",   \
-  type,                                                       \
-  trash ? (strcasecmp (type, "task") ? "_trash" : "") : "",   \
-  field,                                                      \
-  value,                                                      \
-  user_id,                                                    \
-  user_id,                                                    \
-  user_id
+#define ACL_SUPER_CLAUSE_ARGS(type, field, value, user_id, trash)           \
+  type, trash ? (strcasecmp (type, "task") ? "_trash" : "") : "", type,     \
+    trash ? (strcasecmp (type, "task") ? "_trash" : "") : "", field, value, \
+    type, trash ? (strcasecmp (type, "task") ? "_trash" : "") : "", type,   \
+    trash ? (strcasecmp (type, "task") ? "_trash" : "") : "", field, value, \
+    type, trash ? (strcasecmp (type, "task") ? "_trash" : "") : "", type,   \
+    trash ? (strcasecmp (type, "task") ? "_trash" : "") : "", field, value, \
+    user_id, user_id, user_id
 
 /**
  * @brief Test whether a user has Super permission on a resource.
@@ -535,9 +529,7 @@ acl_user_is_owner (const char *type, const char *uuid)
                  " WHERE uuid = '%s'"
                  " AND owner = (SELECT users.id FROM users"
                  "              WHERE users.uuid = '%s');",
-                 type,
-                 quoted_uuid,
-                 current_credentials.uuid);
+                 type, quoted_uuid, current_credentials.uuid);
   g_free (quoted_uuid);
 
   return ret;
@@ -563,10 +555,8 @@ acl_user_owns_uuid (const char *type, const char *uuid, int trash)
 
   assert (current_credentials.uuid);
 
-  if ((strcmp (type, "nvt") == 0)
-      || (strcmp (type, "cve") == 0)
-      || (strcmp (type, "cpe") == 0)
-      || (strcmp (type, "ovaldef") == 0)
+  if ((strcmp (type, "nvt") == 0) || (strcmp (type, "cve") == 0)
+      || (strcmp (type, "cpe") == 0) || (strcmp (type, "ovaldef") == 0)
       || (strcmp (type, "cert_bund_adv") == 0)
       || (strcmp (type, "dfn_cert_adv") == 0))
     return 1;
@@ -581,37 +571,32 @@ acl_user_owns_uuid (const char *type, const char *uuid, int trash)
                    " AND results.report = reports.id"
                    " AND (reports.owner = (SELECT users.id FROM users"
                    "                       WHERE users.uuid = '%s'));",
-                   quoted_uuid,
-                   current_credentials.uuid);
+                   quoted_uuid, current_credentials.uuid);
   else if (strcmp (type, "report") == 0)
     ret = sql_int ("SELECT count(*) FROM reports"
                    " WHERE uuid = '%s'"
                    " AND (owner = (SELECT users.id FROM users"
                    "               WHERE users.uuid = '%s'));",
-                   quoted_uuid,
-                   current_credentials.uuid);
+                   quoted_uuid, current_credentials.uuid);
   else if (strcmp (type, "permission") == 0)
-    ret = sql_int ("SELECT count(*) FROM permissions%s"
-                   " WHERE uuid = '%s'"
-                   " AND ((owner IS NULL)"
-                   "      OR (owner = (SELECT users.id FROM users"
-                   "                   WHERE users.uuid = '%s')));",
-                   trash ? "_trash" : "",
-                   quoted_uuid,
-                   current_credentials.uuid);
+    ret =
+      sql_int ("SELECT count(*) FROM permissions%s"
+               " WHERE uuid = '%s'"
+               " AND ((owner IS NULL)"
+               "      OR (owner = (SELECT users.id FROM users"
+               "                   WHERE users.uuid = '%s')));",
+               trash ? "_trash" : "", quoted_uuid, current_credentials.uuid);
   else
-    ret = sql_int ("SELECT count(*) FROM %ss%s"
-                   " WHERE uuid = '%s'"
-                   "%s"
-                   " AND (owner = (SELECT users.id FROM users"
-                   "               WHERE users.uuid = '%s'));",
-                   type,
-                   (strcmp (type, "task") && trash) ? "_trash" : "",
-                   quoted_uuid,
-                   (strcmp (type, "task")
-                     ? ""
-                     : (trash ? " AND hidden = 2" : " AND hidden < 2")),
-                   current_credentials.uuid);
+    ret = sql_int (
+      "SELECT count(*) FROM %ss%s"
+      " WHERE uuid = '%s'"
+      "%s"
+      " AND (owner = (SELECT users.id FROM users"
+      "               WHERE users.uuid = '%s'));",
+      type, (strcmp (type, "task") && trash) ? "_trash" : "", quoted_uuid,
+      (strcmp (type, "task") ? ""
+                             : (trash ? " AND hidden = 2" : " AND hidden < 2")),
+      current_credentials.uuid);
   g_free (quoted_uuid);
 
   return ret;
@@ -636,10 +621,8 @@ acl_user_owns (const char *type, resource_t resource, int trash)
 
   assert (current_credentials.uuid);
 
-  if ((strcmp (type, "nvt") == 0)
-      || (strcmp (type, "cve") == 0)
-      || (strcmp (type, "cpe") == 0)
-      || (strcmp (type, "ovaldef") == 0)
+  if ((strcmp (type, "nvt") == 0) || (strcmp (type, "cve") == 0)
+      || (strcmp (type, "cpe") == 0) || (strcmp (type, "ovaldef") == 0)
       || (strcmp (type, "cert_bund_adv") == 0)
       || (strcmp (type, "dfn_cert_adv") == 0))
     return 1;
@@ -653,21 +636,18 @@ acl_user_owns (const char *type, resource_t resource, int trash)
                    " AND results.report = reports.id"
                    " AND (reports.owner = (SELECT users.id FROM users"
                    "                       WHERE users.uuid = '%s'));",
-                   resource,
-                   current_credentials.uuid);
+                   resource, current_credentials.uuid);
   else
-    ret = sql_int ("SELECT count(*) FROM %ss%s"
-                   " WHERE id = %llu"
-                   "%s"
-                   " AND (owner = (SELECT users.id FROM users"
-                   "               WHERE users.uuid = '%s'));",
-                   type,
-                   (strcmp (type, "task") && trash) ? "_trash" : "",
-                   resource,
-                   (strcmp (type, "task")
-                     ? ""
-                     : (trash ? " AND hidden = 2" : " AND hidden < 2")),
-                   current_credentials.uuid);
+    ret = sql_int (
+      "SELECT count(*) FROM %ss%s"
+      " WHERE id = %llu"
+      "%s"
+      " AND (owner = (SELECT users.id FROM users"
+      "               WHERE users.uuid = '%s'));",
+      type, (strcmp (type, "task") && trash) ? "_trash" : "", resource,
+      (strcmp (type, "task") ? ""
+                             : (trash ? " AND hidden = 2" : " AND hidden < 2")),
+      current_credentials.uuid);
 
   return ret;
 }
@@ -700,9 +680,7 @@ acl_user_owns_trash_uuid (const char *type, const char *uuid)
                  " WHERE uuid = '%s'"
                  " AND (owner = (SELECT users.id FROM users"
                  "               WHERE users.uuid = '%s'));",
-                 type,
-                 quoted_uuid,
-                 current_credentials.uuid);
+                 type, quoted_uuid, current_credentials.uuid);
   g_free (quoted_uuid);
 
   return ret;
@@ -731,7 +709,7 @@ acl_user_has_access_uuid (const char *type, const char *uuid,
   if (permission && (valid_gmp_command (permission) == 0))
     return 0;
 
-  if (!strcmp (current_credentials.uuid,  ""))
+  if (!strcmp (current_credentials.uuid, ""))
     return 1;
 
   /* The Super case is checked here. */
@@ -749,22 +727,21 @@ acl_user_has_access_uuid (const char *type, const char *uuid,
       task_t task;
       report_t report;
 
-      switch (sql_int64 (&report,
-                         "SELECT id FROM reports WHERE uuid = '%s';",
+      switch (sql_int64 (&report, "SELECT id FROM reports WHERE uuid = '%s';",
                          quoted_uuid))
         {
-          case 0:
-            break;
-          case 1:        /* Too few rows in result of query. */
-            g_free (quoted_uuid);
-            return 0;
-            break;
-          default:       /* Programming error. */
-            assert (0);
-          case -1:
-            g_free (quoted_uuid);
-            return 0;
-            break;
+        case 0:
+          break;
+        case 1: /* Too few rows in result of query. */
+          g_free (quoted_uuid);
+          return 0;
+          break;
+        default: /* Programming error. */
+          assert (0);
+        case -1:
+          g_free (quoted_uuid);
+          return 0;
+          break;
         }
 
       report_task (report, &task);
@@ -779,22 +756,21 @@ acl_user_has_access_uuid (const char *type, const char *uuid,
     {
       task_t task;
 
-      switch (sql_int64 (&task,
-                         "SELECT task FROM results WHERE uuid = '%s';",
-                         uuid))
+      switch (
+        sql_int64 (&task, "SELECT task FROM results WHERE uuid = '%s';", uuid))
         {
-          case 0:
-            break;
-          case 1:        /* Too few rows in result of query. */
-            g_free (quoted_uuid);
-            return 0;
-            break;
-          default:       /* Programming error. */
-            assert (0);
-          case -1:
-            g_free (quoted_uuid);
-            return 0;
-            break;
+        case 0:
+          break;
+        case 1: /* Too few rows in result of query. */
+          g_free (quoted_uuid);
+          return 0;
+          break;
+        default: /* Programming error. */
+          assert (0);
+        case -1:
+          g_free (quoted_uuid);
+          return 0;
+          break;
         }
 
       task_uuid (task, &uuid_task);
@@ -806,37 +782,37 @@ acl_user_has_access_uuid (const char *type, const char *uuid,
       && ((permission == NULL)
           || (strlen (permission) > 3 && strncmp (permission, "get", 3) == 0)))
     {
-      ret = sql_int ("SELECT count(*) FROM permissions"
-                     /* Any permission implies 'get'. */
-                     " WHERE (resource_uuid = '%s'"
-                     /* Users may view any permissions that affect them. */
-                     "        OR uuid = '%s')"
-                     " AND subject_location = " G_STRINGIFY (LOCATION_TABLE)
-                     " AND ((subject_type = 'user'"
-                     "       AND subject"
-                     "           = (SELECT id FROM users"
-                     "              WHERE users.uuid = '%s'))"
-                     "      OR (subject_type = 'group'"
-                     "          AND subject"
-                     "              IN (SELECT DISTINCT \"group\""
-                     "                  FROM group_users"
-                     "                  WHERE \"user\" = (SELECT id"
-                     "                                    FROM users"
-                     "                                    WHERE users.uuid"
-                     "                                          = '%s')))"
-                     "      OR (subject_type = 'role'"
-                     "          AND subject"
-                     "              IN (SELECT DISTINCT role"
-                     "                  FROM role_users"
-                     "                  WHERE \"user\" = (SELECT id"
-                     "                                    FROM users"
-                     "                                    WHERE users.uuid"
-                     "                                          = '%s'))));",
-                     uuid_task ? uuid_task : quoted_uuid,
-                     uuid_task ? uuid_task : quoted_uuid,
-                     current_credentials.uuid,
-                     current_credentials.uuid,
-                     current_credentials.uuid);
+      ret = sql_int (
+        "SELECT count(*) FROM permissions"
+        /* Any permission implies 'get'. */
+        " WHERE (resource_uuid = '%s'"
+        /* Users may view any permissions that affect them. */
+        "        OR uuid = '%s')"
+        " AND subject_location = " G_STRINGIFY (
+          LOCATION_TABLE) " AND ((subject_type = 'user'"
+                          "       AND subject"
+                          "           = (SELECT id FROM users"
+                          "              WHERE users.uuid = '%s'))"
+                          "      OR (subject_type = 'group'"
+                          "          AND subject"
+                          "              IN (SELECT DISTINCT \"group\""
+                          "                  FROM group_users"
+                          "                  WHERE \"user\" = (SELECT id"
+                          "                                    FROM users"
+                          "                                    WHERE users.uuid"
+                          "                                          = '%s')))"
+                          "      OR (subject_type = 'role'"
+                          "          AND subject"
+                          "              IN (SELECT DISTINCT role"
+                          "                  FROM role_users"
+                          "                  WHERE \"user\" = (SELECT id"
+                          "                                    FROM users"
+                          "                                    WHERE users.uuid"
+                          "                                          = "
+                          "'%s'))));",
+        uuid_task ? uuid_task : quoted_uuid,
+        uuid_task ? uuid_task : quoted_uuid, current_credentials.uuid,
+        current_credentials.uuid, current_credentials.uuid);
       free (uuid_task);
       g_free (quoted_uuid);
       return ret;
@@ -855,37 +831,35 @@ acl_user_has_access_uuid (const char *type, const char *uuid,
          || (strlen (permission) > 3 && strncmp (permission, "get", 3) == 0));
   quoted_permission = sql_quote (permission ? permission : "");
 
-  ret = sql_int ("SELECT count(*) FROM permissions"
-                 " WHERE resource_uuid = '%s'"
-                 " AND subject_location = " G_STRINGIFY (LOCATION_TABLE)
-                 " AND ((subject_type = 'user'"
-                 "       AND subject"
-                 "           = (SELECT id FROM users"
-                 "              WHERE users.uuid = '%s'))"
-                 "      OR (subject_type = 'group'"
-                 "          AND subject"
-                 "              IN (SELECT DISTINCT \"group\""
-                 "                  FROM group_users"
-                 "                  WHERE \"user\" = (SELECT id"
-                 "                                    FROM users"
-                 "                                    WHERE users.uuid"
-                 "                                          = '%s')))"
-                 "      OR (subject_type = 'role'"
-                 "          AND subject"
-                 "              IN (SELECT DISTINCT role"
-                 "                  FROM role_users"
-                 "                  WHERE \"user\" = (SELECT id"
-                 "                                    FROM users"
-                 "                                    WHERE users.uuid"
-                 "                                          = '%s'))))"
-                 " %s%s%s;",
-                 uuid_task ? uuid_task : quoted_uuid,
-                 current_credentials.uuid,
-                 current_credentials.uuid,
-                 current_credentials.uuid,
-                 (get ? "" : "AND name = '"),
-                 (get ? "" : quoted_permission),
-                 (get ? "" : "'"));
+  ret = sql_int (
+    "SELECT count(*) FROM permissions"
+    " WHERE resource_uuid = '%s'"
+    " AND subject_location = " G_STRINGIFY (
+      LOCATION_TABLE) " AND ((subject_type = 'user'"
+                      "       AND subject"
+                      "           = (SELECT id FROM users"
+                      "              WHERE users.uuid = '%s'))"
+                      "      OR (subject_type = 'group'"
+                      "          AND subject"
+                      "              IN (SELECT DISTINCT \"group\""
+                      "                  FROM group_users"
+                      "                  WHERE \"user\" = (SELECT id"
+                      "                                    FROM users"
+                      "                                    WHERE users.uuid"
+                      "                                          = '%s')))"
+                      "      OR (subject_type = 'role'"
+                      "          AND subject"
+                      "              IN (SELECT DISTINCT role"
+                      "                  FROM role_users"
+                      "                  WHERE \"user\" = (SELECT id"
+                      "                                    FROM users"
+                      "                                    WHERE users.uuid"
+                      "                                          = '%s'))))"
+                      " %s%s%s;",
+    uuid_task ? uuid_task : quoted_uuid, current_credentials.uuid,
+    current_credentials.uuid, current_credentials.uuid,
+    (get ? "" : "AND name = '"), (get ? "" : quoted_permission),
+    (get ? "" : "'"));
 
   free (uuid_task);
   g_free (quoted_permission);
@@ -924,7 +898,7 @@ acl_where_owned_user (const char *user_id, const char *user_sql,
     *with = NULL;
 
   if (owned == 0)
-   return g_strdup (" t ()");
+    return g_strdup (" t ()");
 
   permission_or = g_string_new ("");
   index = 0;
@@ -938,7 +912,7 @@ acl_where_owned_user (const char *user_id, const char *user_sql,
     for (; index < permissions->len; index++)
       {
         gchar *permission, *quoted;
-        permission = (gchar*) g_ptr_array_index (permissions, index);
+        permission = (gchar *) g_ptr_array_index (permissions, index);
         if (strcasecmp (permission, "any") == 0)
           {
             g_string_free (permission_or, TRUE);
@@ -950,107 +924,97 @@ acl_where_owned_user (const char *user_id, const char *user_sql,
         if (index == 0)
           g_string_append_printf (permission_or, "name = '%s'", quoted);
         else
-          g_string_append_printf (permission_or, " OR name = '%s'",
-                                  quoted);
+          g_string_append_printf (permission_or, " OR name = '%s'", quoted);
         g_free (quoted);
       }
 
   table_trash = get->trash && strcasecmp (type, "task");
   if (resource || (user_id == NULL))
-    owned_clause
-     = g_strdup (" (t ())");
+    owned_clause = g_strdup (" (t ())");
   else if (with)
     {
       gchar *permission_clause;
 
       /* Caller supports WITH clause. */
 
-      *with = g_strdup_printf
-               ("WITH permissions_subject"
-                "     AS (SELECT * FROM permissions"
-                "         WHERE subject_location"
-                "               = " G_STRINGIFY (LOCATION_TABLE)
-                "         AND ((subject_type = 'user'"
-                "               AND subject"
-                "                   = (%s))"
-                "              OR (subject_type = 'group'"
-                "                  AND subject"
-                "                      IN (SELECT DISTINCT \"group\""
-                "                          FROM group_users"
-                "                          WHERE \"user\""
-                "                                = (%s)))"
-                "              OR (subject_type = 'role'"
-                "                  AND subject"
-                "                      IN (SELECT DISTINCT role"
-                "                          FROM role_users"
-                "                          WHERE \"user\""
-                "                                = (%s))))),"
-                "     super_on_users"
-                "     AS (SELECT DISTINCT *"
-                "         FROM (SELECT resource FROM permissions_subject"
-                "               WHERE name = 'Super'"
-                "               AND resource_type = 'user'"
-                "               UNION"
-                "               SELECT \"user\" FROM role_users"
-                "               WHERE role"
-                "                     IN (SELECT resource"
-                "                         FROM permissions_subject"
-                "                         WHERE name = 'Super'"
-                "                         AND resource_type = 'role')"
-                "               UNION"
-                "               SELECT \"user\" FROM group_users"
-                "               WHERE \"group\""
-                "                     IN (SELECT resource"
-                "                         FROM permissions_subject"
-                "                         WHERE name = 'Super'"
-                "                         AND resource_type = 'group'))"
-                "              AS all_users)",
-                user_sql,
-                user_sql,
-                user_sql);
+      *with = g_strdup_printf (
+        "WITH permissions_subject"
+        "     AS (SELECT * FROM permissions"
+        "         WHERE subject_location"
+        "               = " G_STRINGIFY (
+          LOCATION_TABLE) "         AND ((subject_type = 'user'"
+                          "               AND subject"
+                          "                   = (%s))"
+                          "              OR (subject_type = 'group'"
+                          "                  AND subject"
+                          "                      IN (SELECT DISTINCT \"group\""
+                          "                          FROM group_users"
+                          "                          WHERE \"user\""
+                          "                                = (%s)))"
+                          "              OR (subject_type = 'role'"
+                          "                  AND subject"
+                          "                      IN (SELECT DISTINCT role"
+                          "                          FROM role_users"
+                          "                          WHERE \"user\""
+                          "                                = (%s))))),"
+                          "     super_on_users"
+                          "     AS (SELECT DISTINCT *"
+                          "         FROM (SELECT resource FROM "
+                          "permissions_subject"
+                          "               WHERE name = 'Super'"
+                          "               AND resource_type = 'user'"
+                          "               UNION"
+                          "               SELECT \"user\" FROM role_users"
+                          "               WHERE role"
+                          "                     IN (SELECT resource"
+                          "                         FROM permissions_subject"
+                          "                         WHERE name = 'Super'"
+                          "                         AND resource_type = 'role')"
+                          "               UNION"
+                          "               SELECT \"user\" FROM group_users"
+                          "               WHERE \"group\""
+                          "                     IN (SELECT resource"
+                          "                         FROM permissions_subject"
+                          "                         WHERE name = 'Super'"
+                          "                         AND resource_type = "
+                          "'group'))"
+                          "              AS all_users)",
+        user_sql, user_sql, user_sql);
 
       permission_clause = NULL;
       if (user_id && index)
         {
           gchar *clause;
-          clause
-           = g_strdup_printf ("OR EXISTS"
-                              " (SELECT id FROM permissions_subject"
-                              "  WHERE resource = %ss%s.id"
-                              "  AND resource_type = '%s'"
-                              "  AND resource_location = %i"
-                              "  AND (%s))",
-                              type,
-                              get->trash && strcmp (type, "task") ? "_trash" : "",
-                              type,
-                              get->trash ? LOCATION_TRASH : LOCATION_TABLE,
-                              permission_or->str);
+          clause = g_strdup_printf (
+            "OR EXISTS"
+            " (SELECT id FROM permissions_subject"
+            "  WHERE resource = %ss%s.id"
+            "  AND resource_type = '%s'"
+            "  AND resource_location = %i"
+            "  AND (%s))",
+            type, get->trash && strcmp (type, "task") ? "_trash" : "", type,
+            get->trash ? LOCATION_TRASH : LOCATION_TABLE, permission_or->str);
 
           if (strcmp (type, "report") == 0)
-            permission_clause
-             = g_strdup_printf ("%s"
-                                " OR EXISTS"
-                                " (SELECT id FROM permissions_subject"
-                                "  WHERE resource = reports%s.task"
-                                "  AND resource_type = 'task'"
-                                "  AND (%s))",
-                                clause,
-                                get->trash ? "_trash" : "",
-                                permission_or->str);
+            permission_clause = g_strdup_printf (
+              "%s"
+              " OR EXISTS"
+              " (SELECT id FROM permissions_subject"
+              "  WHERE resource = reports%s.task"
+              "  AND resource_type = 'task'"
+              "  AND (%s))",
+              clause, get->trash ? "_trash" : "", permission_or->str);
           else if (strcmp (type, "result") == 0)
-            permission_clause
-             = g_strdup_printf ("%s"
-                                " OR EXISTS"
-                                " (SELECT id FROM permissions_subject"
-                                "  WHERE resource = results%s.task"
-                                "  AND resource_type = 'task'"
-                                "  AND (%s))",
-                                clause,
-                                get->trash ? "_trash" : "",
-                                permission_or->str);
+            permission_clause = g_strdup_printf (
+              "%s"
+              " OR EXISTS"
+              " (SELECT id FROM permissions_subject"
+              "  WHERE resource = results%s.task"
+              "  AND resource_type = 'task'"
+              "  AND (%s))",
+              clause, get->trash ? "_trash" : "", permission_or->str);
 
-          if ((strcmp (type, "report") == 0)
-              || (strcmp (type, "result") == 0))
+          if ((strcmp (type, "report") == 0) || (strcmp (type, "result") == 0))
             g_free (clause);
           else
             permission_clause = clause;
@@ -1063,91 +1027,111 @@ acl_where_owned_user (const char *user_id, const char *user_sql,
           admin = acl_user_can_everything (user_id);
           /* A user sees permissions that involve the user.  Admin users also
            * see all higher level permissions. */
-          owned_clause
-           = g_strdup_printf (/* Either the user is the owner. */
-                              " ((permissions%s.owner = (%s))"
-                              /* Or, for admins, it's a global permission. */
-                              "  %s"
-                              /* Or the permission applies to the user. */
-                              "  OR (%i = 0" /* Skip for trash. */
-                              "      AND (permissions%s.subject_type = 'user'"
-                              "           AND permissions%s.subject_location"
-                              "               = " G_STRINGIFY (LOCATION_TABLE)
-                              "           AND permissions%s.subject"
-                              "               = (%s)))"
-                              /* Or the permission applies to the user's group. */
-                              "  OR (%i = 0" /* Skip for trash. */
-                              "      AND (permissions%s.subject_type = 'group'"
-                              "           AND permissions%s.subject_location"
-                              "               = " G_STRINGIFY (LOCATION_TABLE)
-                              "           AND permissions%s.subject"
-                              "               IN (SELECT DISTINCT \"group\""
-                              "                   FROM group_users"
-                              "                   WHERE \"user\" = (%s))))"
-                              /* Or the permission applies to the user's role. */
-                              "  OR (%i = 0" /* Skip for trash. */
-                              "      AND (permissions%s.subject_type = 'role'"
-                              "           AND permissions%s.subject_location"
-                              "               = " G_STRINGIFY (LOCATION_TABLE)
-                              "           AND permissions%s.subject"
-                              "               IN (SELECT DISTINCT role"
-                              "                   FROM role_users"
-                              "                   WHERE \"user\" = (%s))))"
-                              /* Or the user has super permission on all. */
-                              "  OR EXISTS (SELECT * FROM permissions_subject"
-                              "             WHERE name = 'Super'"
-                              "             AND (resource = 0))"
-                              /* Or the user has super permission on the owner,
-                               * (directly, via the role, or via the group). */
-                              "  OR permissions%s.owner IN (SELECT *"
-                              "                            FROM super_on_users)"
-                              "  %s)",
-                              get->trash ? "_trash" : "",
-                              user_sql,
-                              admin
-                               ? (get->trash
-                                   ? "OR (permissions_trash.owner IS NULL)"
-                                   : "OR (permissions.owner IS NULL)")
-                               : "",
-                              get->trash,
-                              table_trash ? "_trash" : "",
-                              table_trash ? "_trash" : "",
-                              table_trash ? "_trash" : "",
-                              user_sql,
-                              get->trash,
-                              table_trash ? "_trash" : "",
-                              table_trash ? "_trash" : "",
-                              table_trash ? "_trash" : "",
-                              user_sql,
-                              get->trash,
-                              table_trash ? "_trash" : "",
-                              table_trash ? "_trash" : "",
-                              table_trash ? "_trash" : "",
-                              user_sql,
-                              table_trash ? "_trash" : "",
-                              permission_clause ? permission_clause : "");
+          owned_clause =
+            g_strdup_printf (/* Either the user is the owner. */
+                             " ((permissions%s.owner = (%s))"
+                             /* Or, for admins, it's a global permission. */
+                             "  %s"
+                             /* Or the permission applies to the user. */
+                             "  OR (%i = 0" /* Skip for trash. */
+                             "      AND (permissions%s.subject_type = 'user'"
+                             "           AND permissions%s.subject_location"
+                             "               = " G_STRINGIFY (
+                               LOCATION_TABLE) "           AND "
+                                               "permissions%s.subject"
+                                               "               = (%s)))"
+                                               /* Or the permission applies to
+                                                  the user's group. */
+                                               "  OR (%i = 0" /* Skip for trash.
+                                                               */
+                                               "      AND "
+                                               "(permissions%s.subject_type = "
+                                               "'group'"
+                                               "           AND "
+                                               "permissions%s.subject_location"
+                                               "               = " G_STRINGIFY (
+                                                 LOCATION_TABLE) "           "
+                                                                 "AND "
+                                                                 "permissions%"
+                                                                 "s.subject"
+                                                                 "             "
+                                                                 "  IN (SELECT "
+                                                                 "DISTINCT "
+                                                                 "\"group\""
+                                                                 "             "
+                                                                 "      FROM "
+                                                                 "group_users"
+                                                                 "             "
+                                                                 "      WHERE "
+                                                                 "\"user\" = "
+                                                                 "(%s))))"
+                                                                 /* Or the
+                                                                    permission
+                                                                    applies to
+                                                                    the user's
+                                                                    role. */
+                                                                 "  OR (%i = 0" /* Skip for trash. */
+                                                                 "      AND "
+                                                                 "(permissions%"
+                                                                 "s.subject_"
+                                                                 "type = 'role'"
+                                                                 "           "
+                                                                 "AND "
+                                                                 "permissions%"
+                                                                 "s.subject_"
+                                                                 "location"
+                                                                 "             "
+                                                                 "  "
+                                                                 "="
+                                                                 " " G_STRINGIFY (
+                                                                   LOCATION_TABLE) "           AND permissions%s.subject"
+                                                                                   "               IN (SELECT DISTINCT role"
+                                                                                   "                   FROM role_users"
+                                                                                   "                   WHERE \"user\" = (%s))))"
+                                                                                   /* Or the user has super permission on all. */
+                                                                                   "  OR EXISTS (SELECT * FROM permissions_subject"
+                                                                                   "             WHERE name = 'Super'"
+                                                                                   "             AND (resource = 0))"
+                                                                                   /* Or the user has super permission on the owner,
+                                                                                    * (directly, via the role, or via the group). */
+                                                                                   "  OR permissions%s.owner IN (SELECT *"
+                                                                                   "                            FROM super_on_users)"
+                                                                                   "  %s)",
+                             get->trash ? "_trash" : "", user_sql,
+                             admin ? (get->trash
+                                        ? "OR (permissions_trash.owner IS NULL)"
+                                        : "OR (permissions.owner IS NULL)")
+                                   : "",
+                             get->trash, table_trash ? "_trash" : "",
+                             table_trash ? "_trash" : "",
+                             table_trash ? "_trash" : "", user_sql, get->trash,
+                             table_trash ? "_trash" : "",
+                             table_trash ? "_trash" : "",
+                             table_trash ? "_trash" : "", user_sql, get->trash,
+                             table_trash ? "_trash" : "",
+                             table_trash ? "_trash" : "",
+                             table_trash ? "_trash" : "", user_sql,
+                             table_trash ? "_trash" : "",
+                             permission_clause ? permission_clause : "");
         }
       else
         /* Any resource type other than Permissions. */
-        owned_clause
-         = g_strdup_printf (/* Either the user is the owner. */
-                            " ((%ss%s.owner"
-                            "   = (%s))"
-                            /* Or the user has super permission on all. */
-                            "  OR EXISTS (SELECT * FROM permissions_subject"
-                            "             WHERE name = 'Super'"
-                            "             AND (resource = 0))"
-                            /* Or the user has super permission on the owner,
-                             * (directly, via the role, or via the group). */
-                            "  OR %ss%s.owner IN (SELECT *"
-                            "                     FROM super_on_users)"
-                            "  %s)",
-                            type,
-                            table_trash ? "_trash" : "",
-                            user_sql,
-                            type,
-                            table_trash ? "_trash" : "",
-                            permission_clause ? permission_clause : "");
+        owned_clause =
+          g_strdup_printf (/* Either the user is the owner. */
+                           " ((%ss%s.owner"
+                           "   = (%s))"
+                           /* Or the user has super permission on all. */
+                           "  OR EXISTS (SELECT * FROM permissions_subject"
+                           "             WHERE name = 'Super'"
+                           "             AND (resource = 0))"
+                           /* Or the user has super permission on the owner,
+                            * (directly, via the role, or via the group). */
+                           "  OR %ss%s.owner IN (SELECT *"
+                           "                     FROM super_on_users)"
+                           "  %s)",
+                           type, table_trash ? "_trash" : "", user_sql, type,
+                           table_trash ? "_trash" : "",
+                           permission_clause ? permission_clause : "");
 
       g_free (permission_clause);
     }
@@ -1167,15 +1151,15 @@ acl_where_owned_user (const char *user_id, const char *user_sql,
       if (user_id && index)
         {
           gchar *clause;
-          clause
-           = g_strdup_printf ("OR EXISTS"
-                              " (SELECT id FROM permissions"
-                              "  WHERE resource = %ss%s.id"
-                              "  AND resource_type = '%s'"
-                              "  AND resource_location = %i"
-                              "  AND subject_location"
-                              "      = " G_STRINGIFY (LOCATION_TABLE)
-                              "  AND ((subject_type = 'user'"
+          clause = g_strdup_printf (
+            "OR EXISTS"
+            " (SELECT id FROM permissions"
+            "  WHERE resource = %ss%s.id"
+            "  AND resource_type = '%s'"
+            "  AND resource_location = %i"
+            "  AND subject_location"
+            "      = " G_STRINGIFY (
+              LOCATION_TABLE) "  AND ((subject_type = 'user'"
                               "        AND subject"
                               "            = (%s))"
                               "       OR (subject_type = 'group'"
@@ -1191,25 +1175,20 @@ acl_where_owned_user (const char *user_id, const char *user_sql,
                               "                   WHERE \"user\""
                               "                         = (%s))))"
                               "  AND (%s))",
-                              type,
-                              get->trash && strcmp (type, "task") ? "_trash" : "",
-                              type,
-                              get->trash ? LOCATION_TRASH : LOCATION_TABLE,
-                              user_sql,
-                              user_sql,
-                              user_sql,
-                              permission_or->str);
+            type, get->trash && strcmp (type, "task") ? "_trash" : "", type,
+            get->trash ? LOCATION_TRASH : LOCATION_TABLE, user_sql, user_sql,
+            user_sql, permission_or->str);
 
           if (strcmp (type, "report") == 0)
-            permission_clause
-             = g_strdup_printf ("%s"
-                                " OR EXISTS"
-                                " (SELECT id FROM permissions"
-                                "  WHERE resource = reports%s.task"
-                                "  AND resource_type = 'task'"
-                                "  AND subject_location"
-                                "      = " G_STRINGIFY (LOCATION_TABLE)
-                                "  AND ((subject_type = 'user'"
+            permission_clause = g_strdup_printf (
+              "%s"
+              " OR EXISTS"
+              " (SELECT id FROM permissions"
+              "  WHERE resource = reports%s.task"
+              "  AND resource_type = 'task'"
+              "  AND subject_location"
+              "      = " G_STRINGIFY (
+                LOCATION_TABLE) "  AND ((subject_type = 'user'"
                                 "        AND subject"
                                 "            = (%s))"
                                 "       OR (subject_type = 'group'"
@@ -1225,22 +1204,18 @@ acl_where_owned_user (const char *user_id, const char *user_sql,
                                 "                   WHERE \"user\""
                                 "                         = (%s))))"
                                 "  AND (%s))",
-                                clause,
-                                get->trash ? "_trash" : "",
-                                user_sql,
-                                user_sql,
-                                user_sql,
-                                permission_or->str);
+              clause, get->trash ? "_trash" : "", user_sql, user_sql, user_sql,
+              permission_or->str);
           else if (strcmp (type, "result") == 0)
-            permission_clause
-             = g_strdup_printf ("%s"
-                                " OR EXISTS"
-                                " (SELECT id FROM permissions"
-                                "  WHERE resource = results%s.task"
-                                "  AND resource_type = 'task'"
-                                "  AND subject_location"
-                                "      = " G_STRINGIFY (LOCATION_TABLE)
-                                "  AND ((subject_type = 'user'"
+            permission_clause = g_strdup_printf (
+              "%s"
+              " OR EXISTS"
+              " (SELECT id FROM permissions"
+              "  WHERE resource = results%s.task"
+              "  AND resource_type = 'task'"
+              "  AND subject_location"
+              "      = " G_STRINGIFY (
+                LOCATION_TABLE) "  AND ((subject_type = 'user'"
                                 "        AND subject"
                                 "            = (%s))"
                                 "       OR (subject_type = 'group'"
@@ -1256,77 +1231,77 @@ acl_where_owned_user (const char *user_id, const char *user_sql,
                                 "                   WHERE \"user\""
                                 "                         = (%s))))"
                                 "  AND (%s))",
-                                clause,
-                                get->trash ? "_trash" : "",
-                                user_sql,
-                                user_sql,
-                                user_sql,
-                                permission_or->str);
+              clause, get->trash ? "_trash" : "", user_sql, user_sql, user_sql,
+              permission_or->str);
 
-          if ((strcmp (type, "report") == 0)
-              || (strcmp (type, "result") == 0))
+          if ((strcmp (type, "report") == 0) || (strcmp (type, "result") == 0))
             g_free (clause);
           else
             permission_clause = clause;
         }
 
-      owned_clause
-       = g_strdup_printf (/* Either the user is the owner. */
-                          " ((%ss%s.owner"
-                          "   = (%s))"
-                          /* Or the user has super permission. */
-                          "  OR EXISTS (SELECT * FROM permissions"
-                          "             WHERE name = 'Super'"
-                          /*                 Super on everyone. */
-                          "             AND ((resource = 0)"
-                          /*                 Super on other_user. */
-                          "                  OR ((resource_type = 'user')"
-                          "                      AND (resource = %ss%s.owner))"
-                          /*                 Super on other_user's role. */
-                          "                  OR ((resource_type = 'role')"
-                          "                      AND (resource"
-                          "                           IN (SELECT DISTINCT role"
-                          "                               FROM role_users"
-                          "                               WHERE \"user\""
-                          "                                     = %ss%s.owner)))"
-                          /*                 Super on other_user's group. */
-                          "                  OR ((resource_type = 'group')"
-                          "                      AND (resource"
-                          "                           IN (SELECT DISTINCT \"group\""
-                          "                               FROM group_users"
-                          "                               WHERE \"user\""
-                          "                                     = %ss%s.owner))))"
-                          "             AND subject_location"
-                          "                 = " G_STRINGIFY (LOCATION_TABLE)
-                          "             AND ((subject_type = 'user'"
-                          "                   AND subject"
-                          "                       = (%s))"
-                          "                  OR (subject_type = 'group'"
-                          "                      AND subject"
-                          "                          IN (SELECT DISTINCT \"group\""
-                          "                              FROM group_users"
-                          "                              WHERE \"user\""
-                          "                                    = (%s)))"
-                          "                  OR (subject_type = 'role'"
-                          "                      AND subject"
-                          "                          IN (SELECT DISTINCT role"
-                          "                              FROM role_users"
-                          "                              WHERE \"user\""
-                          "                                    = (%s)))))"
-                          "  %s)",
-                          type,
-                          table_trash ? "_trash" : "",
-                          user_sql,
-                          type,
-                          table_trash ? "_trash" : "",
-                          type,
-                          table_trash ? "_trash" : "",
-                          type,
-                          table_trash ? "_trash" : "",
-                          user_sql,
-                          user_sql,
-                          user_sql,
-                          permission_clause ? permission_clause : "");
+      owned_clause =
+        g_strdup_printf (/* Either the user is the owner. */
+                         " ((%ss%s.owner"
+                         "   = (%s))"
+                         /* Or the user has super permission. */
+                         "  OR EXISTS (SELECT * FROM permissions"
+                         "             WHERE name = 'Super'"
+                         /*                 Super on everyone. */
+                         "             AND ((resource = 0)"
+                         /*                 Super on other_user. */
+                         "                  OR ((resource_type = 'user')"
+                         "                      AND (resource = %ss%s.owner))"
+                         /*                 Super on other_user's role. */
+                         "                  OR ((resource_type = 'role')"
+                         "                      AND (resource"
+                         "                           IN (SELECT DISTINCT role"
+                         "                               FROM role_users"
+                         "                               WHERE \"user\""
+                         "                                     = %ss%s.owner)))"
+                         /*                 Super on other_user's group. */
+                         "                  OR ((resource_type = 'group')"
+                         "                      AND (resource"
+                         "                           IN (SELECT DISTINCT "
+                         "\"group\""
+                         "                               FROM group_users"
+                         "                               WHERE \"user\""
+                         "                                     = "
+                         "%ss%s.owner))))"
+                         "             AND subject_location"
+                         "                 = " G_STRINGIFY (
+                           LOCATION_TABLE) "             AND ((subject_type = "
+                                           "'user'"
+                                           "                   AND subject"
+                                           "                       = (%s))"
+                                           "                  OR (subject_type "
+                                           "= 'group'"
+                                           "                      AND subject"
+                                           "                          IN "
+                                           "(SELECT DISTINCT \"group\""
+                                           "                              FROM "
+                                           "group_users"
+                                           "                              "
+                                           "WHERE \"user\""
+                                           "                                   "
+                                           " = (%s)))"
+                                           "                  OR (subject_type "
+                                           "= 'role'"
+                                           "                      AND subject"
+                                           "                          IN "
+                                           "(SELECT DISTINCT role"
+                                           "                              FROM "
+                                           "role_users"
+                                           "                              "
+                                           "WHERE \"user\""
+                                           "                                   "
+                                           " = (%s)))))"
+                                           "  %s)",
+                         type, table_trash ? "_trash" : "", user_sql, type,
+                         table_trash ? "_trash" : "", type,
+                         table_trash ? "_trash" : "", type,
+                         table_trash ? "_trash" : "", user_sql, user_sql,
+                         user_sql, permission_clause ? permission_clause : "");
 
       g_free (permission_clause);
     }
@@ -1338,8 +1313,7 @@ acl_where_owned_user (const char *user_id, const char *user_sql,
       gchar *new;
       new = g_strdup_printf (" (%ss.hidden = 2"
                              "  AND %s)",
-                             type,
-                             owned_clause);
+                             type, owned_clause);
       g_free (owned_clause);
       owned_clause = new;
     }
@@ -1355,15 +1329,13 @@ acl_where_owned_user (const char *user_id, const char *user_sql,
                                              "          FROM users"
                                              "          WHERE name = '%s')"
                                              " AND %s)",
-                                             quoted,
-                                             owned_clause);
+                                             quoted, owned_clause);
       g_free (quoted);
     }
   else
     filter_owned_clause = g_strdup_printf ("((owner = (%s))"
                                            " AND %s)",
-                                           user_sql,
-                                           owned_clause);
+                                           user_sql, owned_clause);
 
   g_free (owned_clause);
 
@@ -1395,8 +1367,7 @@ acl_where_owned (const char *type, const get_data_t *get, int owned,
   else
     user_sql = NULL;
   ret = acl_where_owned_user (current_credentials.uuid, user_sql, type, get,
-                              owned, owner_filter, resource, permissions,
-                              with);
+                              owned, owner_filter, resource, permissions, with);
   g_free (user_sql);
   return ret;
 }
@@ -1423,26 +1394,21 @@ acl_where_owned_for_get (const char *type, const char *user_sql, gchar **with)
   if (user_sql)
     user_sql_new = g_strdup (user_sql);
   else if (current_credentials.uuid)
-    user_sql_new = g_strdup_printf ("SELECT id FROM users WHERE users.uuid = '%s'",
-                                    current_credentials.uuid);
+    user_sql_new = g_strdup_printf (
+      "SELECT id FROM users WHERE users.uuid = '%s'", current_credentials.uuid);
   else
     user_sql_new = NULL;
 
   get.trash = 0;
   permissions = make_array ();
   array_add (permissions, g_strdup_printf ("get_%ss", type));
-  owned_clause = acl_where_owned_user (current_credentials.uuid
-                                        ? current_credentials.uuid
-                                        /* Use user_sql_new. */
-                                        : "",
-                                       user_sql_new,
-                                       type,
-                                       &get,
-                                       1,              /* Do owner checks. */
-                                       "any",
-                                       0,              /* Resource. */
-                                       permissions,
-                                       with);
+  owned_clause =
+    acl_where_owned_user (current_credentials.uuid ? current_credentials.uuid
+                                                   /* Use user_sql_new. */
+                                                   : "",
+                          user_sql_new, type, &get, 1, /* Do owner checks. */
+                          "any", 0,                    /* Resource. */
+                          permissions, with);
   array_free (permissions);
   g_free (user_sql_new);
 
@@ -1483,17 +1449,15 @@ acl_users_with_access_sql (const char *type, const char *resource_id,
       if (acl_user_has_access_uuid (type, resource_id, command, 0))
         {
           if (users_count)
-            g_string_append (users_string,
-                             ", ");
+            g_string_append (users_string, ", ");
 
-          g_string_append_printf (users_string,
-                                  "(%llu)",
+          g_string_append_printf (users_string, "(%llu)",
                                   iterator_int64 (&users, 0));
-          users_count ++;
+          users_count++;
         }
       g_free (current_credentials.uuid);
     }
-  g_string_append(users_string, ")");
+  g_string_append (users_string, ")");
   cleanup_iterator (&users);
 
   current_credentials.uuid = old_user_id;
@@ -1508,7 +1472,6 @@ acl_users_with_access_sql (const char *type, const char *resource_id,
     }
 
   return g_string_free (users_string, FALSE);
-
 }
 
 /**
@@ -1524,7 +1487,7 @@ acl_users_with_access_sql (const char *type, const char *resource_id,
 
 gchar *
 acl_users_with_access_where (const char *type, const char *resource_id,
-                             const char *users_where, const char* user_expr)
+                             const char *users_where, const char *user_expr)
 {
   gchar *values, *ret;
   assert (user_expr);

--- a/src/manage_acl.c
+++ b/src/manage_acl.c
@@ -65,9 +65,13 @@ acl_user_may (const char *operation)
 
   quoted_operation = sql_quote (operation);
 
-  ret = sql_int (ACL_USER_MAY ("0"), current_credentials.uuid,
-                 current_credentials.uuid, current_credentials.uuid,
-                 quoted_operation, quoted_operation, quoted_operation,
+  ret = sql_int (ACL_USER_MAY ("0"),
+                 current_credentials.uuid,
+                 current_credentials.uuid,
+                 current_credentials.uuid,
+                 quoted_operation,
+                 quoted_operation,
+                 quoted_operation,
                  quoted_operation);
 
   g_free (quoted_operation);
@@ -156,7 +160,9 @@ acl_user_can_super_everyone (const char *uuid)
                         "users.uuid"
                         "                                                = "
                         "'%s')))));",
-      quoted_uuid, quoted_uuid, quoted_uuid))
+      quoted_uuid,
+      quoted_uuid,
+      quoted_uuid))
     {
       g_free (quoted_uuid);
       return 1;
@@ -205,7 +211,9 @@ acl_user_can_everything (const char *user_id)
                       "                                    WHERE users.uuid"
                       "                                          = '%s'))))"
                       " AND name = 'Everything';",
-    quoted_user_id, quoted_user_id, quoted_user_id);
+    quoted_user_id,
+    quoted_user_id,
+    quoted_user_id);
   g_free (quoted_user_id);
   return ret;
 }
@@ -274,7 +282,11 @@ acl_user_has_super (const char *super_user_id, user_t other_user)
                         "users.uuid"
                         "                                                = "
                         "'%s')))));",
-      other_user, other_user, other_user, super_user_id, super_user_id,
+      other_user,
+      other_user,
+      other_user,
+      super_user_id,
+      super_user_id,
       super_user_id))
     {
       g_free (quoted_super_user_id);
@@ -476,8 +488,8 @@ acl_user_has_super_on (const char *type, const char *field, const char *value,
   quoted_value = sql_quote (value);
   if (sql_int ("SELECT EXISTS (SELECT * FROM permissions"
                "               WHERE " ACL_SUPER_CLAUSE ("'%s'") ");",
-               ACL_SUPER_CLAUSE_ARGS (type, field, quoted_value,
-                                      current_credentials.uuid, trash)))
+               ACL_SUPER_CLAUSE_ARGS (
+                 type, field, quoted_value, current_credentials.uuid, trash)))
     {
       g_free (quoted_value);
       return 1;
@@ -502,8 +514,8 @@ acl_user_has_super_on_resource (const char *type, const char *field,
 {
   if (sql_int ("SELECT EXISTS (SELECT * FROM permissions"
                "               WHERE " ACL_SUPER_CLAUSE ("%llu") ");",
-               ACL_SUPER_CLAUSE_ARGS (type, field, resource,
-                                      current_credentials.uuid, trash)))
+               ACL_SUPER_CLAUSE_ARGS (
+                 type, field, resource, current_credentials.uuid, trash)))
     return 1;
   return 0;
 }
@@ -529,7 +541,9 @@ acl_user_is_owner (const char *type, const char *uuid)
                  " WHERE uuid = '%s'"
                  " AND owner = (SELECT users.id FROM users"
                  "              WHERE users.uuid = '%s');",
-                 type, quoted_uuid, current_credentials.uuid);
+                 type,
+                 quoted_uuid,
+                 current_credentials.uuid);
   g_free (quoted_uuid);
 
   return ret;
@@ -571,32 +585,37 @@ acl_user_owns_uuid (const char *type, const char *uuid, int trash)
                    " AND results.report = reports.id"
                    " AND (reports.owner = (SELECT users.id FROM users"
                    "                       WHERE users.uuid = '%s'));",
-                   quoted_uuid, current_credentials.uuid);
+                   quoted_uuid,
+                   current_credentials.uuid);
   else if (strcmp (type, "report") == 0)
     ret = sql_int ("SELECT count(*) FROM reports"
                    " WHERE uuid = '%s'"
                    " AND (owner = (SELECT users.id FROM users"
                    "               WHERE users.uuid = '%s'));",
-                   quoted_uuid, current_credentials.uuid);
+                   quoted_uuid,
+                   current_credentials.uuid);
   else if (strcmp (type, "permission") == 0)
-    ret =
-      sql_int ("SELECT count(*) FROM permissions%s"
-               " WHERE uuid = '%s'"
-               " AND ((owner IS NULL)"
-               "      OR (owner = (SELECT users.id FROM users"
-               "                   WHERE users.uuid = '%s')));",
-               trash ? "_trash" : "", quoted_uuid, current_credentials.uuid);
+    ret = sql_int ("SELECT count(*) FROM permissions%s"
+                   " WHERE uuid = '%s'"
+                   " AND ((owner IS NULL)"
+                   "      OR (owner = (SELECT users.id FROM users"
+                   "                   WHERE users.uuid = '%s')));",
+                   trash ? "_trash" : "",
+                   quoted_uuid,
+                   current_credentials.uuid);
   else
-    ret = sql_int (
-      "SELECT count(*) FROM %ss%s"
-      " WHERE uuid = '%s'"
-      "%s"
-      " AND (owner = (SELECT users.id FROM users"
-      "               WHERE users.uuid = '%s'));",
-      type, (strcmp (type, "task") && trash) ? "_trash" : "", quoted_uuid,
-      (strcmp (type, "task") ? ""
-                             : (trash ? " AND hidden = 2" : " AND hidden < 2")),
-      current_credentials.uuid);
+    ret = sql_int ("SELECT count(*) FROM %ss%s"
+                   " WHERE uuid = '%s'"
+                   "%s"
+                   " AND (owner = (SELECT users.id FROM users"
+                   "               WHERE users.uuid = '%s'));",
+                   type,
+                   (strcmp (type, "task") && trash) ? "_trash" : "",
+                   quoted_uuid,
+                   (strcmp (type, "task")
+                      ? ""
+                      : (trash ? " AND hidden = 2" : " AND hidden < 2")),
+                   current_credentials.uuid);
   g_free (quoted_uuid);
 
   return ret;
@@ -636,18 +655,21 @@ acl_user_owns (const char *type, resource_t resource, int trash)
                    " AND results.report = reports.id"
                    " AND (reports.owner = (SELECT users.id FROM users"
                    "                       WHERE users.uuid = '%s'));",
-                   resource, current_credentials.uuid);
+                   resource,
+                   current_credentials.uuid);
   else
-    ret = sql_int (
-      "SELECT count(*) FROM %ss%s"
-      " WHERE id = %llu"
-      "%s"
-      " AND (owner = (SELECT users.id FROM users"
-      "               WHERE users.uuid = '%s'));",
-      type, (strcmp (type, "task") && trash) ? "_trash" : "", resource,
-      (strcmp (type, "task") ? ""
-                             : (trash ? " AND hidden = 2" : " AND hidden < 2")),
-      current_credentials.uuid);
+    ret = sql_int ("SELECT count(*) FROM %ss%s"
+                   " WHERE id = %llu"
+                   "%s"
+                   " AND (owner = (SELECT users.id FROM users"
+                   "               WHERE users.uuid = '%s'));",
+                   type,
+                   (strcmp (type, "task") && trash) ? "_trash" : "",
+                   resource,
+                   (strcmp (type, "task")
+                      ? ""
+                      : (trash ? " AND hidden = 2" : " AND hidden < 2")),
+                   current_credentials.uuid);
 
   return ret;
 }
@@ -680,7 +702,9 @@ acl_user_owns_trash_uuid (const char *type, const char *uuid)
                  " WHERE uuid = '%s'"
                  " AND (owner = (SELECT users.id FROM users"
                  "               WHERE users.uuid = '%s'));",
-                 type, quoted_uuid, current_credentials.uuid);
+                 type,
+                 quoted_uuid,
+                 current_credentials.uuid);
   g_free (quoted_uuid);
 
   return ret;
@@ -727,8 +751,8 @@ acl_user_has_access_uuid (const char *type, const char *uuid,
       task_t task;
       report_t report;
 
-      switch (sql_int64 (&report, "SELECT id FROM reports WHERE uuid = '%s';",
-                         quoted_uuid))
+      switch (sql_int64 (
+        &report, "SELECT id FROM reports WHERE uuid = '%s';", quoted_uuid))
         {
         case 0:
           break;
@@ -811,8 +835,10 @@ acl_user_has_access_uuid (const char *type, const char *uuid,
                           "                                          = "
                           "'%s'))));",
         uuid_task ? uuid_task : quoted_uuid,
-        uuid_task ? uuid_task : quoted_uuid, current_credentials.uuid,
-        current_credentials.uuid, current_credentials.uuid);
+        uuid_task ? uuid_task : quoted_uuid,
+        current_credentials.uuid,
+        current_credentials.uuid,
+        current_credentials.uuid);
       free (uuid_task);
       g_free (quoted_uuid);
       return ret;
@@ -856,9 +882,12 @@ acl_user_has_access_uuid (const char *type, const char *uuid,
                       "                                    WHERE users.uuid"
                       "                                          = '%s'))))"
                       " %s%s%s;",
-    uuid_task ? uuid_task : quoted_uuid, current_credentials.uuid,
-    current_credentials.uuid, current_credentials.uuid,
-    (get ? "" : "AND name = '"), (get ? "" : quoted_permission),
+    uuid_task ? uuid_task : quoted_uuid,
+    current_credentials.uuid,
+    current_credentials.uuid,
+    current_credentials.uuid,
+    (get ? "" : "AND name = '"),
+    (get ? "" : quoted_permission),
     (get ? "" : "'"));
 
   free (uuid_task);
@@ -979,7 +1008,9 @@ acl_where_owned_user (const char *user_id, const char *user_sql,
                           "                         AND resource_type = "
                           "'group'))"
                           "              AS all_users)",
-        user_sql, user_sql, user_sql);
+        user_sql,
+        user_sql,
+        user_sql);
 
       permission_clause = NULL;
       if (user_id && index)
@@ -992,27 +1023,34 @@ acl_where_owned_user (const char *user_id, const char *user_sql,
             "  AND resource_type = '%s'"
             "  AND resource_location = %i"
             "  AND (%s))",
-            type, get->trash && strcmp (type, "task") ? "_trash" : "", type,
-            get->trash ? LOCATION_TRASH : LOCATION_TABLE, permission_or->str);
+            type,
+            get->trash && strcmp (type, "task") ? "_trash" : "",
+            type,
+            get->trash ? LOCATION_TRASH : LOCATION_TABLE,
+            permission_or->str);
 
           if (strcmp (type, "report") == 0)
-            permission_clause = g_strdup_printf (
-              "%s"
-              " OR EXISTS"
-              " (SELECT id FROM permissions_subject"
-              "  WHERE resource = reports%s.task"
-              "  AND resource_type = 'task'"
-              "  AND (%s))",
-              clause, get->trash ? "_trash" : "", permission_or->str);
+            permission_clause =
+              g_strdup_printf ("%s"
+                               " OR EXISTS"
+                               " (SELECT id FROM permissions_subject"
+                               "  WHERE resource = reports%s.task"
+                               "  AND resource_type = 'task'"
+                               "  AND (%s))",
+                               clause,
+                               get->trash ? "_trash" : "",
+                               permission_or->str);
           else if (strcmp (type, "result") == 0)
-            permission_clause = g_strdup_printf (
-              "%s"
-              " OR EXISTS"
-              " (SELECT id FROM permissions_subject"
-              "  WHERE resource = results%s.task"
-              "  AND resource_type = 'task'"
-              "  AND (%s))",
-              clause, get->trash ? "_trash" : "", permission_or->str);
+            permission_clause =
+              g_strdup_printf ("%s"
+                               " OR EXISTS"
+                               " (SELECT id FROM permissions_subject"
+                               "  WHERE resource = results%s.task"
+                               "  AND resource_type = 'task'"
+                               "  AND (%s))",
+                               clause,
+                               get->trash ? "_trash" : "",
+                               permission_or->str);
 
           if ((strcmp (type, "report") == 0) || (strcmp (type, "result") == 0))
             g_free (clause);
@@ -1097,20 +1135,27 @@ acl_where_owned_user (const char *user_id, const char *user_sql,
                                                                                    "  OR permissions%s.owner IN (SELECT *"
                                                                                    "                            FROM super_on_users)"
                                                                                    "  %s)",
-                             get->trash ? "_trash" : "", user_sql,
+                             get->trash ? "_trash" : "",
+                             user_sql,
                              admin ? (get->trash
                                         ? "OR (permissions_trash.owner IS NULL)"
                                         : "OR (permissions.owner IS NULL)")
                                    : "",
-                             get->trash, table_trash ? "_trash" : "",
-                             table_trash ? "_trash" : "",
-                             table_trash ? "_trash" : "", user_sql, get->trash,
+                             get->trash,
                              table_trash ? "_trash" : "",
                              table_trash ? "_trash" : "",
-                             table_trash ? "_trash" : "", user_sql, get->trash,
+                             table_trash ? "_trash" : "",
+                             user_sql,
+                             get->trash,
                              table_trash ? "_trash" : "",
                              table_trash ? "_trash" : "",
-                             table_trash ? "_trash" : "", user_sql,
+                             table_trash ? "_trash" : "",
+                             user_sql,
+                             get->trash,
+                             table_trash ? "_trash" : "",
+                             table_trash ? "_trash" : "",
+                             table_trash ? "_trash" : "",
+                             user_sql,
                              table_trash ? "_trash" : "",
                              permission_clause ? permission_clause : "");
         }
@@ -1129,7 +1174,10 @@ acl_where_owned_user (const char *user_id, const char *user_sql,
                            "  OR %ss%s.owner IN (SELECT *"
                            "                     FROM super_on_users)"
                            "  %s)",
-                           type, table_trash ? "_trash" : "", user_sql, type,
+                           type,
+                           table_trash ? "_trash" : "",
+                           user_sql,
+                           type,
                            table_trash ? "_trash" : "",
                            permission_clause ? permission_clause : "");
 
@@ -1175,9 +1223,14 @@ acl_where_owned_user (const char *user_id, const char *user_sql,
                               "                   WHERE \"user\""
                               "                         = (%s))))"
                               "  AND (%s))",
-            type, get->trash && strcmp (type, "task") ? "_trash" : "", type,
-            get->trash ? LOCATION_TRASH : LOCATION_TABLE, user_sql, user_sql,
-            user_sql, permission_or->str);
+            type,
+            get->trash && strcmp (type, "task") ? "_trash" : "",
+            type,
+            get->trash ? LOCATION_TRASH : LOCATION_TABLE,
+            user_sql,
+            user_sql,
+            user_sql,
+            permission_or->str);
 
           if (strcmp (type, "report") == 0)
             permission_clause = g_strdup_printf (
@@ -1204,7 +1257,11 @@ acl_where_owned_user (const char *user_id, const char *user_sql,
                                 "                   WHERE \"user\""
                                 "                         = (%s))))"
                                 "  AND (%s))",
-              clause, get->trash ? "_trash" : "", user_sql, user_sql, user_sql,
+              clause,
+              get->trash ? "_trash" : "",
+              user_sql,
+              user_sql,
+              user_sql,
               permission_or->str);
           else if (strcmp (type, "result") == 0)
             permission_clause = g_strdup_printf (
@@ -1231,7 +1288,11 @@ acl_where_owned_user (const char *user_id, const char *user_sql,
                                 "                   WHERE \"user\""
                                 "                         = (%s))))"
                                 "  AND (%s))",
-              clause, get->trash ? "_trash" : "", user_sql, user_sql, user_sql,
+              clause,
+              get->trash ? "_trash" : "",
+              user_sql,
+              user_sql,
+              user_sql,
               permission_or->str);
 
           if ((strcmp (type, "report") == 0) || (strcmp (type, "result") == 0))
@@ -1297,11 +1358,19 @@ acl_where_owned_user (const char *user_id, const char *user_sql,
                                            "                                   "
                                            " = (%s)))))"
                                            "  %s)",
-                         type, table_trash ? "_trash" : "", user_sql, type,
-                         table_trash ? "_trash" : "", type,
-                         table_trash ? "_trash" : "", type,
-                         table_trash ? "_trash" : "", user_sql, user_sql,
-                         user_sql, permission_clause ? permission_clause : "");
+                         type,
+                         table_trash ? "_trash" : "",
+                         user_sql,
+                         type,
+                         table_trash ? "_trash" : "",
+                         type,
+                         table_trash ? "_trash" : "",
+                         type,
+                         table_trash ? "_trash" : "",
+                         user_sql,
+                         user_sql,
+                         user_sql,
+                         permission_clause ? permission_clause : "");
 
       g_free (permission_clause);
     }
@@ -1313,7 +1382,8 @@ acl_where_owned_user (const char *user_id, const char *user_sql,
       gchar *new;
       new = g_strdup_printf (" (%ss.hidden = 2"
                              "  AND %s)",
-                             type, owned_clause);
+                             type,
+                             owned_clause);
       g_free (owned_clause);
       owned_clause = new;
     }
@@ -1329,13 +1399,15 @@ acl_where_owned_user (const char *user_id, const char *user_sql,
                                              "          FROM users"
                                              "          WHERE name = '%s')"
                                              " AND %s)",
-                                             quoted, owned_clause);
+                                             quoted,
+                                             owned_clause);
       g_free (quoted);
     }
   else
     filter_owned_clause = g_strdup_printf ("((owner = (%s))"
                                            " AND %s)",
-                                           user_sql, owned_clause);
+                                           user_sql,
+                                           owned_clause);
 
   g_free (owned_clause);
 
@@ -1366,8 +1438,15 @@ acl_where_owned (const char *type, const get_data_t *get, int owned,
                                 current_credentials.uuid);
   else
     user_sql = NULL;
-  ret = acl_where_owned_user (current_credentials.uuid, user_sql, type, get,
-                              owned, owner_filter, resource, permissions, with);
+  ret = acl_where_owned_user (current_credentials.uuid,
+                              user_sql,
+                              type,
+                              get,
+                              owned,
+                              owner_filter,
+                              resource,
+                              permissions,
+                              with);
   g_free (user_sql);
   return ret;
 }
@@ -1406,9 +1485,14 @@ acl_where_owned_for_get (const char *type, const char *user_sql, gchar **with)
     acl_where_owned_user (current_credentials.uuid ? current_credentials.uuid
                                                    /* Use user_sql_new. */
                                                    : "",
-                          user_sql_new, type, &get, 1, /* Do owner checks. */
-                          "any", 0,                    /* Resource. */
-                          permissions, with);
+                          user_sql_new,
+                          type,
+                          &get,
+                          1, /* Do owner checks. */
+                          "any",
+                          0, /* Resource. */
+                          permissions,
+                          with);
   array_free (permissions);
   g_free (user_sql_new);
 
@@ -1435,7 +1519,8 @@ acl_users_with_access_sql (const char *type, const char *resource_id,
   iterator_t users;
 
   old_user_id = current_credentials.uuid;
-  init_iterator (&users, "SELECT id, uuid FROM users WHERE %s;",
+  init_iterator (&users,
+                 "SELECT id, uuid FROM users WHERE %s;",
                  users_where ? users_where : "t()");
 
   users_string = g_string_new ("(VALUES ");
@@ -1451,8 +1536,8 @@ acl_users_with_access_sql (const char *type, const char *resource_id,
           if (users_count)
             g_string_append (users_string, ", ");
 
-          g_string_append_printf (users_string, "(%llu)",
-                                  iterator_int64 (&users, 0));
+          g_string_append_printf (
+            users_string, "(%llu)", iterator_int64 (&users, 0));
           users_count++;
         }
       g_free (current_credentials.uuid);

--- a/src/manage_acl.c
+++ b/src/manage_acl.c
@@ -481,7 +481,9 @@ acl_user_is_user (const char *uuid)
  * @return 1 if user has Super, else 0.
  */
 static int
-acl_user_has_super_on (const char *type, const char *field, const char *value,
+acl_user_has_super_on (const char *type,
+                       const char *field,
+                       const char *value,
                        int trash)
 {
   gchar *quoted_value;
@@ -509,8 +511,10 @@ acl_user_has_super_on (const char *type, const char *field, const char *value,
  * @return 1 if user has Super, else 0.
  */
 static int
-acl_user_has_super_on_resource (const char *type, const char *field,
-                                resource_t resource, int trash)
+acl_user_has_super_on_resource (const char *type,
+                                const char *field,
+                                resource_t resource,
+                                int trash)
 {
   if (sql_int ("SELECT EXISTS (SELECT * FROM permissions"
                "               WHERE " ACL_SUPER_CLAUSE ("%llu") ");",
@@ -721,8 +725,10 @@ acl_user_owns_trash_uuid (const char *type, const char *uuid)
  * @return 1 if user may access resource, else 0.
  */
 int
-acl_user_has_access_uuid (const char *type, const char *uuid,
-                          const char *permission, int trash)
+acl_user_has_access_uuid (const char *type,
+                          const char *uuid,
+                          const char *permission,
+                          int trash)
 {
   int ret, get;
   char *uuid_task;
@@ -913,10 +919,15 @@ acl_user_has_access_uuid (const char *type, const char *uuid,
  * @return Newly allocated owned clause.
  */
 static gchar *
-acl_where_owned_user (const char *user_id, const char *user_sql,
-                      const char *type, const get_data_t *get, int owned,
-                      const gchar *owner_filter, resource_t resource,
-                      array_t *permissions, gchar **with)
+acl_where_owned_user (const char *user_id,
+                      const char *user_sql,
+                      const char *type,
+                      const get_data_t *get,
+                      int owned,
+                      const gchar *owner_filter,
+                      resource_t resource,
+                      array_t *permissions,
+                      gchar **with)
 {
   gchar *owned_clause, *filter_owned_clause;
   GString *permission_or;
@@ -1428,9 +1439,13 @@ acl_where_owned_user (const char *user_id, const char *user_sql,
  * @return Newly allocated owned clause.
  */
 gchar *
-acl_where_owned (const char *type, const get_data_t *get, int owned,
-                 const gchar *owner_filter, resource_t resource,
-                 array_t *permissions, gchar **with)
+acl_where_owned (const char *type,
+                 const get_data_t *get,
+                 int owned,
+                 const gchar *owner_filter,
+                 resource_t resource,
+                 array_t *permissions,
+                 gchar **with)
 {
   gchar *ret, *user_sql;
   if (current_credentials.uuid)
@@ -1510,7 +1525,8 @@ acl_where_owned_for_get (const char *type, const char *user_sql, gchar **with)
  */
 
 gchar *
-acl_users_with_access_sql (const char *type, const char *resource_id,
+acl_users_with_access_sql (const char *type,
+                           const char *resource_id,
                            const char *users_where)
 {
   GString *users_string;
@@ -1571,8 +1587,10 @@ acl_users_with_access_sql (const char *type, const char *resource_id,
  */
 
 gchar *
-acl_users_with_access_where (const char *type, const char *resource_id,
-                             const char *users_where, const char *user_expr)
+acl_users_with_access_where (const char *type,
+                             const char *resource_id,
+                             const char *users_where,
+                             const char *user_expr)
 {
   gchar *values, *ret;
   assert (user_expr);

--- a/src/manage_acl.h
+++ b/src/manage_acl.h
@@ -140,8 +140,13 @@ int
 acl_user_has_access_uuid (const char *, const char *, const char *, int);
 
 gchar *
-acl_where_owned (const char *, const get_data_t *, int, const gchar *,
-                 resource_t, array_t *, gchar **);
+acl_where_owned (const char *,
+                 const get_data_t *,
+                 int,
+                 const gchar *,
+                 resource_t,
+                 array_t *,
+                 gchar **);
 
 gchar *
 acl_where_owned_for_get (const char *, const char *, gchar **);
@@ -150,7 +155,9 @@ gchar *
 acl_users_with_access_sql (const char *, const char *, const char *);
 
 gchar *
-acl_users_with_access_where (const char *, const char *, const char *,
+acl_users_with_access_where (const char *,
+                             const char *,
+                             const char *,
                              const char *);
 
 #endif /* not _GVMD_MANAGE_ACL_H */

--- a/src/manage_acl.h
+++ b/src/manage_acl.h
@@ -26,6 +26,7 @@
 #define _GVMD_MANAGE_ACL_H
 
 #include "manage_sql.h"
+
 #include <glib.h>
 
 /**
@@ -33,45 +34,43 @@
  *
  * @param[in]  resource  Resource.
  */
-#define ACL_USER_MAY(resource)                                        \
-  "SELECT count(*) > 0 FROM permissions"                              \
-  " WHERE resource = " resource                                       \
-  " AND subject_location = " G_STRINGIFY (LOCATION_TABLE)             \
-  " AND ((subject_type = 'user'"                                      \
-  "       AND subject"                                                \
-  "           = (SELECT id FROM users"                                \
-  "              WHERE users.uuid = '%s'))"                           \
-  "      OR (subject_type = 'group'"                                  \
-  "          AND subject"                                             \
-  "              IN (SELECT DISTINCT \"group\""                       \
-  "                  FROM group_users"                                \
-  "                  WHERE \"user\" = (SELECT id"                     \
-  "                                FROM users"                        \
-  "                                WHERE users.uuid"                  \
-  "                                      = '%s')))"                   \
-  "      OR (subject_type = 'role'"                                   \
-  "          AND subject"                                             \
-  "              IN (SELECT DISTINCT role"                            \
-  "                  FROM role_users"                                 \
-  "                  WHERE \"user\" = (SELECT id"                     \
-  "                                    FROM users"                    \
-  "                                    WHERE users.uuid"              \
-  "                                          = '%s'))))"              \
-  /* Any permission implies GET. */                                   \
-  " AND ((lower (substr ('%s', 1, 3)) = 'get'"                        \
-  "       AND name LIKE '%%'"                                         \
-  "                     || lower (substr ('%s',"                      \
-  "                                       5,"                         \
-  "                                       length ('%s') - 5)))"       \
-  "      OR name = lower ('%s'))"
+#define ACL_USER_MAY(resource)                                                                               \
+  "SELECT count(*) > 0 FROM permissions"                                                                     \
+  " WHERE resource = " resource " AND subject_location = " G_STRINGIFY (                                     \
+    LOCATION_TABLE) " AND ((subject_type = 'user'"                                                           \
+                    "       AND subject"                                                                     \
+                    "           = (SELECT id FROM users"                                                     \
+                    "              WHERE users.uuid = '%s'))"                                                \
+                    "      OR (subject_type = 'group'"                                                       \
+                    "          AND subject"                                                                  \
+                    "              IN (SELECT DISTINCT \"group\""                                            \
+                    "                  FROM group_users"                                                     \
+                    "                  WHERE \"user\" = (SELECT id"                                          \
+                    "                                FROM users"                                             \
+                    "                                WHERE users.uuid"                                       \
+                    "                                      = '%s')))"                                        \
+                    "      OR (subject_type = 'role'"                                                        \
+                    "          AND subject"                                                                  \
+                    "              IN (SELECT DISTINCT role"                                                 \
+                    "                  FROM role_users"                                                      \
+                    "                  WHERE \"user\" = (SELECT id"                                          \
+                    "                                    FROM users"                                         \
+                    "                                    WHERE users.uuid"                                   \
+                    "                                          = '%s'))))" /* Any permission implies GET. */ \
+                    " AND ((lower (substr ('%s', 1, 3)) = 'get'"                                             \
+                    "       AND name LIKE '%%'"                                                              \
+                    "                     || lower (substr ('%s',"                                           \
+                    "                                       5,"                                              \
+                    "                                       length ('%s') - "                                \
+                    "5)))"                                                                                   \
+                    "      OR name = lower ('%s'))"
 
 /**
  * @brief Generate SQL for global check.
  *
  * This is the SQL clause for selecting global resources.
  */
-#define ACL_IS_GLOBAL()                                    \
-  "owner IS NULL"
+#define ACL_IS_GLOBAL() "owner IS NULL"
 
 /**
  * @brief Generate SQL for user ownership check.
@@ -81,8 +80,8 @@
  *
  * Caller must organise the single argument, the user's UUID, as a string.
  */
-#define ACL_USER_OWNS()                                    \
-  " (owner = (SELECT users.id FROM users"                  \
+#define ACL_USER_OWNS()                   \
+  " (owner = (SELECT users.id FROM users" \
   "           WHERE users.uuid = '%s'))"
 
 /**
@@ -93,10 +92,10 @@
  *
  * Caller must organise the single argument, the user's UUID, as a string.
  */
-#define ACL_GLOBAL_OR_USER_OWNS()                              \
-  " ((" ACL_IS_GLOBAL () ")"                                   \
-  "  OR (owner = (SELECT users.id FROM users"                  \
-  "               WHERE users.uuid = '%s')))"
+#define ACL_GLOBAL_OR_USER_OWNS()                                    \
+  " ((" ACL_IS_GLOBAL () ")"                                         \
+                         "  OR (owner = (SELECT users.id FROM users" \
+                         "               WHERE users.uuid = '%s')))"
 
 int
 acl_user_may (const char *);
@@ -141,8 +140,8 @@ int
 acl_user_has_access_uuid (const char *, const char *, const char *, int);
 
 gchar *
-acl_where_owned (const char *, const get_data_t *, int, const gchar *, resource_t,
-                 array_t *, gchar **);
+acl_where_owned (const char *, const get_data_t *, int, const gchar *,
+                 resource_t, array_t *, gchar **);
 
 gchar *
 acl_where_owned_for_get (const char *, const char *, gchar **);
@@ -152,6 +151,6 @@ acl_users_with_access_sql (const char *, const char *, const char *);
 
 gchar *
 acl_users_with_access_where (const char *, const char *, const char *,
-                             const char*);
+                             const char *);
 
 #endif /* not _GVMD_MANAGE_ACL_H */

--- a/src/manage_config_discovery.c
+++ b/src/manage_config_discovery.c
@@ -53,526 +53,1046 @@
 void
 make_config_discovery_service_detection (char *const selector_name)
 {
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11929", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900534", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902019", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800991", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900539", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800995", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800997", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800999", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100106", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900381", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901084", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900384", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902023", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900620", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901089", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900387", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902028", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902106", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900547", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900705", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900628", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901087", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900624", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900543", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900629", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801869", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11865", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901174", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.12647", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900550", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901178", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900632", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80079", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900556", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900714", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801874", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900710", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100201", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100206", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100208", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900394", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900712", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11945", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.20377", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900562", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103652", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901188", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902046", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900641", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103579", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902044", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900647", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.17583", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100215", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100217", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100219", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11963", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80092", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900493", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900571", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80095", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902134", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902058", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902137", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900578", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900576", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900659", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100221", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100301", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100302", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902053", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100226", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100224", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.18532", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.18533", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.18534", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801972", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100300", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902061", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902220", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900583", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900744", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900822", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900746", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900748", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900904", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902309", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.101013", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100154", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100313", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801988", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.101019", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.101018", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900827", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100311", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100233", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11986", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11987", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902311", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900596", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902078", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900598", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100082", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100160", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100240", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.101021", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900753", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100243", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900917", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.101025", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.18393", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900839", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100324", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100322", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100407", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100328", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100329", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902081", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902083", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902084", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900681", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902089", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900686", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900923", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100174", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900926", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100254", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100331", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100335", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100259", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100417", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100419", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900930", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900853", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900932", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900855", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100180", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100184", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100261", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100187", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100266", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100423", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100268", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100425", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100503", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.20834", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902187", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100192", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902503", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100194", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900867", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100196", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900945", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100432", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100437", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100517", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.19289", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800300", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100518", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801005", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801007", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.19608", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900950", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100280", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902513", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900956", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100285", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100288", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100367", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102005", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102006", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102009", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.17975", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102003", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800158", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801017", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800317", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102001", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.66286", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902520", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900961", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902447", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900966", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100294", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10159", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100374", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102013", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100376", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100456", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102011", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102017", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801100", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800165", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801102", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103979", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801106", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100292", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800407", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900971", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902533", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900976", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100382", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100540", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100466", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100464", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100468", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800170", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800098", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801112", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.19559", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800413", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801038", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801115", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801117", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801119", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10330", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10175", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902545", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902701", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902547", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100392", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900983", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100460", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100552", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11032", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100395", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100477", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800180", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100479", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801040", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100558", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801121", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103997", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801124", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800268", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801126", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801209", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11120", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11121", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10342", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11128", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902717", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102048", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100801", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100489", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800272", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801053", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800274", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800276", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801213", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800355", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800279", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801138", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801217", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800432", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902480", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902561", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11134", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100486", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100571", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100573", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100651", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800280", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100819", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801069", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800523", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800603", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800525", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801067", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.14664", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800608", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801223", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800446", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100742", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800291", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801072", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801074", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100669", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100748", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801234", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800297", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100827", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.14674", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800617", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800610", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801152", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801232", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11153", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11154", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10379", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801081", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100755", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100911", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100675", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801087", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100838", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801244", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800467", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801403", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800547", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800627", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.802109", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800707", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800464", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800709", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100836", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801247", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10462", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800622", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10622", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100681", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103021", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801091", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800391", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800470", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801251", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800394", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800630", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800553", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800631", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800477", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800712", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.14772", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800559", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800716", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800633", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.14773", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103106", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100846", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801415", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100770", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103111", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100850", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100854", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103118", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801340", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100937", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100859", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800643", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801421", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800568", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800802", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800564", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.17200", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800728", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800807", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.14788", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100845", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.9000001", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100780", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801242", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103123", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103124", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103048", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103125", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100867", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800571", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103206", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800573", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100783", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800575", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103204", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801278", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801350", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801438", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800816", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800818", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800579", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800496", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103207", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800735", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100870", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900200", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100795", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103059", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100950", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801363", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801443", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.802145", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800900", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800901", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800821", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800825", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800905", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.15588", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103140", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10666", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103141", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103143", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103223", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103147", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800590", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800592", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900218", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800594", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.802230", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800832", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800677", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800911", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800913", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800918", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.802158", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103070", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800598", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103073", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103230", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801612", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103156", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901003", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103158", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801381", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800680", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800681", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901008", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800683", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.802244", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103317", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800765", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800688", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800923", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800768", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.17244", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800925", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.15765", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.15766", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800928", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10761", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103081", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103086", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901013", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103245", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801390", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901016", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800690", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801392", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800692", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800693", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.802178", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801394", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800933", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800779", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800936", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103326", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800939", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900242", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103098", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103255", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901025", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80003", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80004", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80005", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80006", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901107", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901023", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800941", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800864", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800786", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800949", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103181", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.20301", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900251", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900253", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900256", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900334", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900259", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900338", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800792", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800790", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901118", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800870", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800951", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901036", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801575", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800877", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800878", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800955", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801812", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.18219", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103190", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801737", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901121", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901044", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80100", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103514", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800884", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800964", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800969", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.20160", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10884", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11822", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900194", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900352", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901056", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11906", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11907", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900357", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800891", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901135", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800893", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11908", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800895", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800898", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801916", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900360", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103294", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11913", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80044", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80045", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801681", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902009", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800980", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800984", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800988", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900371", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900374", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900376", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.108198", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.108199", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.108203", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.108204", "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11929",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900534",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902019",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800991",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900539",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800995",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800997",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800999",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100106",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900381",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901084",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900384",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902023",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900620",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901089",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900387",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902028",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902106",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900547",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900705",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900628",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901087",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900624",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900543",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900629",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801869",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11865",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901174",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.12647",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900550",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901178",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900632",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80079",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900556",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900714",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801874",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900710",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100201",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100206",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100208",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900394",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900712",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11945",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.20377",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900562",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103652",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901188",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902046",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900641",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103579",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902044",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900647",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.17583",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100215",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100217",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100219",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11963",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80092",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900493",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900571",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80095",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902134",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902058",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902137",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900578",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900576",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900659",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100221",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100301",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100302",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902053",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100226",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100224",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.18532",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.18533",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.18534",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801972",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100300",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902061",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902220",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900583",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900744",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900822",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900746",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900748",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900904",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902309",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.101013",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100154",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100313",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801988",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.101019",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.101018",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900827",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100311",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100233",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11986",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11987",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902311",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900596",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902078",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900598",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100082",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100160",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100240",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.101021",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900753",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100243",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900917",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.101025",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.18393",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900839",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100324",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100322",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100407",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100328",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100329",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902081",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902083",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902084",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900681",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902089",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900686",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900923",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100174",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900926",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100254",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100331",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100335",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100259",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100417",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100419",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900930",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900853",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900932",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900855",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100180",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100184",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100261",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100187",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100266",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100423",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100268",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100425",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100503",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.20834",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902187",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100192",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902503",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100194",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900867",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100196",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900945",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100432",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100437",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100517",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.19289",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800300",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100518",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801005",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801007",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.19608",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900950",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100280",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902513",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900956",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100285",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100288",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100367",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102005",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102006",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102009",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.17975",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102003",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800158",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801017",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800317",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102001",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.66286",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902520",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900961",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902447",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900966",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100294",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10159",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100374",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102013",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100376",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100456",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102011",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102017",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801100",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800165",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801102",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103979",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801106",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100292",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800407",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900971",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902533",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900976",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100382",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100540",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100466",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100464",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100468",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800170",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800098",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801112",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.19559",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800413",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801038",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801115",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801117",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801119",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10330",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10175",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902545",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902701",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902547",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100392",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900983",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100460",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100552",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11032",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100395",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100477",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800180",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100479",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801040",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100558",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801121",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103997",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801124",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800268",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801126",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801209",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11120",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11121",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10342",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11128",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902717",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102048",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100801",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100489",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800272",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801053",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800274",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800276",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801213",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800355",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800279",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801138",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801217",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800432",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902480",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902561",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11134",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100486",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100571",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100573",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100651",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800280",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100819",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801069",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800523",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800603",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800525",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801067",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.14664",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800608",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801223",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800446",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100742",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800291",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801072",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801074",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100669",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100748",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801234",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800297",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100827",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.14674",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800617",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800610",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801152",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801232",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11153",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11154",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10379",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801081",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100755",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100911",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100675",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801087",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100838",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801244",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800467",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801403",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800547",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800627",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.802109",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800707",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800464",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800709",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100836",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801247",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10462",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800622",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10622",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100681",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103021",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801091",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800391",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800470",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801251",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800394",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800630",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800553",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800631",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800477",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800712",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.14772",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800559",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800716",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800633",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.14773",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103106",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100846",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801415",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100770",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103111",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100850",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100854",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103118",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801340",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100937",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100859",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800643",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801421",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800568",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800802",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800564",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.17200",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800728",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800807",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.14788",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100845",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.9000001",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100780",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801242",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103123",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103124",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103048",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103125",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100867",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800571",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103206",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800573",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100783",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800575",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103204",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801278",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801350",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801438",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800816",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800818",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800579",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800496",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103207",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800735",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100870",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900200",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100795",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103059",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100950",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801363",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801443",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.802145",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800900",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800901",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800821",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800825",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800905",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.15588",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103140",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10666",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103141",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103143",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103223",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103147",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800590",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800592",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900218",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800594",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.802230",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800832",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800677",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800911",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800913",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800918",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.802158",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103070",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800598",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103073",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103230",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801612",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103156",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901003",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103158",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801381",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800680",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800681",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901008",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800683",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.802244",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103317",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800765",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800688",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800923",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800768",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.17244",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800925",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.15765",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.15766",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800928",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10761",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103081",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103086",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901013",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103245",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801390",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901016",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800690",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801392",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800692",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800693",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.802178",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801394",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800933",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800779",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800936",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103326",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800939",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900242",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103098",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103255",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901025",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80003",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80004",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80005",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80006",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901107",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901023",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800941",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800864",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800786",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800949",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103181",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.20301",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900251",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900253",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900256",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900334",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900259",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900338",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800792",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800790",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901118",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800870",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800951",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901036",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801575",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800877",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800878",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800955",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801812",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.18219",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103190",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801737",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901121",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901044",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80100",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103514",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800884",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800964",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800969",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.20160",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10884",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11822",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900194",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900352",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901056",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11906",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11907",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900357",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800891",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901135",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800893",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11908",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800895",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800898",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801916",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900360",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103294",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11913",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80044",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80045",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801681",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902009",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800980",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800984",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800988",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900371",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900374",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900376",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.108198",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.108199",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.108203",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.108204",
+                "Service detection");
 }
 
 /**
@@ -593,14 +1113,16 @@ make_config_discovery (char *const uuid, char *const selector_name)
        " VALUES ('%s', 'Discovery', NULL,"
        "         '%s', 'Network Discovery scan configuration.',"
        "         0, 0, 0, 0, 0, m_now (), m_now ());",
-       uuid,
-       selector_name);
+       uuid, selector_name);
 
   /* Setup the appropriate NVTs for the config. */
   make_config_discovery_service_detection (selector_name);
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.17586", "Brute force attacks");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.17584", "Brute force attacks");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.17368", "Brute force attacks");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.17586",
+                "Brute force attacks");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.17584",
+                "Brute force attacks");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.17368",
+                "Brute force attacks");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11762", "Firewalls");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80059", "Firewalls");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100083", "Firewalls");
@@ -771,17 +1293,25 @@ make_config_discovery (char *const uuid, char *const selector_name)
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800357", "General");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900217", "General");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.51662", "General");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11431", "Peer-To-Peer File Sharing");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11427", "Peer-To-Peer File Sharing");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11125", "Peer-To-Peer File Sharing");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10946", "Peer-To-Peer File Sharing");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.19585", "Peer-To-Peer File Sharing");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.13751", "Peer-To-Peer File Sharing");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.14644", "Peer-To-Peer File Sharing");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11431",
+                "Peer-To-Peer File Sharing");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11427",
+                "Peer-To-Peer File Sharing");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11125",
+                "Peer-To-Peer File Sharing");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10946",
+                "Peer-To-Peer File Sharing");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.19585",
+                "Peer-To-Peer File Sharing");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.13751",
+                "Peer-To-Peer File Sharing");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.14644",
+                "Peer-To-Peer File Sharing");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10265", "SNMP");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103416", "SNMP");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.18528", "SMTP problems");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.91984", "Remote file access");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.91984",
+                "Remote file access");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900602", "RPC");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11111", "RPC");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11239", "Web Servers");
@@ -789,10 +1319,14 @@ make_config_discovery (char *const uuid, char *const selector_name)
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80024", "Web Servers");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.19689", "Web Servers");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10386", "Web Servers");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.108479", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.108102", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.108478", "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10942", "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.108479",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.108102",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.108478",
+                "Service detection");
+  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10942",
+                "Service detection");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.12231", "Windows");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80039", "Windows");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10394", "Windows");
@@ -924,8 +1458,10 @@ make_config_discovery (char *const uuid, char *const selector_name)
 
   /* Add the Product Detection family. */
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_FAMILY) ","
-       "         'Product detection', 'Product detection');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_FAMILY) ","
+                                   "         'Product detection', 'Product "
+                                   "detection');",
        selector_name);
 
   /* Update number of families and nvts. */
@@ -934,14 +1470,14 @@ make_config_discovery (char *const uuid, char *const selector_name)
        " modification_time = m_now ()"
        " WHERE uuid = '%s';",
        nvt_selector_family_count (selector_name, 0),
-       nvt_selector_nvt_count (selector_name, NULL, 0),
-       uuid);
+       nvt_selector_nvt_count (selector_name, NULL, 0), uuid);
 
   /* Add preferences for "ping host" nvt. */
   sql ("INSERT INTO config_preferences (config, type, name, value)"
        " VALUES ((SELECT id FROM configs WHERE uuid = '%s'),"
        "         'PLUGINS_PREFS',"
-       "         'Ping Host[checkbox]:Mark unrechable Hosts as dead (not scanning)',"
+       "         'Ping Host[checkbox]:Mark unrechable Hosts as dead (not "
+       "scanning)',"
        " 'yes');",
        uuid);
   sql ("INSERT INTO config_preferences (config, type, name, value)"

--- a/src/manage_config_discovery.c
+++ b/src/manage_config_discovery.c
@@ -41,7 +41,9 @@
        " (name, exclude, type, family_or_nvt, family)"                    \
        " VALUES"                                                          \
        " ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ", '%s','%s');", \
-       selector, oid, family)
+       selector,                                                          \
+       oid,                                                               \
+       family)
 
 /**
  * @brief Make Discovery Scan Config.
@@ -53,1046 +55,1046 @@
 void
 make_config_discovery_service_detection (char *const selector_name)
 {
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11929",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900534",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902019",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800991",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900539",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800995",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800997",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800999",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100106",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900381",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901084",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900384",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902023",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900620",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901089",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900387",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902028",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902106",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900547",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900705",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900628",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901087",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900624",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900543",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900629",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801869",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11865",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901174",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.12647",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900550",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901178",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900632",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80079",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900556",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900714",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801874",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900710",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100201",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100206",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100208",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900394",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900712",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11945",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.20377",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900562",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103652",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901188",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902046",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900641",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103579",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902044",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900647",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.17583",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100215",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100217",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100219",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11963",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80092",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900493",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900571",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80095",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902134",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902058",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902137",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900578",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900576",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900659",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100221",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100301",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100302",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902053",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100226",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100224",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.18532",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.18533",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.18534",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801972",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100300",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902061",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902220",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900583",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900744",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900822",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900746",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900748",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900904",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902309",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.101013",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100154",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100313",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801988",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.101019",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.101018",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900827",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100311",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100233",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11986",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11987",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902311",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900596",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902078",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900598",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100082",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100160",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100240",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.101021",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900753",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100243",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900917",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.101025",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.18393",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900839",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100324",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100322",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100407",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100328",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100329",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902081",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902083",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902084",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900681",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902089",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900686",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900923",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100174",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900926",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100254",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100331",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100335",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100259",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100417",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100419",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900930",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900853",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900932",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900855",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100180",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100184",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100261",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100187",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100266",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100423",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100268",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100425",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100503",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.20834",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902187",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100192",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902503",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100194",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900867",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100196",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900945",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100432",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100437",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100517",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.19289",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800300",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100518",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801005",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801007",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.19608",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900950",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100280",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902513",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900956",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100285",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100288",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100367",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102005",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102006",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102009",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.17975",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102003",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800158",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801017",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800317",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102001",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.66286",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902520",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900961",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902447",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900966",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100294",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10159",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100374",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102013",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100376",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100456",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102011",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102017",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801100",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800165",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801102",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103979",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801106",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100292",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800407",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900971",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902533",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900976",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100382",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100540",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100466",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100464",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100468",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800170",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800098",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801112",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.19559",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800413",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801038",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801115",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801117",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801119",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10330",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10175",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902545",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902701",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902547",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100392",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900983",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100460",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100552",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11032",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100395",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100477",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800180",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100479",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801040",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100558",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801121",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103997",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801124",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800268",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801126",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801209",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11120",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11121",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10342",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11128",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902717",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.102048",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100801",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100489",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800272",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801053",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800274",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800276",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801213",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800355",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800279",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801138",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801217",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800432",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902480",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902561",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11134",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100486",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100571",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100573",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100651",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800280",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100819",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801069",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800523",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800603",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800525",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801067",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.14664",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800608",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801223",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800446",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100742",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800291",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801072",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801074",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100669",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100748",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801234",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800297",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100827",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.14674",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800617",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800610",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801152",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801232",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11153",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11154",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10379",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801081",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100755",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100911",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100675",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801087",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100838",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801244",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800467",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801403",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800547",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800627",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.802109",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800707",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800464",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800709",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100836",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801247",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10462",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800622",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10622",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100681",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103021",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801091",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800391",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800470",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801251",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800394",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800630",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800553",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800631",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800477",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800712",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.14772",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800559",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800716",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800633",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.14773",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103106",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100846",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801415",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100770",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103111",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100850",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100854",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103118",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801340",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100937",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100859",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800643",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801421",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800568",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800802",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800564",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.17200",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800728",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800807",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.14788",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100845",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.9000001",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100780",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801242",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103123",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103124",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103048",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103125",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100867",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800571",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103206",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800573",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100783",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800575",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103204",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801278",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801350",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801438",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800816",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800818",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800579",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800496",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103207",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800735",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100870",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900200",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100795",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103059",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100950",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801363",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801443",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.802145",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800900",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800901",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800821",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800825",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800905",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.15588",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103140",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10666",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103141",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103143",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103223",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103147",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800590",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800592",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900218",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800594",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.802230",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800832",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800677",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800911",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800913",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800918",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.802158",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103070",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800598",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103073",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103230",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801612",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103156",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901003",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103158",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801381",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800680",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800681",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901008",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800683",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.802244",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103317",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800765",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800688",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800923",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800768",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.17244",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800925",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.15765",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.15766",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800928",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10761",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103081",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103086",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901013",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103245",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801390",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901016",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800690",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801392",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800692",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800693",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.802178",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801394",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800933",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800779",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800936",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103326",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800939",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900242",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103098",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103255",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901025",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80003",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80004",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80005",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80006",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901107",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901023",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800941",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800864",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800786",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800949",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103181",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.20301",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900251",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900253",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900256",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900334",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900259",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900338",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800792",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800790",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901118",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800870",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800951",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901036",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801575",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800877",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800878",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800955",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801812",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.18219",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103190",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801737",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901121",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901044",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80100",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103514",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800884",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800964",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800969",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.20160",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10884",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11822",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900194",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900352",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901056",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11906",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11907",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900357",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800891",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.901135",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800893",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11908",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800895",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800898",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801916",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900360",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103294",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11913",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80044",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80045",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.801681",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.902009",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800980",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800984",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800988",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900371",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900374",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900376",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.108198",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.108199",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.108203",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.108204",
-                "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.11929", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900534", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902019", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800991", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900539", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800995", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800997", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800999", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100106", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900381", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.901084", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900384", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902023", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900620", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.901089", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900387", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902028", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902106", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900547", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900705", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900628", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.901087", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900624", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900543", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900629", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801869", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.11865", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.901174", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.12647", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900550", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.901178", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900632", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.80079", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900556", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900714", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801874", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900710", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100201", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100206", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100208", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900394", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900712", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.11945", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.20377", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900562", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103652", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.901188", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902046", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900641", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103579", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902044", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900647", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.17583", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100215", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100217", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100219", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.11963", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.80092", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900493", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900571", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.80095", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902134", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902058", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902137", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900578", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900576", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900659", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100221", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100301", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100302", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902053", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100226", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100224", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.18532", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.18533", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.18534", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801972", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100300", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902061", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902220", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900583", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900744", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900822", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900746", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900748", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900904", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902309", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.101013", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100154", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100313", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801988", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.101019", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.101018", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900827", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100311", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100233", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.11986", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.11987", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902311", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900596", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902078", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900598", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100082", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100160", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100240", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.101021", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900753", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100243", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900917", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.101025", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.18393", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900839", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100324", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100322", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100407", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100328", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100329", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902081", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902083", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902084", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900681", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902089", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900686", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900923", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100174", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900926", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100254", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100331", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100335", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100259", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100417", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100419", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900930", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900853", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900932", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900855", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100180", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100184", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100261", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100187", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100266", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100423", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100268", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100425", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100503", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.20834", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902187", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100192", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902503", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100194", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900867", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100196", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900945", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100432", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100437", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100517", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.19289", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800300", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100518", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801005", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801007", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.19608", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900950", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100280", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902513", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900956", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100285", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100288", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100367", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.102005", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.102006", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.102009", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.17975", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.102003", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800158", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801017", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800317", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.102001", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.66286", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902520", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900961", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902447", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900966", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100294", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.10159", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100374", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.102013", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100376", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100456", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.102011", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.102017", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801100", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800165", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801102", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103979", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801106", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100292", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800407", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900971", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902533", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900976", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100382", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100540", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100466", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100464", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100468", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800170", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800098", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801112", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.19559", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800413", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801038", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801115", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801117", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801119", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.10330", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.10175", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902545", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902701", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902547", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100392", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900983", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100460", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100552", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.11032", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100395", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100477", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800180", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100479", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801040", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100558", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801121", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103997", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801124", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800268", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801126", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801209", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.11120", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.11121", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.10342", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.11128", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902717", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.102048", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100801", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100489", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800272", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801053", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800274", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800276", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801213", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800355", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800279", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801138", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801217", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800432", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902480", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902561", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.11134", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100486", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100571", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100573", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100651", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800280", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100819", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801069", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800523", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800603", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800525", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801067", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.14664", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800608", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801223", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800446", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100742", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800291", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801072", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801074", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100669", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100748", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801234", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800297", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100827", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.14674", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800617", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800610", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801152", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801232", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.11153", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.11154", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.10379", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801081", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100755", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100911", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100675", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801087", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100838", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801244", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800467", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801403", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800547", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800627", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.802109", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800707", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800464", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800709", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100836", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801247", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.10462", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800622", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.10622", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100681", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103021", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801091", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800391", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800470", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801251", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800394", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800630", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800553", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800631", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800477", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800712", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.14772", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800559", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800716", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800633", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.14773", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103106", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100846", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801415", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100770", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103111", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100850", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100854", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103118", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801340", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100937", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100859", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800643", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801421", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800568", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800802", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800564", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.17200", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800728", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800807", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.14788", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100845", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.9000001", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100780", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801242", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103123", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103124", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103048", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103125", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100867", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800571", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103206", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800573", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100783", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800575", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103204", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801278", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801350", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801438", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800816", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800818", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800579", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800496", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103207", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800735", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100870", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900200", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100795", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103059", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.100950", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801363", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801443", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.802145", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800900", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800901", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800821", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800825", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800905", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.15588", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103140", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.10666", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103141", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103143", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103223", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103147", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800590", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800592", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900218", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800594", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.802230", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800832", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800677", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800911", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800913", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800918", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.802158", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103070", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800598", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103073", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103230", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801612", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103156", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.901003", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103158", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801381", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800680", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800681", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.901008", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800683", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.802244", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103317", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800765", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800688", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800923", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800768", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.17244", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800925", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.15765", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.15766", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800928", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.10761", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103081", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103086", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.901013", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103245", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801390", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.901016", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800690", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801392", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800692", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800693", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.802178", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801394", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800933", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800779", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800936", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103326", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800939", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900242", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103098", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103255", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.901025", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.80003", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.80004", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.80005", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.80006", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.901107", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.901023", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800941", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800864", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800786", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800949", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103181", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.20301", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900251", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900253", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900256", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900334", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900259", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900338", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800792", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800790", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.901118", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800870", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800951", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.901036", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801575", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800877", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800878", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800955", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801812", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.18219", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103190", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801737", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.901121", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.901044", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.80100", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103514", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800884", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800964", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800969", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.20160", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.10884", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.11822", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900194", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900352", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.901056", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.11906", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.11907", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900357", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800891", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.901135", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800893", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.11908", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800895", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800898", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801916", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900360", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.103294", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.11913", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.80044", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.80045", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.801681", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.902009", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800980", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800984", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.800988", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900371", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900374", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.900376", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.108198", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.108199", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.108203", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.108204", "Service detection");
 }
 
 /**
@@ -1113,16 +1115,17 @@ make_config_discovery (char *const uuid, char *const selector_name)
        " VALUES ('%s', 'Discovery', NULL,"
        "         '%s', 'Network Discovery scan configuration.',"
        "         0, 0, 0, 0, 0, m_now (), m_now ());",
-       uuid, selector_name);
+       uuid,
+       selector_name);
 
   /* Setup the appropriate NVTs for the config. */
   make_config_discovery_service_detection (selector_name);
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.17586",
-                "Brute force attacks");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.17584",
-                "Brute force attacks");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.17368",
-                "Brute force attacks");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.17586", "Brute force attacks");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.17584", "Brute force attacks");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.17368", "Brute force attacks");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11762", "Firewalls");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80059", "Firewalls");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100083", "Firewalls");
@@ -1293,25 +1296,25 @@ make_config_discovery (char *const uuid, char *const selector_name)
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.800357", "General");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900217", "General");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.51662", "General");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11431",
-                "Peer-To-Peer File Sharing");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11427",
-                "Peer-To-Peer File Sharing");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11125",
-                "Peer-To-Peer File Sharing");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10946",
-                "Peer-To-Peer File Sharing");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.19585",
-                "Peer-To-Peer File Sharing");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.13751",
-                "Peer-To-Peer File Sharing");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.14644",
-                "Peer-To-Peer File Sharing");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.11431", "Peer-To-Peer File Sharing");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.11427", "Peer-To-Peer File Sharing");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.11125", "Peer-To-Peer File Sharing");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.10946", "Peer-To-Peer File Sharing");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.19585", "Peer-To-Peer File Sharing");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.13751", "Peer-To-Peer File Sharing");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.14644", "Peer-To-Peer File Sharing");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10265", "SNMP");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.103416", "SNMP");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.18528", "SMTP problems");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.91984",
-                "Remote file access");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.91984", "Remote file access");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900602", "RPC");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11111", "RPC");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.11239", "Web Servers");
@@ -1319,14 +1322,14 @@ make_config_discovery (char *const uuid, char *const selector_name)
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80024", "Web Servers");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.19689", "Web Servers");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10386", "Web Servers");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.108479",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.108102",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.108478",
-                "Service detection");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10942",
-                "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.108479", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.108102", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.108478", "Service detection");
+  NVT_SELECTOR (
+    selector_name, "1.3.6.1.4.1.25623.1.0.10942", "Service detection");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.12231", "Windows");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80039", "Windows");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10394", "Windows");
@@ -1470,7 +1473,8 @@ make_config_discovery (char *const uuid, char *const selector_name)
        " modification_time = m_now ()"
        " WHERE uuid = '%s';",
        nvt_selector_family_count (selector_name, 0),
-       nvt_selector_nvt_count (selector_name, NULL, 0), uuid);
+       nvt_selector_nvt_count (selector_name, NULL, 0),
+       uuid);
 
   /* Add preferences for "ping host" nvt. */
   sql ("INSERT INTO config_preferences (config, type, name, value)"

--- a/src/manage_config_host_discovery.c
+++ b/src/manage_config_host_discovery.c
@@ -57,16 +57,17 @@ make_config_host_discovery (char *const uuid, char *const selector_name)
        " VALUES ('%s', 'Host Discovery', NULL,"
        "         '%s', 'Network Host Discovery scan configuration.',"
        "         0, 0, 0, 0, 0, m_now (), m_now ());",
-       uuid,
-       selector_name);
+       uuid, selector_name);
 
   config = sql_last_insert_id ();
 
   /* Add the Ping Host NVT to the config. */
 
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.100315', 'Port scanners');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.100315', "
+                                "'Port scanners');",
        selector_name);
 
   /* Update number of families and nvts. */
@@ -76,15 +77,15 @@ make_config_host_discovery (char *const uuid, char *const selector_name)
        "     modification_time = m_now ()"
        " WHERE id = %llu;",
        nvt_selector_family_count (selector_name, 0),
-       nvt_selector_nvt_count (selector_name, NULL, 0),
-       config);
+       nvt_selector_nvt_count (selector_name, NULL, 0), config);
 
   /* Add preferences for "ping host" nvt. */
 
   sql ("INSERT INTO config_preferences (config, type, name, value)"
        " VALUES (%llu,"
        "         'PLUGINS_PREFS',"
-       "         'Ping Host[checkbox]:Mark unrechable Hosts as dead (not scanning)',"
+       "         'Ping Host[checkbox]:Mark unrechable Hosts as dead (not "
+       "scanning)',"
        "         'yes');",
        config);
 
@@ -149,11 +150,14 @@ check_config_host_discovery (const char *uuid)
                uuid)
       == 0)
     {
-      sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-           " VALUES ((SELECT nvt_selector FROM configs WHERE uuid = '%s'), 0,"
-           "         " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-           "         '1.3.6.1.4.1.25623.1.0.12288', 'Settings');",
-           uuid);
+      sql (
+        "INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
+        " VALUES ((SELECT nvt_selector FROM configs WHERE uuid = '%s'), 0,"
+        "         " G_STRINGIFY (
+          NVT_SELECTOR_TYPE_NVT) ","
+                                 "         '1.3.6.1.4.1.25623.1.0.12288', "
+                                 "'Settings');",
+        uuid);
       update = 1;
     }
 

--- a/src/manage_config_host_discovery.c
+++ b/src/manage_config_host_discovery.c
@@ -57,7 +57,8 @@ make_config_host_discovery (char *const uuid, char *const selector_name)
        " VALUES ('%s', 'Host Discovery', NULL,"
        "         '%s', 'Network Host Discovery scan configuration.',"
        "         0, 0, 0, 0, 0, m_now (), m_now ());",
-       uuid, selector_name);
+       uuid,
+       selector_name);
 
   config = sql_last_insert_id ();
 
@@ -77,7 +78,8 @@ make_config_host_discovery (char *const uuid, char *const selector_name)
        "     modification_time = m_now ()"
        " WHERE id = %llu;",
        nvt_selector_family_count (selector_name, 0),
-       nvt_selector_nvt_count (selector_name, NULL, 0), config);
+       nvt_selector_nvt_count (selector_name, NULL, 0),
+       config);
 
   /* Add preferences for "ping host" nvt. */
 

--- a/src/manage_config_system_discovery.c
+++ b/src/manage_config_system_discovery.c
@@ -57,7 +57,8 @@ make_config_system_discovery (char *const uuid, char *const selector_name)
        " VALUES ('%s', 'System Discovery', NULL,"
        "         '%s', 'Network System Discovery scan configuration.',"
        "         0, 0, 0, 0, 0, m_now (), m_now ());",
-       uuid, selector_name);
+       uuid,
+       selector_name);
 
   config = sql_last_insert_id ();
 
@@ -251,7 +252,8 @@ make_config_system_discovery (char *const uuid, char *const selector_name)
        "     modification_time = m_now ()"
        " WHERE id = %llu;",
        nvt_selector_family_count (selector_name, 0),
-       nvt_selector_nvt_count (selector_name, NULL, 0), config);
+       nvt_selector_nvt_count (selector_name, NULL, 0),
+       config);
 }
 
 /**

--- a/src/manage_config_system_discovery.c
+++ b/src/manage_config_system_discovery.c
@@ -57,132 +57,191 @@ make_config_system_discovery (char *const uuid, char *const selector_name)
        " VALUES ('%s', 'System Discovery', NULL,"
        "         '%s', 'Network System Discovery scan configuration.',"
        "         0, 0, 0, 0, 0, m_now (), m_now ());",
-       uuid,
-       selector_name);
+       uuid, selector_name);
 
   config = sql_last_insert_id ();
 
   /* Add NVTs to the config. */
 
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.100315', 'Port scanners');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.100315', "
+                                "'Port scanners');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.14259', 'Port scanners');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.14259', 'Port "
+                                "scanners');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.50282', 'General');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.50282', "
+                                "'General');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.51662', 'General');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.51662', "
+                                "'General');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.96207', 'Windows');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.96207', "
+                                "'Windows');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.103621', 'Windows');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.103621', "
+                                "'Windows');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.103220', 'Product detection');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.103220', "
+                                "'Product detection');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.102002', 'Product detection');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.102002', "
+                                "'Product detection');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.103633', 'Product detection');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.103633', "
+                                "'Product detection');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.103804', 'Product detection');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.103804', "
+                                "'Product detection');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.96200', 'Product detection');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.96200', "
+                                "'Product detection');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.103675', 'Product detection');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.103675', "
+                                "'Product detection');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.103817', 'Product detection');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.103817', "
+                                "'Product detection');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.103628', 'Product detection');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.103628', "
+                                "'Product detection');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.803719', 'Product detection');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.803719', "
+                                "'Product detection');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.103799', 'Product detection');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.103799', "
+                                "'Product detection');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.103685', 'Product detection');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.103685', "
+                                "'Product detection');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.103809', 'Product detection');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.103809', "
+                                "'Product detection');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.103707', 'Product detection');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.103707', "
+                                "'Product detection');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.103418', 'Product detection');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.103418', "
+                                "'Product detection');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.10267', 'Product detection');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.10267', "
+                                "'Product detection');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.103417', 'Product detection');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.103417', "
+                                "'Product detection');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.103648', 'Product detection');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.103648', "
+                                "'Product detection');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.103779', 'Product detection');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.103779', "
+                                "'Product detection');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.105937', 'Product detection');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.105937', "
+                                "'Product detection');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.103997', 'Service detection');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.103997', "
+                                "'Service detection');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.10884', 'Service detection');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.10884', "
+                                "'Service detection');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.102011', 'Service detection');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.102011', "
+                                "'Service detection');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.101013', 'Service detection');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.101013', "
+                                "'Service detection');",
        selector_name);
   sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-       " VALUES ('%s', 0, " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-       "         '1.3.6.1.4.1.25623.1.0.103416', 'SNMP');",
+       " VALUES ('%s', 0, " G_STRINGIFY (
+         NVT_SELECTOR_TYPE_NVT) ","
+                                "         '1.3.6.1.4.1.25623.1.0.103416', "
+                                "'SNMP');",
        selector_name);
 
   /* Update number of families and nvts. */
@@ -192,8 +251,7 @@ make_config_system_discovery (char *const uuid, char *const selector_name)
        "     modification_time = m_now ()"
        " WHERE id = %llu;",
        nvt_selector_family_count (selector_name, 0),
-       nvt_selector_nvt_count (selector_name, NULL, 0),
-       config);
+       nvt_selector_nvt_count (selector_name, NULL, 0), config);
 }
 
 /**
@@ -219,11 +277,14 @@ check_config_system_discovery (const char *uuid)
                uuid)
       == 0)
     {
-      sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-           " VALUES ((SELECT nvt_selector FROM configs WHERE uuid = '%s'), 0,"
-           "         " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-           "         '1.3.6.1.4.1.25623.1.0.51662', 'General');",
-           uuid);
+      sql (
+        "INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
+        " VALUES ((SELECT nvt_selector FROM configs WHERE uuid = '%s'), 0,"
+        "         " G_STRINGIFY (
+          NVT_SELECTOR_TYPE_NVT) ","
+                                 "         '1.3.6.1.4.1.25623.1.0.51662', "
+                                 "'General');",
+        uuid);
       update = 1;
     }
 
@@ -234,11 +295,14 @@ check_config_system_discovery (const char *uuid)
                uuid)
       == 0)
     {
-      sql ("INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
-           " VALUES ((SELECT nvt_selector FROM configs WHERE uuid = '%s'), 0,"
-           "         " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT) ","
-           "         '1.3.6.1.4.1.25623.1.0.105937', 'Product detection');",
-           uuid);
+      sql (
+        "INSERT INTO nvt_selectors (name, exclude, type, family_or_nvt, family)"
+        " VALUES ((SELECT nvt_selector FROM configs WHERE uuid = '%s'), 0,"
+        "         " G_STRINGIFY (
+          NVT_SELECTOR_TYPE_NVT) ","
+                                 "         '1.3.6.1.4.1.25623.1.0.105937', "
+                                 "'Product detection');",
+        uuid);
       update = 1;
     }
 

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -489,8 +489,10 @@ manage_update_scap_db_cleanup ()
  * @param[in]  new_name   Name of column in new table.
  */
 void
-sql_rename_column (const char *old_table, const char *new_table,
-                   const char *old_name, const char *new_name)
+sql_rename_column (const char *old_table,
+                   const char *new_table,
+                   const char *old_name,
+                   const char *new_name)
 {
   return;
 }

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -3281,8 +3281,10 @@ check_db_sequences ()
 
       sql_int64 (&old_start, "SELECT last_value + 1 FROM %s;", sequence);
 
-      sql_int64 (&new_start, "SELECT coalesce (max (%s), 0) + 1 FROM %s;",
-                 column, table);
+      sql_int64 (&new_start,
+                 "SELECT coalesce (max (%s), 0) + 1 FROM %s;",
+                 column,
+                 table);
 
       if (old_start < new_start)
         sql ("ALTER SEQUENCE %s RESTART WITH %llu;", sequence, new_start);

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -25,13 +25,13 @@
  * to be coded for each backend.  This is the PostgreSQL version.
  */
 
-#include <strings.h> /* for strcasecmp() */
-#include <assert.h>  /* for assert() */
-
-#include "sql.h"
+#include "manage_acl.h"
 #include "manage_sql.h"
 #include "manage_utils.h"
-#include "manage_acl.h"
+#include "sql.h"
+
+#include <assert.h>  /* for assert() */
+#include <strings.h> /* for strcasecmp() */
 
 #undef G_LOG_DOMAIN
 /**
@@ -39,7 +39,6 @@
  */
 #define G_LOG_DOMAIN "md manage"
 
-
 /* Session. */
 
 /**
@@ -71,7 +70,6 @@ manage_session_set_timezone (const char *zone)
   return;
 }
 
-
 /* Helpers. */
 
 /**
@@ -91,7 +89,6 @@ manage_db_empty ()
          == 0;
 }
 
-
 /* SCAP. */
 
 /**
@@ -163,7 +160,7 @@ manage_update_cert_db_init ()
        "               cve_refs_arg);"
        "       RETURN;"
        "     EXCEPTION WHEN unique_violation THEN"
-       "       NULL;"  /* Try again. */
+       "       NULL;" /* Try again. */
        "     END;"
        "   END LOOP;"
        " END;"
@@ -200,7 +197,7 @@ manage_update_cert_db_init ()
        "               cve_refs_arg);"
        "       RETURN;"
        "     EXCEPTION WHEN unique_violation THEN"
-       "       NULL;"  /* Try again. */
+       "       NULL;" /* Try again. */
        "     END;"
        "   END LOOP;"
        " END;"
@@ -269,7 +266,7 @@ manage_update_scap_db_init ()
        "               nvd_id_arg);"
        "       RETURN;"
        "     EXCEPTION WHEN unique_violation THEN"
-       "       NULL;"  /* Try again. */
+       "       NULL;" /* Try again. */
        "     END;"
        "   END LOOP;"
        " END;"
@@ -322,7 +319,7 @@ manage_update_scap_db_init ()
        "               availability_impact_arg, products_arg);"
        "       RETURN;"
        "     EXCEPTION WHEN unique_violation THEN"
-       "       NULL;"  /* Try again. */
+       "       NULL;" /* Try again. */
        "     END;"
        "   END LOOP;"
        " END;"
@@ -347,7 +344,7 @@ manage_update_scap_db_init ()
        "       VALUES (uuid_arg, name_arg, published_arg, modified_arg);"
        "       RETURN;"
        "     EXCEPTION WHEN unique_violation THEN"
-       "       NULL;"  /* Try again. */
+       "       NULL;" /* Try again. */
        "     END;"
        "   END LOOP;"
        " END;"
@@ -370,7 +367,7 @@ manage_update_scap_db_init ()
        "       VALUES (cve_arg, cpe_arg);"
        "       RETURN;"
        "     EXCEPTION WHEN unique_violation THEN"
-       "       NULL;"  /* Try again. */
+       "       NULL;" /* Try again. */
        "     END;"
        "   END LOOP;"
        " END;"
@@ -423,7 +420,7 @@ manage_update_scap_db_init ()
        "               status_arg, 0.0, cve_refs_arg);"
        "       RETURN;"
        "     EXCEPTION WHEN unique_violation THEN"
-       "       NULL;"  /* Try again. */
+       "       NULL;" /* Try again. */
        "     END;"
        "   END LOOP;"
        " END;"
@@ -481,7 +478,6 @@ manage_update_scap_db_cleanup ()
        "                             cve_refs_arg INTEGER);");
 }
 
-
 /* SQL functions. */
 
 /**
@@ -502,40 +498,41 @@ sql_rename_column (const char *old_table, const char *new_table,
 /**
  * @brief Common overrides SQL for SQL functions.
  */
-#define OVERRIDES_SQL(severity_sql)                         \
- " coalesce"                                                \
- "  ((SELECT overrides.new_severity"                        \
- "    FROM overrides"                                       \
- "    WHERE overrides.result_nvt = results.result_nvt"      \
- "    AND ((overrides.owner IS NULL)"                       \
- "         OR (overrides.owner ="                           \
- "             (SELECT id FROM users"                       \
- "              WHERE users.uuid"                           \
- "                    = (SELECT uuid"                       \
- "                       FROM current_credentials))))"      \
- "    AND ((overrides.end_time = 0)"                        \
- "         OR (overrides.end_time >= m_now ()))"            \
- "    AND (overrides.task = results.task"                   \
- "         OR overrides.task = 0)"                          \
- "    AND (overrides.result = results.id"                   \
- "         OR overrides.result = 0)"                        \
- "    AND (overrides.hosts is NULL"                         \
- "         OR overrides.hosts = ''"                         \
- "         OR hosts_contains (overrides.hosts,"             \
- "                            results.host))"               \
- "    AND (overrides.port is NULL"                          \
- "         OR overrides.port = ''"                          \
- "         OR overrides.port = results.port)"               \
- "    AND severity_matches_ov"                              \
- "         (" severity_sql ", overrides.severity)"          \
- "    ORDER BY overrides.result DESC,"                      \
- "             overrides.task DESC,"                        \
- "             overrides.port DESC,"                        \
- "             overrides.severity ASC,"                     \
- "             overrides.creation_time DESC"                \
- "    LIMIT 1),"                                            \
- "   " severity_sql ")"
+#define OVERRIDES_SQL(severity_sql)                     \
+  " coalesce"                                           \
+  "  ((SELECT overrides.new_severity"                   \
+  "    FROM overrides"                                  \
+  "    WHERE overrides.result_nvt = results.result_nvt" \
+  "    AND ((overrides.owner IS NULL)"                  \
+  "         OR (overrides.owner ="                      \
+  "             (SELECT id FROM users"                  \
+  "              WHERE users.uuid"                      \
+  "                    = (SELECT uuid"                  \
+  "                       FROM current_credentials))))" \
+  "    AND ((overrides.end_time = 0)"                   \
+  "         OR (overrides.end_time >= m_now ()))"       \
+  "    AND (overrides.task = results.task"              \
+  "         OR overrides.task = 0)"                     \
+  "    AND (overrides.result = results.id"              \
+  "         OR overrides.result = 0)"                   \
+  "    AND (overrides.hosts is NULL"                    \
+  "         OR overrides.hosts = ''"                    \
+  "         OR hosts_contains (overrides.hosts,"        \
+  "                            results.host))"          \
+  "    AND (overrides.port is NULL"                     \
+  "         OR overrides.port = ''"                     \
+  "         OR overrides.port = results.port)"          \
+  "    AND severity_matches_ov"                         \
+  "         (" severity_sql ", overrides.severity)"     \
+  "    ORDER BY overrides.result DESC,"                 \
+  "             overrides.task DESC,"                   \
+  "             overrides.port DESC,"                   \
+  "             overrides.severity ASC,"                \
+  "             overrides.creation_time DESC"           \
+  "    LIMIT 1),"                                       \
+  "   " severity_sql ")"
 
+// clang-format off
 /**
  * @brief Create functions.
  *
@@ -1977,8 +1974,8 @@ manage_create_sql_functions ()
 
   return 0;
 }
+// clang-format on
 
-
 /* Creation. */
 
 /**
@@ -1998,10 +1995,12 @@ manage_create_result_indexes ()
 /**
  * @brief Results WHERE SQL for creating views in create_tabes.
  */
-#define VULNS_RESULTS_WHERE                                           \
-  " WHERE uuid IN"                                                    \
-  "   (SELECT nvt FROM results"                                       \
+#define VULNS_RESULTS_WHERE     \
+  " WHERE uuid IN"              \
+  "   (SELECT nvt FROM results" \
   "     WHERE (results.severity != " G_STRINGIFY (SEVERITY_ERROR) "))"
+
+// clang-format off
 
 /**
  * @brief Create all tables.
@@ -3254,6 +3253,7 @@ create_tables ()
        "         'result_nvt_reports',"
        "         'report');");
 }
+// clang-format on
 
 /**
  * @brief Ensure sequences for automatic ids are in a consistent state.
@@ -3264,27 +3264,24 @@ void
 check_db_sequences ()
 {
   iterator_t sequence_tables;
-  init_iterator(&sequence_tables,
-                "SELECT table_name, column_name,"
-                "       pg_get_serial_sequence (table_name, column_name)"
-                "  FROM information_schema.columns"
-                "  WHERE table_schema = 'public'"
-                "    AND pg_get_serial_sequence (table_name, column_name)"
-                "        IS NOT NULL;");
+  init_iterator (&sequence_tables,
+                 "SELECT table_name, column_name,"
+                 "       pg_get_serial_sequence (table_name, column_name)"
+                 "  FROM information_schema.columns"
+                 "  WHERE table_schema = 'public'"
+                 "    AND pg_get_serial_sequence (table_name, column_name)"
+                 "        IS NOT NULL;");
 
   while (next (&sequence_tables))
     {
-      const char* table = iterator_string (&sequence_tables, 0);
-      const char* column = iterator_string (&sequence_tables, 1);
-      const char* sequence = iterator_string (&sequence_tables, 2);
+      const char *table = iterator_string (&sequence_tables, 0);
+      const char *column = iterator_string (&sequence_tables, 1);
+      const char *sequence = iterator_string (&sequence_tables, 2);
       resource_t old_start, new_start;
 
-      sql_int64 (&old_start,
-                 "SELECT last_value + 1 FROM %s;",
-                 sequence);
+      sql_int64 (&old_start, "SELECT last_value + 1 FROM %s;", sequence);
 
-      sql_int64 (&new_start,
-                 "SELECT coalesce (max (%s), 0) + 1 FROM %s;",
+      sql_int64 (&new_start, "SELECT coalesce (max (%s), 0) + 1 FROM %s;",
                  column, table);
 
       if (old_start < new_start)
@@ -3294,7 +3291,6 @@ check_db_sequences ()
   cleanup_iterator (&sequence_tables);
 }
 
-
 /* SecInfo. */
 
 /**
@@ -3524,13 +3520,13 @@ manage_db_init (const gchar *name)
       sql ("CREATE TABLE scap.ovaldefs"
            " (id SERIAL PRIMARY KEY,"
            "  uuid text UNIQUE,"
-           "  name text,"                   /* OVAL identifier. */
+           "  name text," /* OVAL identifier. */
            "  comment text,"
            "  creation_time integer,"
            "  modification_time integer,"
            "  version INTEGER,"
            "  deprecated INTEGER,"
-           "  def_class TEXT,"              /* Enum. */
+           "  def_class TEXT," /* Enum. */
            "  title TEXT,"
            "  description TEXT,"
            "  xml_file TEXT,"
@@ -3570,7 +3566,7 @@ manage_db_init (const gchar *name)
            "$$ LANGUAGE plpgsql;");
 
       sql ("CREATE TRIGGER cves_delete AFTER DELETE ON cves"
-	   " FOR EACH ROW EXECUTE PROCEDURE scap_delete_affected ();");
+           " FOR EACH ROW EXECUTE PROCEDURE scap_delete_affected ();");
 
       sql ("CREATE OR REPLACE FUNCTION scap_update_cpes ()"
            " RETURNS TRIGGER AS $$"
@@ -3605,7 +3601,7 @@ manage_db_init (const gchar *name)
 
       sql ("CREATE TRIGGER affected_ovaldefs_delete"
            " AFTER DELETE ON affected_ovaldefs"
-	   " FOR EACH ROW EXECUTE PROCEDURE scap_update_oval ();");
+           " FOR EACH ROW EXECUTE PROCEDURE scap_update_oval ();");
 
       /* Init tables. */
 
@@ -3679,7 +3675,6 @@ manage_scap_loaded ()
                     sql_database ());
 }
 
-
 /* Backup. */
 
 /**
@@ -3696,7 +3691,6 @@ manage_backup_db (const gchar *database)
   return -1;
 }
 
-
 /* Migrator helper. */
 
 /**

--- a/src/manage_pg_server.c
+++ b/src/manage_pg_server.c
@@ -25,12 +25,11 @@
  * functions for the management layer that need to be implemented in C.
  */
 
-#include "manage_utils.h"
-
-#include "postgres.h"
-#include "fmgr.h"
 #include "executor/spi.h"
+#include "fmgr.h"
 #include "glib.h"
+#include "manage_utils.h"
+#include "postgres.h"
 
 #include <gvm/base/hosts.h>
 
@@ -70,7 +69,7 @@ get_max_hosts ()
   ret = SPI_exec ("SELECT coalesce ((SELECT value FROM meta"
                   "                  WHERE name = 'max_hosts'),"
                   "                 '4095');", /* Same as MANAGE_MAX_HOSTS. */
-                  1); /* Max 1 row returned. */
+                  1);                          /* Max 1 row returned. */
   if (SPI_processed > 0 && ret > 0 && SPI_tuptable != NULL)
     {
       char *cell;
@@ -98,8 +97,7 @@ PG_FUNCTION_INFO_V1 (sql_hosts_contains);
  *
  * @return Postgres Datum.
  */
-Datum
-sql_hosts_contains (PG_FUNCTION_ARGS)
+Datum sql_hosts_contains (PG_FUNCTION_ARGS)
 {
   if (PG_ARGISNULL (0) || PG_ARGISNULL (1))
     PG_RETURN_BOOL (0);
@@ -109,16 +107,15 @@ sql_hosts_contains (PG_FUNCTION_ARGS)
       char *hosts, *find_host;
       int max_hosts, ret;
 
-      hosts_arg = PG_GETARG_TEXT_P(0);
+      hosts_arg = PG_GETARG_TEXT_P (0);
       hosts = textndup (hosts_arg, VARSIZE (hosts_arg) - VARHDRSZ);
 
-      find_host_arg = PG_GETARG_TEXT_P(1);
+      find_host_arg = PG_GETARG_TEXT_P (1);
       find_host = textndup (find_host_arg, VARSIZE (find_host_arg) - VARHDRSZ);
 
       max_hosts = get_max_hosts ();
 
-      if (hosts_str_contains ((gchar *) hosts, (gchar *) find_host,
-                              max_hosts))
+      if (hosts_str_contains ((gchar *) hosts, (gchar *) find_host, max_hosts))
         ret = 1;
       else
         ret = 0;
@@ -141,8 +138,7 @@ PG_FUNCTION_INFO_V1 (sql_next_time);
  *
  * @return Postgres Datum.
  */
-Datum
-sql_next_time (PG_FUNCTION_ARGS)
+Datum sql_next_time (PG_FUNCTION_ARGS)
 {
   int32 first, period, period_months, byday, periods_offset;
   char *zone;
@@ -153,22 +149,21 @@ sql_next_time (PG_FUNCTION_ARGS)
   period_months = PG_GETARG_INT32 (2);
   byday = PG_GETARG_INT32 (3);
 
-  if (PG_NARGS() < 5 || PG_ARGISNULL (4))
+  if (PG_NARGS () < 5 || PG_ARGISNULL (4))
     zone = NULL;
   else
     {
-      text* timezone_arg;
+      text *timezone_arg;
       timezone_arg = PG_GETARG_TEXT_P (4);
       zone = textndup (timezone_arg, VARSIZE (timezone_arg) - VARHDRSZ);
     }
 
-  if (PG_NARGS() < 6 || PG_ARGISNULL (5))
+  if (PG_NARGS () < 6 || PG_ARGISNULL (5))
     periods_offset = 0;
   else
     periods_offset = PG_GETARG_INT32 (5);
 
-  ret = next_time (first, period, period_months, byday, zone,
-                   periods_offset);
+  ret = next_time (first, period, period_months, byday, zone, periods_offset);
   if (zone)
     pfree (zone);
   PG_RETURN_INT32 (ret);
@@ -186,38 +181,36 @@ PG_FUNCTION_INFO_V1 (sql_next_time_ical);
  *
  * @return Postgres Datum.
  */
-Datum
-sql_next_time_ical (PG_FUNCTION_ARGS)
+Datum sql_next_time_ical (PG_FUNCTION_ARGS)
 {
   char *ical_string, *zone;
   int periods_offset;
   int32 ret;
 
-  if (PG_NARGS() < 1 || PG_ARGISNULL (0))
+  if (PG_NARGS () < 1 || PG_ARGISNULL (0))
     {
       PG_RETURN_NULL ();
     }
   else
     {
-      text* ical_string_arg;
+      text *ical_string_arg;
       ical_string_arg = PG_GETARG_TEXT_P (0);
-      ical_string = textndup (ical_string_arg,
-                              VARSIZE (ical_string_arg) - VARHDRSZ);
+      ical_string =
+        textndup (ical_string_arg, VARSIZE (ical_string_arg) - VARHDRSZ);
     }
 
-  if (PG_NARGS() < 2 || PG_ARGISNULL (1))
+  if (PG_NARGS () < 2 || PG_ARGISNULL (1))
     zone = NULL;
   else
     {
-      text* timezone_arg;
+      text *timezone_arg;
       timezone_arg = PG_GETARG_TEXT_P (1);
       zone = textndup (timezone_arg, VARSIZE (timezone_arg) - VARHDRSZ);
     }
 
   periods_offset = PG_GETARG_INT32 (2);
 
-  ret = icalendar_next_time_from_string (ical_string, zone,
-                                         periods_offset);
+  ret = icalendar_next_time_from_string (ical_string, zone, periods_offset);
   if (ical_string)
     pfree (ical_string);
   if (zone)
@@ -237,8 +230,7 @@ PG_FUNCTION_INFO_V1 (sql_max_hosts);
  *
  * @return Postgres Datum.
  */
-Datum
-sql_max_hosts (PG_FUNCTION_ARGS)
+Datum sql_max_hosts (PG_FUNCTION_ARGS)
 {
   if (PG_ARGISNULL (0))
     PG_RETURN_INT32 (0);
@@ -282,8 +274,7 @@ PG_FUNCTION_INFO_V1 (sql_level_min_severity);
  *
  * @return Postgres Datum.
  */
-Datum
-sql_level_min_severity (PG_FUNCTION_ARGS)
+Datum sql_level_min_severity (PG_FUNCTION_ARGS)
 {
   if (PG_ARGISNULL (0))
     PG_RETURN_FLOAT8 (0.0);
@@ -319,8 +310,7 @@ PG_FUNCTION_INFO_V1 (sql_level_max_severity);
  *
  * @return Postgres Datum.
  */
-Datum
-sql_level_max_severity (PG_FUNCTION_ARGS)
+Datum sql_level_max_severity (PG_FUNCTION_ARGS)
 {
   if (PG_ARGISNULL (0))
     PG_RETURN_FLOAT8 (0.0);
@@ -356,8 +346,7 @@ PG_FUNCTION_INFO_V1 (sql_severity_matches_ov);
  *
  * @return Postgres Datum.
  */
-Datum
-sql_severity_matches_ov (PG_FUNCTION_ARGS)
+Datum sql_severity_matches_ov (PG_FUNCTION_ARGS)
 {
   if (PG_ARGISNULL (0))
     PG_RETURN_BOOL (0);
@@ -388,8 +377,7 @@ PG_FUNCTION_INFO_V1 (sql_valid_db_resource_type);
  *
  * @return Postgres Datum.
  */
-Datum
-sql_valid_db_resource_type (PG_FUNCTION_ARGS)
+Datum sql_valid_db_resource_type (PG_FUNCTION_ARGS)
 {
   if (PG_ARGISNULL (0))
     PG_RETURN_BOOL (0);
@@ -421,8 +409,7 @@ PG_FUNCTION_INFO_V1 (sql_regexp);
  *
  * @return Postgres Datum.
  */
-Datum
-sql_regexp (PG_FUNCTION_ARGS)
+Datum sql_regexp (PG_FUNCTION_ARGS)
 {
   if (PG_ARGISNULL (0) || PG_ARGISNULL (1))
     PG_RETURN_BOOL (0);
@@ -432,10 +419,10 @@ sql_regexp (PG_FUNCTION_ARGS)
       char *string, *regexp;
       int ret;
 
-      regexp_arg = PG_GETARG_TEXT_P(1);
+      regexp_arg = PG_GETARG_TEXT_P (1);
       regexp = textndup (regexp_arg, VARSIZE (regexp_arg) - VARHDRSZ);
 
-      string_arg = PG_GETARG_TEXT_P(0);
+      string_arg = PG_GETARG_TEXT_P (0);
       string = textndup (string_arg, VARSIZE (string_arg) - VARHDRSZ);
 
       if (g_regex_match_simple ((gchar *) regexp, (gchar *) string, 0, 0))

--- a/src/manage_pg_server.c
+++ b/src/manage_pg_server.c
@@ -25,11 +25,13 @@
  * functions for the management layer that need to be implemented in C.
  */
 
+// clang-format off
+#include "postgres.h" /* Keep include before executor/spi.h */
+// clang-format on
 #include "executor/spi.h"
 #include "fmgr.h"
 #include "glib.h"
 #include "manage_utils.h"
-#include "postgres.h"
 
 #include <gvm/base/hosts.h>
 

--- a/src/manage_ranges_all_tcp_nmap_5_51_top_100.c
+++ b/src/manage_ranges_all_tcp_nmap_5_51_top_100.c
@@ -35,8 +35,7 @@
 /**
  * @brief Insert a port range.
  */
-#define RANGE(type, start, end)                                      \
-  insert_port_range (list, type, start, end)
+#define RANGE(type, start, end) insert_port_range (list, type, start, end)
 
 /**
  * @brief Make port ranges for IANA TCP 2012.

--- a/src/manage_ranges_all_tcp_nmap_5_51_top_1000.c
+++ b/src/manage_ranges_all_tcp_nmap_5_51_top_1000.c
@@ -35,8 +35,7 @@
 /**
  * @brief Insert a port range.
  */
-#define RANGE(type, start, end)                                      \
-  insert_port_range (list, type, start, end)
+#define RANGE(type, start, end) insert_port_range (list, type, start, end)
 
 /**
  * @brief Make port ranges for IANA TCP 2012.

--- a/src/manage_ranges_iana_tcp_2012.c
+++ b/src/manage_ranges_iana_tcp_2012.c
@@ -35,8 +35,7 @@
 /**
  * @brief Insert a port range.
  */
-#define RANGE(type, start, end)                                      \
-  insert_port_range (list, type, start, end)
+#define RANGE(type, start, end) insert_port_range (list, type, start, end)
 
 /**
  * @brief Make port ranges for IANA TCP 2012.

--- a/src/manage_ranges_iana_tcp_udp_2012.c
+++ b/src/manage_ranges_iana_tcp_udp_2012.c
@@ -35,8 +35,7 @@
 /**
  * @brief Insert a port range.
  */
-#define RANGE(type, start, end)                                      \
-  insert_port_range (list, type, start, end)
+#define RANGE(type, start, end) insert_port_range (list, type, start, end)
 
 /**
  * @brief Make port ranges for IANA TCP and UDP 2012.

--- a/src/manage_ranges_nmap_5_51_top_2000_top_100.c
+++ b/src/manage_ranges_nmap_5_51_top_2000_top_100.c
@@ -35,8 +35,7 @@
 /**
  * @brief Insert a port range.
  */
-#define RANGE(type, start, end)                                      \
-  insert_port_range (list, type, start, end)
+#define RANGE(type, start, end) insert_port_range (list, type, start, end)
 
 /**
  * @brief Make port ranges for Nmap top 2000 top 100.

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -25,12 +25,11 @@
 #ifndef _GVMD_MANAGE_SQL_H
 #define _GVMD_MANAGE_SQL_H
 
-#include <gvm/util/xmlutils.h> /* for entity_t */
-
 #include "manage.h"
 #include "manage_utils.h"
 
-
+#include <gvm/util/xmlutils.h> /* for entity_t */
+
 /* Internal types and preprocessor definitions. */
 
 /**
@@ -42,7 +41,7 @@
  * @brief UUID of 'Full and fast ultimate' config.
  */
 #define CONFIG_UUID_FULL_AND_FAST_ULTIMATE \
- "698f691e-7489-11df-9d8c-002264764cea"
+  "698f691e-7489-11df-9d8c-002264764cea"
 
 /**
  * @brief UUID of 'Full and very deep' config.
@@ -53,7 +52,7 @@
  * @brief UUID of 'Full and very deep ultimate' config.
  */
 #define CONFIG_UUID_FULL_AND_VERY_DEEP_ULTIMATE \
- "74db13d6-7489-11df-91b9-002264764cea"
+  "74db13d6-7489-11df-91b9-002264764cea"
 
 /**
  * @brief UUID of 'Empty' config.
@@ -93,19 +92,20 @@
 /**
  * @brief UUID of 'Discovery' NVT selector.
  */
-#define MANAGE_NVT_SELECTOR_UUID_DISCOVERY "0d9a2738-8fe2-4e22-8f26-bb886179e759"
+#define MANAGE_NVT_SELECTOR_UUID_DISCOVERY \
+  "0d9a2738-8fe2-4e22-8f26-bb886179e759"
 
 /**
  * @brief UUID of 'Host Discovery' NVT selector.
  */
 #define MANAGE_NVT_SELECTOR_UUID_HOST_DISCOVERY \
- "f5f80744-55c7-11e3-8dc6-406186ea4fc5"
+  "f5f80744-55c7-11e3-8dc6-406186ea4fc5"
 
 /**
  * @brief UUID of 'System Discovery' NVT selector.
  */
 #define MANAGE_NVT_SELECTOR_UUID_SYSTEM_DISCOVERY \
- "07045d1c-a951-11e3-8da7-406186ea4fc5"
+  "07045d1c-a951-11e3-8da7-406186ea4fc5"
 
 /**
  * @brief Predefined role UUID.
@@ -115,7 +115,8 @@
 /**
  * @brief Predefined role UUID.
  */
-#define PERMISSION_UUID_SUPER_ADMIN_EVERYTHING "a9801074-6fe2-11e4-9d81-406186ea4fc5"
+#define PERMISSION_UUID_SUPER_ADMIN_EVERYTHING \
+  "a9801074-6fe2-11e4-9d81-406186ea4fc5"
 
 /**
  * @brief UUID of 'OpenVAS Default' port list.
@@ -130,12 +131,14 @@
 /**
  * @brief UUID of 'All TCP and Nmap 5.51 Top 100 UDP' port list.
  */
-#define PORT_LIST_UUID_ALL_TCP_NMAP_5_51_TOP_100 "730ef368-57e2-11e1-a90f-406186ea4fc5"
+#define PORT_LIST_UUID_ALL_TCP_NMAP_5_51_TOP_100 \
+  "730ef368-57e2-11e1-a90f-406186ea4fc5"
 
 /**
  * @brief UUID of 'All TCP and Nmap 5.51 Top 1000 UDP' port list.
  */
-#define PORT_LIST_UUID_ALL_TCP_NMAP_5_51_TOP_1000 "9ddce1ae-57e7-11e1-b13c-406186ea4fc5"
+#define PORT_LIST_UUID_ALL_TCP_NMAP_5_51_TOP_1000 \
+  "9ddce1ae-57e7-11e1-b13c-406186ea4fc5"
 
 /**
  * @brief UUID of 'All privileged TCP' port list.
@@ -155,12 +158,14 @@
 /**
  * @brief UUID of 'All privileged TCP and UDP' port list.
  */
-#define PORT_LIST_UUID_ALL_IANA_TCP_UDP_2012 "4a4717fe-57d2-11e1-9a26-406186ea4fc5"
+#define PORT_LIST_UUID_ALL_IANA_TCP_UDP_2012 \
+  "4a4717fe-57d2-11e1-9a26-406186ea4fc5"
 
 /**
  * @brief UUID of 'Nmap 5.51 top 2000 TCP top 100 UDP' port list.
  */
-#define PORT_LIST_UUID_NMAP_5_51_TOP_2000_TOP_100 "ab33f6b0-57f8-11e1-96f5-406186ea4fc5"
+#define PORT_LIST_UUID_NMAP_5_51_TOP_2000_TOP_100 \
+  "ab33f6b0-57f8-11e1-96f5-406186ea4fc5"
 
 /**
  * @brief Predefined role UUID.
@@ -250,10 +255,9 @@
 /**
  * @brief Number of milliseconds between timevals a and b (performs a-b).
  */
-#define TIMEVAL_SUBTRACT_MS(a,b) ((((a).tv_sec - (b).tv_sec) * 1000) + \
-                                  ((a).tv_usec - (b).tv_usec) / 1000)
+#define TIMEVAL_SUBTRACT_MS(a, b) \
+  ((((a).tv_sec - (b).tv_sec) * 1000) + ((a).tv_usec - (b).tv_usec) / 1000)
 
-
 /* Macros. */
 
 /**
@@ -265,17 +269,16 @@
  * @param[in]  name  Name of accessor.
  * @param[in]  col   Column number to access.
  */
-#define DEF_ACCESS(name, col)                                     \
-const char*                                                       \
-name (iterator_t* iterator)                                       \
-{                                                                 \
-  const char *ret;                                                \
-  if (iterator->done) return NULL;                                \
-  ret = iterator_string (iterator, col);                          \
-  return ret;                                                     \
-}
+#define DEF_ACCESS(name, col)              \
+  const char *name (iterator_t *iterator)  \
+  {                                        \
+    const char *ret;                       \
+    if (iterator->done)                    \
+      return NULL;                         \
+    ret = iterator_string (iterator, col); \
+    return ret;                            \
+  }
 
-
 /* Iterator definitions. */
 
 /**
@@ -291,23 +294,22 @@ typedef struct
 /**
  * @brief Filter columns for GET iterator.
  */
-#define ANON_GET_ITERATOR_FILTER_COLUMNS "uuid", \
- "created", "modified", "_owner"
+#define ANON_GET_ITERATOR_FILTER_COLUMNS "uuid", "created", "modified", "_owner"
 
 /**
  * @brief Filter columns for GET iterator.
  */
-#define GET_ITERATOR_FILTER_COLUMNS "uuid", "name", "comment", \
- "created", "modified", "_owner"
+#define GET_ITERATOR_FILTER_COLUMNS \
+  "uuid", "name", "comment", "created", "modified", "_owner"
 
 /**
  * @brief Columns for GET iterator, as a single string.
  *
  * @param[in]  prefix  Column prefix.
  */
-#define GET_ITERATOR_COLUMNS_STRING                                \
-  "id, uuid, name, comment, iso_time (creation_time),"             \
-  " iso_time (modification_time), creation_time AS created,"       \
+#define GET_ITERATOR_COLUMNS_STRING                          \
+  "id, uuid, name, comment, iso_time (creation_time),"       \
+  " iso_time (modification_time), creation_time AS created," \
   " modification_time AS modified"
 
 /**
@@ -316,54 +318,55 @@ typedef struct
  * @param[in]  prefix  Column prefix.
  */
 #define GET_ITERATOR_COLUMNS_PREFIX(prefix)                                 \
-  { prefix "id", NULL, KEYWORD_TYPE_INTEGER },                              \
-  { prefix "uuid", NULL, KEYWORD_TYPE_STRING },                             \
-  { prefix "name", NULL, KEYWORD_TYPE_STRING },                             \
-  { prefix "comment", NULL, KEYWORD_TYPE_STRING },                          \
-  { " iso_time (" prefix "creation_time)", NULL, KEYWORD_TYPE_STRING },     \
-  { " iso_time (" prefix "modification_time)", NULL, KEYWORD_TYPE_STRING }, \
-  { prefix "creation_time", "created", KEYWORD_TYPE_INTEGER },              \
-  { prefix "modification_time", "modified", KEYWORD_TYPE_INTEGER }
+  {prefix "id", NULL, KEYWORD_TYPE_INTEGER},                                \
+    {prefix "uuid", NULL, KEYWORD_TYPE_STRING},                             \
+    {prefix "name", NULL, KEYWORD_TYPE_STRING},                             \
+    {prefix "comment", NULL, KEYWORD_TYPE_STRING},                          \
+    {" iso_time (" prefix "creation_time)", NULL, KEYWORD_TYPE_STRING},     \
+    {" iso_time (" prefix "modification_time)", NULL, KEYWORD_TYPE_STRING}, \
+    {prefix "creation_time", "created", KEYWORD_TYPE_INTEGER},              \
+  {                                                                         \
+    prefix "modification_time", "modified", KEYWORD_TYPE_INTEGER            \
+  }
 
 /**
  * @brief Columns for GET iterator.
  *
  * @param[in]  table  Table.
  */
-#define GET_ITERATOR_COLUMNS(table)                                             \
-  GET_ITERATOR_COLUMNS_PREFIX(""),                                              \
-  {                                                                             \
-    "(SELECT name FROM users AS inner_users"                                    \
-    " WHERE inner_users.id = " G_STRINGIFY (table) ".owner)",                   \
-    "_owner",                                                                   \
-    KEYWORD_TYPE_STRING                                                         \
-  },                                                                            \
-  { "owner", NULL, KEYWORD_TYPE_INTEGER }
+#define GET_ITERATOR_COLUMNS(table)                            \
+  GET_ITERATOR_COLUMNS_PREFIX (""),                            \
+    {"(SELECT name FROM users AS inner_users"                  \
+     " WHERE inner_users.id = " G_STRINGIFY (table) ".owner)", \
+     "_owner", KEYWORD_TYPE_STRING},                           \
+  {                                                            \
+    "owner", NULL, KEYWORD_TYPE_INTEGER                        \
+  }
 
 /**
  * @brief Number of columns for GET iterator.
  */
 #define GET_ITERATOR_COLUMN_COUNT 10
 
-
 /* Variables */
 
 extern gchar *gvmd_db_name;
 
-
 /* Function prototypes */
 
 typedef long long int rowid_t;
 
-int manage_db_empty ();
+int
+manage_db_empty ();
 
 gboolean
 host_nthlast_report_host (const char *, report_host_t *, int);
 
-char*
+char *
 report_host_ip (const char *);
 
-gchar *tag_value (const gchar *, const gchar *);
+gchar *
+tag_value (const gchar *, const gchar *);
 
 void trim_report (report_t);
 
@@ -371,122 +374,172 @@ int delete_report_internal (report_t);
 
 int set_report_scan_run_status (report_t, task_status_t);
 
-int set_report_slave_progress (report_t, int);
+int
+set_report_slave_progress (report_t, int);
 
-int update_from_slave (task_t, entity_t, entity_t *, int *);
+int
+update_from_slave (task_t, entity_t, entity_t *, int *);
 
-void set_report_slave_task_uuid (report_t, const char *);
+void
+set_report_slave_task_uuid (report_t, const char *);
 
-int set_task_requested (task_t, task_status_t *);
+int
+set_task_requested (task_t, task_status_t *);
 
-void init_task_file_iterator (iterator_t *, task_t, const char *);
-const char *task_file_iterator_name (iterator_t *);
-const char *task_file_iterator_content (iterator_t *);
+void
+init_task_file_iterator (iterator_t *, task_t, const char *);
+const char *
+task_file_iterator_name (iterator_t *);
+const char *
+task_file_iterator_content (iterator_t *);
 
 void set_task_schedule_next_time (task_t, time_t);
 
-void set_task_schedule_next_time_uuid (const gchar *, time_t);
+void
+set_task_schedule_next_time_uuid (const gchar *, time_t);
 
-void init_otp_pref_iterator (iterator_t *, config_t, const char *);
-const char *otp_pref_iterator_name (iterator_t *);
-const char *otp_pref_iterator_value (iterator_t *);
+void
+init_otp_pref_iterator (iterator_t *, config_t, const char *);
+const char *
+otp_pref_iterator_name (iterator_t *);
+const char *
+otp_pref_iterator_value (iterator_t *);
 
 port_list_t target_port_list (target_t);
 credential_t target_ssh_credential (target_t);
 credential_t target_smb_credential (target_t);
 credential_t target_esxi_credential (target_t);
 
-int create_current_report (task_t, char **, task_status_t);
+int
+create_current_report (task_t, char **, task_status_t);
 
-char *alert_data (alert_t, const char *, const char *);
+char *
+alert_data (alert_t, const char *, const char *);
 
-int init_task_schedule_iterator (iterator_t *);
+int
+init_task_schedule_iterator (iterator_t *);
 
-void cleanup_task_schedule_iterator (iterator_t *);
+void
+cleanup_task_schedule_iterator (iterator_t *);
 
-task_t task_schedule_iterator_task (iterator_t *);
+task_t
+task_schedule_iterator_task (iterator_t *);
 
-const char *task_schedule_iterator_task_uuid (iterator_t *);
+const char *
+task_schedule_iterator_task_uuid (iterator_t *);
 
-schedule_t task_schedule_iterator_schedule (iterator_t *);
+schedule_t
+task_schedule_iterator_schedule (iterator_t *);
 
-const char *task_schedule_iterator_icalendar (iterator_t *);
+const char *
+task_schedule_iterator_icalendar (iterator_t *);
 
-const char *task_schedule_iterator_timezone (iterator_t *);
+const char *
+task_schedule_iterator_timezone (iterator_t *);
 
-const char *task_schedule_iterator_owner_uuid (iterator_t *);
+const char *
+task_schedule_iterator_owner_uuid (iterator_t *);
 
-const char *task_schedule_iterator_owner_name (iterator_t *);
+const char *
+task_schedule_iterator_owner_name (iterator_t *);
 
-gboolean task_schedule_iterator_timed_out (iterator_t *);
+gboolean
+task_schedule_iterator_timed_out (iterator_t *);
 
-gboolean task_schedule_iterator_start_due (iterator_t *);
+gboolean
+task_schedule_iterator_start_due (iterator_t *);
 
-gboolean task_schedule_iterator_stop_due (iterator_t *);
+gboolean
+task_schedule_iterator_stop_due (iterator_t *);
 
-time_t task_schedule_iterator_initial_offset (iterator_t *);
+time_t
+task_schedule_iterator_initial_offset (iterator_t *);
 
-int set_task_schedule_uuid (const gchar*, schedule_t, int);
+int
+set_task_schedule_uuid (const gchar *, schedule_t, int);
 
-void reinit_manage_process ();
+void
+reinit_manage_process ();
 
-int manage_update_nvti_cache ();
+int
+manage_update_nvti_cache ();
 
-int manage_report_host_details (report_t, const char *, entity_t);
+int
+manage_report_host_details (report_t, const char *, entity_t);
 
 const char *run_status_name_internal (task_status_t);
 
-gchar *get_ovaldef_short_filename (char*);
+gchar *
+get_ovaldef_short_filename (char *);
 
-void update_config_cache_init (const char *);
+void
+update_config_cache_init (const char *);
 
 alive_test_t target_alive_tests (target_t);
 
-void manage_session_init (const char *);
+void
+manage_session_init (const char *);
 
-int valid_gmp_command (const char *);
+int
+valid_gmp_command (const char *);
 
-void check_generate_scripts ();
+void
+check_generate_scripts ();
 
-void auto_delete_reports ();
+void
+auto_delete_reports ();
 
-int parse_iso_time (const char *);
+int
+parse_iso_time (const char *);
 
 void set_report_scheduled (report_t);
 
-gchar *resource_uuid (const gchar *, resource_t);
+gchar *
+resource_uuid (const gchar *, resource_t);
 
-gboolean find_resource_with_permission (const char *, const char *,
-                                        resource_t *, const char *, int);
+gboolean
+find_resource_with_permission (const char *, const char *, resource_t *,
+                               const char *, int);
 
-void parse_osp_report (task_t, report_t, const char *);
+void
+parse_osp_report (task_t, report_t, const char *);
 
-void reschedule_task (const gchar *);
+void
+reschedule_task (const gchar *);
 
-void insert_port_range (port_list_t, port_protocol_t, int, int);
+void
+insert_port_range (port_list_t, port_protocol_t, int, int);
 
-int manage_update_cert_db_init ();
+int
+manage_update_cert_db_init ();
 
-void manage_update_cert_db_cleanup ();
+void
+manage_update_cert_db_cleanup ();
 
-int manage_update_scap_db_init ();
+int
+manage_update_scap_db_init ();
 
-void manage_update_scap_db_cleanup ();
+void
+manage_update_scap_db_cleanup ();
 
-int manage_cert_db_exists ();
+int
+manage_cert_db_exists ();
 
-int manage_scap_db_exists ();
+int
+manage_scap_db_exists ();
 
-void manage_db_check_mode (const gchar *);
+void
+manage_db_check_mode (const gchar *);
 
-int manage_db_check (const gchar *);
+int
+manage_db_check (const gchar *);
 
 int
 count (const char *, const get_data_t *, column_t *, column_t *, const char **,
        int, const char *, const char *, int);
 
 int
-init_get_iterator (iterator_t*, const char *, const get_data_t *, column_t *,
+init_get_iterator (iterator_t *, const char *, const get_data_t *, column_t *,
                    column_t *, const char **, int, const char *, const char *,
                    int);
 
@@ -494,7 +547,7 @@ gchar *
 columns_build_select (column_t *);
 
 gchar *
-filter_clause (const char*, const char*, const char **, column_t *,
+filter_clause (const char *, const char *, const char **, column_t *,
                column_t *, int, gchar **, int *, int *, array_t **, gchar **);
 
 void
@@ -535,7 +588,8 @@ gboolean
 resource_with_name_exists (const char *, const char *, resource_t);
 
 int
-create_permission_internal (const char *, const char *, const char *, const char *,
-                            const char *, const char *, permission_t *);
+create_permission_internal (const char *, const char *, const char *,
+                            const char *, const char *, const char *,
+                            permission_t *);
 
 #endif /* not _GVMD_MANAGE_SQL_H */

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -338,7 +338,8 @@ typedef struct
   GET_ITERATOR_COLUMNS_PREFIX (""),                            \
     {"(SELECT name FROM users AS inner_users"                  \
      " WHERE inner_users.id = " G_STRINGIFY (table) ".owner)", \
-     "_owner", KEYWORD_TYPE_STRING},                           \
+     "_owner",                                                 \
+     KEYWORD_TYPE_STRING},                                     \
   {                                                            \
     "owner", NULL, KEYWORD_TYPE_INTEGER                        \
   }

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -499,8 +499,11 @@ gchar *
 resource_uuid (const gchar *, resource_t);
 
 gboolean
-find_resource_with_permission (const char *, const char *, resource_t *,
-                               const char *, int);
+find_resource_with_permission (const char *,
+                               const char *,
+                               resource_t *,
+                               const char *,
+                               int);
 
 void
 parse_osp_report (task_t, report_t, const char *);
@@ -536,20 +539,43 @@ int
 manage_db_check (const gchar *);
 
 int
-count (const char *, const get_data_t *, column_t *, column_t *, const char **,
-       int, const char *, const char *, int);
+count (const char *,
+       const get_data_t *,
+       column_t *,
+       column_t *,
+       const char **,
+       int,
+       const char *,
+       const char *,
+       int);
 
 int
-init_get_iterator (iterator_t *, const char *, const get_data_t *, column_t *,
-                   column_t *, const char **, int, const char *, const char *,
+init_get_iterator (iterator_t *,
+                   const char *,
+                   const get_data_t *,
+                   column_t *,
+                   column_t *,
+                   const char **,
+                   int,
+                   const char *,
+                   const char *,
                    int);
 
 gchar *
 columns_build_select (column_t *);
 
 gchar *
-filter_clause (const char *, const char *, const char **, column_t *,
-               column_t *, int, gchar **, int *, int *, array_t **, gchar **);
+filter_clause (const char *,
+               const char *,
+               const char **,
+               column_t *,
+               column_t *,
+               int,
+               gchar **,
+               int *,
+               int *,
+               array_t **,
+               gchar **);
 
 void
 check_alerts ();
@@ -582,15 +608,25 @@ void
 permissions_set_orphans (const char *, resource_t, int);
 
 int
-copy_resource (const char *, const char *, const char *, const char *,
-               const char *, int, resource_t *, resource_t *);
+copy_resource (const char *,
+               const char *,
+               const char *,
+               const char *,
+               const char *,
+               int,
+               resource_t *,
+               resource_t *);
 
 gboolean
 resource_with_name_exists (const char *, const char *, resource_t);
 
 int
-create_permission_internal (const char *, const char *, const char *,
-                            const char *, const char *, const char *,
+create_permission_internal (const char *,
+                            const char *,
+                            const char *,
+                            const char *,
+                            const char *,
+                            const char *,
                             permission_t *);
 
 #endif /* not _GVMD_MANAGE_SQL_H */

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -131,7 +131,8 @@ set_nvts_feed_version (const char *feed_version)
   sql ("DELETE FROM %s.meta WHERE name = 'nvts_feed_version';", sql_schema ());
   sql ("INSERT INTO %s.meta (name, value)"
        " VALUES ('nvts_feed_version', '%s');",
-       sql_schema (), quoted);
+       sql_schema (),
+       quoted);
   g_free (quoted);
 
   sql ("UPDATE %s.meta SET value = 1 WHERE name = 'update_nvti_cache';",
@@ -228,7 +229,8 @@ make_nvt_from_nvti (const nvti_t *nvti)
                    == 0)
                && ((*point)[strlen ("creation_date")] == '='))
               || ((strlen (*point) > strlen ("last_modification"))
-                  && (strncmp (*point, "last_modification",
+                  && (strncmp (*point,
+                               "last_modification",
                                strlen ("last_modification"))
                       == 0)
                   && ((*point)[strlen ("last_modification")] == '=')))
@@ -283,8 +285,10 @@ make_nvt_from_nvti (const nvti_t *nvti)
   switch (parse_time (value, &creation_time))
     {
     case -1:
-      g_warning ("%s: Failed to parse creation time of %s: %s", __FUNCTION__,
-                 nvti_oid (nvti), value);
+      g_warning ("%s: Failed to parse creation time of %s: %s",
+                 __FUNCTION__,
+                 nvti_oid (nvti),
+                 value);
       creation_time = 0;
       break;
     case -2:
@@ -292,8 +296,8 @@ make_nvt_from_nvti (const nvti_t *nvti)
       creation_time = 0;
       break;
     case -3:
-      g_warning ("%s: Failed to parse timezone offset: %s", __FUNCTION__,
-                 value);
+      g_warning (
+        "%s: Failed to parse timezone offset: %s", __FUNCTION__, value);
       creation_time = 0;
       break;
     }
@@ -304,7 +308,9 @@ make_nvt_from_nvti (const nvti_t *nvti)
     {
     case -1:
       g_warning ("%s: Failed to parse last_modification time of %s: %s",
-                 __FUNCTION__, nvti_oid (nvti), value);
+                 __FUNCTION__,
+                 nvti_oid (nvti),
+                 value);
       modification_time = 0;
       break;
     case -2:
@@ -312,8 +318,8 @@ make_nvt_from_nvti (const nvti_t *nvti)
       modification_time = 0;
       break;
     case -3:
-      g_warning ("%s: Failed to parse timezone offset: %s", __FUNCTION__,
-                 value);
+      g_warning (
+        "%s: Failed to parse timezone offset: %s", __FUNCTION__, value);
       modification_time = 0;
       break;
     }
@@ -330,7 +336,8 @@ make_nvt_from_nvti (const nvti_t *nvti)
 
   if (sql_int ("SELECT EXISTS (SELECT * FROM nvts WHERE oid = '%s');",
                nvti_oid (nvti)))
-    g_warning ("%s: NVT with OID %s exists already, ignoring", __FUNCTION__,
+    g_warning ("%s: NVT with OID %s exists already, ignoring",
+               __FUNCTION__,
                nvti_oid (nvti));
   else
     sql ("INSERT into nvts (oid, name,"
@@ -339,10 +346,21 @@ make_nvt_from_nvti (const nvti_t *nvti)
          " qod, qod_type)"
          " VALUES ('%s', '%s', '%s', '%s', '%s',"
          " '%s', %i, '%s', '%s', %i, %i, '%s', '%s', %d, '%s');",
-         nvti_oid (nvti), quoted_name, quoted_cve, quoted_bid, quoted_xref,
-         quoted_tag, nvti_category (nvti), quoted_family, quoted_cvss_base,
-         creation_time, modification_time, nvti_oid (nvti),
-         quoted_solution_type, qod, quoted_qod_type);
+         nvti_oid (nvti),
+         quoted_name,
+         quoted_cve,
+         quoted_bid,
+         quoted_xref,
+         quoted_tag,
+         nvti_category (nvti),
+         quoted_family,
+         quoted_cvss_base,
+         creation_time,
+         modification_time,
+         nvti_oid (nvti),
+         quoted_solution_type,
+         qod,
+         quoted_qod_type);
 
   if (chunk_count == 0)
     sql_commit ();
@@ -395,11 +413,18 @@ init_nvt_info_iterator (iterator_t *iterator, get_data_t *get, const char *name)
       get->filter = NULL;
     }
 
-  ret = init_get_iterator (iterator, "nvt", get,
+  ret = init_get_iterator (iterator,
+                           "nvt",
+                           get,
                            /* Columns. */
                            columns,
                            /* Columns for trashcan. */
-                           NULL, filter_columns, 0, NULL, clause, 0);
+                           NULL,
+                           filter_columns,
+                           0,
+                           NULL,
+                           clause,
+                           0);
 
   g_free (clause);
   return ret;
@@ -496,7 +521,8 @@ select_config_nvts (const config_t config, const char *family, int ascending,
             sql = g_strdup_printf ("SELECT %s"
                                    " FROM nvts WHERE family = '%s'"
                                    " ORDER BY %s %s;",
-                                   nvt_iterator_columns (), quoted_family,
+                                   nvt_iterator_columns (),
+                                   quoted_family,
                                    sort_field ? sort_field : "name",
                                    ascending ? "ASC" : "DESC");
           else
@@ -509,7 +535,8 @@ select_config_nvts (const config_t config, const char *family, int ascending,
                     " AND type = " G_STRINGIFY (
                       NVT_SELECTOR_TYPE_FAMILY) " AND family_or_nvt = '%s'"
                                                 ";",
-                    quoted_selector, quoted_family))
+                    quoted_selector,
+                    quoted_family))
                 /* The family is excluded, just iterate the NVT includes. */
                 sql = g_strdup_printf (
                   "SELECT %s"
@@ -523,8 +550,11 @@ select_config_nvts (const config_t config, const char *family, int ascending,
                                            " AND nvts.oid = "
                                            "nvt_selectors.family_or_nvt"
                                            " ORDER BY %s %s;",
-                  nvt_iterator_columns_nvts (), quoted_family, quoted_selector,
-                  quoted_family, sort_field ? sort_field : "nvts.name",
+                  nvt_iterator_columns_nvts (),
+                  quoted_family,
+                  quoted_selector,
+                  quoted_family,
+                  sort_field ? sort_field : "nvts.name",
                   ascending ? "ASC" : "DESC");
               else
                 /* The family is included.
@@ -546,8 +576,11 @@ select_config_nvts (const config_t config, const char *family, int ascending,
                                            " AND nvts.oid = "
                                            "nvt_selectors.family_or_nvt"
                                            " ORDER BY %s %s;",
-                  nvt_iterator_columns (), quoted_family,
-                  nvt_iterator_columns_nvts (), quoted_family, quoted_selector,
+                  nvt_iterator_columns (),
+                  quoted_family,
+                  nvt_iterator_columns_nvts (),
+                  quoted_family,
+                  quoted_selector,
                   quoted_family,
                   // FIX PG "ERROR: missing FROM-clause" using nvts.name.
                   sort_field && strcmp (sort_field, "nvts.name")
@@ -567,7 +600,8 @@ select_config_nvts (const config_t config, const char *family, int ascending,
                      " WHERE name = '%s' AND exclude = 0"
                      " AND type = " G_STRINGIFY (
                        NVT_SELECTOR_TYPE_FAMILY) " AND family_or_nvt = '%s';",
-                     quoted_selector, quoted_family);
+                     quoted_selector,
+                     quoted_family);
 
           if (all)
             /* There is a family include for this family. */
@@ -587,8 +621,11 @@ select_config_nvts (const config_t config, const char *family, int ascending,
                                        " AND nvts.oid = "
                                        "nvt_selectors.family_or_nvt"
                                        " ORDER BY %s %s;",
-              nvt_iterator_columns (), quoted_family,
-              nvt_iterator_columns_nvts (), quoted_family, quoted_selector,
+              nvt_iterator_columns (),
+              quoted_family,
+              nvt_iterator_columns_nvts (),
+              quoted_family,
+              quoted_selector,
               quoted_family,
               // FIX PG "ERROR: missing FROM-clause" using nvts.name.
               sort_field && strcmp (sort_field, "nvts.name")
@@ -608,8 +645,11 @@ select_config_nvts (const config_t config, const char *family, int ascending,
                                        " AND nvts.oid = "
                                        "nvt_selectors.family_or_nvt"
                                        " ORDER BY %s %s;",
-              nvt_iterator_columns_nvts (), quoted_family, quoted_selector,
-              quoted_family, sort_field ? sort_field : "nvts.name",
+              nvt_iterator_columns_nvts (),
+              quoted_family,
+              quoted_selector,
+              quoted_family,
+              sort_field ? sort_field : "nvts.name",
               ascending ? "ASC" : "DESC");
         }
     }
@@ -627,8 +667,11 @@ select_config_nvts (const config_t config, const char *family, int ascending,
           NVT_SELECTOR_TYPE_NVT) " AND nvt_selectors.name = '%s'"
                                  " AND nvts.oid = nvt_selectors.family_or_nvt"
                                  " ORDER BY %s %s;",
-        nvt_iterator_columns_nvts (), quoted_family, quoted_selector,
-        sort_field ? sort_field : "nvts.id", ascending ? "ASC" : "DESC");
+        nvt_iterator_columns_nvts (),
+        quoted_family,
+        quoted_selector,
+        sort_field ? sort_field : "nvts.id",
+        ascending ? "ASC" : "DESC");
     }
 
   g_free (quoted_selector);
@@ -662,7 +705,8 @@ init_nvt_iterator (iterator_t *iterator, nvt_t nvt, config_t config,
       gchar *sql;
       sql = g_strdup_printf ("SELECT %s"
                              " FROM nvts WHERE id = %llu;",
-                             nvt_iterator_columns (), nvt);
+                             nvt_iterator_columns (),
+                             nvt);
       init_iterator (iterator, sql);
       g_free (sql);
     }
@@ -691,7 +735,8 @@ init_nvt_iterator (iterator_t *iterator, nvt_t nvt, config_t config,
                      " FROM nvts"
                      " WHERE family = '%s'"
                      " ORDER BY %s %s;",
-                     nvt_iterator_columns (), quoted_family,
+                     nvt_iterator_columns (),
+                     quoted_family,
                      sort_field ? sort_field : "name",
                      ascending ? "ASC" : "DESC");
       g_free (quoted_family);
@@ -705,7 +750,8 @@ init_nvt_iterator (iterator_t *iterator, nvt_t nvt, config_t config,
                      " FROM nvts"
                      " WHERE category = '%s'"
                      " ORDER BY %s %s;",
-                     nvt_iterator_columns (), quoted_category,
+                     nvt_iterator_columns (),
+                     quoted_category,
                      sort_field ? sort_field : "name",
                      ascending ? "ASC" : "DESC");
       g_free (quoted_category);
@@ -715,7 +761,8 @@ init_nvt_iterator (iterator_t *iterator, nvt_t nvt, config_t config,
                    "SELECT %s"
                    " FROM nvts"
                    " ORDER BY %s %s;",
-                   nvt_iterator_columns (), sort_field ? sort_field : "name",
+                   nvt_iterator_columns (),
+                   sort_field ? sort_field : "name",
                    ascending ? "ASC" : "DESC");
 }
 
@@ -736,8 +783,11 @@ init_cve_nvt_iterator (iterator_t *iterator, const char *cve, int ascending,
                  " FROM nvts"
                  " WHERE cve %s '%%%s%%'"
                  " ORDER BY %s %s;",
-                 nvt_iterator_columns (), sql_ilike_op (), cve ? cve : "",
-                 sort_field ? sort_field : "name", ascending ? "ASC" : "DESC");
+                 nvt_iterator_columns (),
+                 sql_ilike_op (),
+                 cve ? cve : "",
+                 sort_field ? sort_field : "name",
+                 ascending ? "ASC" : "DESC");
 }
 
 /**
@@ -1031,7 +1081,9 @@ refresh_nvt_cves ()
               quoted_oid = sql_insert (iterator_string (&nvts, 1));
               sql ("INSERT INTO nvt_cves (nvt, oid, cve_name)"
                    " VALUES (%llu, %s, %s);",
-                   iterator_int64 (&nvts, 0), quoted_oid, quoted_cve);
+                   iterator_int64 (&nvts, 0),
+                   quoted_oid,
+                   quoted_cve);
               g_free (quoted_cve);
               g_free (quoted_oid);
             }

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -486,7 +486,9 @@ nvt_info_count (const get_data_t *get)
  * @return Freshly allocated SELECT statement on success, or NULL on error.
  */
 static gchar *
-select_config_nvts (const config_t config, const char *family, int ascending,
+select_config_nvts (const config_t config,
+                    const char *family,
+                    int ascending,
                     const char *sort_field)
 {
   gchar *quoted_selector, *quoted_family, *sql;
@@ -694,8 +696,12 @@ select_config_nvts (const config_t config, const char *family, int ascending,
  * @param[in]  sort_field  Field to sort on, or NULL for "id".
  */
 void
-init_nvt_iterator (iterator_t *iterator, nvt_t nvt, config_t config,
-                   const char *family, const char *category, int ascending,
+init_nvt_iterator (iterator_t *iterator,
+                   nvt_t nvt,
+                   config_t config,
+                   const char *family,
+                   const char *category,
+                   int ascending,
                    const char *sort_field)
 {
   assert ((nvt && family) == 0);
@@ -775,7 +781,9 @@ init_nvt_iterator (iterator_t *iterator, nvt_t nvt, config_t config,
  * @param[in]  sort_field  Field to sort on, or NULL for "id".
  */
 void
-init_cve_nvt_iterator (iterator_t *iterator, const char *cve, int ascending,
+init_cve_nvt_iterator (iterator_t *iterator,
+                       const char *cve,
+                       int ascending,
                        const char *sort_field)
 {
   init_iterator (iterator,

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -29,14 +29,15 @@
  */
 #define _GNU_SOURCE
 
+#include "manage_sql_nvts.h"
+
+#include "manage_sql.h"
+#include "sql.h"
+#include "utils.h"
+
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include "manage_sql.h"
-#include "manage_sql_nvts.h"
-#include "sql.h"
-#include "utils.h"
 
 #undef G_LOG_DOMAIN
 /**
@@ -44,13 +45,11 @@
  */
 #define G_LOG_DOMAIN "md manage"
 
-
 /* Static headers. */
 
 static void
 refresh_nvt_cves ();
 
-
 /* NVT's. */
 
 /**
@@ -99,8 +98,8 @@ char *
 nvt_oid (const char *name)
 {
   gchar *quoted_name = sql_quote (name);
-  char *ret = sql_string ("SELECT oid FROM nvts WHERE name = '%s' LIMIT 1;",
-                          quoted_name);
+  char *ret =
+    sql_string ("SELECT oid FROM nvts WHERE name = '%s' LIMIT 1;", quoted_name);
   g_free (quoted_name);
   return ret;
 }
@@ -110,7 +109,7 @@ nvt_oid (const char *name)
  *
  * @return Feed version of plugins if the plugins are cached, else NULL.
  */
-char*
+char *
 nvts_feed_version ()
 {
   return sql_string ("SELECT value FROM %s.meta"
@@ -128,13 +127,11 @@ nvts_feed_version ()
 void
 set_nvts_feed_version (const char *feed_version)
 {
-  gchar* quoted = sql_quote (feed_version);
-  sql ("DELETE FROM %s.meta WHERE name = 'nvts_feed_version';",
-       sql_schema ());
+  gchar *quoted = sql_quote (feed_version);
+  sql ("DELETE FROM %s.meta WHERE name = 'nvts_feed_version';", sql_schema ());
   sql ("INSERT INTO %s.meta (name, value)"
        " VALUES ('nvts_feed_version', '%s');",
-       sql_schema (),
-       quoted);
+       sql_schema (), quoted);
   g_free (quoted);
 
   sql ("UPDATE %s.meta SET value = 1 WHERE name = 'update_nvti_cache';",
@@ -150,22 +147,20 @@ set_nvts_feed_version (const char *feed_version)
  * @return FALSE on success (including if failed to find NVT), TRUE on error.
  */
 gboolean
-find_nvt (const char* oid, nvt_t* nvt)
+find_nvt (const char *oid, nvt_t *nvt)
 {
-  switch (sql_int64 (nvt,
-                     "SELECT id FROM nvts WHERE oid = '%s';",
-                     oid))
+  switch (sql_int64 (nvt, "SELECT id FROM nvts WHERE oid = '%s';", oid))
     {
-      case 0:
-        break;
-      case 1:        /* Too few rows in result of query. */
-        *nvt = 0;
-        break;
-      default:       /* Programming error. */
-        assert (0);
-      case -1:
-        return TRUE;
-        break;
+    case 0:
+      break;
+    case 1: /* Too few rows in result of query. */
+      *nvt = 0;
+      break;
+    default: /* Programming error. */
+      assert (0);
+    case -1:
+      return TRUE;
+      break;
     }
 
   return FALSE;
@@ -268,9 +263,8 @@ make_nvt_from_nvti (const nvti_t *nvti)
     }
   else
     quoted_tag = g_strdup ("");
-  quoted_cvss_base = sql_quote (nvti_cvss_base (nvti)
-                                 ? nvti_cvss_base (nvti)
-                                 : "");
+  quoted_cvss_base =
+    sql_quote (nvti_cvss_base (nvti) ? nvti_cvss_base (nvti) : "");
 
   qod_str = tag_value (nvti_tag (nvti), "qod");
   qod_type = tag_value (nvti_tag (nvti), "qod_type");
@@ -288,42 +282,40 @@ make_nvt_from_nvti (const nvti_t *nvti)
   value = tag_value (nvti_tag (nvti), "creation_date");
   switch (parse_time (value, &creation_time))
     {
-      case -1:
-        g_warning ("%s: Failed to parse creation time of %s: %s",
-                   __FUNCTION__, nvti_oid (nvti), value);
-        creation_time = 0;
-        break;
-      case -2:
-        g_warning ("%s: Failed to make time: %s", __FUNCTION__, value);
-        creation_time = 0;
-        break;
-      case -3:
-        g_warning ("%s: Failed to parse timezone offset: %s",
-                   __FUNCTION__,
-                   value);
-        creation_time = 0;
-        break;
+    case -1:
+      g_warning ("%s: Failed to parse creation time of %s: %s", __FUNCTION__,
+                 nvti_oid (nvti), value);
+      creation_time = 0;
+      break;
+    case -2:
+      g_warning ("%s: Failed to make time: %s", __FUNCTION__, value);
+      creation_time = 0;
+      break;
+    case -3:
+      g_warning ("%s: Failed to parse timezone offset: %s", __FUNCTION__,
+                 value);
+      creation_time = 0;
+      break;
     }
   g_free (value);
 
   value = tag_value (nvti_tag (nvti), "last_modification");
   switch (parse_time (value, &modification_time))
     {
-      case -1:
-        g_warning ("%s: Failed to parse last_modification time of %s: %s",
-                   __FUNCTION__, nvti_oid (nvti), value);
-        modification_time = 0;
-        break;
-      case -2:
-        g_warning ("%s: Failed to make time: %s", __FUNCTION__, value);
-        modification_time = 0;
-        break;
-      case -3:
-        g_warning ("%s: Failed to parse timezone offset: %s",
-                   __FUNCTION__,
-                   value);
-        modification_time = 0;
-        break;
+    case -1:
+      g_warning ("%s: Failed to parse last_modification time of %s: %s",
+                 __FUNCTION__, nvti_oid (nvti), value);
+      modification_time = 0;
+      break;
+    case -2:
+      g_warning ("%s: Failed to make time: %s", __FUNCTION__, value);
+      modification_time = 0;
+      break;
+    case -3:
+      g_warning ("%s: Failed to parse timezone offset: %s", __FUNCTION__,
+                 value);
+      modification_time = 0;
+      break;
     }
   g_free (value);
 
@@ -347,11 +339,10 @@ make_nvt_from_nvti (const nvti_t *nvti)
          " qod, qod_type)"
          " VALUES ('%s', '%s', '%s', '%s', '%s',"
          " '%s', %i, '%s', '%s', %i, %i, '%s', '%s', %d, '%s');",
-         nvti_oid (nvti), quoted_name,
-         quoted_cve, quoted_bid, quoted_xref, quoted_tag,
-         nvti_category (nvti), quoted_family, quoted_cvss_base, creation_time,
-         modification_time, nvti_oid (nvti), quoted_solution_type,
-         qod, quoted_qod_type);
+         nvti_oid (nvti), quoted_name, quoted_cve, quoted_bid, quoted_xref,
+         quoted_tag, nvti_category (nvti), quoted_family, quoted_cvss_base,
+         creation_time, modification_time, nvti_oid (nvti),
+         quoted_solution_type, qod, quoted_qod_type);
 
   if (chunk_count == 0)
     sql_commit ();
@@ -380,7 +371,7 @@ make_nvt_from_nvti (const nvti_t *nvti)
  *         -1 error.
  */
 int
-init_nvt_info_iterator (iterator_t* iterator, get_data_t *get, const char *name)
+init_nvt_info_iterator (iterator_t *iterator, get_data_t *get, const char *name)
 {
   static const char *filter_columns[] = NVT_INFO_ITERATOR_FILTER_COLUMNS;
   static column_t columns[] = NVT_ITERATOR_COLUMNS;
@@ -404,18 +395,11 @@ init_nvt_info_iterator (iterator_t* iterator, get_data_t *get, const char *name)
       get->filter = NULL;
     }
 
-  ret = init_get_iterator (iterator,
-                           "nvt",
-                           get,
+  ret = init_get_iterator (iterator, "nvt", get,
                            /* Columns. */
                            columns,
                            /* Columns for trashcan. */
-                           NULL,
-                           filter_columns,
-                           0,
-                           NULL,
-                           clause,
-                           0);
+                           NULL, filter_columns, 0, NULL, clause, 0);
 
   g_free (clause);
   return ret;
@@ -463,8 +447,7 @@ nvt_info_count (const get_data_t *get)
 {
   static const char *extra_columns[] = NVT_INFO_ITERATOR_FILTER_COLUMNS;
   static column_t columns[] = NVT_ITERATOR_COLUMNS;
-  return count ("nvt", get, columns, NULL, extra_columns, 0, 0, 0,
-                FALSE);
+  return count ("nvt", get, columns, NULL, extra_columns, 0, 0, 0, FALSE);
 }
 
 /**
@@ -478,8 +461,8 @@ nvt_info_count (const get_data_t *get)
  * @return Freshly allocated SELECT statement on success, or NULL on error.
  */
 static gchar *
-select_config_nvts (const config_t config, const char* family, int ascending,
-                    const char* sort_field)
+select_config_nvts (const config_t config, const char *family, int ascending,
+                    const char *sort_field)
 {
   gchar *quoted_selector, *quoted_family, *sql;
   char *selector;
@@ -510,75 +493,67 @@ select_config_nvts (const config_t config, const char* family, int ascending,
                        quoted_selector)
               == 1)
             /* There is one selector, it should be the all selector. */
-            sql = g_strdup_printf
-                   ("SELECT %s"
-                    " FROM nvts WHERE family = '%s'"
-                    " ORDER BY %s %s;",
-                    nvt_iterator_columns (),
-                    quoted_family,
-                    sort_field ? sort_field : "name",
-                    ascending ? "ASC" : "DESC");
+            sql = g_strdup_printf ("SELECT %s"
+                                   " FROM nvts WHERE family = '%s'"
+                                   " ORDER BY %s %s;",
+                                   nvt_iterator_columns (), quoted_family,
+                                   sort_field ? sort_field : "name",
+                                   ascending ? "ASC" : "DESC");
           else
             {
               /* There are multiple selectors. */
 
-              if (sql_int ("SELECT COUNT(*) FROM nvt_selectors"
-                           " WHERE name = '%s' AND exclude = 1"
-                           " AND type = "
-                           G_STRINGIFY (NVT_SELECTOR_TYPE_FAMILY)
-                           " AND family_or_nvt = '%s'"
-                           ";",
-                           quoted_selector,
-                           quoted_family))
+              if (sql_int (
+                    "SELECT COUNT(*) FROM nvt_selectors"
+                    " WHERE name = '%s' AND exclude = 1"
+                    " AND type = " G_STRINGIFY (
+                      NVT_SELECTOR_TYPE_FAMILY) " AND family_or_nvt = '%s'"
+                                                ";",
+                    quoted_selector, quoted_family))
                 /* The family is excluded, just iterate the NVT includes. */
-                sql = g_strdup_printf
-                       ("SELECT %s"
-                        " FROM nvts, nvt_selectors"
-                        " WHERE"
-                        " nvts.family = '%s'"
-                        " AND nvt_selectors.name = '%s'"
-                        " AND nvt_selectors.family = '%s'"
-                        " AND nvt_selectors.type = "
-                        G_STRINGIFY (NVT_SELECTOR_TYPE_NVT)
-                        " AND nvt_selectors.exclude = 0"
-                        " AND nvts.oid = nvt_selectors.family_or_nvt"
-                        " ORDER BY %s %s;",
-                        nvt_iterator_columns_nvts (),
-                        quoted_family,
-                        quoted_selector,
-                        quoted_family,
-                        sort_field ? sort_field : "nvts.name",
-                        ascending ? "ASC" : "DESC");
+                sql = g_strdup_printf (
+                  "SELECT %s"
+                  " FROM nvts, nvt_selectors"
+                  " WHERE"
+                  " nvts.family = '%s'"
+                  " AND nvt_selectors.name = '%s'"
+                  " AND nvt_selectors.family = '%s'"
+                  " AND nvt_selectors.type = " G_STRINGIFY (
+                    NVT_SELECTOR_TYPE_NVT) " AND nvt_selectors.exclude = 0"
+                                           " AND nvts.oid = "
+                                           "nvt_selectors.family_or_nvt"
+                                           " ORDER BY %s %s;",
+                  nvt_iterator_columns_nvts (), quoted_family, quoted_selector,
+                  quoted_family, sort_field ? sort_field : "nvts.name",
+                  ascending ? "ASC" : "DESC");
               else
                 /* The family is included.
                  *
                  * Iterate all NVT's minus excluded NVT's. */
-                sql = g_strdup_printf
-                       ("SELECT %s"
-                        " FROM nvts"
-                        " WHERE family = '%s'"
-                        " EXCEPT"
-                        " SELECT %s"
-                        " FROM nvt_selectors, nvts"
-                        " WHERE"
-                        " nvts.family = '%s'"
-                        " AND nvt_selectors.name = '%s'"
-                        " AND nvt_selectors.family = '%s'"
-                        " AND nvt_selectors.type = "
-                        G_STRINGIFY (NVT_SELECTOR_TYPE_NVT)
-                        " AND nvt_selectors.exclude = 1"
-                        " AND nvts.oid = nvt_selectors.family_or_nvt"
-                        " ORDER BY %s %s;",
-                        nvt_iterator_columns (),
-                        quoted_family,
-                        nvt_iterator_columns_nvts (),
-                        quoted_family,
-                        quoted_selector,
-                        quoted_family,
-                        // FIX PG "ERROR: missing FROM-clause" using nvts.name.
-                        sort_field && strcmp (sort_field, "nvts.name")
-                         ? sort_field : "3", /* 3 is nvts.name. */
-                        ascending ? "ASC" : "DESC");
+                sql = g_strdup_printf (
+                  "SELECT %s"
+                  " FROM nvts"
+                  " WHERE family = '%s'"
+                  " EXCEPT"
+                  " SELECT %s"
+                  " FROM nvt_selectors, nvts"
+                  " WHERE"
+                  " nvts.family = '%s'"
+                  " AND nvt_selectors.name = '%s'"
+                  " AND nvt_selectors.family = '%s'"
+                  " AND nvt_selectors.type = " G_STRINGIFY (
+                    NVT_SELECTOR_TYPE_NVT) " AND nvt_selectors.exclude = 1"
+                                           " AND nvts.oid = "
+                                           "nvt_selectors.family_or_nvt"
+                                           " ORDER BY %s %s;",
+                  nvt_iterator_columns (), quoted_family,
+                  nvt_iterator_columns_nvts (), quoted_family, quoted_selector,
+                  quoted_family,
+                  // FIX PG "ERROR: missing FROM-clause" using nvts.name.
+                  sort_field && strcmp (sort_field, "nvts.name")
+                    ? sort_field
+                    : "3", /* 3 is nvts.name. */
+                  ascending ? "ASC" : "DESC");
             }
         }
       else
@@ -587,61 +562,55 @@ select_config_nvts (const config_t config, const char* family, int ascending,
 
           /* Generating from empty. */
 
-          all = sql_int ("SELECT COUNT(*) FROM nvt_selectors"
-                         " WHERE name = '%s' AND exclude = 0"
-                         " AND type = "
-                         G_STRINGIFY (NVT_SELECTOR_TYPE_FAMILY)
-                         " AND family_or_nvt = '%s';",
-                         quoted_selector,
-                         quoted_family);
+          all =
+            sql_int ("SELECT COUNT(*) FROM nvt_selectors"
+                     " WHERE name = '%s' AND exclude = 0"
+                     " AND type = " G_STRINGIFY (
+                       NVT_SELECTOR_TYPE_FAMILY) " AND family_or_nvt = '%s';",
+                     quoted_selector, quoted_family);
 
           if (all)
             /* There is a family include for this family. */
-            sql = g_strdup_printf
-                   ("SELECT %s"
-                    " FROM nvts"
-                    " WHERE family = '%s'"
-                    " EXCEPT"
-                    " SELECT %s"
-                    " FROM nvt_selectors, nvts"
-                    " WHERE"
-                    " nvts.family = '%s'"
-                    " AND nvt_selectors.name = '%s'"
-                    " AND nvt_selectors.family = '%s'"
-                    " AND nvt_selectors.type = "
-                    G_STRINGIFY (NVT_SELECTOR_TYPE_NVT)
-                    " AND nvt_selectors.exclude = 1"
-                    " AND nvts.oid = nvt_selectors.family_or_nvt"
-                    " ORDER BY %s %s;",
-                    nvt_iterator_columns (),
-                    quoted_family,
-                    nvt_iterator_columns_nvts (),
-                    quoted_family,
-                    quoted_selector,
-                    quoted_family,
-                    // FIX PG "ERROR: missing FROM-clause" using nvts.name.
-                    sort_field && strcmp (sort_field, "nvts.name")
-                     ? sort_field : "3", /* 3 is nvts.name. */
-                    ascending ? "ASC" : "DESC");
+            sql = g_strdup_printf (
+              "SELECT %s"
+              " FROM nvts"
+              " WHERE family = '%s'"
+              " EXCEPT"
+              " SELECT %s"
+              " FROM nvt_selectors, nvts"
+              " WHERE"
+              " nvts.family = '%s'"
+              " AND nvt_selectors.name = '%s'"
+              " AND nvt_selectors.family = '%s'"
+              " AND nvt_selectors.type = " G_STRINGIFY (
+                NVT_SELECTOR_TYPE_NVT) " AND nvt_selectors.exclude = 1"
+                                       " AND nvts.oid = "
+                                       "nvt_selectors.family_or_nvt"
+                                       " ORDER BY %s %s;",
+              nvt_iterator_columns (), quoted_family,
+              nvt_iterator_columns_nvts (), quoted_family, quoted_selector,
+              quoted_family,
+              // FIX PG "ERROR: missing FROM-clause" using nvts.name.
+              sort_field && strcmp (sort_field, "nvts.name")
+                ? sort_field
+                : "3", /* 3 is nvts.name. */
+              ascending ? "ASC" : "DESC");
           else
-            sql = g_strdup_printf
-                   (" SELECT %s"
-                    " FROM nvt_selectors, nvts"
-                    " WHERE"
-                    " nvts.family = '%s'"
-                    " AND nvt_selectors.name = '%s'"
-                    " AND nvt_selectors.family = '%s'"
-                    " AND nvt_selectors.type = "
-                    G_STRINGIFY (NVT_SELECTOR_TYPE_NVT)
-                    " AND nvt_selectors.exclude = 0"
-                    " AND nvts.oid = nvt_selectors.family_or_nvt"
-                    " ORDER BY %s %s;",
-                    nvt_iterator_columns_nvts (),
-                    quoted_family,
-                    quoted_selector,
-                    quoted_family,
-                    sort_field ? sort_field : "nvts.name",
-                    ascending ? "ASC" : "DESC");
+            sql = g_strdup_printf (
+              " SELECT %s"
+              " FROM nvt_selectors, nvts"
+              " WHERE"
+              " nvts.family = '%s'"
+              " AND nvt_selectors.name = '%s'"
+              " AND nvt_selectors.family = '%s'"
+              " AND nvt_selectors.type = " G_STRINGIFY (
+                NVT_SELECTOR_TYPE_NVT) " AND nvt_selectors.exclude = 0"
+                                       " AND nvts.oid = "
+                                       "nvt_selectors.family_or_nvt"
+                                       " ORDER BY %s %s;",
+              nvt_iterator_columns_nvts (), quoted_family, quoted_selector,
+              quoted_family, sort_field ? sort_field : "nvts.name",
+              ascending ? "ASC" : "DESC");
         }
     }
   else
@@ -649,20 +618,17 @@ select_config_nvts (const config_t config, const char* family, int ascending,
       /* The number of NVT's is static.  Assume a simple list of NVT
        * includes. */
 
-      sql = g_strdup_printf
-             ("SELECT %s"
-              " FROM nvt_selectors, nvts"
-              " WHERE nvts.family = '%s'"
-              " AND nvt_selectors.exclude = 0"
-              " AND nvt_selectors.type = " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT)
-              " AND nvt_selectors.name = '%s'"
-              " AND nvts.oid = nvt_selectors.family_or_nvt"
-              " ORDER BY %s %s;",
-              nvt_iterator_columns_nvts (),
-              quoted_family,
-              quoted_selector,
-              sort_field ? sort_field : "nvts.id",
-              ascending ? "ASC" : "DESC");
+      sql = g_strdup_printf (
+        "SELECT %s"
+        " FROM nvt_selectors, nvts"
+        " WHERE nvts.family = '%s'"
+        " AND nvt_selectors.exclude = 0"
+        " AND nvt_selectors.type = " G_STRINGIFY (
+          NVT_SELECTOR_TYPE_NVT) " AND nvt_selectors.name = '%s'"
+                                 " AND nvts.oid = nvt_selectors.family_or_nvt"
+                                 " ORDER BY %s %s;",
+        nvt_iterator_columns_nvts (), quoted_family, quoted_selector,
+        sort_field ? sort_field : "nvts.id", ascending ? "ASC" : "DESC");
     }
 
   g_free (quoted_selector);
@@ -685,26 +651,26 @@ select_config_nvts (const config_t config, const char* family, int ascending,
  * @param[in]  sort_field  Field to sort on, or NULL for "id".
  */
 void
-init_nvt_iterator (iterator_t* iterator, nvt_t nvt, config_t config,
-                   const char* family, const char *category, int ascending,
-                   const char* sort_field)
+init_nvt_iterator (iterator_t *iterator, nvt_t nvt, config_t config,
+                   const char *family, const char *category, int ascending,
+                   const char *sort_field)
 {
   assert ((nvt && family) == 0);
 
   if (nvt)
     {
-      gchar* sql;
+      gchar *sql;
       sql = g_strdup_printf ("SELECT %s"
                              " FROM nvts WHERE id = %llu;",
-                             nvt_iterator_columns (),
-                             nvt);
+                             nvt_iterator_columns (), nvt);
       init_iterator (iterator, sql);
       g_free (sql);
     }
   else if (config)
     {
-      gchar* sql;
-      if (family == NULL) abort ();
+      gchar *sql;
+      if (family == NULL)
+        abort ();
       sql = select_config_nvts (config, family, ascending, sort_field);
       if (sql)
         {
@@ -725,8 +691,7 @@ init_nvt_iterator (iterator_t* iterator, nvt_t nvt, config_t config,
                      " FROM nvts"
                      " WHERE family = '%s'"
                      " ORDER BY %s %s;",
-                     nvt_iterator_columns (),
-                     quoted_family,
+                     nvt_iterator_columns (), quoted_family,
                      sort_field ? sort_field : "name",
                      ascending ? "ASC" : "DESC");
       g_free (quoted_family);
@@ -740,8 +705,7 @@ init_nvt_iterator (iterator_t* iterator, nvt_t nvt, config_t config,
                      " FROM nvts"
                      " WHERE category = '%s'"
                      " ORDER BY %s %s;",
-                     nvt_iterator_columns (),
-                     quoted_category,
+                     nvt_iterator_columns (), quoted_category,
                      sort_field ? sort_field : "name",
                      ascending ? "ASC" : "DESC");
       g_free (quoted_category);
@@ -751,8 +715,7 @@ init_nvt_iterator (iterator_t* iterator, nvt_t nvt, config_t config,
                    "SELECT %s"
                    " FROM nvts"
                    " ORDER BY %s %s;",
-                   nvt_iterator_columns (),
-                   sort_field ? sort_field : "name",
+                   nvt_iterator_columns (), sort_field ? sort_field : "name",
                    ascending ? "ASC" : "DESC");
 }
 
@@ -765,19 +728,16 @@ init_nvt_iterator (iterator_t* iterator, nvt_t nvt, config_t config,
  * @param[in]  sort_field  Field to sort on, or NULL for "id".
  */
 void
-init_cve_nvt_iterator (iterator_t* iterator, const char *cve, int ascending,
-                       const char* sort_field)
+init_cve_nvt_iterator (iterator_t *iterator, const char *cve, int ascending,
+                       const char *sort_field)
 {
   init_iterator (iterator,
                  "SELECT %s"
                  " FROM nvts"
                  " WHERE cve %s '%%%s%%'"
                  " ORDER BY %s %s;",
-                 nvt_iterator_columns (),
-                 sql_ilike_op (),
-                 cve ? cve : "",
-                 sort_field ? sort_field : "name",
-                 ascending ? "ASC" : "DESC");
+                 nvt_iterator_columns (), sql_ilike_op (), cve ? cve : "",
+                 sort_field ? sort_field : "name", ascending ? "ASC" : "DESC");
 }
 
 /**
@@ -848,10 +808,11 @@ DEF_ACCESS (nvt_iterator_tag, GET_ITERATOR_COLUMN_COUNT + 6);
  * @return Category.
  */
 int
-nvt_iterator_category (iterator_t* iterator)
+nvt_iterator_category (iterator_t *iterator)
 {
   int ret;
-  if (iterator->done) return -1;
+  if (iterator->done)
+    return -1;
   ret = iterator_int (iterator, GET_ITERATOR_COLUMN_COUNT + 7);
   return ret;
 }
@@ -904,7 +865,7 @@ DEF_ACCESS (nvt_iterator_qod_type, GET_ITERATOR_COLUMN_COUNT + 13);
  * @return  Newly allocated string of the timeout in seconds or NULL.
  */
 char *
-nvt_default_timeout (const char* oid)
+nvt_default_timeout (const char *oid)
 {
   return sql_string ("SELECT value FROM nvt_preferences"
                      " WHERE name = (SELECT name FROM nvts"
@@ -935,8 +896,8 @@ family_nvt_count (const char *family)
     }
 
   quoted_family = sql_quote (family);
-  int ret = sql_int ("SELECT COUNT(*) FROM nvts WHERE family = '%s';",
-                     quoted_family);
+  int ret =
+    sql_int ("SELECT COUNT(*) FROM nvts WHERE family = '%s';", quoted_family);
   g_free (quoted_family);
   return ret;
 }
@@ -983,7 +944,7 @@ insert_nvt_preference (gpointer nvt_preference, gpointer dummy)
   if (nvt_preference == NULL)
     return;
 
-  preference = (preference_t*) nvt_preference;
+  preference = (preference_t *) nvt_preference;
   manage_nvt_preference_add (preference->name, preference->value);
 }
 
@@ -1002,7 +963,8 @@ insert_nvts_list (GList *nvts_list)
 }
 
 /**
- * @brief Inserts NVT preferences in DB from a list of nvt_preference_t structures.
+ * @brief Inserts NVT preferences in DB from a list of nvt_preference_t
+ * structures.
  *
  * @param[in]  nvt_preferences_list     List of nvts to be inserted.
  */
@@ -1069,9 +1031,7 @@ refresh_nvt_cves ()
               quoted_oid = sql_insert (iterator_string (&nvts, 1));
               sql ("INSERT INTO nvt_cves (nvt, oid, cve_name)"
                    " VALUES (%llu, %s, %s);",
-                   iterator_int64 (&nvts, 0),
-                   quoted_oid,
-                   quoted_cve);
+                   iterator_int64 (&nvts, 0), quoted_oid, quoted_cve);
               g_free (quoted_cve);
               g_free (quoted_oid);
             }

--- a/src/manage_sql_nvts.h
+++ b/src/manage_sql_nvts.h
@@ -29,63 +29,62 @@
  * @brief Filter columns for NVT info iterator.
  */
 #define NVT_INFO_ITERATOR_FILTER_COLUMNS                                    \
- { GET_ITERATOR_FILTER_COLUMNS, "version", "cve", "bid", "xref",            \
-   "family", "cvss_base", "severity", "cvss", "script_tags", "qod",         \
-   "qod_type", "solution_type", NULL }
+  {                                                                         \
+    GET_ITERATOR_FILTER_COLUMNS, "version", "cve", "bid", "xref", "family", \
+      "cvss_base", "severity", "cvss", "script_tags", "qod", "qod_type",    \
+      "solution_type", NULL                                                 \
+  }
 
 /**
  * @brief NVT iterator columns.
  */
-#define NVT_ITERATOR_COLUMNS                                                \
- {                                                                          \
-   GET_ITERATOR_COLUMNS_PREFIX (""),                                        \
-   { "''", "_owner", KEYWORD_TYPE_STRING },                                 \
-   { "0", NULL, KEYWORD_TYPE_INTEGER },                                     \
-   { "oid", NULL, KEYWORD_TYPE_STRING },                                    \
-   { "modification_time", "version", KEYWORD_TYPE_INTEGER },                \
-   { "name", NULL, KEYWORD_TYPE_STRING },                                   \
-   { "cve", NULL, KEYWORD_TYPE_STRING },                                    \
-   { "bid", NULL, KEYWORD_TYPE_STRING },                                    \
-   { "xref", NULL, KEYWORD_TYPE_STRING },                                   \
-   { "tag", NULL, KEYWORD_TYPE_STRING },                                    \
-   { "category", NULL, KEYWORD_TYPE_STRING },                               \
-   { "family", NULL, KEYWORD_TYPE_STRING },                                 \
-   { "cvss_base", NULL, KEYWORD_TYPE_DOUBLE },                              \
-   { "cvss_base", "severity", KEYWORD_TYPE_DOUBLE },                        \
-   { "cvss_base", "cvss", KEYWORD_TYPE_DOUBLE },                            \
-   { "qod", NULL, KEYWORD_TYPE_INTEGER },                                   \
-   { "qod_type", NULL, KEYWORD_TYPE_STRING },                               \
-   { "solution_type", NULL, KEYWORD_TYPE_STRING },                          \
-   { "tag", "script_tags", KEYWORD_TYPE_STRING},                            \
-   { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                                     \
- }
+#define NVT_ITERATOR_COLUMNS                                                   \
+  {                                                                            \
+    GET_ITERATOR_COLUMNS_PREFIX (""), {"''", "_owner", KEYWORD_TYPE_STRING},   \
+      {"0", NULL, KEYWORD_TYPE_INTEGER}, {"oid", NULL, KEYWORD_TYPE_STRING},   \
+      {"modification_time", "version", KEYWORD_TYPE_INTEGER},                  \
+      {"name", NULL, KEYWORD_TYPE_STRING}, {"cve", NULL, KEYWORD_TYPE_STRING}, \
+      {"bid", NULL, KEYWORD_TYPE_STRING}, {"xref", NULL, KEYWORD_TYPE_STRING}, \
+      {"tag", NULL, KEYWORD_TYPE_STRING},                                      \
+      {"category", NULL, KEYWORD_TYPE_STRING},                                 \
+      {"family", NULL, KEYWORD_TYPE_STRING},                                   \
+      {"cvss_base", NULL, KEYWORD_TYPE_DOUBLE},                                \
+      {"cvss_base", "severity", KEYWORD_TYPE_DOUBLE},                          \
+      {"cvss_base", "cvss", KEYWORD_TYPE_DOUBLE},                              \
+      {"qod", NULL, KEYWORD_TYPE_INTEGER},                                     \
+      {"qod_type", NULL, KEYWORD_TYPE_STRING},                                 \
+      {"solution_type", NULL, KEYWORD_TYPE_STRING},                            \
+      {"tag", "script_tags", KEYWORD_TYPE_STRING},                             \
+    {                                                                          \
+      NULL, NULL, KEYWORD_TYPE_UNKNOWN                                         \
+    }                                                                          \
+  }
 
 /**
  * @brief NVT iterator columns.
  */
-#define NVT_ITERATOR_COLUMNS_NVTS                                           \
- {                                                                          \
-   GET_ITERATOR_COLUMNS_PREFIX ("nvts."),                                   \
-   { "''", "_owner", KEYWORD_TYPE_STRING },                                 \
-   { "0", NULL, KEYWORD_TYPE_STRING },                                      \
-   { "oid", NULL, KEYWORD_TYPE_STRING },                                    \
-   { "modification_time", "version", KEYWORD_TYPE_INTEGER },                \
-   { "nvts.name", NULL, KEYWORD_TYPE_STRING },                              \
-   { "cve", NULL, KEYWORD_TYPE_STRING },                                    \
-   { "bid", NULL, KEYWORD_TYPE_STRING },                                    \
-   { "xref", NULL, KEYWORD_TYPE_STRING },                                   \
-   { "tag", NULL, KEYWORD_TYPE_STRING },                                    \
-   { "category", NULL, KEYWORD_TYPE_STRING },                               \
-   { "nvts.family", NULL, KEYWORD_TYPE_STRING },                            \
-   { "cvss_base", NULL, KEYWORD_TYPE_DOUBLE },                              \
-   { "cvss_base", "severity", KEYWORD_TYPE_DOUBLE },                        \
-   { "cvss_base", "cvss", KEYWORD_TYPE_DOUBLE },                            \
-   { "qod", NULL, KEYWORD_TYPE_INTEGER },                                   \
-   { "qod_type", NULL, KEYWORD_TYPE_STRING },                               \
-   { "solution_type", NULL, KEYWORD_TYPE_STRING },                          \
-   { "tag", "script_tags", KEYWORD_TYPE_STRING },                           \
-   { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                                     \
- }
+#define NVT_ITERATOR_COLUMNS_NVTS                                              \
+  {                                                                            \
+    GET_ITERATOR_COLUMNS_PREFIX ("nvts."),                                     \
+      {"''", "_owner", KEYWORD_TYPE_STRING}, {"0", NULL, KEYWORD_TYPE_STRING}, \
+      {"oid", NULL, KEYWORD_TYPE_STRING},                                      \
+      {"modification_time", "version", KEYWORD_TYPE_INTEGER},                  \
+      {"nvts.name", NULL, KEYWORD_TYPE_STRING},                                \
+      {"cve", NULL, KEYWORD_TYPE_STRING}, {"bid", NULL, KEYWORD_TYPE_STRING},  \
+      {"xref", NULL, KEYWORD_TYPE_STRING}, {"tag", NULL, KEYWORD_TYPE_STRING}, \
+      {"category", NULL, KEYWORD_TYPE_STRING},                                 \
+      {"nvts.family", NULL, KEYWORD_TYPE_STRING},                              \
+      {"cvss_base", NULL, KEYWORD_TYPE_DOUBLE},                                \
+      {"cvss_base", "severity", KEYWORD_TYPE_DOUBLE},                          \
+      {"cvss_base", "cvss", KEYWORD_TYPE_DOUBLE},                              \
+      {"qod", NULL, KEYWORD_TYPE_INTEGER},                                     \
+      {"qod_type", NULL, KEYWORD_TYPE_STRING},                                 \
+      {"solution_type", NULL, KEYWORD_TYPE_STRING},                            \
+      {"tag", "script_tags", KEYWORD_TYPE_STRING},                             \
+    {                                                                          \
+      NULL, NULL, KEYWORD_TYPE_UNKNOWN                                         \
+    }                                                                          \
+  }
 
 void
 check_db_nvts ();

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -246,7 +246,9 @@ DEF_ACCESS (cpe_info_iterator_nvd_id, GET_ITERATOR_COLUMN_COUNT + 5);
  * @param[in]  sort_field  Field to sort on, or NULL for "id".
  */
 void
-init_cpe_cve_iterator (iterator_t *iterator, const char *cve, int ascending,
+init_cpe_cve_iterator (iterator_t *iterator,
+                       const char *cve,
+                       int ascending,
                        const char *sort_field)
 {
   gchar *quoted_cpe;
@@ -472,7 +474,8 @@ DEF_ACCESS (cve_info_iterator_description, GET_ITERATOR_COLUMN_COUNT + 8);
  *         -1 error.
  */
 int
-init_ovaldef_info_iterator (iterator_t *iterator, get_data_t *get,
+init_ovaldef_info_iterator (iterator_t *iterator,
+                            get_data_t *get,
                             const char *name)
 {
   static const char *filter_columns[] = OVALDEF_INFO_ITERATOR_FILTER_COLUMNS;
@@ -756,7 +759,8 @@ ovaldef_cves (const char *id)
  *         -1 error.
  */
 int
-init_cert_bund_adv_info_iterator (iterator_t *iterator, get_data_t *get,
+init_cert_bund_adv_info_iterator (iterator_t *iterator,
+                                  get_data_t *get,
                                   const char *name)
 {
   static const char *filter_columns[] =
@@ -869,8 +873,10 @@ DEF_ACCESS (cert_bund_adv_info_iterator_max_cvss,
  * @param[in]  sort_field  Field to sort on, or NULL for "id".
  */
 void
-init_cve_cert_bund_adv_iterator (iterator_t *iterator, const char *cve,
-                                 int ascending, const char *sort_field)
+init_cve_cert_bund_adv_iterator (iterator_t *iterator,
+                                 const char *cve,
+                                 int ascending,
+                                 const char *sort_field)
 {
   static column_t select_columns[] = CERT_BUND_ADV_INFO_ITERATOR_COLUMNS;
   gchar *columns;
@@ -900,8 +906,10 @@ init_cve_cert_bund_adv_iterator (iterator_t *iterator, const char *cve,
  * @param[in]  sort_field  Field to sort on, or NULL for "id".
  */
 void
-init_nvt_cert_bund_adv_iterator (iterator_t *iterator, const char *oid,
-                                 int ascending, const char *sort_field)
+init_nvt_cert_bund_adv_iterator (iterator_t *iterator,
+                                 const char *oid,
+                                 int ascending,
+                                 const char *sort_field)
 {
   static column_t select_columns[] = DFN_CERT_ADV_INFO_ITERATOR_COLUMNS;
   gchar *columns;
@@ -937,7 +945,8 @@ init_nvt_cert_bund_adv_iterator (iterator_t *iterator, const char *oid,
  *         -1 error.
  */
 int
-init_dfn_cert_adv_info_iterator (iterator_t *iterator, get_data_t *get,
+init_dfn_cert_adv_info_iterator (iterator_t *iterator,
+                                 get_data_t *get,
                                  const char *name)
 {
   static const char *filter_columns[] =
@@ -1048,8 +1057,10 @@ DEF_ACCESS (dfn_cert_adv_info_iterator_max_cvss, GET_ITERATOR_COLUMN_COUNT + 3);
  * @param[in]  sort_field  Field to sort on, or NULL for "id".
  */
 void
-init_cve_dfn_cert_adv_iterator (iterator_t *iterator, const char *cve,
-                                int ascending, const char *sort_field)
+init_cve_dfn_cert_adv_iterator (iterator_t *iterator,
+                                const char *cve,
+                                int ascending,
+                                const char *sort_field)
 {
   static column_t select_columns[] = DFN_CERT_ADV_INFO_ITERATOR_COLUMNS;
   gchar *columns;
@@ -1079,8 +1090,10 @@ init_cve_dfn_cert_adv_iterator (iterator_t *iterator, const char *cve,
  * @param[in]  sort_field  Field to sort on, or NULL for "id".
  */
 void
-init_nvt_dfn_cert_adv_iterator (iterator_t *iterator, const char *oid,
-                                int ascending, const char *sort_field)
+init_nvt_dfn_cert_adv_iterator (iterator_t *iterator,
+                                const char *oid,
+                                int ascending,
+                                const char *sort_field)
 {
   static column_t select_columns[] = DFN_CERT_ADV_INFO_ITERATOR_COLUMNS;
   gchar *columns;
@@ -1424,7 +1437,8 @@ DEF_ACCESS (ovaldi_file_iterator_name, 0);
  * @return 0 nothing to do, 1 updated, -1 error.
  */
 static int
-update_dfn_xml (const gchar *xml_path, int last_cert_update,
+update_dfn_xml (const gchar *xml_path,
+                int last_cert_update,
                 int last_dfn_update)
 {
   GError *error;
@@ -1698,7 +1712,8 @@ update_dfn_cert_advisories (int last_cert_update)
  * @return 0 nothing to do, 1 updated, -1 error.
  */
 static int
-update_bund_xml (const gchar *xml_path, int last_cert_update,
+update_bund_xml (const gchar *xml_path,
+                 int last_cert_update,
                  int last_bund_update)
 {
   GError *error;
@@ -2168,7 +2183,8 @@ fail:
  * @return 0 nothing to do, 1 updated, -1 error.
  */
 static int
-update_cve_xml (const gchar *xml_path, int last_scap_update,
+update_cve_xml (const gchar *xml_path,
+                int last_scap_update,
                 int last_cve_update)
 {
   GError *error;
@@ -2569,7 +2585,8 @@ update_scap_cves (int last_scap_update)
  * @param[out] definition_date_oldest  Oldest date.
  */
 static void
-oval_definition_dates (entity_t definition, int *definition_date_newest,
+oval_definition_dates (entity_t definition,
+                       int *definition_date_newest,
                        int *definition_date_oldest)
 {
   entity_t metadata, oval_repository, date, dates;
@@ -2797,8 +2814,10 @@ verify_oval_file (const gchar *full_path)
  * @return 0 nothing to do, 1 updated, -1 error.
  */
 static int
-update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
-                    int last_ovaldef_update, int private)
+update_ovaldef_xml (gchar **file_and_date,
+                    int last_scap_update,
+                    int last_ovaldef_update,
+                    int private)
 {
   GError *error;
   entity_t entity, child;
@@ -3227,7 +3246,9 @@ static array_t *oval_files = NULL;
  * @return 0 success, -1 error.
  */
 static int
-oval_files_add (const char *path, const struct stat *stat, int flag,
+oval_files_add (const char *path,
+                const struct stat *stat,
+                int flag,
                 struct FTW *traversal)
 {
   GError *error;
@@ -3625,8 +3646,10 @@ manage_db_reinit (const gchar *name)
  * @param[in]  lockfile_basename  Basename for lockfile.
  */
 static void
-sync_secinfo (sigset_t *sigmask_current, int (*update) (int),
-              const gchar *process_title, const gchar *lockfile_basename)
+sync_secinfo (sigset_t *sigmask_current,
+              int (*update) (int),
+              const gchar *process_title,
+              const gchar *lockfile_basename)
 {
   int pid, lockfile;
   gchar *lockfile_name;
@@ -3854,7 +3877,8 @@ update_cert_timestamp ()
  * @param[in]  last_scap_update  Time of last SCAP update.
  */
 static void
-update_cvss_dfn_cert (int updated_dfn_cert, int last_cert_update,
+update_cvss_dfn_cert (int updated_dfn_cert,
+                      int last_cert_update,
                       int last_scap_update)
 {
   /* TODO greenbone-certdata-sync did retries. */
@@ -3886,7 +3910,8 @@ update_cvss_dfn_cert (int updated_dfn_cert, int last_cert_update,
  * @param[in]  last_scap_update  Time of last SCAP update.
  */
 static void
-update_cvss_cert_bund (int updated_cert_bund, int last_cert_update,
+update_cvss_cert_bund (int updated_cert_bund,
+                       int last_cert_update,
                        int last_scap_update)
 {
   /* TODO greenbone-certdata-sync did retries. */

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -171,8 +171,16 @@ init_cpe_info_iterator (iterator_t *iterator, get_data_t *get, const char *name)
       g_free (get->filter);
       get->filter = NULL;
     }
-  ret = init_get_iterator (iterator, "cpe", get, columns, NULL, filter_columns,
-                           0, NULL, clause, FALSE);
+  ret = init_get_iterator (iterator,
+                           "cpe",
+                           get,
+                           columns,
+                           NULL,
+                           filter_columns,
+                           0,
+                           NULL,
+                           clause,
+                           FALSE);
   g_free (clause);
   return ret;
 }
@@ -250,7 +258,8 @@ init_cpe_cve_iterator (iterator_t *iterator, const char *cve, int ascending,
                  "  WHERE cpe ="
                  "  (SELECT id FROM cpes WHERE name = '%s'))"
                  " ORDER BY %s %s;",
-                 quoted_cpe, sort_field ? sort_field : "cvss DESC, name",
+                 quoted_cpe,
+                 sort_field ? sort_field : "cvss DESC, name",
                  ascending ? "ASC" : "DESC");
   g_free (quoted_cpe);
 }
@@ -344,8 +353,16 @@ init_cve_info_iterator (iterator_t *iterator, get_data_t *get, const char *name)
       g_free (get->filter);
       get->filter = NULL;
     }
-  ret = init_get_iterator (iterator, "cve", get, columns, NULL, filter_columns,
-                           0, NULL, clause, FALSE);
+  ret = init_get_iterator (iterator,
+                           "cve",
+                           get,
+                           columns,
+                           NULL,
+                           filter_columns,
+                           0,
+                           NULL,
+                           clause,
+                           FALSE);
   g_free (clause);
   return ret;
 }
@@ -481,8 +498,16 @@ init_ovaldef_info_iterator (iterator_t *iterator, get_data_t *get,
       g_free (get->filter);
       get->filter = NULL;
     }
-  ret = init_get_iterator (iterator, "ovaldef", get, columns, NULL,
-                           filter_columns, 0, NULL, clause, FALSE);
+  ret = init_get_iterator (iterator,
+                           "ovaldef",
+                           get,
+                           columns,
+                           NULL,
+                           filter_columns,
+                           0,
+                           NULL,
+                           clause,
+                           FALSE);
   g_free (clause);
   return ret;
 }
@@ -635,7 +660,8 @@ ovaldef_uuid (const char *name, const char *fname)
   quoted_fname = sql_quote (fname);
   ret = sql_string ("SELECT uuid FROM ovaldefs WHERE name = '%s'"
                     " AND xml_file = '%s';",
-                    name, fname);
+                    name,
+                    fname);
   g_free (quoted_name);
   g_free (quoted_fname);
   return ret;
@@ -709,8 +735,8 @@ ovaldef_cves (const char *id)
   while (next (&iterator))
     {
       char *tmp = ret;
-      ret = g_strdup_printf ("%s%s%s", ret ?: "", ret ? ", " : "",
-                             iterator_string (&iterator, 0));
+      ret = g_strdup_printf (
+        "%s%s%s", ret ?: "", ret ? ", " : "", iterator_string (&iterator, 0));
       g_free (tmp);
     }
   cleanup_iterator (&iterator);
@@ -757,8 +783,16 @@ init_cert_bund_adv_info_iterator (iterator_t *iterator, get_data_t *get,
       g_free (get->filter);
       get->filter = NULL;
     }
-  ret = init_get_iterator (iterator, "cert_bund_adv", get, columns, NULL,
-                           filter_columns, 0, NULL, clause, FALSE);
+  ret = init_get_iterator (iterator,
+                           "cert_bund_adv",
+                           get,
+                           columns,
+                           NULL,
+                           filter_columns,
+                           0,
+                           NULL,
+                           clause,
+                           FALSE);
   g_free (clause);
   return ret;
 }
@@ -776,8 +810,8 @@ cert_bund_adv_info_count (const get_data_t *get)
   static const char *filter_columns[] =
     CERT_BUND_ADV_INFO_ITERATOR_FILTER_COLUMNS;
   static column_t columns[] = CERT_BUND_ADV_INFO_ITERATOR_COLUMNS;
-  return count ("cert_bund_adv", get, columns, NULL, filter_columns, 0, 0, 0,
-                FALSE);
+  return count (
+    "cert_bund_adv", get, columns, NULL, filter_columns, 0, 0, 0, FALSE);
 }
 
 /**
@@ -850,7 +884,9 @@ init_cve_cert_bund_adv_iterator (iterator_t *iterator, const char *cve,
                  " WHERE id IN (SELECT adv_id FROM cert_bund_cves"
                  "              WHERE cve_name = '%s')"
                  " ORDER BY %s %s;",
-                 columns, cve, sort_field ? sort_field : "name",
+                 columns,
+                 cve,
+                 sort_field ? sort_field : "name",
                  ascending ? "ASC" : "DESC");
   g_free (columns);
 }
@@ -881,7 +917,9 @@ init_nvt_cert_bund_adv_iterator (iterator_t *iterator, const char *oid,
                  "                                 FROM nvt_cves"
                  "                                 WHERE oid = '%s'))"
                  " ORDER BY %s %s;",
-                 columns, oid, sort_field ? sort_field : "name",
+                 columns,
+                 oid,
+                 sort_field ? sort_field : "name",
                  ascending ? "ASC" : "DESC");
   g_free (columns);
 }
@@ -926,8 +964,16 @@ init_dfn_cert_adv_info_iterator (iterator_t *iterator, get_data_t *get,
       g_free (get->filter);
       get->filter = NULL;
     }
-  ret = init_get_iterator (iterator, "dfn_cert_adv", get, columns, NULL,
-                           filter_columns, 0, NULL, clause, FALSE);
+  ret = init_get_iterator (iterator,
+                           "dfn_cert_adv",
+                           get,
+                           columns,
+                           NULL,
+                           filter_columns,
+                           0,
+                           NULL,
+                           clause,
+                           FALSE);
   g_free (clause);
   return ret;
 }
@@ -945,8 +991,8 @@ dfn_cert_adv_info_count (const get_data_t *get)
   static const char *filter_columns[] =
     DFN_CERT_ADV_INFO_ITERATOR_FILTER_COLUMNS;
   static column_t columns[] = DFN_CERT_ADV_INFO_ITERATOR_COLUMNS;
-  return count ("dfn_cert_adv", get, columns, NULL, filter_columns, 0, 0, 0,
-                FALSE);
+  return count (
+    "dfn_cert_adv", get, columns, NULL, filter_columns, 0, 0, 0, FALSE);
 }
 
 /**
@@ -1017,7 +1063,9 @@ init_cve_dfn_cert_adv_iterator (iterator_t *iterator, const char *cve,
                  " WHERE id IN (SELECT adv_id FROM dfn_cert_cves"
                  "              WHERE cve_name = '%s')"
                  " ORDER BY %s %s;",
-                 columns, cve, sort_field ? sort_field : "name",
+                 columns,
+                 cve,
+                 sort_field ? sort_field : "name",
                  ascending ? "ASC" : "DESC");
   g_free (columns);
 }
@@ -1048,7 +1096,9 @@ init_nvt_dfn_cert_adv_iterator (iterator_t *iterator, const char *oid,
                  "                                 FROM nvt_cves"
                  "                                 WHERE oid = '%s'))"
                  " ORDER BY %s %s;",
-                 columns, oid, sort_field ? sort_field : "name",
+                 columns,
+                 oid,
+                 sort_field ? sort_field : "name",
                  ascending ? "ASC" : "DESC");
   g_free (columns);
 }
@@ -1096,9 +1146,17 @@ total_info_count (const get_data_t *get, int filtered)
       else
         filter = NULL;
 
-      clause = filter_clause ("allinfo", filter ? filter : get->filter,
-                              filter_columns, select_columns, NULL, get->trash,
-                              NULL, NULL, NULL, NULL, NULL);
+      clause = filter_clause ("allinfo",
+                              filter ? filter : get->filter,
+                              filter_columns,
+                              select_columns,
+                              NULL,
+                              get->trash,
+                              NULL,
+                              NULL,
+                              NULL,
+                              NULL,
+                              NULL);
       if (clause)
         return sql_int (
           "SELECT count (id) FROM" ALL_INFO_UNION_COLUMNS " WHERE %s;", clause);
@@ -1155,9 +1213,17 @@ init_all_info_iterator (iterator_t *iterator, get_data_t *get, const char *name)
   else
     filter = NULL;
 
-  clause = filter_clause ("allinfo", filter ? filter : get->filter,
-                          filter_columns, select_columns, NULL, get->trash,
-                          &order, &first, &max, NULL, NULL);
+  clause = filter_clause ("allinfo",
+                          filter ? filter : get->filter,
+                          filter_columns,
+                          select_columns,
+                          NULL,
+                          get->trash,
+                          &order,
+                          &first,
+                          &max,
+                          NULL,
+                          NULL);
   columns = columns_build_select (select_columns);
 
   subselect_limit_clause =
@@ -1166,46 +1232,110 @@ init_all_info_iterator (iterator_t *iterator, get_data_t *get, const char *name)
   limit_clause =
     g_strdup_printf ("LIMIT %s OFFSET %i", sql_select_limit (max), first);
 
-  cve_clause = filter_clause ("cve", filter ? filter : get->filter,
-                              filter_columns, cve_select_columns, NULL,
-                              get->trash, &cve_order, NULL, NULL, NULL, NULL);
-  cpe_clause = filter_clause ("cpe", filter ? filter : get->filter,
-                              filter_columns, cpe_select_columns, NULL,
-                              get->trash, &cpe_order, NULL, NULL, NULL, NULL);
-  nvt_clause = filter_clause ("nvt", filter ? filter : get->filter,
-                              filter_columns, nvt_select_columns, NULL,
-                              get->trash, &nvt_order, NULL, NULL, NULL, NULL);
-  cert_clause = filter_clause ("cert_bund_adv", filter ? filter : get->filter,
-                               filter_columns, cert_select_columns, NULL,
-                               get->trash, &cert_order, NULL, NULL, NULL, NULL);
-  dfn_clause = filter_clause ("dfn_cert_adv", filter ? filter : get->filter,
-                              filter_columns, dfn_select_columns, NULL,
-                              get->trash, &dfn_order, NULL, NULL, NULL, NULL);
-  ovaldef_clause =
-    filter_clause ("ovaldef", filter ? filter : get->filter, filter_columns,
-                   ovaldef_select_columns, NULL, get->trash, &ovaldef_order,
-                   NULL, NULL, NULL, NULL);
+  cve_clause = filter_clause ("cve",
+                              filter ? filter : get->filter,
+                              filter_columns,
+                              cve_select_columns,
+                              NULL,
+                              get->trash,
+                              &cve_order,
+                              NULL,
+                              NULL,
+                              NULL,
+                              NULL);
+  cpe_clause = filter_clause ("cpe",
+                              filter ? filter : get->filter,
+                              filter_columns,
+                              cpe_select_columns,
+                              NULL,
+                              get->trash,
+                              &cpe_order,
+                              NULL,
+                              NULL,
+                              NULL,
+                              NULL);
+  nvt_clause = filter_clause ("nvt",
+                              filter ? filter : get->filter,
+                              filter_columns,
+                              nvt_select_columns,
+                              NULL,
+                              get->trash,
+                              &nvt_order,
+                              NULL,
+                              NULL,
+                              NULL,
+                              NULL);
+  cert_clause = filter_clause ("cert_bund_adv",
+                               filter ? filter : get->filter,
+                               filter_columns,
+                               cert_select_columns,
+                               NULL,
+                               get->trash,
+                               &cert_order,
+                               NULL,
+                               NULL,
+                               NULL,
+                               NULL);
+  dfn_clause = filter_clause ("dfn_cert_adv",
+                              filter ? filter : get->filter,
+                              filter_columns,
+                              dfn_select_columns,
+                              NULL,
+                              get->trash,
+                              &dfn_order,
+                              NULL,
+                              NULL,
+                              NULL,
+                              NULL);
+  ovaldef_clause = filter_clause ("ovaldef",
+                                  filter ? filter : get->filter,
+                                  filter_columns,
+                                  ovaldef_select_columns,
+                                  NULL,
+                                  get->trash,
+                                  &ovaldef_order,
+                                  NULL,
+                                  NULL,
+                                  NULL,
+                                  NULL);
 
-  init_iterator (
-    iterator,
-    "SELECT %s"
-    " FROM " ALL_INFO_UNION_COLUMNS_LIMIT " %s%s"
-    " %s"
-    " %s;",
-    /* For the outer SELECT. */
-    columns,
-    /* For the inner SELECTs. */
-    cve_clause ? "WHERE " : "", cve_clause ? cve_clause : "", cve_order,
-    subselect_limit_clause, cpe_clause ? "WHERE " : "",
-    cpe_clause ? cpe_clause : "", cpe_order, subselect_limit_clause,
-    nvt_clause ? "WHERE " : "", nvt_clause ? nvt_clause : "", nvt_order,
-    subselect_limit_clause, cert_clause ? "WHERE " : "",
-    cert_clause ? cert_clause : "", cert_order, subselect_limit_clause,
-    dfn_clause ? "WHERE " : "", dfn_clause ? dfn_clause : "", dfn_order,
-    subselect_limit_clause, ovaldef_clause ? "WHERE " : "",
-    ovaldef_clause ? ovaldef_clause : "", ovaldef_order, subselect_limit_clause,
-    /* For the outer SELECT. */
-    clause ? "WHERE " : "", clause ? clause : "", order, limit_clause);
+  init_iterator (iterator,
+                 "SELECT %s"
+                 " FROM " ALL_INFO_UNION_COLUMNS_LIMIT " %s%s"
+                 " %s"
+                 " %s;",
+                 /* For the outer SELECT. */
+                 columns,
+                 /* For the inner SELECTs. */
+                 cve_clause ? "WHERE " : "",
+                 cve_clause ? cve_clause : "",
+                 cve_order,
+                 subselect_limit_clause,
+                 cpe_clause ? "WHERE " : "",
+                 cpe_clause ? cpe_clause : "",
+                 cpe_order,
+                 subselect_limit_clause,
+                 nvt_clause ? "WHERE " : "",
+                 nvt_clause ? nvt_clause : "",
+                 nvt_order,
+                 subselect_limit_clause,
+                 cert_clause ? "WHERE " : "",
+                 cert_clause ? cert_clause : "",
+                 cert_order,
+                 subselect_limit_clause,
+                 dfn_clause ? "WHERE " : "",
+                 dfn_clause ? dfn_clause : "",
+                 dfn_order,
+                 subselect_limit_clause,
+                 ovaldef_clause ? "WHERE " : "",
+                 ovaldef_clause ? ovaldef_clause : "",
+                 ovaldef_order,
+                 subselect_limit_clause,
+                 /* For the outer SELECT. */
+                 clause ? "WHERE " : "",
+                 clause ? clause : "",
+                 order,
+                 limit_clause);
 
   g_free (subselect_limit_clause);
   g_free (limit_clause);
@@ -1313,8 +1443,8 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
 
   if (g_stat (full_path, &state))
     {
-      g_warning ("%s: Failed to stat CERT file: %s", __FUNCTION__,
-                 strerror (errno));
+      g_warning (
+        "%s: Failed to stat CERT file: %s", __FUNCTION__, strerror (errno));
       return -1;
     }
 
@@ -1331,8 +1461,8 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
   g_file_get_contents (full_path, &xml, &xml_len, &error);
   if (error)
     {
-      g_warning ("%s: Failed to get contents: %s", __FUNCTION__,
-                 error->message);
+      g_warning (
+        "%s: Failed to get contents: %s", __FUNCTION__, error->message);
       g_error_free (error);
       g_free (full_path);
       return -1;
@@ -1422,9 +1552,12 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
               quoted_summary = sql_quote (entity_text (summary));
               sql ("SELECT merge_dfn_cert_adv"
                    "        ('%s', %i, %i, '%s', '%s', %i);",
-                   quoted_refnum, parse_iso_time (entity_text (published)),
-                   parse_iso_time (entity_text (updated)), quoted_title,
-                   quoted_summary, cve_refs);
+                   quoted_refnum,
+                   parse_iso_time (entity_text (published)),
+                   parse_iso_time (entity_text (updated)),
+                   quoted_title,
+                   quoted_summary,
+                   cve_refs);
               increment_transaction_size (&transaction_size);
               g_free (quoted_title);
               g_free (quoted_summary);
@@ -1462,7 +1595,8 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
                                    " ((SELECT id FROM dfn_cert_advs"
                                    "   WHERE name = '%s'),"
                                    "  '%s')",
-                                   quoted_refnum, quoted_point);
+                                   quoted_refnum,
+                                   quoted_point);
                               increment_transaction_size (&transaction_size);
                               g_free (quoted_point);
                             }
@@ -1514,8 +1648,10 @@ update_dfn_cert_advisories (int last_cert_update)
   dir = g_dir_open (GVM_CERT_DATA_DIR, 0, &error);
   if (dir == NULL)
     {
-      g_warning ("%s: Failed to open directory '%s': %s", __FUNCTION__,
-                 GVM_CERT_DATA_DIR, error->message);
+      g_warning ("%s: Failed to open directory '%s': %s",
+                 __FUNCTION__,
+                 GVM_CERT_DATA_DIR,
+                 error->message);
       g_error_free (error);
       return -1;
     }
@@ -1579,8 +1715,8 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
 
   if (g_stat (full_path, &state))
     {
-      g_warning ("%s: Failed to stat CERT file: %s", __FUNCTION__,
-                 strerror (errno));
+      g_warning (
+        "%s: Failed to stat CERT file: %s", __FUNCTION__, strerror (errno));
       return -1;
     }
 
@@ -1597,8 +1733,8 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
   g_file_get_contents (full_path, &xml, &xml_len, &error);
   if (error)
     {
-      g_warning ("%s: Failed to get contents: %s", __FUNCTION__,
-                 error->message);
+      g_warning (
+        "%s: Failed to get contents: %s", __FUNCTION__, error->message);
       g_error_free (error);
       g_free (full_path);
       return -1;
@@ -1699,9 +1835,12 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
               g_string_free (summary, TRUE);
               sql ("SELECT merge_bund_adv"
                    "        ('%s', %i, %i, '%s', '%s', %i);",
-                   quoted_refnum, parse_iso_time (entity_text (date)),
-                   parse_iso_time (entity_text (date)), quoted_title,
-                   quoted_summary, cve_refs);
+                   quoted_refnum,
+                   parse_iso_time (entity_text (date)),
+                   parse_iso_time (entity_text (date)),
+                   quoted_title,
+                   quoted_summary,
+                   cve_refs);
               increment_transaction_size (&transaction_size);
               g_free (quoted_title);
               g_free (quoted_summary);
@@ -1726,7 +1865,8 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
                                " ((SELECT id FROM cert_bund_advs"
                                "   WHERE name = '%s'),"
                                "  '%s')",
-                               quoted_refnum, quoted_cve);
+                               quoted_refnum,
+                               quoted_cve);
                           increment_transaction_size (&transaction_size);
                           g_free (quoted_cve);
                         }
@@ -1775,8 +1915,10 @@ update_cert_bund_advisories (int last_cert_update)
   dir = g_dir_open (GVM_CERT_DATA_DIR, 0, &error);
   if (dir == NULL)
     {
-      g_warning ("%s: Failed to open directory '%s': %s", __FUNCTION__,
-                 GVM_CERT_DATA_DIR, error->message);
+      g_warning ("%s: Failed to open directory '%s': %s",
+                 __FUNCTION__,
+                 GVM_CERT_DATA_DIR,
+                 error->message);
       g_error_free (error);
       return -1;
     }
@@ -1832,13 +1974,13 @@ update_scap_cpes (int last_scap_update)
   int transaction_size = 0;
 
   updated_scap_cpes = 0;
-  full_path = g_build_filename (GVM_SCAP_DATA_DIR,
-                                "official-cpe-dictionary_v2.2.xml", NULL);
+  full_path = g_build_filename (
+    GVM_SCAP_DATA_DIR, "official-cpe-dictionary_v2.2.xml", NULL);
 
   if (g_stat (full_path, &state))
     {
-      g_warning ("%s: No CPE dictionary found at %s", __FUNCTION__,
-                 strerror (errno));
+      g_warning (
+        "%s: No CPE dictionary found at %s", __FUNCTION__, strerror (errno));
       return -1;
     }
 
@@ -1863,8 +2005,8 @@ update_scap_cpes (int last_scap_update)
   g_free (full_path);
   if (error)
     {
-      g_warning ("%s: Failed to get contents: %s", __FUNCTION__,
-                 error->message);
+      g_warning (
+        "%s: Failed to get contents: %s", __FUNCTION__, error->message);
       g_error_free (error);
       return -1;
     }
@@ -1940,12 +2082,13 @@ update_scap_cpes (int last_scap_update)
               deprecated =
                 entity_attribute (item_metadata, "deprecated-by-nvd-id");
               if (deprecated
-                  && (g_regex_match_simple ("^[0-9]+$", (gchar *) deprecated, 0,
-                                            0)
+                  && (g_regex_match_simple (
+                        "^[0-9]+$", (gchar *) deprecated, 0, 0)
                       == 0))
                 {
                   g_warning ("%s: invalid deprecated-by-nvd-id: %s",
-                             __FUNCTION__, deprecated);
+                             __FUNCTION__,
+                             deprecated);
                   free_entity (entity);
                   goto fail;
                 }
@@ -1984,10 +2127,13 @@ update_scap_cpes (int last_scap_update)
               quoted_nvd_id = sql_quote (nvd_id);
               sql ("SELECT merge_cpe"
                    "        ('%s', '%s', %i, %i, '%s', %s, '%s');",
-                   quoted_name, quoted_title,
+                   quoted_name,
+                   quoted_title,
                    parse_iso_time (modification_date),
-                   parse_iso_time (modification_date), quoted_status,
-                   deprecated ? deprecated : "NULL", quoted_nvd_id);
+                   parse_iso_time (modification_date),
+                   quoted_status,
+                   deprecated ? deprecated : "NULL",
+                   quoted_nvd_id);
               increment_transaction_size (&transaction_size);
               g_free (quoted_title);
               g_free (quoted_name);
@@ -2039,8 +2185,8 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
 
   if (g_stat (full_path, &state))
     {
-      g_warning ("%s: Failed to stat SCAP file: %s", __FUNCTION__,
-                 strerror (errno));
+      g_warning (
+        "%s: Failed to stat SCAP file: %s", __FUNCTION__, strerror (errno));
       return -1;
     }
 
@@ -2059,8 +2205,8 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
   g_file_get_contents (full_path, &xml, &xml_len, &error);
   if (error)
     {
-      g_warning ("%s: Failed to get contents: %s", __FUNCTION__,
-                 error->message);
+      g_warning (
+        "%s: Failed to get contents: %s", __FUNCTION__, error->message);
       g_error_free (error);
       g_free (full_path);
       return -1;
@@ -2229,8 +2375,8 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                   while ((product = first_entity (products)))
                     {
                       if (strcmp (entity_name (product), "vuln:product") == 0)
-                        g_string_append_printf (software, "%s ",
-                                                entity_text (product));
+                        g_string_append_printf (
+                          software, "%s ", entity_text (product));
                       products = next_entities (products);
                     }
                 }
@@ -2262,11 +2408,18 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
               sql ("SELECT merge_cve"
                    "        ('%s', '%s', %i, %i, %s, '%s', '%s', '%s', '%s',"
                    "         '%s', '%s', '%s', '%s');",
-                   quoted_id, quoted_id, time_published, time_modified,
-                   score ? entity_text (score) : "NULL", quoted_summary,
-                   quoted_access_vector, quoted_access_complexity,
-                   quoted_authentication, quoted_confidentiality_impact,
-                   quoted_integrity_impact, quoted_availability_impact,
+                   quoted_id,
+                   quoted_id,
+                   time_published,
+                   time_modified,
+                   score ? entity_text (score) : "NULL",
+                   quoted_summary,
+                   quoted_access_vector,
+                   quoted_access_complexity,
+                   quoted_authentication,
+                   quoted_confidentiality_impact,
+                   quoted_integrity_impact,
+                   quoted_availability_impact,
                    quoted_software);
               increment_transaction_size (&transaction_size);
               g_free (quoted_summary);
@@ -2309,13 +2462,16 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                               g_free (product_tilde);
 
                               sql ("SELECT merge_cpe_name ('%s', '%s', %i, %i)",
-                                   quoted_product, quoted_product,
-                                   time_published, time_modified);
+                                   quoted_product,
+                                   quoted_product,
+                                   time_published,
+                                   time_modified);
                               sql ("SELECT merge_affected_product"
                                    "        (%llu,"
                                    "         (SELECT id FROM cpes"
                                    "          WHERE name='%s'))",
-                                   cve_rowid, quoted_product);
+                                   cve_rowid,
+                                   quoted_product);
                               transaction_size++;
                               increment_transaction_size (&transaction_size);
                               g_free (quoted_product);
@@ -2366,8 +2522,10 @@ update_scap_cves (int last_scap_update)
   dir = g_dir_open (GVM_SCAP_DATA_DIR, 0, &error);
   if (dir == NULL)
     {
-      g_warning ("%s: Failed to open directory '%s': %s", __FUNCTION__,
-                 GVM_SCAP_DATA_DIR, error->message);
+      g_warning ("%s: Failed to open directory '%s': %s",
+                 __FUNCTION__,
+                 GVM_SCAP_DATA_DIR,
+                 error->message);
       g_error_free (error);
       return -1;
     }
@@ -2523,8 +2681,8 @@ verify_oval_file (const gchar *full_path)
   g_file_get_contents (full_path, &xml, &xml_len, &error);
   if (error)
     {
-      g_warning ("%s: Failed to get contents: %s", __FUNCTION__,
-                 error->message);
+      g_warning (
+        "%s: Failed to get contents: %s", __FUNCTION__, error->message);
       g_error_free (error);
       return -1;
     }
@@ -2664,7 +2822,9 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
 
   if (g_stat (xml_path, &state))
     {
-      g_warning ("%s: Failed to stat OVAL file %s: %s", __FUNCTION__, xml_path,
+      g_warning ("%s: Failed to stat OVAL file %s: %s",
+                 __FUNCTION__,
+                 xml_path,
                  strerror (errno));
       return -1;
     }
@@ -2680,8 +2840,8 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
   xml_basename = strstr (xml_path, GVM_SCAP_DATA_DIR);
   if (xml_basename == NULL)
     {
-      g_warning ("%s: xml_path missing GVM_SCAP_DATA_DIR: %s", __FUNCTION__,
-                 xml_path);
+      g_warning (
+        "%s: xml_path missing GVM_SCAP_DATA_DIR: %s", __FUNCTION__, xml_path);
       return -1;
     }
   xml_basename += strlen (GVM_SCAP_DATA_DIR);
@@ -2723,8 +2883,8 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
   g_file_get_contents (xml_path, &xml, &xml_len, &error);
   if (error)
     {
-      g_warning ("%s: Failed to get contents: %s", __FUNCTION__,
-                 error->message);
+      g_warning (
+        "%s: Failed to get contents: %s", __FUNCTION__, error->message);
       g_error_free (error);
       g_free (quoted_xml_basename);
       return -1;
@@ -2746,7 +2906,8 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
   sql ("INSERT INTO ovalfiles (xml_file)"
        " SELECT '%s' WHERE NOT EXISTS (SELECT * FROM ovalfiles"
        "                               WHERE xml_file = '%s');",
-       quoted_xml_basename, quoted_xml_basename);
+       quoted_xml_basename,
+       quoted_xml_basename);
 
   sql_commit ();
   sql_begin_immediate ();
@@ -2775,8 +2936,8 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
 
               /* The newest and oldest of this definition's dates (created,
                * modified, etc), from the OVAL XML. */
-              oval_definition_dates (definition, &definition_date_newest,
-                                     &definition_date_oldest);
+              oval_definition_dates (
+                definition, &definition_date_newest, &definition_date_oldest);
 
               if (definition_date_oldest
                   && (definition_date_oldest <= last_oval_update))
@@ -2785,7 +2946,9 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
 
                   id = entity_attribute (definition, "id");
                   quoted_oval_id = sql_quote (id ? id : "");
-                  g_info ("%s: Filtered %s (%i)", __FUNCTION__, quoted_oval_id,
+                  g_info ("%s: Filtered %s (%i)",
+                          __FUNCTION__,
+                          quoted_oval_id,
                           definition_date_oldest);
                   g_free (quoted_oval_id);
                 }
@@ -2865,8 +3028,8 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                   if (g_regex_match_simple ("^[0-9]+$", (gchar *) version, 0, 0)
                       == 0)
                     {
-                      g_warning ("%s: invalid version: %s", __FUNCTION__,
-                                 version);
+                      g_warning (
+                        "%s: invalid version: %s", __FUNCTION__, version);
                       free_entity (entity);
                       goto fail;
                     }
@@ -2886,15 +3049,20 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                   sql ("SELECT merge_ovaldef ('%s', '%s', '', %i, %i, %i, %i,"
                        "                      '%s', '%s', '%s', '%s', '%s',"
                        "                      %i);",
-                       quoted_id, quoted_oval_id,
+                       quoted_id,
+                       quoted_oval_id,
                        definition_date_oldest == 0 ? file_timestamp
                                                    : definition_date_newest,
                        definition_date_oldest == 0 ? file_timestamp
                                                    : definition_date_oldest,
                        version,
                        (deprecated && strcasecmp (deprecated, "TRUE")) ? 1 : 0,
-                       quoted_class, quoted_title, quoted_description,
-                       quoted_xml_basename, quoted_status, cve_count);
+                       quoted_class,
+                       quoted_title,
+                       quoted_description,
+                       quoted_xml_basename,
+                       quoted_status,
+                       cve_count);
                   increment_transaction_size (&transaction_size);
                   g_free (quoted_id);
                   g_free (quoted_class);
@@ -2925,7 +3093,8 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                             " AND NOT EXISTS (SELECT * FROM affected_ovaldefs"
                             "                 WHERE cve = cves.id"
                             "                 AND ovaldef = ovaldefs.id);",
-                            quoted_ref_id, quoted_oval_id);
+                            quoted_ref_id,
+                            quoted_oval_id);
                           increment_transaction_size (&transaction_size);
                         }
                       references = next_entities (references);
@@ -3079,7 +3248,9 @@ oval_files_add (const char *path, const struct stat *stat, int flag,
   g_file_get_contents (path, &oval_xml, &len, &error);
   if (error)
     {
-      g_warning ("%s: Failed get contents of %s: %s", __FUNCTION__, path,
+      g_warning ("%s: Failed get contents of %s: %s",
+                 __FUNCTION__,
+                 path,
                  error->message);
       g_error_free (error);
       return -1;
@@ -3211,7 +3382,9 @@ update_scap_ovaldefs (int last_scap_update, int private)
           oval_files_free ();
           return 0;
         }
-      g_warning ("%s: failed to lstat '%s': %s", __FUNCTION__, oval_dir,
+      g_warning ("%s: failed to lstat '%s': %s",
+                 __FUNCTION__,
+                 oval_dir,
                  strerror (errno));
       g_free (oval_dir);
       oval_files_free ();
@@ -3224,16 +3397,20 @@ update_scap_ovaldefs (int last_scap_update, int private)
       if (errno == ENOENT)
         {
           if (private)
-            g_debug ("%s: nftw of private '%s': %s", __FUNCTION__, oval_dir,
+            g_debug ("%s: nftw of private '%s': %s",
+                     __FUNCTION__,
+                     oval_dir,
                      strerror (errno));
           else
-            g_warning ("%s: nftw of '%s': %s", __FUNCTION__, oval_dir,
-                       strerror (errno));
+            g_warning (
+              "%s: nftw of '%s': %s", __FUNCTION__, oval_dir, strerror (errno));
           g_free (oval_dir);
           oval_files_free ();
           return 0;
         }
-      g_warning ("%s: failed to traverse '%s': %s", __FUNCTION__, oval_dir,
+      g_warning ("%s: failed to traverse '%s': %s",
+                 __FUNCTION__,
+                 oval_dir,
                  strerror (errno));
       g_free (oval_dir);
       oval_files_free ();
@@ -3267,8 +3444,8 @@ update_scap_ovaldefs (int last_scap_update, int private)
             }
           else
             {
-              g_warning ("g_dir_open (%s) failed - %s", oval_dir,
-                         error->message);
+              g_warning (
+                "g_dir_open (%s) failed - %s", oval_dir, error->message);
               g_free (oval_dir);
               g_error_free (error);
               oval_files_free ();
@@ -3344,14 +3521,15 @@ update_scap_ovaldefs (int last_scap_update, int private)
           if (suffix == NULL)
             {
               g_warning ("%s: pair[0] missing GVM_SCAP_DATA_DIR: %s",
-                         __FUNCTION__, pair[0]);
+                         __FUNCTION__,
+                         pair[0]);
               g_free (oval_dir);
               oval_files_free ();
               return -1;
             }
           suffix += strlen (GVM_SCAP_DATA_DIR);
-          g_string_append_printf (oval_files_clause, "%s'%s'",
-                                  first ? "" : ", ", suffix);
+          g_string_append_printf (
+            oval_files_clause, "%s'%s'", first ? "" : ", ", suffix);
           first = 0;
         }
       g_string_append (oval_files_clause, "))");
@@ -3410,7 +3588,8 @@ write_sync_start (int lockfile)
           if (errno == EAGAIN || errno == EINTR)
             /* Interrupted, try write again. */
             continue;
-          g_warning ("%s: failed to write to lockfile: %s", __FUNCTION__,
+          g_warning ("%s: failed to write to lockfile: %s",
+                     __FUNCTION__,
                      strerror (errno));
           break;
         }
@@ -3474,13 +3653,16 @@ sync_secinfo (sigset_t *sigmask_current, int (*update) (int),
       lockfile_name =
         g_build_filename (g_get_tmp_dir (), lockfile_basename, NULL);
 
-      lockfile = open (lockfile_name, O_RDWR | O_CREAT | O_APPEND,
+      lockfile = open (lockfile_name,
+                       O_RDWR | O_CREAT | O_APPEND,
                        /* "-rw-r--r--" */
                        S_IWUSR | S_IRUSR | S_IROTH | S_IRGRP);
       if (lockfile == -1)
         {
-          g_warning ("%s: failed to open lock file '%s': %s", __FUNCTION__,
-                     lockfile_name, strerror (errno));
+          g_warning ("%s: failed to open lock file '%s': %s",
+                     __FUNCTION__,
+                     lockfile_name,
+                     strerror (errno));
           g_free (lockfile_name);
           exit (EXIT_FAILURE);
         }
@@ -3524,8 +3706,8 @@ sync_secinfo (sigset_t *sigmask_current, int (*update) (int),
   if (close (lockfile))
     {
       g_free (lockfile_name);
-      g_warning ("%s: failed to close lock file: %s", __FUNCTION__,
-                 strerror (errno));
+      g_warning (
+        "%s: failed to close lock file: %s", __FUNCTION__, strerror (errno));
       exit (EXIT_FAILURE);
     }
 
@@ -3551,19 +3733,19 @@ manage_feed_timestamp (const gchar *name)
 
   error = NULL;
   if (strcasecmp (name, "scap") == 0)
-    g_file_get_contents (GVM_SCAP_DATA_DIR "/timestamp", &timestamp, &len,
-                         &error);
+    g_file_get_contents (
+      GVM_SCAP_DATA_DIR "/timestamp", &timestamp, &len, &error);
   else
-    g_file_get_contents (GVM_CERT_DATA_DIR "/timestamp", &timestamp, &len,
-                         &error);
+    g_file_get_contents (
+      GVM_CERT_DATA_DIR "/timestamp", &timestamp, &len, &error);
   if (error)
     {
       if (error->code == G_FILE_ERROR_NOENT)
         stamp = 0;
       else
         {
-          g_warning ("%s: Failed to get timestamp: %s", __FUNCTION__,
-                     error->message);
+          g_warning (
+            "%s: Failed to get timestamp: %s", __FUNCTION__, error->message);
           return -1;
         }
     }
@@ -3571,8 +3753,8 @@ manage_feed_timestamp (const gchar *name)
     {
       if (strlen (timestamp) < 8)
         {
-          g_warning ("%s: Feed timestamp too short: %s", __FUNCTION__,
-                     timestamp);
+          g_warning (
+            "%s: Feed timestamp too short: %s", __FUNCTION__, timestamp);
           g_free (timestamp);
           return -1;
         }
@@ -3626,16 +3808,16 @@ update_cert_timestamp ()
   time_t stamp;
 
   error = NULL;
-  g_file_get_contents (GVM_CERT_DATA_DIR "/timestamp", &timestamp, &len,
-                       &error);
+  g_file_get_contents (
+    GVM_CERT_DATA_DIR "/timestamp", &timestamp, &len, &error);
   if (error)
     {
       if (error->code == G_FILE_ERROR_NOENT)
         stamp = 0;
       else
         {
-          g_warning ("%s: Failed to get timestamp: %s", __FUNCTION__,
-                     error->message);
+          g_warning (
+            "%s: Failed to get timestamp: %s", __FUNCTION__, error->message);
           return -1;
         }
     }
@@ -3643,8 +3825,8 @@ update_cert_timestamp ()
     {
       if (strlen (timestamp) < 8)
         {
-          g_warning ("%s: Feed timestamp too short: %s", __FUNCTION__,
-                     timestamp);
+          g_warning (
+            "%s: Feed timestamp too short: %s", __FUNCTION__, timestamp);
           g_free (timestamp);
           return -1;
         }
@@ -3847,8 +4029,8 @@ sync_cert (int lockfile)
   /* Clear date from lock file. */
 
   if (ftruncate (lockfile, 0))
-    g_warning ("%s: failed to ftruncate lockfile: %s", __FUNCTION__,
-               strerror (errno));
+    g_warning (
+      "%s: failed to ftruncate lockfile: %s", __FUNCTION__, strerror (errno));
 
   return 0;
 
@@ -3856,8 +4038,8 @@ fail:
   /* Clear date from lock file. */
 
   if (ftruncate (lockfile, 0))
-    g_warning ("%s: failed to ftruncate lockfile: %s", __FUNCTION__,
-               strerror (errno));
+    g_warning (
+      "%s: failed to ftruncate lockfile: %s", __FUNCTION__, strerror (errno));
 
   return -1;
 }
@@ -3870,8 +4052,8 @@ fail:
 void
 manage_sync_cert (sigset_t *sigmask_current)
 {
-  sync_secinfo (sigmask_current, sync_cert, "gvmd: Syncing CERT",
-                "gvm-sync-cert");
+  sync_secinfo (
+    sigmask_current, sync_cert, "gvmd: Syncing CERT", "gvm-sync-cert");
 }
 
 /* SCAP update. */
@@ -3923,16 +4105,16 @@ update_scap_timestamp ()
   time_t stamp;
 
   error = NULL;
-  g_file_get_contents (GVM_SCAP_DATA_DIR "/timestamp", &timestamp, &len,
-                       &error);
+  g_file_get_contents (
+    GVM_SCAP_DATA_DIR "/timestamp", &timestamp, &len, &error);
   if (error)
     {
       if (error->code == G_FILE_ERROR_NOENT)
         stamp = 0;
       else
         {
-          g_warning ("%s: Failed to get timestamp: %s", __FUNCTION__,
-                     error->message);
+          g_warning (
+            "%s: Failed to get timestamp: %s", __FUNCTION__, error->message);
           return -1;
         }
     }
@@ -3940,8 +4122,8 @@ update_scap_timestamp ()
     {
       if (strlen (timestamp) < 8)
         {
-          g_warning ("%s: Feed timestamp too short: %s", __FUNCTION__,
-                     timestamp);
+          g_warning (
+            "%s: Feed timestamp too short: %s", __FUNCTION__, timestamp);
           g_free (timestamp);
           return -1;
         }
@@ -4154,8 +4336,8 @@ sync_scap (int lockfile)
       break;
     }
 
-  update_scap_cvss (updated_scap_cves, updated_scap_cpes,
-                    updated_scap_ovaldefs);
+  update_scap_cvss (
+    updated_scap_cves, updated_scap_cpes, updated_scap_ovaldefs);
   update_scap_placeholders (updated_scap_cves);
 
   g_debug ("%s: update timestamp", __FUNCTION__);
@@ -4173,8 +4355,8 @@ sync_scap (int lockfile)
   /* Clear date from lock file. */
 
   if (ftruncate (lockfile, 0))
-    g_warning ("%s: failed to ftruncate lockfile: %s", __FUNCTION__,
-               strerror (errno));
+    g_warning (
+      "%s: failed to ftruncate lockfile: %s", __FUNCTION__, strerror (errno));
 
   return 0;
 
@@ -4182,8 +4364,8 @@ fail:
   /* Clear date from lock file. */
 
   if (ftruncate (lockfile, 0))
-    g_warning ("%s: failed to ftruncate lockfile: %s", __FUNCTION__,
-               strerror (errno));
+    g_warning (
+      "%s: failed to ftruncate lockfile: %s", __FUNCTION__, strerror (errno));
 
   return -1;
 }
@@ -4196,8 +4378,8 @@ fail:
 void
 manage_sync_scap (sigset_t *sigmask_current)
 {
-  sync_secinfo (sigmask_current, sync_scap, "gvmd: Syncing SCAP",
-                "gvm-sync-scap");
+  sync_secinfo (
+    sigmask_current, sync_scap, "gvmd: Syncing SCAP", "gvm-sync-scap");
 }
 
 /**

--- a/src/manage_sql_secinfo.h
+++ b/src/manage_sql_secinfo.h
@@ -28,294 +28,305 @@
 /**
  * @brief SQL to check if a result has CERT Bunds.
  */
-#define SECINFO_SQL_RESULT_HAS_CERT_BUNDS                          \
- "(SELECT EXISTS (SELECT * FROM cert_bund_cves"                    \
- "                WHERE cve_name IN (SELECT cve_name"              \
- "                                   FROM nvt_cves"                \
- "                                   WHERE oid = results.nvt)))"
+#define SECINFO_SQL_RESULT_HAS_CERT_BUNDS              \
+  "(SELECT EXISTS (SELECT * FROM cert_bund_cves"       \
+  "                WHERE cve_name IN (SELECT cve_name" \
+  "                                   FROM nvt_cves"   \
+  "                                   WHERE oid = results.nvt)))"
 
 /**
  * @brief SQL to check if a result has CERT Bunds.
  */
-#define SECINFO_SQL_RESULT_HAS_DFN_CERTS                           \
- "(SELECT EXISTS (SELECT * FROM dfn_cert_cves"                     \
- "                WHERE cve_name IN (SELECT cve_name"              \
- "                                   FROM nvt_cves"                \
- "                                   WHERE oid = results.nvt)))"
+#define SECINFO_SQL_RESULT_HAS_DFN_CERTS               \
+  "(SELECT EXISTS (SELECT * FROM dfn_cert_cves"        \
+  "                WHERE cve_name IN (SELECT cve_name" \
+  "                                   FROM nvt_cves"   \
+  "                                   WHERE oid = results.nvt)))"
 
 /**
  * @brief Filter columns for CVE iterator.
  */
-#define CVE_INFO_ITERATOR_FILTER_COLUMNS                         \
- { GET_ITERATOR_FILTER_COLUMNS, "vector",                        \
-   "complexity", "authentication", "confidentiality_impact",     \
-   "integrity_impact", "availability_impact", "products",        \
-   "cvss", "description", "severity", "published", NULL }
+#define CVE_INFO_ITERATOR_FILTER_COLUMNS                                   \
+  {                                                                        \
+    GET_ITERATOR_FILTER_COLUMNS, "vector", "complexity", "authentication", \
+      "confidentiality_impact", "integrity_impact", "availability_impact", \
+      "products", "cvss", "description", "severity", "published", NULL     \
+  }
 
 /**
  * @brief CVE iterator columns.
  */
-#define CVE_INFO_ITERATOR_COLUMNS                               \
- {                                                              \
-   GET_ITERATOR_COLUMNS_PREFIX (""),                            \
-   { "''", "_owner", KEYWORD_TYPE_STRING },                     \
-   { "0", NULL, KEYWORD_TYPE_INTEGER },                         \
-   { "vector", NULL, KEYWORD_TYPE_STRING },                     \
-   { "complexity", NULL, KEYWORD_TYPE_STRING },                 \
-   { "authentication", NULL, KEYWORD_TYPE_STRING },             \
-   { "confidentiality_impact", NULL, KEYWORD_TYPE_STRING },     \
-   { "integrity_impact", NULL, KEYWORD_TYPE_STRING },           \
-   { "availability_impact", NULL, KEYWORD_TYPE_STRING },        \
-   { "products", NULL, KEYWORD_TYPE_STRING },                   \
-   { "cvss", NULL, KEYWORD_TYPE_DOUBLE },                       \
-   { "description", NULL, KEYWORD_TYPE_STRING },                \
-   { "cvss", "severity", KEYWORD_TYPE_DOUBLE },                 \
-   { "creation_time", "published", KEYWORD_TYPE_INTEGER },      \
-   { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                         \
- }
+#define CVE_INFO_ITERATOR_COLUMNS                                            \
+  {                                                                          \
+    GET_ITERATOR_COLUMNS_PREFIX (""), {"''", "_owner", KEYWORD_TYPE_STRING}, \
+      {"0", NULL, KEYWORD_TYPE_INTEGER},                                     \
+      {"vector", NULL, KEYWORD_TYPE_STRING},                                 \
+      {"complexity", NULL, KEYWORD_TYPE_STRING},                             \
+      {"authentication", NULL, KEYWORD_TYPE_STRING},                         \
+      {"confidentiality_impact", NULL, KEYWORD_TYPE_STRING},                 \
+      {"integrity_impact", NULL, KEYWORD_TYPE_STRING},                       \
+      {"availability_impact", NULL, KEYWORD_TYPE_STRING},                    \
+      {"products", NULL, KEYWORD_TYPE_STRING},                               \
+      {"cvss", NULL, KEYWORD_TYPE_DOUBLE},                                   \
+      {"description", NULL, KEYWORD_TYPE_STRING},                            \
+      {"cvss", "severity", KEYWORD_TYPE_DOUBLE},                             \
+      {"creation_time", "published", KEYWORD_TYPE_INTEGER},                  \
+    {                                                                        \
+      NULL, NULL, KEYWORD_TYPE_UNKNOWN                                       \
+    }                                                                        \
+  }
 
 /**
  * @brief Filter columns for CVE iterator.
  */
-#define CPE_INFO_ITERATOR_FILTER_COLUMNS                    \
- { GET_ITERATOR_FILTER_COLUMNS, "title", "status",          \
-   "deprecated_by_id", "max_cvss", "cves", "nvd_id",        \
-   "severity", NULL }
+#define CPE_INFO_ITERATOR_FILTER_COLUMNS                                \
+  {                                                                     \
+    GET_ITERATOR_FILTER_COLUMNS, "title", "status", "deprecated_by_id", \
+      "max_cvss", "cves", "nvd_id", "severity", NULL                    \
+  }
 
 /**
  * @brief CPE iterator columns.
  */
-#define CPE_INFO_ITERATOR_COLUMNS                               \
- {                                                              \
-   GET_ITERATOR_COLUMNS_PREFIX (""),                            \
-   { "''", "_owner", KEYWORD_TYPE_STRING },                     \
-   { "0", NULL, KEYWORD_TYPE_INTEGER },                         \
-   { "title", NULL, KEYWORD_TYPE_STRING },                      \
-   { "status", NULL, KEYWORD_TYPE_STRING },                     \
-   { "deprecated_by_id", NULL, KEYWORD_TYPE_INTEGER },          \
-   { "max_cvss", NULL, KEYWORD_TYPE_DOUBLE },                   \
-   { "cve_refs", "cves", KEYWORD_TYPE_INTEGER },                \
-   { "nvd_id", NULL, KEYWORD_TYPE_INTEGER },                    \
-   { "max_cvss", "severity", KEYWORD_TYPE_DOUBLE },             \
-   { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                         \
- }
+#define CPE_INFO_ITERATOR_COLUMNS                                              \
+  {                                                                            \
+    GET_ITERATOR_COLUMNS_PREFIX (""), {"''", "_owner", KEYWORD_TYPE_STRING},   \
+      {"0", NULL, KEYWORD_TYPE_INTEGER}, {"title", NULL, KEYWORD_TYPE_STRING}, \
+      {"status", NULL, KEYWORD_TYPE_STRING},                                   \
+      {"deprecated_by_id", NULL, KEYWORD_TYPE_INTEGER},                        \
+      {"max_cvss", NULL, KEYWORD_TYPE_DOUBLE},                                 \
+      {"cve_refs", "cves", KEYWORD_TYPE_INTEGER},                              \
+      {"nvd_id", NULL, KEYWORD_TYPE_INTEGER},                                  \
+      {"max_cvss", "severity", KEYWORD_TYPE_DOUBLE},                           \
+    {                                                                          \
+      NULL, NULL, KEYWORD_TYPE_UNKNOWN                                         \
+    }                                                                          \
+  }
 
 /**
  * @brief Filter columns for OVALDEF iterator.
  */
-#define OVALDEF_INFO_ITERATOR_FILTER_COLUMNS                \
- { GET_ITERATOR_FILTER_COLUMNS, "version", "deprecated",    \
-   "class", "title", "description", "file",                 \
-   "status", "max_cvss", "cves", "severity", NULL }
+#define OVALDEF_INFO_ITERATOR_FILTER_COLUMNS                                \
+  {                                                                         \
+    GET_ITERATOR_FILTER_COLUMNS, "version", "deprecated", "class", "title", \
+      "description", "file", "status", "max_cvss", "cves", "severity", NULL \
+  }
 
 /**
  * @brief OVALDEF iterator columns.
  */
-#define OVALDEF_INFO_ITERATOR_COLUMNS                            \
- {                                                               \
-   GET_ITERATOR_COLUMNS_PREFIX (""),                             \
-   { "''", "_owner", KEYWORD_TYPE_STRING },                      \
-   { "0", NULL, KEYWORD_TYPE_INTEGER },                          \
-   { "version", NULL, KEYWORD_TYPE_INTEGER },                    \
-   { "deprecated", NULL, KEYWORD_TYPE_INTEGER },                 \
-   { "def_class", "class", KEYWORD_TYPE_STRING },                \
-   { "title", NULL, KEYWORD_TYPE_STRING },                       \
-   { "description", NULL, KEYWORD_TYPE_STRING },                 \
-   { "xml_file", "file", KEYWORD_TYPE_STRING },                  \
-   { "status", NULL, KEYWORD_TYPE_STRING },                      \
-   { "max_cvss", NULL, KEYWORD_TYPE_DOUBLE },                    \
-   { "cve_refs", "cves", KEYWORD_TYPE_INTEGER },                 \
-   { "max_cvss", "severity", KEYWORD_TYPE_DOUBLE },              \
-   { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                          \
- }
+#define OVALDEF_INFO_ITERATOR_COLUMNS                                        \
+  {                                                                          \
+    GET_ITERATOR_COLUMNS_PREFIX (""), {"''", "_owner", KEYWORD_TYPE_STRING}, \
+      {"0", NULL, KEYWORD_TYPE_INTEGER},                                     \
+      {"version", NULL, KEYWORD_TYPE_INTEGER},                               \
+      {"deprecated", NULL, KEYWORD_TYPE_INTEGER},                            \
+      {"def_class", "class", KEYWORD_TYPE_STRING},                           \
+      {"title", NULL, KEYWORD_TYPE_STRING},                                  \
+      {"description", NULL, KEYWORD_TYPE_STRING},                            \
+      {"xml_file", "file", KEYWORD_TYPE_STRING},                             \
+      {"status", NULL, KEYWORD_TYPE_STRING},                                 \
+      {"max_cvss", NULL, KEYWORD_TYPE_DOUBLE},                               \
+      {"cve_refs", "cves", KEYWORD_TYPE_INTEGER},                            \
+      {"max_cvss", "severity", KEYWORD_TYPE_DOUBLE},                         \
+    {                                                                        \
+      NULL, NULL, KEYWORD_TYPE_UNKNOWN                                       \
+    }                                                                        \
+  }
 
 /**
  * @brief Filter columns for CERT_BUND_ADV iterator.
  */
-#define CERT_BUND_ADV_INFO_ITERATOR_FILTER_COLUMNS           \
- { GET_ITERATOR_FILTER_COLUMNS, "title", "summary",         \
-   "cves", "max_cvss", "severity", NULL }
+#define CERT_BUND_ADV_INFO_ITERATOR_FILTER_COLUMNS                       \
+  {                                                                      \
+    GET_ITERATOR_FILTER_COLUMNS, "title", "summary", "cves", "max_cvss", \
+      "severity", NULL                                                   \
+  }
 
 /**
  * @brief CERT_BUND_ADV iterator columns.
  */
-#define CERT_BUND_ADV_INFO_ITERATOR_COLUMNS                       \
- {                                                               \
-   GET_ITERATOR_COLUMNS_PREFIX (""),                             \
-   { "''", "_owner", KEYWORD_TYPE_STRING },                      \
-   { "0", NULL, KEYWORD_TYPE_INTEGER },                          \
-   { "title", NULL, KEYWORD_TYPE_STRING },                       \
-   { "summary", NULL, KEYWORD_TYPE_STRING },                     \
-   { "cve_refs", "cves", KEYWORD_TYPE_INTEGER },                 \
-   { "max_cvss", NULL, KEYWORD_TYPE_DOUBLE },                    \
-   { "max_cvss", "severity", KEYWORD_TYPE_DOUBLE },              \
-   { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                          \
- }
+#define CERT_BUND_ADV_INFO_ITERATOR_COLUMNS                                    \
+  {                                                                            \
+    GET_ITERATOR_COLUMNS_PREFIX (""), {"''", "_owner", KEYWORD_TYPE_STRING},   \
+      {"0", NULL, KEYWORD_TYPE_INTEGER}, {"title", NULL, KEYWORD_TYPE_STRING}, \
+      {"summary", NULL, KEYWORD_TYPE_STRING},                                  \
+      {"cve_refs", "cves", KEYWORD_TYPE_INTEGER},                              \
+      {"max_cvss", NULL, KEYWORD_TYPE_DOUBLE},                                 \
+      {"max_cvss", "severity", KEYWORD_TYPE_DOUBLE},                           \
+    {                                                                          \
+      NULL, NULL, KEYWORD_TYPE_UNKNOWN                                         \
+    }                                                                          \
+  }
 
 /**
  * @brief Filter columns for DFN_CERT_ADV iterator.
  */
-#define DFN_CERT_ADV_INFO_ITERATOR_FILTER_COLUMNS           \
- { GET_ITERATOR_FILTER_COLUMNS, "title", "summary",         \
-   "cves", "max_cvss", "severity", NULL }
+#define DFN_CERT_ADV_INFO_ITERATOR_FILTER_COLUMNS                        \
+  {                                                                      \
+    GET_ITERATOR_FILTER_COLUMNS, "title", "summary", "cves", "max_cvss", \
+      "severity", NULL                                                   \
+  }
 
 /**
  * @brief DFN_CERT_ADV iterator columns.
  */
-#define DFN_CERT_ADV_INFO_ITERATOR_COLUMNS                       \
- {                                                               \
-   GET_ITERATOR_COLUMNS_PREFIX (""),                             \
-   { "''", "_owner", KEYWORD_TYPE_STRING },                      \
-   { "0", NULL, KEYWORD_TYPE_INTEGER },                          \
-   { "title", NULL, KEYWORD_TYPE_STRING },                       \
-   { "summary", NULL, KEYWORD_TYPE_STRING },                     \
-   { "cve_refs", "cves", KEYWORD_TYPE_INTEGER },                 \
-   { "max_cvss", NULL, KEYWORD_TYPE_DOUBLE },                    \
-   { "max_cvss", "severity", KEYWORD_TYPE_DOUBLE },              \
-   { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                          \
- }
+#define DFN_CERT_ADV_INFO_ITERATOR_COLUMNS                                     \
+  {                                                                            \
+    GET_ITERATOR_COLUMNS_PREFIX (""), {"''", "_owner", KEYWORD_TYPE_STRING},   \
+      {"0", NULL, KEYWORD_TYPE_INTEGER}, {"title", NULL, KEYWORD_TYPE_STRING}, \
+      {"summary", NULL, KEYWORD_TYPE_STRING},                                  \
+      {"cve_refs", "cves", KEYWORD_TYPE_INTEGER},                              \
+      {"max_cvss", NULL, KEYWORD_TYPE_DOUBLE},                                 \
+      {"max_cvss", "severity", KEYWORD_TYPE_DOUBLE},                           \
+    {                                                                          \
+      NULL, NULL, KEYWORD_TYPE_UNKNOWN                                         \
+    }                                                                          \
+  }
 
 /**
  * @brief Filter columns for All SecInfo iterator.
  */
-#define ALL_INFO_ITERATOR_FILTER_COLUMNS                               \
- { GET_ITERATOR_FILTER_COLUMNS, "type", "extra", "severity", NULL }
+#define ALL_INFO_ITERATOR_FILTER_COLUMNS                           \
+  {                                                                \
+    GET_ITERATOR_FILTER_COLUMNS, "type", "extra", "severity", NULL \
+  }
 
 /**
  * @brief All SecInfo iterator columns.
  */
-#define ALL_INFO_ITERATOR_COLUMNS                                       \
- {                                                                      \
-   { "id", NULL, KEYWORD_TYPE_INTEGER },                                \
-   { "uuid", NULL, KEYWORD_TYPE_STRING },                               \
-   { "name", NULL, KEYWORD_TYPE_STRING },                               \
-   { "comment", NULL, KEYWORD_TYPE_STRING },                            \
-   { "iso_time (created)", NULL, KEYWORD_TYPE_STRING },                 \
-   { "iso_time (modified)", NULL, KEYWORD_TYPE_STRING },                \
-   { "created", NULL, KEYWORD_TYPE_INTEGER },                           \
-   { "modified", NULL, KEYWORD_TYPE_INTEGER },                          \
-   { "''", "_owner", KEYWORD_TYPE_STRING },                             \
-   { "0", NULL, KEYWORD_TYPE_INTEGER },                                 \
-   { "type", NULL, KEYWORD_TYPE_STRING },                               \
-   { "extra", NULL, KEYWORD_TYPE_STRING },                              \
-   { "severity", NULL, KEYWORD_TYPE_DOUBLE },                           \
-   { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                                 \
- }
+#define ALL_INFO_ITERATOR_COLUMNS                                             \
+  {                                                                           \
+    {"id", NULL, KEYWORD_TYPE_INTEGER}, {"uuid", NULL, KEYWORD_TYPE_STRING},  \
+      {"name", NULL, KEYWORD_TYPE_STRING},                                    \
+      {"comment", NULL, KEYWORD_TYPE_STRING},                                 \
+      {"iso_time (created)", NULL, KEYWORD_TYPE_STRING},                      \
+      {"iso_time (modified)", NULL, KEYWORD_TYPE_STRING},                     \
+      {"created", NULL, KEYWORD_TYPE_INTEGER},                                \
+      {"modified", NULL, KEYWORD_TYPE_INTEGER},                               \
+      {"''", "_owner", KEYWORD_TYPE_STRING},                                  \
+      {"0", NULL, KEYWORD_TYPE_INTEGER}, {"type", NULL, KEYWORD_TYPE_STRING}, \
+      {"extra", NULL, KEYWORD_TYPE_STRING},                                   \
+      {"severity", NULL, KEYWORD_TYPE_DOUBLE},                                \
+    {                                                                         \
+      NULL, NULL, KEYWORD_TYPE_UNKNOWN                                        \
+    }                                                                         \
+  }
 
 /**
  * @brief All SecInfo iterator columns.
  */
-#define ALL_INFO_ITERATOR_COLUMNS_ARGS(type, extra, severity)           \
- {                                                                      \
-   { "id", NULL, KEYWORD_TYPE_INTEGER },                                \
-   { "uuid", NULL, KEYWORD_TYPE_STRING },                               \
-   { "name", NULL, KEYWORD_TYPE_STRING },                               \
-   { "comment", NULL, KEYWORD_TYPE_STRING },                            \
-   { "iso_time (created)", NULL, KEYWORD_TYPE_STRING },                 \
-   { "iso_time (modified)", NULL, KEYWORD_TYPE_STRING },                \
-   { "created", NULL, KEYWORD_TYPE_INTEGER },                           \
-   { "modified", NULL, KEYWORD_TYPE_INTEGER },                          \
-   { "''", "_owner", KEYWORD_TYPE_STRING },                             \
-   { "0", NULL, KEYWORD_TYPE_INTEGER },                                 \
-   { type, "type", KEYWORD_TYPE_STRING },                               \
-   { extra, "extra", KEYWORD_TYPE_STRING },                             \
-   { severity, "severity", KEYWORD_TYPE_DOUBLE },                       \
-   { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                                 \
- }
+#define ALL_INFO_ITERATOR_COLUMNS_ARGS(type, extra, severity)                 \
+  {                                                                           \
+    {"id", NULL, KEYWORD_TYPE_INTEGER}, {"uuid", NULL, KEYWORD_TYPE_STRING},  \
+      {"name", NULL, KEYWORD_TYPE_STRING},                                    \
+      {"comment", NULL, KEYWORD_TYPE_STRING},                                 \
+      {"iso_time (created)", NULL, KEYWORD_TYPE_STRING},                      \
+      {"iso_time (modified)", NULL, KEYWORD_TYPE_STRING},                     \
+      {"created", NULL, KEYWORD_TYPE_INTEGER},                                \
+      {"modified", NULL, KEYWORD_TYPE_INTEGER},                               \
+      {"''", "_owner", KEYWORD_TYPE_STRING},                                  \
+      {"0", NULL, KEYWORD_TYPE_INTEGER}, {type, "type", KEYWORD_TYPE_STRING}, \
+      {extra, "extra", KEYWORD_TYPE_STRING},                                  \
+      {severity, "severity", KEYWORD_TYPE_DOUBLE},                            \
+    {                                                                         \
+      NULL, NULL, KEYWORD_TYPE_UNKNOWN                                        \
+    }                                                                         \
+  }
 
- /**
+/**
  * @brief All SecInfo iterator column union.
  */
-#define ALL_INFO_UNION_COLUMNS                                                 \
-  "(SELECT " GET_ITERATOR_COLUMNS_STRING ", '' AS _owner, 'cve' AS type,"      \
-  "        description AS extra, cvss AS severity"                             \
-  " FROM cves"                                                                 \
-  " UNION ALL SELECT " GET_ITERATOR_COLUMNS_STRING ", '' AS _owner,"           \
-  "                  'cpe' AS type, title AS extra, max_cvss AS severity"      \
-  "           FROM cpes"                                                       \
-  " UNION ALL SELECT " GET_ITERATOR_COLUMNS_STRING ", '' AS _owner,"           \
-  "                  'nvt' AS type, tag AS extra,"                             \
-  "                  CAST (cvss_base AS float) AS severity"                    \
-  "           FROM nvts"                                                       \
-  " UNION ALL SELECT " GET_ITERATOR_COLUMNS_STRING ", '' AS _owner,"           \
-  "                  'cert_bund_adv' AS type, title AS extra,"                 \
-  "                  max_cvss AS severity"                                     \
-  "           FROM cert_bund_advs"                                             \
-  " UNION ALL SELECT " GET_ITERATOR_COLUMNS_STRING ", '' AS _owner,"           \
-  "                  'dfn_cert_adv' AS type, title AS extra,"                  \
-  "                  max_cvss AS severity"                                     \
-  "           FROM dfn_cert_advs"                                              \
-  " UNION ALL SELECT " GET_ITERATOR_COLUMNS_STRING ", '' AS _owner,"           \
-  "                  'ovaldef' AS type, title AS extra, max_cvss AS severity"  \
-  "           FROM ovaldefs)"                                                  \
+#define ALL_INFO_UNION_COLUMNS                                                \
+  "(SELECT " GET_ITERATOR_COLUMNS_STRING ", '' AS _owner, 'cve' AS type,"     \
+  "        description AS extra, cvss AS severity"                            \
+  " FROM cves"                                                                \
+  " UNION ALL SELECT " GET_ITERATOR_COLUMNS_STRING ", '' AS _owner,"          \
+  "                  'cpe' AS type, title AS extra, max_cvss AS severity"     \
+  "           FROM cpes"                                                      \
+  " UNION ALL SELECT " GET_ITERATOR_COLUMNS_STRING ", '' AS _owner,"          \
+  "                  'nvt' AS type, tag AS extra,"                            \
+  "                  CAST (cvss_base AS float) AS severity"                   \
+  "           FROM nvts"                                                      \
+  " UNION ALL SELECT " GET_ITERATOR_COLUMNS_STRING ", '' AS _owner,"          \
+  "                  'cert_bund_adv' AS type, title AS extra,"                \
+  "                  max_cvss AS severity"                                    \
+  "           FROM cert_bund_advs"                                            \
+  " UNION ALL SELECT " GET_ITERATOR_COLUMNS_STRING ", '' AS _owner,"          \
+  "                  'dfn_cert_adv' AS type, title AS extra,"                 \
+  "                  max_cvss AS severity"                                    \
+  "           FROM dfn_cert_advs"                                             \
+  " UNION ALL SELECT " GET_ITERATOR_COLUMNS_STRING ", '' AS _owner,"          \
+  "                  'ovaldef' AS type, title AS extra, max_cvss AS severity" \
+  "           FROM ovaldefs)"                                                 \
   " AS allinfo"
 
 /**
  * @brief All SecInfo iterator column union, with specifiers for LIMIT clause.
  */
-#define ALL_INFO_UNION_COLUMNS_LIMIT                                           \
-  "(SELECT * FROM (SELECT " GET_ITERATOR_COLUMNS_STRING ","                    \
-  "                       CAST ('' AS text) AS _owner,"                        \
-  "                       CAST ('cve' AS text) AS type,"                       \
-  "                       description as extra, cvss as severity"              \
-  "                FROM cves"                                                  \
-  "                %s%s"                                                       \
-  "                %s"                                                         \
-  "                %s)"                                                        \
-  "               AS union_sub_1"                                              \
-  " UNION ALL"                                                                 \
-  " SELECT * FROM (SELECT " GET_ITERATOR_COLUMNS_STRING ","                    \
-  "                       CAST ('' AS text) AS _owner,"                        \
-  "                       CAST ('cpe' AS text) AS type, title as extra,"       \
-  "                       max_cvss as severity"                                \
-  "                FROM cpes"                                                  \
-  "                %s%s"                                                       \
-  "                %s"                                                         \
-  "                %s)"                                                        \
-  "               AS union_sub_2"                                              \
-  " UNION ALL"                                                                 \
-  " SELECT * FROM (SELECT " GET_ITERATOR_COLUMNS_STRING ","                    \
-  "                       CAST ('' AS text) AS _owner,"                        \
-  "                       CAST ('nvt' AS text) AS type,"                       \
-  "                       tag AS extra,"                                       \
-  "                       CAST (cvss_base AS float) as severity"               \
-  "                FROM nvts"                                                  \
-  "                %s%s"                                                       \
-  "                %s"                                                         \
-  "                %s)"                                                        \
-  "               AS union_sub_3"                                              \
-  " UNION ALL"                                                                 \
-  " SELECT * FROM (SELECT " GET_ITERATOR_COLUMNS_STRING ","                    \
-  "                       CAST ('' AS text) AS _owner,"                        \
-  "                       CAST ('cert_bund_adv' AS text) AS type,"             \
-  "                       title as extra,"                                     \
-  "                       max_cvss as severity"                                \
-  "                FROM cert_bund_advs"                                        \
-  "                %s%s"                                                       \
-  "                %s"                                                         \
-  "                %s)"                                                        \
-  "               AS union_sub_4"                                              \
-  " UNION ALL"                                                                 \
-  " SELECT * FROM (SELECT " GET_ITERATOR_COLUMNS_STRING ","                    \
-  "                       CAST ('' AS text) AS _owner,"                        \
-  "                       CAST ('dfn_cert_adv' AS text) AS type,"              \
-  "                       title as extra,"                                     \
-  "                       max_cvss as severity"                                \
-  "                FROM dfn_cert_advs"                                         \
-  "                %s%s"                                                       \
-  "                %s"                                                         \
-  "                %s)"                                                        \
-  "               AS union_sub_5"                                              \
-  " UNION ALL"                                                                 \
-  " SELECT * FROM (SELECT " GET_ITERATOR_COLUMNS_STRING ","                    \
-  "                       CAST ('' AS text) AS _owner,"                        \
-  "                       CAST ('ovaldef' AS text) AS type, title as extra,"   \
-  "                       max_cvss as severity"                                \
-  "                FROM ovaldefs"                                              \
-  "                %s%s"                                                       \
-  "                %s"                                                         \
-  "                %s)"                                                        \
-  "               AS union_sub_6)"                                             \
+#define ALL_INFO_UNION_COLUMNS_LIMIT                                         \
+  "(SELECT * FROM (SELECT " GET_ITERATOR_COLUMNS_STRING ","                  \
+  "                       CAST ('' AS text) AS _owner,"                      \
+  "                       CAST ('cve' AS text) AS type,"                     \
+  "                       description as extra, cvss as severity"            \
+  "                FROM cves"                                                \
+  "                %s%s"                                                     \
+  "                %s"                                                       \
+  "                %s)"                                                      \
+  "               AS union_sub_1"                                            \
+  " UNION ALL"                                                               \
+  " SELECT * FROM (SELECT " GET_ITERATOR_COLUMNS_STRING ","                  \
+  "                       CAST ('' AS text) AS _owner,"                      \
+  "                       CAST ('cpe' AS text) AS type, title as extra,"     \
+  "                       max_cvss as severity"                              \
+  "                FROM cpes"                                                \
+  "                %s%s"                                                     \
+  "                %s"                                                       \
+  "                %s)"                                                      \
+  "               AS union_sub_2"                                            \
+  " UNION ALL"                                                               \
+  " SELECT * FROM (SELECT " GET_ITERATOR_COLUMNS_STRING ","                  \
+  "                       CAST ('' AS text) AS _owner,"                      \
+  "                       CAST ('nvt' AS text) AS type,"                     \
+  "                       tag AS extra,"                                     \
+  "                       CAST (cvss_base AS float) as severity"             \
+  "                FROM nvts"                                                \
+  "                %s%s"                                                     \
+  "                %s"                                                       \
+  "                %s)"                                                      \
+  "               AS union_sub_3"                                            \
+  " UNION ALL"                                                               \
+  " SELECT * FROM (SELECT " GET_ITERATOR_COLUMNS_STRING ","                  \
+  "                       CAST ('' AS text) AS _owner,"                      \
+  "                       CAST ('cert_bund_adv' AS text) AS type,"           \
+  "                       title as extra,"                                   \
+  "                       max_cvss as severity"                              \
+  "                FROM cert_bund_advs"                                      \
+  "                %s%s"                                                     \
+  "                %s"                                                       \
+  "                %s)"                                                      \
+  "               AS union_sub_4"                                            \
+  " UNION ALL"                                                               \
+  " SELECT * FROM (SELECT " GET_ITERATOR_COLUMNS_STRING ","                  \
+  "                       CAST ('' AS text) AS _owner,"                      \
+  "                       CAST ('dfn_cert_adv' AS text) AS type,"            \
+  "                       title as extra,"                                   \
+  "                       max_cvss as severity"                              \
+  "                FROM dfn_cert_advs"                                       \
+  "                %s%s"                                                     \
+  "                %s"                                                       \
+  "                %s)"                                                      \
+  "               AS union_sub_5"                                            \
+  " UNION ALL"                                                               \
+  " SELECT * FROM (SELECT " GET_ITERATOR_COLUMNS_STRING ","                  \
+  "                       CAST ('' AS text) AS _owner,"                      \
+  "                       CAST ('ovaldef' AS text) AS type, title as extra," \
+  "                       max_cvss as severity"                              \
+  "                FROM ovaldefs"                                            \
+  "                %s%s"                                                     \
+  "                %s"                                                       \
+  "                %s)"                                                      \
+  "               AS union_sub_6)"                                           \
   " AS allinfo"
 
 /**

--- a/src/manage_sql_secinfo.h
+++ b/src/manage_sql_secinfo.h
@@ -22,6 +22,8 @@
  * @brief Manager Manage library: SQL backend headers.
  */
 
+#include <signal.h>
+
 #ifndef _GVMD_MANAGE_SQL_SECINFO_H
 #define _GVMD_MANAGE_SQL_SECINFO_H
 

--- a/src/manage_sql_tickets.c
+++ b/src/manage_sql_tickets.c
@@ -121,10 +121,12 @@ ticket_status_name (ticket_status_t status)
 #define TICKET_ITERATOR_COLUMNS                                                \
   {                                                                            \
     GET_ITERATOR_COLUMNS (tickets),                                            \
-      {"(SELECT uuid FROM users WHERE id = assigned_to)", NULL,                \
+      {"(SELECT uuid FROM users WHERE id = assigned_to)",                      \
+       NULL,                                                                   \
        KEYWORD_TYPE_STRING},                                                   \
       {"(SELECT uuid FROM tasks WHERE id = task)", NULL, KEYWORD_TYPE_STRING}, \
-      {"(SELECT uuid FROM reports WHERE id = report)", NULL,                   \
+      {"(SELECT uuid FROM reports WHERE id = report)",                         \
+       NULL,                                                                   \
        KEYWORD_TYPE_STRING},                                                   \
       {"(CASE"                                                                 \
        " WHEN (SELECT EXISTS (SELECT * FROM ticket_results"                    \
@@ -143,7 +145,8 @@ ticket_status_name (ticket_status_t status)
        "       LIMIT 1)"                                                       \
        " ELSE severity"                                                        \
        " END)",                                                                \
-       "severity", KEYWORD_TYPE_DOUBLE},                                       \
+       "severity",                                                             \
+       KEYWORD_TYPE_DOUBLE},                                                   \
       {"host", NULL, KEYWORD_TYPE_STRING},                                     \
       {"location", NULL, KEYWORD_TYPE_STRING},                                 \
       {"solution_type", NULL, KEYWORD_TYPE_STRING},                            \
@@ -162,20 +165,24 @@ ticket_status_name (ticket_status_t status)
        " THEN 0"                                                               \
        " ELSE 1"                                                               \
        " END)",                                                                \
-       "orphan", KEYWORD_TYPE_INTEGER},                                        \
+       "orphan",                                                               \
+       KEYWORD_TYPE_INTEGER},                                                  \
       {"open_note", NULL, KEYWORD_TYPE_STRING},                                \
       {"fixed_note", NULL, KEYWORD_TYPE_STRING},                               \
       {"closed_note", NULL, KEYWORD_TYPE_STRING},                              \
-      {"(SELECT uuid FROM reports WHERE id = fix_verified_report)", NULL,      \
+      {"(SELECT uuid FROM reports WHERE id = fix_verified_report)",            \
+       NULL,                                                                   \
        KEYWORD_TYPE_STRING},                                                   \
       {"nvt", NULL, KEYWORD_TYPE_STRING},                                      \
-      {"(SELECT name FROM users WHERE id = assigned_to)", NULL,                \
+      {"(SELECT name FROM users WHERE id = assigned_to)",                      \
+       NULL,                                                                   \
        KEYWORD_TYPE_STRING},                                                   \
       {"(SELECT name FROM tasks WHERE id = task)", NULL, KEYWORD_TYPE_STRING}, \
       {"(SELECT result_uuid FROM ticket_results"                               \
        " WHERE ticket = tickets.id"                                            \
        " AND result_location = " G_STRINGIFY (LOCATION_TABLE) " LIMIT 1)",     \
-       "result_id", KEYWORD_TYPE_STRING},                                      \
+       "result_id",                                                            \
+       KEYWORD_TYPE_STRING},                                                   \
     {                                                                          \
       NULL, NULL, KEYWORD_TYPE_UNKNOWN                                         \
     }                                                                          \
@@ -187,10 +194,12 @@ ticket_status_name (ticket_status_t status)
 #define TICKET_ITERATOR_TRASH_COLUMNS                                          \
   {                                                                            \
     GET_ITERATOR_COLUMNS (tickets_trash),                                      \
-      {"(SELECT uuid FROM users WHERE id = assigned_to)", NULL,                \
+      {"(SELECT uuid FROM users WHERE id = assigned_to)",                      \
+       NULL,                                                                   \
        KEYWORD_TYPE_STRING},                                                   \
       {"(SELECT uuid FROM tasks WHERE id = task)", NULL, KEYWORD_TYPE_STRING}, \
-      {"(SELECT uuid FROM reports WHERE id = report)", NULL,                   \
+      {"(SELECT uuid FROM reports WHERE id = report)",                         \
+       NULL,                                                                   \
        KEYWORD_TYPE_STRING},                                                   \
       {"severity", NULL, KEYWORD_TYPE_DOUBLE},                                 \
       {"host", NULL, KEYWORD_TYPE_STRING},                                     \
@@ -211,20 +220,24 @@ ticket_status_name (ticket_status_t status)
        " THEN 0"                                                               \
        " ELSE 1"                                                               \
        " END)",                                                                \
-       "orphan", KEYWORD_TYPE_INTEGER},                                        \
+       "orphan",                                                               \
+       KEYWORD_TYPE_INTEGER},                                                  \
       {"open_note", NULL, KEYWORD_TYPE_STRING},                                \
       {"fixed_note", NULL, KEYWORD_TYPE_STRING},                               \
       {"closed_note", NULL, KEYWORD_TYPE_STRING},                              \
-      {"(SELECT uuid FROM reports WHERE id = fix_verified_report)", NULL,      \
+      {"(SELECT uuid FROM reports WHERE id = fix_verified_report)",            \
+       NULL,                                                                   \
        KEYWORD_TYPE_STRING},                                                   \
       {"nvt", NULL, KEYWORD_TYPE_STRING},                                      \
-      {"(SELECT name FROM users WHERE id = assigned_to)", NULL,                \
+      {"(SELECT name FROM users WHERE id = assigned_to)",                      \
+       NULL,                                                                   \
        KEYWORD_TYPE_STRING},                                                   \
       {"(SELECT name FROM tasks WHERE id = task)", NULL, KEYWORD_TYPE_STRING}, \
       {"(SELECT result_uuid FROM ticket_results_trash"                         \
        " WHERE ticket = tickets_trash.id"                                      \
        " AND result_location = " G_STRINGIFY (LOCATION_TABLE) " LIMIT 1)",     \
-       "result_id", KEYWORD_TYPE_STRING},                                      \
+       "result_id",                                                            \
+       KEYWORD_TYPE_STRING},                                                   \
     {                                                                          \
       NULL, NULL, KEYWORD_TYPE_UNKNOWN                                         \
     }                                                                          \
@@ -244,8 +257,8 @@ ticket_count (const get_data_t *get)
   static column_t columns[] = TICKET_ITERATOR_COLUMNS;
   static column_t trash_columns[] = TICKET_ITERATOR_TRASH_COLUMNS;
 
-  return count ("ticket", get, columns, trash_columns, extra_columns, 0, 0, 0,
-                TRUE);
+  return count (
+    "ticket", get, columns, trash_columns, extra_columns, 0, 0, 0, TRUE);
 }
 
 /**
@@ -264,8 +277,16 @@ init_ticket_iterator (iterator_t *iterator, const get_data_t *get)
   static column_t columns[] = TICKET_ITERATOR_COLUMNS;
   static column_t trash_columns[] = TICKET_ITERATOR_TRASH_COLUMNS;
 
-  return init_get_iterator (iterator, "ticket", get, columns, trash_columns,
-                            filter_columns, 0, NULL, NULL, TRUE);
+  return init_get_iterator (iterator,
+                            "ticket",
+                            get,
+                            columns,
+                            trash_columns,
+                            filter_columns,
+                            0,
+                            NULL,
+                            NULL,
+                            TRUE);
 }
 
 /**
@@ -490,7 +511,9 @@ init_ticket_result_iterator (iterator_t *iterator, const gchar *ticket_id,
                  " FROM ticket_results%s"
                  " WHERE ticket = %llu"
                  " ORDER BY id;",
-                 LOCATION_TABLE, trash ? "_trash" : "", ticket);
+                 LOCATION_TABLE,
+                 trash ? "_trash" : "",
+                 ticket);
   return 0;
 }
 
@@ -535,7 +558,9 @@ init_result_ticket_iterator (iterator_t *iterator, result_t result)
                  "              AND result_location = %i)"
                  " AND %s"
                  " ORDER BY id;",
-                 with_clause ? with_clause : "", result, LOCATION_TABLE,
+                 with_clause ? with_clause : "",
+                 result,
+                 LOCATION_TABLE,
                  owned_clause);
 
   g_free (with_clause);
@@ -681,8 +706,8 @@ delete_ticket (const char *ticket_id, int ultimate)
 
   /* Search in the regular table. */
 
-  if (find_resource_with_permission ("ticket", ticket_id, &ticket,
-                                     "delete_ticket", 0))
+  if (find_resource_with_permission (
+        "ticket", ticket_id, &ticket, "delete_ticket", 0))
     {
       sql_rollback ();
       return -1;
@@ -713,7 +738,8 @@ delete_ticket (const char *ticket_id, int ultimate)
            " WHERE resource_type = 'ticket'"
            " AND resource_location = %i"
            " AND resource = %llu;",
-           LOCATION_TRASH, ticket);
+           LOCATION_TRASH,
+           ticket);
 
       sql ("DELETE FROM permissions"
            " WHERE resource_type = 'task'"
@@ -760,10 +786,11 @@ delete_ticket (const char *ticket_id, int ultimate)
            " SELECT %llu, result, result_location, result_uuid, report"
            " FROM ticket_results"
            " WHERE ticket = %llu;",
-           trash_ticket, ticket);
+           trash_ticket,
+           ticket);
 
-      permissions_set_locations ("ticket", ticket, trash_ticket,
-                                 LOCATION_TRASH);
+      permissions_set_locations (
+        "ticket", ticket, trash_ticket, LOCATION_TRASH);
       tags_set_locations ("ticket", ticket, trash_ticket, LOCATION_TRASH);
     }
   else
@@ -774,7 +801,8 @@ delete_ticket (const char *ticket_id, int ultimate)
            " WHERE resource_type = 'ticket'"
            " AND resource_location = %i"
            " AND resource = %llu;",
-           LOCATION_TABLE, ticket);
+           LOCATION_TABLE,
+           ticket);
 
       sql ("DELETE FROM permissions"
            " WHERE resource_type = 'task'"
@@ -840,7 +868,8 @@ restore_ticket (const char *ticket_id)
        " SELECT %llu, result, result_location, result_uuid, report"
        " FROM ticket_results_trash"
        " WHERE ticket = %llu;",
-       ticket, trash_ticket);
+       ticket,
+       trash_ticket);
 
   /* Adjust references to the ticket. */
 
@@ -957,10 +986,19 @@ create_ticket (const char *comment, const char *result_id, const char *user_id,
        "  (SELECT id FROM users WHERE users.uuid = '%s'),"
        "  '%s', '%s', %llu, %llu, %0.1f, '%s', '%s', '%s',"
        "  %llu, %i, m_now (), '%s', m_now (), m_now ());",
-       quoted_name, current_credentials.uuid, quoted_comment, quoted_oid, task,
+       quoted_name,
+       current_credentials.uuid,
+       quoted_comment,
+       quoted_oid,
+       task,
        result_iterator_report (&results),
-       result_iterator_severity_double (&results), quoted_host, quoted_location,
-       quoted_solution, user, TICKET_STATUS_OPEN, quoted_open_note);
+       result_iterator_severity_double (&results),
+       quoted_host,
+       quoted_location,
+       quoted_solution,
+       user,
+       TICKET_STATUS_OPEN,
+       quoted_open_note);
 
   g_free (quoted_open_note);
   g_free (quoted_location);
@@ -980,8 +1018,11 @@ create_ticket (const char *comment, const char *result_id, const char *user_id,
   sql ("INSERT INTO ticket_results"
        " (ticket, result, result_location, result_uuid, report)"
        " VALUES (%llu, %llu, %i, '%s', %llu)",
-       new_ticket, result_iterator_result (&results), LOCATION_TABLE,
-       quoted_uuid, result_iterator_report (&results));
+       new_ticket,
+       result_iterator_result (&results),
+       LOCATION_TABLE,
+       quoted_uuid,
+       result_iterator_report (&results));
 
   g_free (quoted_uuid);
   cleanup_iterator (&results);
@@ -991,8 +1032,12 @@ create_ticket (const char *comment, const char *result_id, const char *user_id,
   /* Give assigned user permission to access ticket and ticket's task. */
 
   if (create_permission_internal ("modify_ticket",
-                                  "Automatically created for ticket", NULL,
-                                  new_ticket_id, "user", user_id, &permission))
+                                  "Automatically created for ticket",
+                                  NULL,
+                                  new_ticket_id,
+                                  "user",
+                                  user_id,
+                                  &permission))
     {
       sql_rollback ();
       return -1;
@@ -1000,8 +1045,12 @@ create_ticket (const char *comment, const char *result_id, const char *user_id,
 
   task_uuid (task, &task_id);
   if (create_permission_internal ("get_tasks",
-                                  "Automatically created for ticket", NULL,
-                                  task_id, "user", user_id, &permission))
+                                  "Automatically created for ticket",
+                                  NULL,
+                                  task_id,
+                                  "user",
+                                  user_id,
+                                  &permission))
     {
       free (task_id);
       sql_rollback ();
@@ -1038,13 +1087,18 @@ copy_ticket (const char *comment, const char *ticket_id, ticket_t *new_ticket)
 
   assert (new_ticket);
 
-  ret = copy_resource ("ticket", NULL, comment, ticket_id,
+  ret = copy_resource ("ticket",
+                       NULL,
+                       comment,
+                       ticket_id,
                        "nvt, task, report, severity, host, location,"
                        " solution_type, assigned_to, status, open_time,"
                        " open_note, fixed_time, fixed_note,"
                        " fix_verified_time, fix_verified_report, closed_time,"
                        " closed_note",
-                       0, new_ticket, &old_ticket);
+                       0,
+                       new_ticket,
+                       &old_ticket);
   if (ret)
     return ret;
 
@@ -1053,7 +1107,8 @@ copy_ticket (const char *comment, const char *ticket_id, ticket_t *new_ticket)
        " SELECT %llu, result, result_location, result_uuid, report"
        " FROM ticket_results"
        " WHERE ticket = %llu",
-       *new_ticket, old_ticket);
+       *new_ticket,
+       old_ticket);
 
   return 0;
 }
@@ -1090,7 +1145,9 @@ set_note (ticket_t ticket, const gchar *name, const gchar *note)
       quoted_note = sql_quote (note);
       sql ("UPDATE tickets SET %s = '%s'"
            " WHERE id = %llu;",
-           name, quoted_note, ticket);
+           name,
+           quoted_note,
+           ticket);
       g_free (quoted_note);
 
       return 1;
@@ -1143,8 +1200,8 @@ modify_ticket (const gchar *ticket_id, const gchar *comment,
     }
 
   ticket = 0;
-  if (find_resource_with_permission ("ticket", ticket_id, &ticket,
-                                     "modify_ticket", 0))
+  if (find_resource_with_permission (
+        "ticket", ticket_id, &ticket, "modify_ticket", 0))
     {
       sql_rollback ();
       return -1;
@@ -1167,7 +1224,8 @@ modify_ticket (const gchar *ticket_id, const gchar *comment,
            " comment = '%s',"
            " modification_time = m_now ()"
            " WHERE id = %llu;",
-           quoted_comment, ticket);
+           quoted_comment,
+           ticket);
       g_free (quoted_comment);
 
       updated = 1;
@@ -1236,7 +1294,9 @@ modify_ticket (const gchar *ticket_id, const gchar *comment,
            " modification_time = m_now (),"
            " %s = m_now ()"
            " WHERE id = %llu;",
-           status, time_column, ticket);
+           status,
+           time_column,
+           ticket);
 
       updated = 1;
     }
@@ -1281,15 +1341,20 @@ modify_ticket (const gchar *ticket_id, const gchar *comment,
                " assigned_to = %llu,"
                " modification_time = m_now ()"
                " WHERE id = %llu;",
-               user, ticket);
+               user,
+               ticket);
 
           updated = 1;
 
           /* Ensure that the user can access the ticket and task. */
 
-          if (create_permission_internal (
-                "modify_ticket", "Automatically created for ticket", NULL,
-                ticket_id, "user", user_id, &permission))
+          if (create_permission_internal ("modify_ticket",
+                                          "Automatically created for ticket",
+                                          NULL,
+                                          ticket_id,
+                                          "user",
+                                          user_id,
+                                          &permission))
             {
               sql_rollback ();
               return -1;
@@ -1304,7 +1369,10 @@ modify_ticket (const gchar *ticket_id, const gchar *comment,
               if (create_permission_internal ("get_tasks",
                                               "Automatically created for"
                                               " ticket",
-                                              NULL, task_id, "user", user_id,
+                                              NULL,
+                                              task_id,
+                                              "user",
+                                              user_id,
                                               &permission))
                 {
                   free (task_id);
@@ -1323,7 +1391,8 @@ modify_ticket (const gchar *ticket_id, const gchar *comment,
       /* An Assigned Ticket Changed event is not generated if the ticket
        * assignee modifies the ticket. */
       if (sql_int ("SELECT id != %llu FROM users WHERE uuid = '%s';",
-                   assigned_to, current_credentials.uuid))
+                   assigned_to,
+                   current_credentials.uuid))
         event (EVENT_ASSIGNED_TICKET_CHANGED, NULL, ticket, 0);
 
       /* An Owned Ticket Changed event is not generated if the ticket owner
@@ -1331,7 +1400,8 @@ modify_ticket (const gchar *ticket_id, const gchar *comment,
       if (sql_int ("SELECT owner != (SELECT id FROM users WHERE uuid = '%s')"
                    " FROM tickets"
                    " WHERE id = %llu;",
-                   current_credentials.uuid, ticket))
+                   current_credentials.uuid,
+                   ticket))
         event (EVENT_OWNED_TICKET_CHANGED, NULL, ticket, 0);
     }
 
@@ -1352,7 +1422,8 @@ empty_trashcan_tickets ()
        " AND resource IN (SELECT id FROM tickets_trash"
        "                  WHERE owner = (SELECT id FROM users"
        "                                 WHERE uuid = '%s'));",
-       LOCATION_TRASH, current_credentials.uuid);
+       LOCATION_TRASH,
+       current_credentials.uuid);
 
   sql ("DELETE FROM permissions"
        " WHERE resource_type = 'task'"
@@ -1387,7 +1458,8 @@ check_tickets (task_t task)
     {
       g_warning ("%s: failed to get last report of task %llu,"
                  " skipping ticket check",
-                 __FUNCTION__, task);
+                 __FUNCTION__,
+                 task);
       return;
     }
 
@@ -1419,8 +1491,13 @@ check_tickets (task_t task)
     "                 WHERE report = %llu"
     /*                SMB Login Failed For Authenticated Checks. */
     "                 AND nvt = '1.3.6.1.4.1.25623.1.0.106091');",
-    task, TICKET_STATUS_OPEN, TICKET_STATUS_FIXED, report, LOCATION_TABLE,
-    report, report);
+    task,
+    TICKET_STATUS_OPEN,
+    TICKET_STATUS_FIXED,
+    report,
+    LOCATION_TABLE,
+    report,
+    report);
   while (next (&tickets))
     {
       ticket_t ticket;
@@ -1432,7 +1509,9 @@ check_tickets (task_t task)
            "     fix_verified_time = m_now (),"
            "     fix_verified_report = %llu"
            " WHERE id = %llu;",
-           TICKET_STATUS_FIX_VERIFIED, report, ticket);
+           TICKET_STATUS_FIX_VERIFIED,
+           report,
+           ticket);
 
       event (EVENT_OWNED_TICKET_CHANGED, NULL, ticket, 0);
       event (EVENT_ASSIGNED_TICKET_CHANGED, NULL, ticket, 0);
@@ -1487,14 +1566,17 @@ inherit_tickets (user_t user, user_t inheritor)
 
   sql ("UPDATE tickets SET owner = %llu WHERE owner = %llu;", inheritor, user);
   sql ("UPDATE tickets SET assigned_to = %llu WHERE assigned_to = %llu;",
-       inheritor, user);
+       inheritor,
+       user);
 
   /* Trash tickets. */
 
-  sql ("UPDATE tickets_trash SET owner = %llu WHERE owner = %llu;", inheritor,
+  sql ("UPDATE tickets_trash SET owner = %llu WHERE owner = %llu;",
+       inheritor,
        user);
   sql ("UPDATE tickets_trash SET assigned_to = %llu WHERE assigned_to = %llu;",
-       inheritor, user);
+       inheritor,
+       user);
 }
 
 /**
@@ -1541,14 +1623,18 @@ tickets_trash_task (task_t task)
        "               WHERE task = %llu"
        "               AND uuid = ticket_results.result_uuid)"
        " WHERE result IN (SELECT id FROM results WHERE task = %llu);",
-       LOCATION_TRASH, task, task);
+       LOCATION_TRASH,
+       task,
+       task);
   sql ("UPDATE ticket_results_trash"
        " SET result_location = %i,"
        "     result = (SELECT id FROM results_trash"
        "               WHERE task = %llu"
        "               AND uuid = ticket_results_trash.result_uuid)"
        " WHERE result IN (SELECT id FROM results WHERE task = %llu);",
-       LOCATION_TRASH, task, task);
+       LOCATION_TRASH,
+       task,
+       task);
 }
 
 /**
@@ -1567,12 +1653,16 @@ tickets_restore_task (task_t task)
        "               WHERE task = %llu"
        "               AND uuid = ticket_results.result_uuid)"
        " WHERE result IN (SELECT id FROM results_trash WHERE task = %llu);",
-       LOCATION_TABLE, task, task);
+       LOCATION_TABLE,
+       task,
+       task);
   sql ("UPDATE ticket_results_trash"
        " SET result_location = %i,"
        "     result = (SELECT id FROM results"
        "               WHERE task = %llu"
        "               AND uuid = ticket_results_trash.result_uuid)"
        " WHERE result IN (SELECT id FROM results_trash WHERE task = %llu);",
-       LOCATION_TABLE, task, task);
+       LOCATION_TABLE,
+       task,
+       task);
 }

--- a/src/manage_sql_tickets.c
+++ b/src/manage_sql_tickets.c
@@ -487,7 +487,8 @@ DEF_ACCESS (ticket_iterator_task_name, GET_ITERATOR_COLUMN_COUNT + 23);
  * @return 0 success, 1 failed to find ticket, -1 error.
  */
 int
-init_ticket_result_iterator (iterator_t *iterator, const gchar *ticket_id,
+init_ticket_result_iterator (iterator_t *iterator,
+                             const gchar *ticket_id,
                              int trash)
 {
   ticket_t ticket;
@@ -898,8 +899,11 @@ restore_ticket (const char *ticket_id)
  *         99 permission denied, -1 error.
  */
 int
-create_ticket (const char *comment, const char *result_id, const char *user_id,
-               const char *open_note, ticket_t *ticket)
+create_ticket (const char *comment,
+               const char *result_id,
+               const char *user_id,
+               const char *open_note,
+               ticket_t *ticket)
 {
   ticket_t new_ticket;
   permission_t permission;
@@ -1175,9 +1179,12 @@ set_note (ticket_t ticket, const gchar *name, const gchar *note)
  *         99 permission denied, -1 error.
  */
 int
-modify_ticket (const gchar *ticket_id, const gchar *comment,
-               const gchar *status_name, const gchar *open_note,
-               const gchar *fixed_note, const gchar *closed_note,
+modify_ticket (const gchar *ticket_id,
+               const gchar *comment,
+               const gchar *status_name,
+               const gchar *open_note,
+               const gchar *fixed_note,
+               const gchar *closed_note,
                const gchar *user_id)
 {
   ticket_t ticket;

--- a/src/manage_sql_tickets.h
+++ b/src/manage_sql_tickets.h
@@ -31,21 +31,18 @@
 /**
  * @brief SQL to check if a result may have tickets.
  */
-#define TICKET_SQL_RESULT_MAY_HAVE_TICKETS                                     \
- "(SELECT EXISTS (SELECT * FROM tickets"                                       \
- "                WHERE id IN (SELECT ticket FROM ticket_results"              \
- "                             WHERE result = results.id"                      \
- "                             AND result_location"                            \
- "                                 = " G_STRINGIFY (LOCATION_TABLE) ")))"
+#define TICKET_SQL_RESULT_MAY_HAVE_TICKETS                         \
+  "(SELECT EXISTS (SELECT * FROM tickets"                          \
+  "                WHERE id IN (SELECT ticket FROM ticket_results" \
+  "                             WHERE result = results.id"         \
+  "                             AND result_location"               \
+  "                                 = " G_STRINGIFY (LOCATION_TABLE) ")))"
 
-user_t
-ticket_owner (ticket_t);
+user_t ticket_owner (ticket_t);
 
-user_t
-ticket_assigned_to (ticket_t);
+user_t ticket_assigned_to (ticket_t);
 
-gchar *
-ticket_nvt_name (ticket_t);
+gchar *ticket_nvt_name (ticket_t);
 
 int
 delete_ticket (const char *, int);
@@ -59,22 +56,16 @@ empty_trashcan_tickets ();
 void
 check_tickets ();
 
-void
-delete_tickets_user (user_t);
+void delete_tickets_user (user_t);
 
-void
-inherit_tickets (user_t, user_t);
+void inherit_tickets (user_t, user_t);
 
-void
-tickets_remove_task (task_t);
+void tickets_remove_task (task_t);
 
-void
-tickets_remove_tasks_user (user_t);
+void tickets_remove_tasks_user (user_t);
 
-void
-tickets_trash_task (task_t);
+void tickets_trash_task (task_t);
 
-void
-tickets_restore_task (task_t);
+void tickets_restore_task (task_t);
 
 #endif /* not _GVMD_MANAGE_SQL_TICKETS_H */

--- a/src/manage_sqlite3.c
+++ b/src/manage_sqlite3.c
@@ -32,21 +32,20 @@
  */
 #define _XOPEN_SOURCE
 
-#include "sql.h"
 #include "manage.h"
-#include "manage_utils.h"
 #include "manage_acl.h"
+#include "manage_utils.h"
+#include "sql.h"
 
 #include <assert.h>
 #include <errno.h>
-#include <sqlite3.h>
-#include <string.h>
-#include <stdlib.h>
-#include <time.h>
-#include <unistd.h>
-
 #include <gvm/base/hosts.h>
 #include <gvm/util/uuidutils.h>
+#include <sqlite3.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
 
 #undef G_LOG_DOMAIN
 /**
@@ -74,16 +73,13 @@
  */
 #define CERT_DB_FILE CERT_DB_DIR "cert.db"
 
-
 /* Variables */
 
-extern sqlite3 *
-gvmd_db;
+extern sqlite3 *gvmd_db;
 
-
 /* Headers of manage_sql.c functions also used here. */
 
-gchar*
+gchar *
 clean_hosts (const char *, int *);
 
 char *
@@ -98,15 +94,14 @@ resource_name (const char *, const char *, int, char **);
 int
 resource_exists (const char *, resource_t, int);
 
-
 /* Session. */
 
 /**
  * @brief WHERE clause for view vulns.
  */
-#define VULNS_RESULTS_WHERE                                           \
-  " WHERE uuid IN"                                                    \
-  "   (SELECT nvt FROM results"                                       \
+#define VULNS_RESULTS_WHERE     \
+  " WHERE uuid IN"              \
+  "   (SELECT nvt FROM results" \
   "     WHERE (results.severity != " G_STRINGIFY (SEVERITY_ERROR) "))"
 
 /**
@@ -130,29 +125,29 @@ manage_session_init (const char *uuid)
 
   sql ("DROP VIEW IF EXISTS vulns;");
   if (manage_scap_loaded ())
-    sql ("CREATE TEMPORARY VIEW vulns AS"
-         " SELECT id, uuid, name, creation_time, modification_time,"
-         "        cast (cvss_base AS double precision) AS severity, qod,"
-         "        'nvt' AS type"
-         " FROM nvts"
-         VULNS_RESULTS_WHERE
-         " UNION ALL SELECT id, uuid, name, creation_time, modification_time,"
-         "       cvss AS severity, " G_STRINGIFY (QOD_DEFAULT) " AS qod,"
-         "       'cve' AS type"
-         " FROM scap.cves"
-         VULNS_RESULTS_WHERE
-         " UNION ALL SELECT id, uuid, name, creation_time, modification_time,"
-         "       max_cvss AS severity, " G_STRINGIFY (QOD_DEFAULT) " AS qod,"
-         "       'ovaldef' AS type"
-         " FROM scap.ovaldefs"
-         VULNS_RESULTS_WHERE);
+    sql (
+      "CREATE TEMPORARY VIEW vulns AS"
+      " SELECT id, uuid, name, creation_time, modification_time,"
+      "        cast (cvss_base AS double precision) AS severity, qod,"
+      "        'nvt' AS type"
+      " FROM nvts" VULNS_RESULTS_WHERE
+      " UNION ALL SELECT id, uuid, name, creation_time, modification_time,"
+      "       cvss AS severity, " G_STRINGIFY (
+        QOD_DEFAULT) " AS qod,"
+                     "       'cve' AS type"
+                     " FROM scap.cves" VULNS_RESULTS_WHERE
+                     " UNION ALL SELECT id, uuid, name, creation_time, "
+                     "modification_time,"
+                     "       max_cvss AS severity, " G_STRINGIFY (
+                       QOD_DEFAULT) " AS qod,"
+                                    "       'ovaldef' AS type"
+                                    " FROM scap.ovaldefs" VULNS_RESULTS_WHERE);
   else
     sql ("CREATE TEMPORARY VIEW vulns AS"
          " SELECT id, uuid, name, creation_time, modification_time,"
          "        cast (cvss_base AS double precision) AS severity, qod,"
          "        'nvt' AS type"
-         " FROM nvts"
-         VULNS_RESULTS_WHERE);
+         " FROM nvts" VULNS_RESULTS_WHERE);
 
 #undef VULNS_RESULTS_WHERE
 }
@@ -168,7 +163,6 @@ manage_session_set_timezone (const char *zone)
   return;
 }
 
-
 /* Helpers. */
 
 /**
@@ -185,7 +179,6 @@ manage_db_empty ()
          == 0;
 }
 
-
 /* SQL functions. */
 
 /**
@@ -198,7 +191,7 @@ manage_db_empty ()
  * @param[in]  argv     Argument array.
  */
 void
-sql_t (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_t (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   assert (argc == 0);
 
@@ -217,8 +210,7 @@ sql_t (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_strpos (sqlite3_context *context, int argc,
-            sqlite3_value** argv)
+sql_strpos (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   const unsigned char *str, *substr, *substr_in_str;
 
@@ -239,11 +231,10 @@ sql_strpos (sqlite3_context *context, int argc,
       return;
     }
 
-  substr_in_str = (const unsigned char *)g_strrstr ((const gchar*)str,
-                                                    (const gchar*)substr);
+  substr_in_str = (const unsigned char *) g_strrstr ((const gchar *) str,
+                                                     (const gchar *) substr);
 
-  sqlite3_result_int (context,
-                      substr_in_str ? substr_in_str - str + 1 : 0);
+  sqlite3_result_int (context, substr_in_str ? substr_in_str - str + 1 : 0);
 }
 
 /**
@@ -256,7 +247,7 @@ sql_strpos (sqlite3_context *context, int argc,
  * @param[in]  argv     Argument array.
  */
 void
-sql_order_inet (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_order_inet (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   const char *ip;
   unsigned int one, two, three, four;
@@ -270,15 +261,12 @@ sql_order_inet (sqlite3_context *context, int argc, sqlite3_value** argv)
     sqlite3_result_int (context, 0);
   else
     {
-      if (g_regex_match_simple ("^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$",
-                                ip, 0, 0)
+      if (g_regex_match_simple ("^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$", ip, 0, 0)
           && sscanf (ip, "%u.%u.%u.%u", &one, &two, &three, &four) == 4)
         {
-          ip_expanded = g_strdup_printf ("%03u.%03u.%03u.%03u",
-                                         one, two, three, four);
-          sqlite3_result_text (context,
-                               ip_expanded,
-                               -1, SQLITE_TRANSIENT);
+          ip_expanded =
+            g_strdup_printf ("%03u.%03u.%03u.%03u", one, two, three, four);
+          sqlite3_result_text (context, ip_expanded, -1, SQLITE_TRANSIENT);
           g_free (ip_expanded);
         }
       else
@@ -297,7 +285,7 @@ sql_order_inet (sqlite3_context *context, int argc, sqlite3_value** argv)
  */
 void
 sql_order_message_type (sqlite3_context *context, int argc,
-                        sqlite3_value** argv)
+                        sqlite3_value **argv)
 {
   const char *type;
 
@@ -332,7 +320,7 @@ sql_order_message_type (sqlite3_context *context, int argc,
  * @param[in]  argv     Argument array.
  */
 void
-sql_order_port (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_order_port (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   const char *port;
   int port_num;
@@ -360,7 +348,7 @@ sql_order_port (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_order_role (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_order_role (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   const char *name;
 
@@ -385,7 +373,7 @@ sql_order_role (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_order_threat (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_order_threat (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   const char *type;
 
@@ -422,7 +410,7 @@ sql_order_threat (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_make_uuid (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_make_uuid (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   char *uuid;
 
@@ -448,21 +436,21 @@ sql_make_uuid (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_hosts_contains (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_hosts_contains (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   const char *hosts, *host;
   int max_hosts;
 
   assert (argc == 2);
 
-  hosts = (const char*)sqlite3_value_text (argv[0]);
+  hosts = (const char *) sqlite3_value_text (argv[0]);
   if (hosts == NULL)
     {
       sqlite3_result_error (context, "Failed to get hosts argument", -1);
       return;
     }
 
-  host = (const char*)sqlite3_value_text (argv[1]);
+  host = (const char *) sqlite3_value_text (argv[1]);
   if (host == NULL)
     {
       sqlite3_result_error (context, "Failed to get host argument", -1);
@@ -486,7 +474,7 @@ sql_hosts_contains (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_clean_hosts (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_clean_hosts (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   const unsigned char *hosts;
   gchar *clean;
@@ -500,7 +488,7 @@ sql_clean_hosts (sqlite3_context *context, int argc, sqlite3_value** argv)
       return;
     }
 
-  clean = clean_hosts ((gchar*) hosts, NULL);
+  clean = clean_hosts ((gchar *) hosts, NULL);
   sqlite3_result_text (context, clean, -1, SQLITE_TRANSIENT);
   g_free (clean);
 }
@@ -516,7 +504,7 @@ sql_clean_hosts (sqlite3_context *context, int argc, sqlite3_value** argv)
  */
 void
 sql_merge_dfn_cert_adv (sqlite3_context *context, int argc,
-                        sqlite3_value** argv)
+                        sqlite3_value **argv)
 {
   const unsigned char *refnum, *title, *summary;
   time_t published, updated;
@@ -551,22 +539,17 @@ sql_merge_dfn_cert_adv (sqlite3_context *context, int argc,
 
   cve_refs = sqlite3_value_int (argv[5]);
 
-  quoted_refnum = sql_quote ((const char*) refnum);
-  quoted_title = sql_quote ((const char*) title);
-  quoted_summary = sql_quote ((const char*) summary);
+  quoted_refnum = sql_quote ((const char *) refnum);
+  quoted_title = sql_quote ((const char *) title);
+  quoted_summary = sql_quote ((const char *) summary);
 
   sql ("INSERT OR REPLACE INTO dfn_cert_advs"
        " (uuid, name, comment, creation_time, modification_time,"
        "  title, summary, cve_refs)"
        " VALUES"
        " ('%s', '%s', '', %i, %i, '%s', '%s', %i);",
-       quoted_refnum,
-       quoted_refnum,
-       published,
-       updated,
-       quoted_title,
-       quoted_summary,
-       cve_refs);
+       quoted_refnum, quoted_refnum, published, updated, quoted_title,
+       quoted_summary, cve_refs);
 
   g_free (quoted_refnum);
   g_free (quoted_title);
@@ -583,8 +566,7 @@ sql_merge_dfn_cert_adv (sqlite3_context *context, int argc,
  * @param[in]  argv     Argument array.
  */
 void
-sql_merge_bund_adv (sqlite3_context *context, int argc,
-                    sqlite3_value** argv)
+sql_merge_bund_adv (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   const unsigned char *refnum, *title, *summary;
   time_t published, updated;
@@ -619,22 +601,17 @@ sql_merge_bund_adv (sqlite3_context *context, int argc,
 
   cve_refs = sqlite3_value_int (argv[5]);
 
-  quoted_refnum = sql_quote ((const char*) refnum);
-  quoted_title = sql_quote ((const char*) title);
-  quoted_summary = sql_quote ((const char*) summary);
+  quoted_refnum = sql_quote ((const char *) refnum);
+  quoted_title = sql_quote ((const char *) title);
+  quoted_summary = sql_quote ((const char *) summary);
 
   sql ("INSERT OR REPLACE INTO cert_bund_advs"
        " (uuid, name, comment, creation_time, modification_time,"
        "  title, summary, cve_refs)"
        " VALUES"
        " ('%s', '%s', '', %i, %i, '%s', '%s', %i);",
-       quoted_refnum,
-       quoted_refnum,
-       published,
-       updated,
-       quoted_title,
-       quoted_summary,
-       cve_refs);
+       quoted_refnum, quoted_refnum, published, updated, quoted_title,
+       quoted_summary, cve_refs);
 
   g_free (quoted_refnum);
   g_free (quoted_title);
@@ -651,8 +628,7 @@ sql_merge_bund_adv (sqlite3_context *context, int argc,
  * @param[in]  argv     Argument array.
  */
 void
-sql_merge_cpe (sqlite3_context *context, int argc,
-               sqlite3_value** argv)
+sql_merge_cpe (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   const unsigned char *name, *title, *status, *nvd_id;
   gchar *quoted_name, *quoted_title, *quoted_status, *quoted_nvd_id;
@@ -693,24 +669,18 @@ sql_merge_cpe (sqlite3_context *context, int argc,
       return;
     }
 
-  quoted_name = sql_quote ((const char*) name);
-  quoted_title = sql_quote ((const char*) title);
-  quoted_status = sql_quote ((const char*) status);
-  quoted_nvd_id = sql_quote ((const char*) nvd_id);
+  quoted_name = sql_quote ((const char *) name);
+  quoted_title = sql_quote ((const char *) title);
+  quoted_status = sql_quote ((const char *) status);
+  quoted_nvd_id = sql_quote ((const char *) nvd_id);
 
   sql ("INSERT OR REPLACE INTO cpes"
        " (uuid, name, title, creation_time, modification_time, status,"
        "  deprecated_by_id, nvd_id)"
        " VALUES"
        " ('%s', '%s', '%s', %i, %i, '%s', %i, '%s');",
-       quoted_name,
-       quoted_name,
-       quoted_title,
-       created,
-       modified,
-       quoted_status,
-       deprecated_by_id,
-       quoted_nvd_id);
+       quoted_name, quoted_name, quoted_title, created, modified, quoted_status,
+       deprecated_by_id, quoted_nvd_id);
 
   g_free (quoted_name);
   g_free (quoted_title);
@@ -728,8 +698,7 @@ sql_merge_cpe (sqlite3_context *context, int argc,
  * @param[in]  argv     Argument array.
  */
 void
-sql_merge_cve (sqlite3_context *context, int argc,
-               sqlite3_value** argv)
+sql_merge_cve (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   const unsigned char *uuid, *name, *cvss, *description, *vector, *complexity;
   const unsigned char *authentication, *confidentiality, *integrity;
@@ -803,56 +772,50 @@ sql_merge_cve (sqlite3_context *context, int argc,
   authentication = sqlite3_value_text (argv[8]);
   if (authentication == NULL)
     {
-      sqlite3_result_error (context,
-                            "Failed to get authentication argument", -1);
+      sqlite3_result_error (context, "Failed to get authentication argument",
+                            -1);
       return;
     }
 
   confidentiality = sqlite3_value_text (argv[9]);
   if (confidentiality == NULL)
     {
-      sqlite3_result_error (context,
-                            "Failed to get confidentiality_impact argument",
-                            -1);
+      sqlite3_result_error (
+        context, "Failed to get confidentiality_impact argument", -1);
       return;
     }
 
   integrity = sqlite3_value_text (argv[10]);
   if (integrity == NULL)
     {
-      sqlite3_result_error (context,
-                            "Failed to get integrity argument",
-                            -1);
+      sqlite3_result_error (context, "Failed to get integrity argument", -1);
       return;
     }
 
   availability = sqlite3_value_text (argv[11]);
   if (availability == NULL)
     {
-      sqlite3_result_error (context,
-                            "Failed to get availability argument",
-                            -1);
+      sqlite3_result_error (context, "Failed to get availability argument", -1);
       return;
     }
 
   products = sqlite3_value_text (argv[12]);
   if (products == NULL)
     {
-      sqlite3_result_error (context,
-                            "Failed to get products argument", -1);
+      sqlite3_result_error (context, "Failed to get products argument", -1);
       return;
     }
 
-  quoted_uuid = sql_quote ((const char*) uuid);
-  quoted_name = sql_quote ((const char*) name);
-  quoted_description = sql_quote ((const char*) description);
-  quoted_vector = sql_quote ((const char*) vector);
-  quoted_complexity = sql_quote ((const char*) complexity);
-  quoted_authentication = sql_quote ((const char*) authentication);
-  quoted_confidentiality = sql_quote ((const char*) confidentiality);
-  quoted_integrity = sql_quote ((const char*) integrity);
-  quoted_availability = sql_quote ((const char*) availability);
-  quoted_products = sql_quote ((const char*) products);
+  quoted_uuid = sql_quote ((const char *) uuid);
+  quoted_name = sql_quote ((const char *) name);
+  quoted_description = sql_quote ((const char *) description);
+  quoted_vector = sql_quote ((const char *) vector);
+  quoted_complexity = sql_quote ((const char *) complexity);
+  quoted_authentication = sql_quote ((const char *) authentication);
+  quoted_confidentiality = sql_quote ((const char *) confidentiality);
+  quoted_integrity = sql_quote ((const char *) integrity);
+  quoted_availability = sql_quote ((const char *) availability);
+  quoted_products = sql_quote ((const char *) products);
 
   sql ("INSERT OR REPLACE INTO cves"
        " (uuid, name, creation_time, modification_time, cvss, description,"
@@ -861,18 +824,9 @@ sql_merge_cve (sqlite3_context *context, int argc,
        " VALUES"
        " ('%s', '%s', %i, %i, %s, '%s', '%s', '%s', '%s', '%s', '%s', '%s',"
        "  '%s');",
-       quoted_uuid,
-       quoted_name,
-       created,
-       modified,
-       cvss,
-       quoted_description,
-       quoted_vector,
-       quoted_complexity,
-       quoted_authentication,
-       quoted_confidentiality,
-       quoted_integrity,
-       quoted_availability,
+       quoted_uuid, quoted_name, created, modified, cvss, quoted_description,
+       quoted_vector, quoted_complexity, quoted_authentication,
+       quoted_confidentiality, quoted_integrity, quoted_availability,
        quoted_products);
 
   g_free (quoted_uuid);
@@ -897,8 +851,7 @@ sql_merge_cve (sqlite3_context *context, int argc,
  * @param[in]  argv     Argument array.
  */
 void
-sql_merge_cpe_name (sqlite3_context *context, int argc,
-                    sqlite3_value** argv)
+sql_merge_cpe_name (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   const unsigned char *uuid, *name;
   gchar *quoted_uuid, *quoted_name;
@@ -923,17 +876,14 @@ sql_merge_cpe_name (sqlite3_context *context, int argc,
   creation_time = sqlite3_value_int (argv[2]);
   modification_time = sqlite3_value_int (argv[3]);
 
-  quoted_uuid = sql_quote ((const char*) uuid);
-  quoted_name = sql_quote ((const char*) name);
+  quoted_uuid = sql_quote ((const char *) uuid);
+  quoted_name = sql_quote ((const char *) name);
 
   sql ("INSERT OR IGNORE INTO cpes"
        " (uuid, name, creation_time, modification_time)"
        " VALUES"
        " ('%s', '%s', %i, %i);",
-       quoted_uuid,
-       quoted_name,
-       creation_time,
-       modification_time);
+       quoted_uuid, quoted_name, creation_time, modification_time);
 
   g_free (quoted_uuid);
   g_free (quoted_name);
@@ -950,7 +900,7 @@ sql_merge_cpe_name (sqlite3_context *context, int argc,
  */
 void
 sql_merge_affected_product (sqlite3_context *context, int argc,
-                            sqlite3_value** argv)
+                            sqlite3_value **argv)
 {
   int cve, cpe;
 
@@ -963,8 +913,7 @@ sql_merge_affected_product (sqlite3_context *context, int argc,
        " (cve, cpe)"
        " VALUES"
        " (%i, %i);",
-       cve,
-       cpe);
+       cve, cpe);
 }
 
 /**
@@ -977,8 +926,7 @@ sql_merge_affected_product (sqlite3_context *context, int argc,
  * @param[in]  argv     Argument array.
  */
 void
-sql_merge_ovaldef (sqlite3_context *context, int argc,
-                   sqlite3_value** argv)
+sql_merge_ovaldef (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   const unsigned char *uuid, *name, *comment, *def_class, *title, *description;
   const unsigned char *xml_file, *status;
@@ -1033,39 +981,34 @@ sql_merge_ovaldef (sqlite3_context *context, int argc,
   description = sqlite3_value_text (argv[9]);
   if (description == NULL)
     {
-      sqlite3_result_error (context,
-                            "Failed to get description argument", -1);
+      sqlite3_result_error (context, "Failed to get description argument", -1);
       return;
     }
 
   xml_file = sqlite3_value_text (argv[10]);
   if (xml_file == NULL)
     {
-      sqlite3_result_error (context,
-                            "Failed to get xml_file argument",
-                            -1);
+      sqlite3_result_error (context, "Failed to get xml_file argument", -1);
       return;
     }
 
   status = sqlite3_value_text (argv[11]);
   if (status == NULL)
     {
-      sqlite3_result_error (context,
-                            "Failed to get status argument",
-                            -1);
+      sqlite3_result_error (context, "Failed to get status argument", -1);
       return;
     }
 
   cve_refs = sqlite3_value_int (argv[12]);
 
-  quoted_uuid = sql_quote ((const char*) uuid);
-  quoted_name = sql_quote ((const char*) name);
-  quoted_comment = sql_quote ((const char*) comment);
-  quoted_def_class = sql_quote ((const char*) def_class);
-  quoted_title = sql_quote ((const char*) title);
-  quoted_description = sql_quote ((const char*) description);
-  quoted_xml_file = sql_quote ((const char*) xml_file);
-  quoted_status = sql_quote ((const char*) status);
+  quoted_uuid = sql_quote ((const char *) uuid);
+  quoted_name = sql_quote ((const char *) name);
+  quoted_comment = sql_quote ((const char *) comment);
+  quoted_def_class = sql_quote ((const char *) def_class);
+  quoted_title = sql_quote ((const char *) title);
+  quoted_description = sql_quote ((const char *) description);
+  quoted_xml_file = sql_quote ((const char *) xml_file);
+  quoted_status = sql_quote ((const char *) status);
 
   sql ("INSERT OR REPLACE INTO ovaldefs"
        " (uuid, name, comment, creation_time, modification_time, version,"
@@ -1074,19 +1017,9 @@ sql_merge_ovaldef (sqlite3_context *context, int argc,
        " VALUES"
        " ('%s', '%s', '%s', %i, %i, %i, %i, '%s', '%s', '%s', '%s', '%s',"
        "  0.0, %i);",
-       quoted_uuid,
-       quoted_name,
-       quoted_comment,
-       created,
-       modified,
-       version,
-       deprecated,
-       quoted_def_class,
-       quoted_title,
-       quoted_description,
-       quoted_xml_file,
-       quoted_status,
-       cve_refs);
+       quoted_uuid, quoted_name, quoted_comment, created, modified, version,
+       deprecated, quoted_def_class, quoted_title, quoted_description,
+       quoted_xml_file, quoted_status, cve_refs);
 
   g_free (quoted_uuid);
   g_free (quoted_name);
@@ -1110,7 +1043,7 @@ sql_merge_ovaldef (sqlite3_context *context, int argc,
  * @param[in]  argv     Argument array.
  */
 void
-sql_uniquify (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_uniquify (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   const unsigned char *proposed_name, *type, *suffix;
   gchar *candidate_name, *quoted_candidate_name;
@@ -1129,8 +1062,7 @@ sql_uniquify (sqlite3_context *context, int argc, sqlite3_value** argv)
   proposed_name = sqlite3_value_text (argv[1]);
   if (proposed_name == NULL)
     {
-      sqlite3_result_error (context,
-                            "Failed to get proposed name argument",
+      sqlite3_result_error (context, "Failed to get proposed name argument",
                             -1);
       return;
     }
@@ -1140,31 +1072,25 @@ sql_uniquify (sqlite3_context *context, int argc, sqlite3_value** argv)
   suffix = sqlite3_value_text (argv[3]);
   if (suffix == NULL)
     {
-      sqlite3_result_error (context,
-                            "Failed to get suffix argument",
-                            -1);
+      sqlite3_result_error (context, "Failed to get suffix argument", -1);
       return;
     }
 
   number = 0;
-  candidate_name = g_strdup_printf ("%s%s%c%i", proposed_name, suffix,
-                                    strcmp ((char*) type, "user") ? ' ' : '_',
-                                    ++number);
+  candidate_name =
+    g_strdup_printf ("%s%s%c%i", proposed_name, suffix,
+                     strcmp ((char *) type, "user") ? ' ' : '_', ++number);
   quoted_candidate_name = sql_quote (candidate_name);
 
   while (sql_int ("SELECT COUNT (*) FROM %ss WHERE name = '%s'"
-                   " AND ((owner IS NULL) OR (owner = %llu));",
-                  type,
-                  quoted_candidate_name,
-                  owner))
+                  " AND ((owner IS NULL) OR (owner = %llu));",
+                  type, quoted_candidate_name, owner))
     {
       g_free (candidate_name);
       g_free (quoted_candidate_name);
-      candidate_name = g_strdup_printf ("%s%s%c%u", proposed_name, suffix,
-                                        strcmp ((char*) type, "user")
-                                          ? ' '
-                                          : '_',
-                                        ++number);
+      candidate_name =
+        g_strdup_printf ("%s%s%c%u", proposed_name, suffix,
+                         strcmp ((char *) type, "user") ? ' ' : '_', ++number);
       quoted_candidate_name = sql_quote (candidate_name);
     }
 
@@ -1184,7 +1110,7 @@ sql_uniquify (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_iso_time (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_iso_time (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   time_t epoch_time;
 
@@ -1215,7 +1141,7 @@ sql_iso_time (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_days_from_now (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_days_from_now (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   time_t epoch_time;
 
@@ -1245,7 +1171,7 @@ sql_days_from_now (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_parse_time (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_parse_time (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   const gchar *string;
   int epoch_time;
@@ -1256,22 +1182,21 @@ sql_parse_time (sqlite3_context *context, int argc, sqlite3_value** argv)
 
   switch (parse_time (string, &epoch_time))
     {
-      case -1:
-        g_warning ("%s: Failed to parse time: %s", __FUNCTION__, string);
-        sqlite3_result_int (context, 0);
-        break;
-      case -2:
-        g_warning ("%s: Failed to make time: %s", __FUNCTION__, string);
-        sqlite3_result_int (context, 0);
-        break;
-      case -3:
-        g_warning ("%s: Failed to parse timezone offset: %s",
-                   __FUNCTION__,
-                   string);
-        sqlite3_result_int (context, 0);
-        break;
-      default:
-        sqlite3_result_int (context, epoch_time);
+    case -1:
+      g_warning ("%s: Failed to parse time: %s", __FUNCTION__, string);
+      sqlite3_result_int (context, 0);
+      break;
+    case -2:
+      g_warning ("%s: Failed to make time: %s", __FUNCTION__, string);
+      sqlite3_result_int (context, 0);
+      break;
+    case -3:
+      g_warning ("%s: Failed to parse timezone offset: %s", __FUNCTION__,
+                 string);
+      sqlite3_result_int (context, 0);
+      break;
+    default:
+      sqlite3_result_int (context, epoch_time);
     }
 }
 
@@ -1285,7 +1210,7 @@ sql_parse_time (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_next_time (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_next_time (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   time_t first;
   time_t period;
@@ -1301,16 +1226,15 @@ sql_next_time (sqlite3_context *context, int argc, sqlite3_value** argv)
   if (argc < 5 || sqlite3_value_type (argv[4]) == SQLITE_NULL)
     zone = NULL;
   else
-    zone = (char*) sqlite3_value_text (argv[4]);
+    zone = (char *) sqlite3_value_text (argv[4]);
 
   if (argc < 6 || sqlite3_value_type (argv[5]) == SQLITE_NULL)
     periods_offset = 0;
   else
     periods_offset = sqlite3_value_int (argv[5]);
 
-  sqlite3_result_int (context,
-                      next_time (first, period, period_months, byday, zone,
-                                 periods_offset));
+  sqlite3_result_int (context, next_time (first, period, period_months, byday,
+                                          zone, periods_offset));
 }
 
 /**
@@ -1323,31 +1247,30 @@ sql_next_time (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_next_time_ical (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_next_time_ical (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   int periods_offset;
   const char *icalendar, *zone;
 
-  assert (argc == 2 || argc == 3 );
+  assert (argc == 2 || argc == 3);
 
   if (argc < 1 || sqlite3_value_type (argv[0]) == SQLITE_NULL)
     icalendar = NULL;
   else
-    icalendar = (char*) sqlite3_value_text (argv[0]);
+    icalendar = (char *) sqlite3_value_text (argv[0]);
 
   if (argc < 2 || sqlite3_value_type (argv[1]) == SQLITE_NULL)
     zone = NULL;
   else
-    zone = (char*) sqlite3_value_text (argv[1]);
+    zone = (char *) sqlite3_value_text (argv[1]);
 
   if (argc < 3 || sqlite3_value_type (argv[2]) == SQLITE_NULL)
     periods_offset = 0;
   else
     periods_offset = sqlite3_value_int (argv[2]);
 
-  sqlite3_result_int (context,
-                      icalendar_next_time_from_string (icalendar, zone,
-                                                       periods_offset));
+  sqlite3_result_int (
+    context, icalendar_next_time_from_string (icalendar, zone, periods_offset));
 }
 
 /**
@@ -1360,7 +1283,7 @@ sql_next_time_ical (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_now (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_now (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   assert (argc == 0);
   sqlite3_result_int (context, time (NULL));
@@ -1376,21 +1299,21 @@ sql_now (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_tag (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_tag (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   const char *tags, *tag;
   gchar *value;
 
   assert (argc == 2);
 
-  tags = (char*) sqlite3_value_text (argv[0]);
+  tags = (char *) sqlite3_value_text (argv[0]);
   if (tags == NULL)
     {
       sqlite3_result_error (context, "Failed to get tags argument", -1);
       return;
     }
 
-  tag = (char*) sqlite3_value_text (argv[1]);
+  tag = (char *) sqlite3_value_text (argv[1]);
   if (tag == NULL)
     {
       sqlite3_result_error (context, "Failed to get tag argument", -1);
@@ -1414,7 +1337,7 @@ sql_tag (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_max_hosts (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_max_hosts (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   const unsigned char *hosts, *exclude_hosts;
   gchar *max;
@@ -1430,8 +1353,8 @@ sql_max_hosts (sqlite3_context *context, int argc, sqlite3_value** argv)
     }
   exclude_hosts = sqlite3_value_text (argv[1]);
 
-  max = g_strdup_printf ("%i", manage_count_hosts ((gchar*) hosts,
-                                                   (gchar *) exclude_hosts));
+  max = g_strdup_printf (
+    "%i", manage_count_hosts ((gchar *) hosts, (gchar *) exclude_hosts));
   sqlite3_result_text (context, max, -1, SQLITE_TRANSIENT);
   g_free (max);
 }
@@ -1471,11 +1394,9 @@ sql_rename_column (const char *old_table, const char *new_table,
         {
           const char *name;
           name = iterator_column_name (&rows, column);
-          g_string_append_printf (one, "%s%s",
-                                  (first ? "" : ", "),
-                                  (strcmp (name, old_name) == 0
-                                    ? new_name
-                                    : name));
+          g_string_append_printf (
+            one, "%s%s", (first ? "" : ", "),
+            (strcmp (name, old_name) == 0 ? new_name : name));
           if (first)
             first = 0;
           else
@@ -1507,7 +1428,7 @@ sql_rename_column (const char *old_table, const char *new_table,
  * @param[in]  argv     Argument array.
  */
 void
-sql_common_cve (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_common_cve (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   gchar **split_1, **split_2, **point_1, **point_2;
   const unsigned char *cve1, *cve2;
@@ -1530,15 +1451,16 @@ sql_common_cve (sqlite3_context *context, int argc, sqlite3_value** argv)
       return;
     }
 
-  split_1 = g_strsplit ((gchar*) cve1, ",", 0);
-  split_2 = g_strsplit ((gchar*) cve2, ",", 0);
+  split_1 = g_strsplit ((gchar *) cve1, ",", 0);
+  split_2 = g_strsplit ((gchar *) cve2, ",", 0);
   point_1 = split_1;
   point_2 = split_2;
   while (*point_1)
     {
       while (*point_2)
         {
-          g_debug ("   %s: %s vs %s", __FUNCTION__, g_strstrip (*point_1), g_strstrip (*point_2));
+          g_debug ("   %s: %s vs %s", __FUNCTION__, g_strstrip (*point_1),
+                   g_strstrip (*point_2));
           if (strcmp (g_strstrip (*point_1), g_strstrip (*point_2)) == 0)
             {
               g_strfreev (split_1);
@@ -1566,7 +1488,7 @@ sql_common_cve (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_cpe_title (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_cpe_title (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   const unsigned char *cpe_id;
   gchar *quoted_cpe_id;
@@ -1576,10 +1498,9 @@ sql_cpe_title (sqlite3_context *context, int argc, sqlite3_value** argv)
 
   cpe_id = sqlite3_value_text (argv[0]);
 
-  if (manage_scap_loaded ()
-      && sqlite3_value_type(argv[0]) != SQLITE_NULL)
+  if (manage_scap_loaded () && sqlite3_value_type (argv[0]) != SQLITE_NULL)
     {
-      quoted_cpe_id = sql_quote ((gchar*) cpe_id);
+      quoted_cpe_id = sql_quote ((gchar *) cpe_id);
       cpe_title = sql_string ("SELECT title FROM scap.cpes"
                               " WHERE uuid = '%s';",
                               quoted_cpe_id);
@@ -1611,11 +1532,11 @@ sql_cpe_title (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_credential_value (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_credential_value (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   credential_t credential;
   int trash;
-  const unsigned char* type;
+  const unsigned char *type;
   gchar *quoted_type, *result;
 
   assert (argc == 3);
@@ -1624,7 +1545,7 @@ sql_credential_value (sqlite3_context *context, int argc, sqlite3_value** argv)
   trash = sqlite3_value_int (argv[1]);
   type = sqlite3_value_text (argv[2]);
 
-  quoted_type = sql_quote ((const char*) type);
+  quoted_type = sql_quote ((const char *) type);
   if (trash)
     {
       result = sql_string ("SELECT value FROM credentials_trash_data"
@@ -1656,12 +1577,11 @@ sql_credential_value (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_current_offset (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_current_offset (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   assert (argc == 1);
-  sqlite3_result_int
-   (context,
-    (int) current_offset ((const char *) sqlite3_value_text (argv[0])));
+  sqlite3_result_int (context, (int) current_offset (
+                                 (const char *) sqlite3_value_text (argv[0])));
 }
 
 /**
@@ -1674,7 +1594,7 @@ sql_current_offset (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_task_trend (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_task_trend (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   unsigned int overrides;
   int min_qod;
@@ -1705,11 +1625,11 @@ sql_task_trend (sqlite3_context *context, int argc, sqlite3_value** argv)
  */
 typedef struct
 {
-  task_t task;                ///< Task.
-  gchar *severity;            ///< Severity.
-  task_t overrides_task;      ///< Task.
-  gchar *overrides_severity;  ///< Severity.
-  int min_qod;                ///< Minimum QoD.
+  task_t task;               ///< Task.
+  gchar *severity;           ///< Severity.
+  task_t overrides_task;     ///< Task.
+  gchar *overrides_severity; ///< Severity.
+  int min_qod;               ///< Minimum QoD.
 } sql_severity_t;
 
 /**
@@ -1722,8 +1642,9 @@ clear_cache (void *cache_arg)
 {
   sql_severity_t *cache;
 
-  cache = (sql_severity_t*) cache_arg;
-  g_debug ("   %s: %llu, %llu", __FUNCTION__, cache->task, cache->overrides_task);
+  cache = (sql_severity_t *) cache_arg;
+  g_debug ("   %s: %llu, %llu", __FUNCTION__, cache->task,
+           cache->overrides_task);
   cache->task = 0;
   cache->overrides_task = 0;
   free (cache->severity);
@@ -1752,10 +1673,11 @@ static char *
 cached_task_severity (sqlite3_context *context, task_t task, int overrides,
                       int min_qod)
 {
-  static sql_severity_t static_cache = { .task = 0, .severity = NULL,
-                                         .min_qod = MIN_QOD_DEFAULT,
-                                         .overrides_task = 0,
-                                         .overrides_severity = NULL };
+  static sql_severity_t static_cache = {.task = 0,
+                                        .severity = NULL,
+                                        .min_qod = MIN_QOD_DEFAULT,
+                                        .overrides_task = 0,
+                                        .overrides_severity = NULL};
   sql_severity_t *cache;
   char *severity;
 
@@ -1810,14 +1732,14 @@ cached_task_severity (sqlite3_context *context, task_t task, int overrides,
  * @param[in]  argv     Argument array.
  */
 void
-sql_task_threat_level (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_task_threat_level (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   task_t task;
   report_t last_report;
   const char *threat;
   unsigned int overrides;
   int min_qod;
-  char* severity;
+  char *severity;
   double severity_dbl;
 
   assert (argc == 3);
@@ -1838,8 +1760,7 @@ sql_task_threat_level (sqlite3_context *context, int argc, sqlite3_value** argv)
 
   severity = cached_task_severity (context, task, overrides, min_qod);
 
-  if (severity == NULL
-      || sscanf (severity, "%lf", &severity_dbl) != 1)
+  if (severity == NULL || sscanf (severity, "%lf", &severity_dbl) != 1)
     threat = NULL;
   else
     threat = severity_to_level (severity_dbl, 0);
@@ -1872,7 +1793,7 @@ sql_task_threat_level (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_report_progress (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_report_progress (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   report_t report;
   task_t task;
@@ -1906,7 +1827,7 @@ sql_report_progress (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_report_severity (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_report_severity (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   report_t report;
   double severity;
@@ -1946,8 +1867,7 @@ sql_report_severity (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @return    The number of results.
  */
 static int
-report_severity_count (report_t report, int overrides, int min_qod,
-                       char *level)
+report_severity_count (report_t report, int overrides, int min_qod, char *level)
 {
   int debugs, false_positives, logs, lows, mediums, highs;
   get_data_t *get;
@@ -1955,10 +1875,8 @@ report_severity_count (report_t report, int overrides, int min_qod,
   if (current_credentials.uuid == NULL
       || strcmp (current_credentials.uuid, "") == 0)
     return 0;
-  get = report_results_get_data (1   /* first */,
-                                 -1, /* rows */
-                                 overrides,
-                                 0,  /* autofp */
+  get = report_results_get_data (1 /* first */, -1, /* rows */
+                                 overrides, 0,      /* autofp */
                                  min_qod);
   report_counts_id (report, &debugs, &highs, &lows, &logs, &mediums,
                     &false_positives, NULL, get, NULL);
@@ -1992,12 +1910,12 @@ report_severity_count (report_t report, int overrides, int min_qod,
  */
 void
 sql_report_severity_count (sqlite3_context *context, int argc,
-                           sqlite3_value** argv)
+                           sqlite3_value **argv)
 {
   report_t report;
   unsigned int overrides;
   int min_qod;
-  char* level;
+  char *level;
   int count;
 
   assert (argc == 4);
@@ -2016,7 +1934,7 @@ sql_report_severity_count (sqlite3_context *context, int argc,
   else
     min_qod = sqlite3_value_int (argv[2]);
 
-  level = (char*) sqlite3_value_text (argv[3]);
+  level = (char *) sqlite3_value_text (argv[3]);
   if (level == 0)
     {
       sqlite3_result_text (context, "", -1, SQLITE_TRANSIENT);
@@ -2039,8 +1957,7 @@ sql_report_severity_count (sqlite3_context *context, int argc,
  * @param[in]  argv     Argument array.
  */
 void
-sql_report_host_count (sqlite3_context *context,
-                       int argc, sqlite3_value** argv)
+sql_report_host_count (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   report_t report;
   int host_count;
@@ -2070,8 +1987,8 @@ sql_report_host_count (sqlite3_context *context,
  * @param[in]  argv     Argument array.
  */
 void
-sql_report_result_host_count (sqlite3_context *context,
-                              int argc, sqlite3_value** argv)
+sql_report_result_host_count (sqlite3_context *context, int argc,
+                              sqlite3_value **argv)
 {
   report_t report;
   int min_qod;
@@ -2107,7 +2024,7 @@ sql_report_result_host_count (sqlite3_context *context,
  * @param[in]  argv     Argument array.
  */
 void
-sql_task_severity (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_task_severity (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   task_t task;
   report_t last_report;
@@ -2162,7 +2079,7 @@ sql_task_severity (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_task_last_report (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_task_last_report (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   task_t task;
   report_t report;
@@ -2187,7 +2104,7 @@ sql_task_last_report (sqlite3_context *context, int argc, sqlite3_value** argv)
  */
 void
 sql_severity_matches_ov (sqlite3_context *context, int argc,
-                         sqlite3_value** argv)
+                         sqlite3_value **argv)
 {
   double severity, ov_severity;
 
@@ -2200,7 +2117,7 @@ sql_severity_matches_ov (sqlite3_context *context, int argc,
     }
 
   if (sqlite3_value_type (argv[1]) == SQLITE_NULL
-      || strcmp ((const char*) (sqlite3_value_text (argv[1])), "") == 0)
+      || strcmp ((const char *) (sqlite3_value_text (argv[1])), "") == 0)
     {
       sqlite3_result_int (context, 1);
       return;
@@ -2210,8 +2127,7 @@ sql_severity_matches_ov (sqlite3_context *context, int argc,
       severity = sqlite3_value_double (argv[0]);
       ov_severity = sqlite3_value_double (argv[1]);
 
-      sqlite3_result_int (context,
-                          severity_matches_ov (severity, ov_severity));
+      sqlite3_result_int (context, severity_matches_ov (severity, ov_severity));
       return;
     }
 }
@@ -2226,8 +2142,7 @@ sql_severity_matches_ov (sqlite3_context *context, int argc,
  * @param[in]  argv     Argument array.
  */
 void
-sql_severity_to_level (sqlite3_context *context, int argc,
-                       sqlite3_value** argv)
+sql_severity_to_level (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   double severity;
   int mode;
@@ -2235,7 +2150,7 @@ sql_severity_to_level (sqlite3_context *context, int argc,
   assert (argc == 2);
 
   if (sqlite3_value_type (argv[0]) == SQLITE_NULL
-      || strcmp ((const char*)(sqlite3_value_text (argv[0])), "") == 0)
+      || strcmp ((const char *) (sqlite3_value_text (argv[0])), "") == 0)
     {
       sqlite3_result_null (context);
       return;
@@ -2245,8 +2160,8 @@ sql_severity_to_level (sqlite3_context *context, int argc,
 
   severity = sqlite3_value_double (argv[0]);
 
-  sqlite3_result_text (context, severity_to_level (severity, mode),
-                       -1, SQLITE_TRANSIENT);
+  sqlite3_result_text (context, severity_to_level (severity, mode), -1,
+                       SQLITE_TRANSIENT);
   return;
 }
 
@@ -2260,15 +2175,14 @@ sql_severity_to_level (sqlite3_context *context, int argc,
  * @param[in]  argv     Argument array.
  */
 void
-sql_severity_to_type (sqlite3_context *context, int argc,
-                      sqlite3_value** argv)
+sql_severity_to_type (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   double severity;
 
   assert (argc == 1);
 
   if (sqlite3_value_type (argv[0]) == SQLITE_NULL
-      || strcmp ((const char*)(sqlite3_value_text (argv[0])), "") == 0)
+      || strcmp ((const char *) (sqlite3_value_text (argv[0])), "") == 0)
     {
       sqlite3_result_null (context);
       return;
@@ -2276,8 +2190,8 @@ sql_severity_to_type (sqlite3_context *context, int argc,
 
   severity = sqlite3_value_double (argv[0]);
 
-  sqlite3_result_text (context, severity_to_type (severity),
-                       -1, SQLITE_TRANSIENT);
+  sqlite3_result_text (context, severity_to_type (severity), -1,
+                       SQLITE_TRANSIENT);
   return;
 }
 
@@ -2291,7 +2205,7 @@ sql_severity_to_type (sqlite3_context *context, int argc,
  * @param[in]  argv     Argument array.
  */
 void
-sql_regexp (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_regexp (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   const unsigned char *string, *regexp;
 
@@ -2331,7 +2245,7 @@ sql_regexp (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_run_status_name (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_run_status_name (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   const char *name;
   int status;
@@ -2358,7 +2272,7 @@ sql_run_status_name (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_resource_exists (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_resource_exists (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   const char *type;
   resource_t resource;
@@ -2366,13 +2280,13 @@ sql_resource_exists (sqlite3_context *context, int argc, sqlite3_value** argv)
 
   assert (argc == 3);
 
-  type = (char*) sqlite3_value_text (argv[0]);
+  type = (char *) sqlite3_value_text (argv[0]);
   if (type == NULL)
     {
       sqlite3_result_int (context, 0);
       return;
     }
-  if (valid_db_resource_type ((char*) type) == 0)
+  if (valid_db_resource_type ((char *) type) == 0)
     {
       sqlite3_result_error (context, "Invalid resource type argument", -1);
       return;
@@ -2410,7 +2324,7 @@ sql_resource_exists (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_resource_name (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_resource_name (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   const char *type, *id;
   int location;
@@ -2418,14 +2332,14 @@ sql_resource_name (sqlite3_context *context, int argc, sqlite3_value** argv)
 
   assert (argc == 3);
 
-  type = (char*) sqlite3_value_text (argv[0]);
+  type = (char *) sqlite3_value_text (argv[0]);
   if (type == NULL)
     {
       sqlite3_result_null (context);
       return;
     }
 
-  id = (char*) sqlite3_value_text (argv[1]);
+  id = (char *) sqlite3_value_text (argv[1]);
   if (id == NULL)
     {
       sqlite3_result_null (context);
@@ -2463,7 +2377,7 @@ sql_resource_name (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_severity_in_level (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_severity_in_level (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   double severity;
   const char *threat;
@@ -2472,7 +2386,7 @@ sql_severity_in_level (sqlite3_context *context, int argc, sqlite3_value** argv)
 
   severity = sqlite3_value_double (argv[0]);
 
-  threat = (char*) sqlite3_value_text (argv[1]);
+  threat = (char *) sqlite3_value_text (argv[1]);
   if (threat == NULL)
     {
       sqlite3_result_null (context);
@@ -2494,7 +2408,7 @@ sql_severity_in_level (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_target_credential (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_target_credential (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   target_t target;
   int trash;
@@ -2504,7 +2418,7 @@ sql_target_credential (sqlite3_context *context, int argc, sqlite3_value** argv)
 
   target = sqlite3_value_int64 (argv[0]);
   trash = sqlite3_value_int (argv[1]);
-  type = (char*) sqlite3_value_text (argv[2]);
+  type = (char *) sqlite3_value_text (argv[2]);
 
   if (type == NULL)
     {
@@ -2530,8 +2444,8 @@ sql_target_credential (sqlite3_context *context, int argc, sqlite3_value** argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_trash_target_credential_location (sqlite3_context *context,
-                                      int argc, sqlite3_value** argv)
+sql_trash_target_credential_location (sqlite3_context *context, int argc,
+                                      sqlite3_value **argv)
 {
   target_t target;
   const char *type;
@@ -2539,7 +2453,7 @@ sql_trash_target_credential_location (sqlite3_context *context,
   assert (argc == 2);
 
   target = sqlite3_value_int64 (argv[0]);
-  type = (char*) sqlite3_value_text (argv[1]);
+  type = (char *) sqlite3_value_text (argv[1]);
 
   if (type == NULL)
     {
@@ -2562,7 +2476,7 @@ sql_trash_target_credential_location (sqlite3_context *context,
  * @param[in]  argv     Argument array.
  */
 void
-sql_target_login_port (sqlite3_context *context, int argc, sqlite3_value** argv)
+sql_target_login_port (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   target_t target;
   int trash;
@@ -2572,7 +2486,7 @@ sql_target_login_port (sqlite3_context *context, int argc, sqlite3_value** argv)
 
   target = sqlite3_value_int64 (argv[0]);
   trash = sqlite3_value_int (argv[1]);
-  type = (char*) sqlite3_value_text (argv[2]);
+  type = (char *) sqlite3_value_text (argv[2]);
 
   if (type == NULL)
     {
@@ -2581,8 +2495,7 @@ sql_target_login_port (sqlite3_context *context, int argc, sqlite3_value** argv)
     }
 
   if (trash)
-    sqlite3_result_int64 (context,
-                          trash_target_login_port (target, type));
+    sqlite3_result_int64 (context, trash_target_login_port (target, type));
   else
     sqlite3_result_int64 (context, target_login_port (target, type));
 
@@ -2600,7 +2513,7 @@ sql_target_login_port (sqlite3_context *context, int argc, sqlite3_value** argv)
  */
 void
 sql_user_can_everything (sqlite3_context *context, int argc,
-                         sqlite3_value** argv)
+                         sqlite3_value **argv)
 {
   const unsigned char *uuid;
 
@@ -2627,7 +2540,7 @@ sql_user_can_everything (sqlite3_context *context, int argc,
  */
 void
 sql_user_has_access_uuid (sqlite3_context *context, int argc,
-                          sqlite3_value** argv)
+                          sqlite3_value **argv)
 {
   const unsigned char *type, *uuid, *permission;
   int trash;
@@ -2658,8 +2571,8 @@ sql_user_has_access_uuid (sqlite3_context *context, int argc,
 
   trash = sqlite3_value_int (argv[3]);
 
-  ret = acl_user_has_access_uuid ((char*)type, (char*)uuid, (char *)permission,
-                                  trash);
+  ret = acl_user_has_access_uuid ((char *) type, (char *) uuid,
+                                  (char *) permission, trash);
 
   sqlite3_result_int (context, ret);
 }
@@ -2674,8 +2587,7 @@ sql_user_has_access_uuid (sqlite3_context *context, int argc,
  * @param[in]  argv     Argument array.
  */
 void
-sql_user_owns (sqlite3_context *context, int argc,
-               sqlite3_value** argv)
+sql_user_owns (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   const unsigned char *type;
   resource_t resource;
@@ -2709,8 +2621,7 @@ sql_user_owns (sqlite3_context *context, int argc,
  * @param[in]  argv     Argument array.
  */
 void
-sql_vuln_results (sqlite3_context *context, int argc,
-                  sqlite3_value** argv)
+sql_vuln_results (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   const unsigned char *nvt_oid, *host;
   gchar *nvt_oid_quoted, *host_quoted;
@@ -2726,7 +2637,7 @@ sql_vuln_results (sqlite3_context *context, int argc,
       sqlite3_result_error (context, "Failed to get nvt_oid argument", -1);
       return;
     }
-  nvt_oid_quoted = sql_quote ((char*) nvt_oid);
+  nvt_oid_quoted = sql_quote ((char *) nvt_oid);
 
   task = sqlite3_value_int64 (argv[1]);
   task_null = sqlite3_value_type (argv[1]) == SQLITE_NULL;
@@ -2736,30 +2647,26 @@ sql_vuln_results (sqlite3_context *context, int argc,
 
   host = sqlite3_value_text (argv[3]);
   if (host)
-    host_quoted = sql_quote ((char*) host);
+    host_quoted = sql_quote ((char *) host);
   else
     host_quoted = NULL;
 
-  ret
-    = sql_int ("SELECT count(*) FROM results"
-               " WHERE results.nvt = '%s'"
-               "   AND (%d OR results.report = %llu)"
-               "   AND (%d OR results.task = %llu)"
-               "   AND (%d OR results.host = '%s')"
-               "   AND (results.severity != " G_STRINGIFY (SEVERITY_ERROR) ")"
-               "   AND (SELECT has_permission FROM permissions_get_tasks"
-               "         WHERE \"user\" = (SELECT id FROM users"
-               "                           WHERE uuid ="
-               "                             (SELECT uuid"
-               "                              FROM current_credentials))"
-               "           AND task = results.task)",
-               nvt_oid_quoted,
-               report_null,
-               report,
-               task_null,
-               task,
-               host == NULL,
-               host ? (char*)host : "");
+  ret = sql_int (
+    "SELECT count(*) FROM results"
+    " WHERE results.nvt = '%s'"
+    "   AND (%d OR results.report = %llu)"
+    "   AND (%d OR results.task = %llu)"
+    "   AND (%d OR results.host = '%s')"
+    "   AND (results.severity != " G_STRINGIFY (
+      SEVERITY_ERROR) ")"
+                      "   AND (SELECT has_permission FROM permissions_get_tasks"
+                      "         WHERE \"user\" = (SELECT id FROM users"
+                      "                           WHERE uuid ="
+                      "                             (SELECT uuid"
+                      "                              FROM current_credentials))"
+                      "           AND task = results.task)",
+    nvt_oid_quoted, report_null, report, task_null, task, host == NULL,
+    host ? (char *) host : "");
 
   g_free (nvt_oid_quoted);
   g_free (host_quoted);
@@ -2775,714 +2682,538 @@ sql_vuln_results (sqlite3_context *context, int argc,
 int
 manage_create_sql_functions ()
 {
-  if (sqlite3_create_function (gvmd_db,
-                               "t",
-                               0,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_t,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "t", 0,   /* Number of args. */
+                               SQLITE_UTF8, NULL, /* Callback data. */
+                               sql_t, NULL,       /* xStep. */
+                               NULL)              /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to t", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "strpos",
-                               2,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_strpos,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "strpos", 2, /* Number of args. */
+                               SQLITE_UTF8, NULL,    /* Callback data. */
+                               sql_strpos, NULL,     /* xStep. */
+                               NULL)                 /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create strpos", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "order_inet",
-                               1,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_order_inet,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "order_inet", 1, /* Number of args. */
+                               SQLITE_UTF8, NULL,        /* Callback data. */
+                               sql_order_inet, NULL,     /* xStep. */
+                               NULL)                     /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create order_inet", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "order_message_type",
-                               1,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_order_message_type,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "order_message_type",
+                               1,                 /* Number of args. */
+                               SQLITE_UTF8, NULL, /* Callback data. */
+                               sql_order_message_type, NULL, /* xStep. */
+                               NULL)                         /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create order_message_type", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "order_port",
-                               1,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_order_port,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "order_port", 1, /* Number of args. */
+                               SQLITE_UTF8, NULL,        /* Callback data. */
+                               sql_order_port, NULL,     /* xStep. */
+                               NULL)                     /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create order_port", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "order_role",
-                               1,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_order_role,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "order_role", 1, /* Number of args. */
+                               SQLITE_UTF8, NULL,        /* Callback data. */
+                               sql_order_role, NULL,     /* xStep. */
+                               NULL)                     /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create order_role", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "order_threat",
-                               1,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_order_threat,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "order_threat", 1, /* Number of args. */
+                               SQLITE_UTF8, NULL,          /* Callback data. */
+                               sql_order_threat, NULL,     /* xStep. */
+                               NULL)                       /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create order_threat", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "make_uuid",
-                               0,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_make_uuid,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "make_uuid", 0, /* Number of args. */
+                               SQLITE_UTF8, NULL,       /* Callback data. */
+                               sql_make_uuid, NULL,     /* xStep. */
+                               NULL)                    /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create make_uuid", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "hosts_contains",
-                               2,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_hosts_contains,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "hosts_contains",
+                               2,                        /* Number of args. */
+                               SQLITE_UTF8, NULL,        /* Callback data. */
+                               sql_hosts_contains, NULL, /* xStep. */
+                               NULL)                     /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create hosts_contains", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "clean_hosts",
-                               1,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_clean_hosts,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "clean_hosts", 1, /* Number of args. */
+                               SQLITE_UTF8, NULL,         /* Callback data. */
+                               sql_clean_hosts, NULL,     /* xStep. */
+                               NULL)                      /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create clean_hosts", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "iso_time",
-                               1,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_iso_time,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "iso_time", 1, /* Number of args. */
+                               SQLITE_UTF8, NULL,      /* Callback data. */
+                               sql_iso_time, NULL,     /* xStep. */
+                               NULL)                   /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create iso_time", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "days_from_now",
-                               1,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_days_from_now,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "days_from_now",
+                               1,                       /* Number of args. */
+                               SQLITE_UTF8, NULL,       /* Callback data. */
+                               sql_days_from_now, NULL, /* xStep. */
+                               NULL)                    /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create days_from_now", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "parse_time",
-                               1,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_parse_time,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "parse_time", 1, /* Number of args. */
+                               SQLITE_UTF8, NULL,        /* Callback data. */
+                               sql_parse_time, NULL,     /* xStep. */
+                               NULL)                     /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create parse_time", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "tag",
-                               2,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_tag,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "tag", 2, /* Number of args. */
+                               SQLITE_UTF8, NULL, /* Callback data. */
+                               sql_tag, NULL,     /* xStep. */
+                               NULL)              /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create tag", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "uniquify",
-                               4,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_uniquify,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "uniquify", 4, /* Number of args. */
+                               SQLITE_UTF8, NULL,      /* Callback data. */
+                               sql_uniquify, NULL,     /* xStep. */
+                               NULL)                   /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create uniquify", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "next_time",
-                               4,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_next_time,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "next_time", 4, /* Number of args. */
+                               SQLITE_UTF8, NULL,       /* Callback data. */
+                               sql_next_time, NULL,     /* xStep. */
+                               NULL)                    /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create next_time", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "next_time",
-                               5,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_next_time,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "next_time", 5, /* Number of args. */
+                               SQLITE_UTF8, NULL,       /* Callback data. */
+                               sql_next_time, NULL,     /* xStep. */
+                               NULL)                    /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create next_time", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "next_time",
-                               6,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_next_time,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "next_time", 6, /* Number of args. */
+                               SQLITE_UTF8, NULL,       /* Callback data. */
+                               sql_next_time, NULL,     /* xStep. */
+                               NULL)                    /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create next_time", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "next_time_ical",
-                               2,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_next_time_ical,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "next_time_ical",
+                               2,                        /* Number of args. */
+                               SQLITE_UTF8, NULL,        /* Callback data. */
+                               sql_next_time_ical, NULL, /* xStep. */
+                               NULL)                     /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create next_time_ical", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "next_time_ical",
-                               3,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_next_time_ical,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "next_time_ical",
+                               3,                        /* Number of args. */
+                               SQLITE_UTF8, NULL,        /* Callback data. */
+                               sql_next_time_ical, NULL, /* xStep. */
+                               NULL)                     /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create next_time_ical", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "m_now",
-                               0,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_now,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "m_now", 0, /* Number of args. */
+                               SQLITE_UTF8, NULL,   /* Callback data. */
+                               sql_now, NULL,       /* xStep. */
+                               NULL)                /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create m_now", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "max_hosts",
-                               2,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_max_hosts,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "max_hosts", 2, /* Number of args. */
+                               SQLITE_UTF8, NULL,       /* Callback data. */
+                               sql_max_hosts, NULL,     /* xStep. */
+                               NULL)                    /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create max_hosts", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "common_cve",
-                               2,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_common_cve,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "common_cve", 2, /* Number of args. */
+                               SQLITE_UTF8, NULL,        /* Callback data. */
+                               sql_common_cve, NULL,     /* xStep. */
+                               NULL)                     /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create common_cve", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "cpe_title",
-                               1,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_cpe_title,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "cpe_title", 1, /* Number of args. */
+                               SQLITE_UTF8, NULL,       /* Callback data. */
+                               sql_cpe_title, NULL,     /* xStep. */
+                               NULL)                    /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create cpe_title", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "credential_value",
-                               3,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_credential_value,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "credential_value",
+                               3,                          /* Number of args. */
+                               SQLITE_UTF8, NULL,          /* Callback data. */
+                               sql_credential_value, NULL, /* xStep. */
+                               NULL)                       /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create credential_value", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "current_offset",
-                               1,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_current_offset,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "current_offset",
+                               1,                        /* Number of args. */
+                               SQLITE_UTF8, NULL,        /* Callback data. */
+                               sql_current_offset, NULL, /* xStep. */
+                               NULL)                     /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create current_offset", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "task_trend",
-                               3,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_task_trend,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "task_trend", 3, /* Number of args. */
+                               SQLITE_UTF8, NULL,        /* Callback data. */
+                               sql_task_trend, NULL,     /* xStep. */
+                               NULL)                     /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create task_trend", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "task_threat_level",
-                               3,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_task_threat_level,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "task_threat_level",
+                               3,                 /* Number of args. */
+                               SQLITE_UTF8, NULL, /* Callback data. */
+                               sql_task_threat_level, NULL, /* xStep. */
+                               NULL)                        /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create task_threat_level", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "report_progress",
-                               1,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_report_progress,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "report_progress",
+                               1,                         /* Number of args. */
+                               SQLITE_UTF8, NULL,         /* Callback data. */
+                               sql_report_progress, NULL, /* xStep. */
+                               NULL)                      /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create report_progress", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "report_severity",
-                               3,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_report_severity,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "report_severity",
+                               3,                         /* Number of args. */
+                               SQLITE_UTF8, NULL,         /* Callback data. */
+                               sql_report_severity, NULL, /* xStep. */
+                               NULL)                      /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create report_severity", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "report_severity_count",
-                               4,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_report_severity_count,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "report_severity_count",
+                               4,                 /* Number of args. */
+                               SQLITE_UTF8, NULL, /* Callback data. */
+                               sql_report_severity_count, NULL, /* xStep. */
+                               NULL)                            /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create report_severity_count", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "report_host_count",
-                               1,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_report_host_count,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "report_host_count",
+                               1,                 /* Number of args. */
+                               SQLITE_UTF8, NULL, /* Callback data. */
+                               sql_report_host_count, NULL, /* xStep. */
+                               NULL)                        /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create report_result_host_count", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "report_result_host_count",
-                               2,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_report_result_host_count,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "report_result_host_count",
+                               2,                 /* Number of args. */
+                               SQLITE_UTF8, NULL, /* Callback data. */
+                               sql_report_result_host_count, NULL, /* xStep. */
+                               NULL)                               /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create report_result_host_count", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "task_severity",
-                               3,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_task_severity,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "task_severity",
+                               3,                       /* Number of args. */
+                               SQLITE_UTF8, NULL,       /* Callback data. */
+                               sql_task_severity, NULL, /* xStep. */
+                               NULL)                    /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create task_severity", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "task_last_report",
-                               1,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_task_last_report,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "task_last_report",
+                               1,                          /* Number of args. */
+                               SQLITE_UTF8, NULL,          /* Callback data. */
+                               sql_task_last_report, NULL, /* xStep. */
+                               NULL)                       /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create task_last_report", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "severity_matches_ov",
-                               2,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_severity_matches_ov,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "severity_matches_ov",
+                               2,                 /* Number of args. */
+                               SQLITE_UTF8, NULL, /* Callback data. */
+                               sql_severity_matches_ov, NULL, /* xStep. */
+                               NULL)                          /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create severity_matches_ov", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "severity_to_level",
-                               1,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_severity_to_level,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "severity_to_level",
+                               1,                 /* Number of args. */
+                               SQLITE_UTF8, NULL, /* Callback data. */
+                               sql_severity_to_level, NULL, /* xStep. */
+                               NULL)                        /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create severity_to_level", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "severity_to_level",
-                               2,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_severity_to_level,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "severity_to_level",
+                               2,                 /* Number of args. */
+                               SQLITE_UTF8, NULL, /* Callback data. */
+                               sql_severity_to_level, NULL, /* xStep. */
+                               NULL)                        /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create severity_to_level", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "severity_to_type",
-                               1,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_severity_to_type,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "severity_to_type",
+                               1,                          /* Number of args. */
+                               SQLITE_UTF8, NULL,          /* Callback data. */
+                               sql_severity_to_type, NULL, /* xStep. */
+                               NULL)                       /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create severity_to_type", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "run_status_name",
-                               1,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_run_status_name,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "run_status_name",
+                               1,                         /* Number of args. */
+                               SQLITE_UTF8, NULL,         /* Callback data. */
+                               sql_run_status_name, NULL, /* xStep. */
+                               NULL)                      /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create run_status_name", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "resource_exists",
-                               3,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_resource_exists,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "resource_exists",
+                               3,                         /* Number of args. */
+                               SQLITE_UTF8, NULL,         /* Callback data. */
+                               sql_resource_exists, NULL, /* xStep. */
+                               NULL)                      /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create resource_exists", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "regexp",
-                               2,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_regexp,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "regexp", 2, /* Number of args. */
+                               SQLITE_UTF8, NULL,    /* Callback data. */
+                               sql_regexp, NULL,     /* xStep. */
+                               NULL)                 /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create regexp", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "resource_name",
-                               3,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_resource_name,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "resource_name",
+                               3,                       /* Number of args. */
+                               SQLITE_UTF8, NULL,       /* Callback data. */
+                               sql_resource_name, NULL, /* xStep. */
+                               NULL)                    /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create resource_name", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "severity_in_level",
-                               2,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_severity_in_level,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "severity_in_level",
+                               2,                 /* Number of args. */
+                               SQLITE_UTF8, NULL, /* Callback data. */
+                               sql_severity_in_level, NULL, /* xStep. */
+                               NULL)                        /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create severity_in_level", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "target_credential",
-                               3,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_target_credential,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "target_credential",
+                               3,                 /* Number of args. */
+                               SQLITE_UTF8, NULL, /* Callback data. */
+                               sql_target_credential, NULL, /* xStep. */
+                               NULL)                        /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create target_login_data", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "trash_target_credential_location",
-                               2,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_trash_target_credential_location,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (
+        gvmd_db, "trash_target_credential_location", 2, /* Number of args. */
+        SQLITE_UTF8, NULL,                              /* Callback data. */
+        sql_trash_target_credential_location, NULL,     /* xStep. */
+        NULL)                                           /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create target_login_data", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "target_login_port",
-                               3,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_target_login_port,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "target_login_port",
+                               3,                 /* Number of args. */
+                               SQLITE_UTF8, NULL, /* Callback data. */
+                               sql_target_login_port, NULL, /* xStep. */
+                               NULL)                        /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create target_login_data", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "user_can_everything",
-                               1,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_user_can_everything,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "user_can_everything",
+                               1,                 /* Number of args. */
+                               SQLITE_UTF8, NULL, /* Callback data. */
+                               sql_user_can_everything, NULL, /* xStep. */
+                               NULL)                          /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create user_can_everything", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "user_has_access_uuid",
-                               4,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_user_has_access_uuid,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "user_has_access_uuid",
+                               4,                 /* Number of args. */
+                               SQLITE_UTF8, NULL, /* Callback data. */
+                               sql_user_has_access_uuid, NULL, /* xStep. */
+                               NULL)                           /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create user_has_access_uuid", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "user_owns",
-                               2,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_user_owns,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "user_owns", 2, /* Number of args. */
+                               SQLITE_UTF8, NULL,       /* Callback data. */
+                               sql_user_owns, NULL,     /* xStep. */
+                               NULL)                    /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create user_owns", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "vuln_results",
-                               4,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_vuln_results,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "vuln_results", 4, /* Number of args. */
+                               SQLITE_UTF8, NULL,          /* Callback data. */
+                               sql_vuln_results, NULL,     /* xStep. */
+                               NULL)                       /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create user_has_access_uuid", __FUNCTION__);
@@ -3492,7 +3223,6 @@ manage_create_sql_functions ()
   return 0;
 }
 
-
 /* Creation. */
 
 /**
@@ -3609,10 +3339,11 @@ create_tables ()
   sql ("CREATE TABLE IF NOT EXISTS hosts"
        " (id INTEGER PRIMARY KEY, uuid UNIQUE, owner INTEGER, name, comment,"
        "  creation_time, modification_time);");
-  sql ("CREATE TABLE IF NOT EXISTS host_identifiers"
-       " (id INTEGER PRIMARY KEY, uuid UNIQUE, host INTEGER, owner INTEGER, name,"
-       "  comment, value, source_type, source_id, source_data, creation_time,"
-       "  modification_time);");
+  sql (
+    "CREATE TABLE IF NOT EXISTS host_identifiers"
+    " (id INTEGER PRIMARY KEY, uuid UNIQUE, host INTEGER, owner INTEGER, name,"
+    "  comment, value, source_type, source_id, source_data, creation_time,"
+    "  modification_time);");
   sql ("CREATE INDEX IF NOT EXISTS host_identifiers_by_host"
        " ON host_identifiers (host);");
   sql ("CREATE INDEX IF NOT EXISTS host_identifiers_by_value"
@@ -3725,9 +3456,10 @@ create_tables ()
   sql ("CREATE TABLE IF NOT EXISTS port_ranges_trash"
        " (id INTEGER PRIMARY KEY, uuid UNIQUE, port_list INTEGER, type, start,"
        "  end, comment, exclude);");
-  sql ("CREATE TABLE IF NOT EXISTS report_host_details"
-       " (id INTEGER PRIMARY KEY, report_host INTEGER, source_type, source_name,"
-       "  source_description, name, value);");
+  sql (
+    "CREATE TABLE IF NOT EXISTS report_host_details"
+    " (id INTEGER PRIMARY KEY, report_host INTEGER, source_type, source_name,"
+    "  source_description, name, value);");
   sql ("CREATE INDEX IF NOT EXISTS"
        " report_host_details_by_report_host_and_name_and_value"
        " ON report_host_details (report_host, name, value);");
@@ -3943,121 +3675,163 @@ create_tables ()
   g_free (owned_clause);
 
   sql ("DROP VIEW IF EXISTS result_new_severities;");
-  sql ("CREATE VIEW result_new_severities AS"
-       "  SELECT results.id as result, users.id as user, dynamic, override,"
-       "    CASE WHEN dynamic THEN"
-       "      CASE WHEN override THEN"
-       "        coalesce ((SELECT ov_new_severity FROM result_overrides"
-       "                   WHERE result = results.id"
-       "                     AND result_overrides.user = users.id"
-       "                     AND severity_matches_ov"
-       "                           (coalesce ((CASE WHEN results.severity"
-       "                                                 > " G_STRINGIFY
-                                                              (SEVERITY_LOG)
-       "                                       THEN (SELECT cvss_base"
-       "                                             FROM nvts"
-       "                                             WHERE nvts.oid = results.nvt)"
-       "                                       ELSE results.severity"
-       "                                       END),"
-       "                                      results.severity),"
-       "                            ov_old_severity)),"
-       "                  coalesce ((CASE WHEN results.severity"
-       "                                       > " G_STRINGIFY (SEVERITY_LOG)
-       "                             THEN (SELECT cvss_base"
-       "                                   FROM nvts"
-       "                                   WHERE nvts.oid = results.nvt)"
-       "                             ELSE results.severity"
-       "                             END),"
-       "                            results.severity))"
-       "      ELSE"
-       "        coalesce ((CASE WHEN results.severity"
-       "                             > " G_STRINGIFY (SEVERITY_LOG)
-       "                   THEN (SELECT cvss_base"
-       "                         FROM nvts"
-       "                         WHERE nvts.oid = results.nvt)"
-       "                   ELSE results.severity"
-       "                   END),"
-       "                  results.severity)"
-       "      END"
-       "    ELSE"
-       "      CASE WHEN override THEN"
-       "        coalesce ((SELECT ov_new_severity FROM result_overrides"
-       "                   WHERE result = results.id"
-       "                     AND result_overrides.user = users.id"
-       "                     AND severity_matches_ov"
-       "                           (results.severity,"
-       "                            ov_old_severity)),"
-       "                   results.severity)"
-       "      ELSE"
-       "        results.severity"
-       "      END"
-       "    END AS new_severity"
-       "  FROM results, users"
-       "  JOIN (SELECT 0 AS override UNION SELECT 1 AS override_opts)"
-       "  JOIN (SELECT 0 AS dynamic UNION SELECT 1 AS dynamic_opts);");
+  sql (
+    "CREATE VIEW result_new_severities AS"
+    "  SELECT results.id as result, users.id as user, dynamic, override,"
+    "    CASE WHEN dynamic THEN"
+    "      CASE WHEN override THEN"
+    "        coalesce ((SELECT ov_new_severity FROM result_overrides"
+    "                   WHERE result = results.id"
+    "                     AND result_overrides.user = users.id"
+    "                     AND severity_matches_ov"
+    "                           (coalesce ((CASE WHEN results.severity"
+    "                                                 > " G_STRINGIFY (
+      SEVERITY_LOG) "                                       THEN (SELECT "
+                    "cvss_base"
+                    "                                             FROM nvts"
+                    "                                             WHERE "
+                    "nvts.oid = results.nvt)"
+                    "                                       ELSE "
+                    "results.severity"
+                    "                                       END),"
+                    "                                      results.severity),"
+                    "                            ov_old_severity)),"
+                    "                  coalesce ((CASE WHEN results.severity"
+                    "                                       > " G_STRINGIFY (
+                      SEVERITY_LOG) "                             THEN (SELECT "
+                                    "cvss_base"
+                                    "                                   FROM "
+                                    "nvts"
+                                    "                                   WHERE "
+                                    "nvts.oid = results.nvt)"
+                                    "                             ELSE "
+                                    "results.severity"
+                                    "                             END),"
+                                    "                            "
+                                    "results.severity))"
+                                    "      ELSE"
+                                    "        coalesce ((CASE WHEN "
+                                    "results.severity"
+                                    "                             "
+                                    "> " G_STRINGIFY (
+                                      SEVERITY_LOG) "                   THEN "
+                                                    "(SELECT cvss_base"
+                                                    "                         "
+                                                    "FROM nvts"
+                                                    "                         "
+                                                    "WHERE nvts.oid = "
+                                                    "results.nvt)"
+                                                    "                   ELSE "
+                                                    "results.severity"
+                                                    "                   END),"
+                                                    "                  "
+                                                    "results.severity)"
+                                                    "      END"
+                                                    "    ELSE"
+                                                    "      CASE WHEN override "
+                                                    "THEN"
+                                                    "        coalesce ((SELECT "
+                                                    "ov_new_severity FROM "
+                                                    "result_overrides"
+                                                    "                   WHERE "
+                                                    "result = results.id"
+                                                    "                     AND "
+                                                    "result_overrides.user = "
+                                                    "users.id"
+                                                    "                     AND "
+                                                    "severity_matches_ov"
+                                                    "                          "
+                                                    " (results.severity,"
+                                                    "                          "
+                                                    "  ov_old_severity)),"
+                                                    "                   "
+                                                    "results.severity)"
+                                                    "      ELSE"
+                                                    "        results.severity"
+                                                    "      END"
+                                                    "    END AS new_severity"
+                                                    "  FROM results, users"
+                                                    "  JOIN (SELECT 0 AS "
+                                                    "override UNION SELECT 1 "
+                                                    "AS override_opts)"
+                                                    "  JOIN (SELECT 0 AS "
+                                                    "dynamic UNION SELECT 1 AS "
+                                                    "dynamic_opts);");
 
   sql ("DROP VIEW IF EXISTS results_autofp;");
-  sql ("CREATE VIEW results_autofp AS"
-       " SELECT results.id as result, autofp_selection,"
-       "        (CASE autofp_selection"
-       "         WHEN 1 THEN"
-       "          (CASE WHEN"
-       "           (((SELECT family FROM nvts WHERE oid = results.nvt)"
-       "              IN (" LSC_FAMILY_LIST "))"
-       "            OR results.nvt = '0'" /* Open ports previously had 0 NVT. */
-       "            OR EXISTS"
-       "              (SELECT id FROM nvts"
-       "               WHERE oid = results.nvt"
-       "               AND"
-       "               (cve = 'NOCVE'"
-       "                 OR cve NOT IN (SELECT cve FROM nvts"
-       "                                WHERE oid IN (SELECT source_name"
-       "                                    FROM report_host_details"
-       "                                    WHERE report_host"
-       "                                    = (SELECT id"
-       "                                       FROM report_hosts"
-       "                                       WHERE report = %llu"
-       "                                       AND host = results.host)"
-       "                                    AND name = 'EXIT_CODE'"
-       "                                    AND value = 'EXIT_NOTVULN')"
-       "                                AND family IN (" LSC_FAMILY_LIST ")))))"
-       "           THEN NULL"
-       "           WHEN severity = " G_STRINGIFY (SEVERITY_ERROR) " THEN NULL"
-       "           ELSE 1 END)"
-       "         WHEN 2 THEN"
-       "          (CASE WHEN"
-       "            (((SELECT family FROM nvts WHERE oid = results.nvt)"
-       "              IN (" LSC_FAMILY_LIST "))"
-       "             OR results.nvt = '0'" /* Open ports previously had 0 NVT.*/
-       "             OR EXISTS"
-       "             (SELECT id FROM nvts AS outer_nvts"
-       "              WHERE oid = results.nvt"
-       "              AND"
-       "              (cve = 'NOCVE'"
-       "               OR NOT EXISTS"
-       "                  (SELECT cve FROM nvts"
-       "                   WHERE oid IN (SELECT source_name"
-       "                                 FROM report_host_details"
-       "                                 WHERE report_host"
-       "                                 = (SELECT id"
-       "                                    FROM report_hosts"
-       "                                    WHERE report = results.report"
-       "                                    AND host = results.host)"
-       "                                 AND name = 'EXIT_CODE'"
-       "                                 AND value = 'EXIT_NOTVULN')"
-       "                   AND family IN (" LSC_FAMILY_LIST ")"
-       /* The CVE of the result NVT is outer_nvts.cve.  The CVE of the
-        * NVT that has registered the "closed" host detail is nvts.cve.
-        * Either can be a list of CVEs. */
-       "                   AND common_cve (nvts.cve, outer_nvts.cve)))))"
-       "           THEN NULL"
-       "           WHEN severity = " G_STRINGIFY (SEVERITY_ERROR) " THEN NULL"
-       "           ELSE 1 END)"
-       "         ELSE 0 END) AS autofp"
-       " FROM results,"
-       "  (SELECT 0 AS autofp_selection"
-       "   UNION SELECT 1 AS autofp_selection"
-       "   UNION SELECT 2 AS autofp_selection) AS autofp_opts;");
+  sql (
+    "CREATE VIEW results_autofp AS"
+    " SELECT results.id as result, autofp_selection,"
+    "        (CASE autofp_selection"
+    "         WHEN 1 THEN"
+    "          (CASE WHEN"
+    "           (((SELECT family FROM nvts WHERE oid = results.nvt)"
+    "              IN (" LSC_FAMILY_LIST "))"
+    "            OR results.nvt = '0'" /* Open ports previously had 0 NVT. */
+    "            OR EXISTS"
+    "              (SELECT id FROM nvts"
+    "               WHERE oid = results.nvt"
+    "               AND"
+    "               (cve = 'NOCVE'"
+    "                 OR cve NOT IN (SELECT cve FROM nvts"
+    "                                WHERE oid IN (SELECT source_name"
+    "                                    FROM report_host_details"
+    "                                    WHERE report_host"
+    "                                    = (SELECT id"
+    "                                       FROM report_hosts"
+    "                                       WHERE report = %llu"
+    "                                       AND host = results.host)"
+    "                                    AND name = 'EXIT_CODE'"
+    "                                    AND value = 'EXIT_NOTVULN')"
+    "                                AND family IN (" LSC_FAMILY_LIST ")))))"
+    "           THEN NULL"
+    "           WHEN severity = " G_STRINGIFY (
+      SEVERITY_ERROR) " THEN NULL"
+                      "           ELSE 1 END)"
+                      "         WHEN 2 THEN"
+                      "          (CASE WHEN"
+                      "            (((SELECT family FROM nvts WHERE oid = "
+                      "results.nvt)"
+                      "              IN (" LSC_FAMILY_LIST "))"
+                      "             OR results.nvt = '0'" /* Open ports
+                                                             previously had 0
+                                                             NVT.*/
+                      "             OR EXISTS"
+                      "             (SELECT id FROM nvts AS outer_nvts"
+                      "              WHERE oid = results.nvt"
+                      "              AND"
+                      "              (cve = 'NOCVE'"
+                      "               OR NOT EXISTS"
+                      "                  (SELECT cve FROM nvts"
+                      "                   WHERE oid IN (SELECT source_name"
+                      "                                 FROM "
+                      "report_host_details"
+                      "                                 WHERE report_host"
+                      "                                 = (SELECT id"
+                      "                                    FROM report_hosts"
+                      "                                    WHERE report = "
+                      "results.report"
+                      "                                    AND host = "
+                      "results.host)"
+                      "                                 AND name = 'EXIT_CODE'"
+                      "                                 AND value = "
+                      "'EXIT_NOTVULN')"
+                      "                   AND family IN (" LSC_FAMILY_LIST ")"
+                      /* The CVE of the result NVT is outer_nvts.cve.  The CVE
+                       * of the NVT that has registered the "closed" host detail
+                       * is nvts.cve. Either can be a list of CVEs. */
+                      "                   AND common_cve (nvts.cve, "
+                      "outer_nvts.cve)))))"
+                      "           THEN NULL"
+                      "           WHEN severity = " G_STRINGIFY (
+                        SEVERITY_ERROR) " THEN NULL"
+                                        "           ELSE 1 END)"
+                                        "         ELSE 0 END) AS autofp"
+                                        " FROM results,"
+                                        "  (SELECT 0 AS autofp_selection"
+                                        "   UNION SELECT 1 AS autofp_selection"
+                                        "   UNION SELECT 2 AS "
+                                        "autofp_selection) AS autofp_opts;");
 
   /* Vulnerabilities view is created in manage_session_init because
      it must be temporary to allow using the attached SCAP database */
@@ -4072,7 +3846,6 @@ check_db_sequences ()
   // Do nothing because this is only relevant for PostgreSQL.
 }
 
-
 /* SecInfo. */
 
 /**
@@ -4086,13 +3859,12 @@ manage_attach_databases ()
   if (access (SCAP_DB_FILE, R_OK))
     switch (errno)
       {
-        case ENOENT:
-          break;
-        default:
-          g_warning ("%s: failed to stat SCAP database: %s",
-                     __FUNCTION__,
-                     strerror (errno));
-          break;
+      case ENOENT:
+        break;
+      default:
+        g_warning ("%s: failed to stat SCAP database: %s", __FUNCTION__,
+                   strerror (errno));
+        break;
       }
   else
     sql_error ("ATTACH DATABASE '" SCAP_DB_FILE "'"
@@ -4103,13 +3875,12 @@ manage_attach_databases ()
   if (access (CERT_DB_FILE, R_OK))
     switch (errno)
       {
-        case ENOENT:
-          break;
-        default:
-          g_warning ("%s: failed to stat CERT database: %s",
-                     __FUNCTION__,
-                     strerror (errno));
-          break;
+      case ENOENT:
+        break;
+      default:
+        g_warning ("%s: failed to stat CERT database: %s", __FUNCTION__,
+                   strerror (errno));
+        break;
       }
   else
     sql_error ("ATTACH DATABASE '" CERT_DB_FILE "'"
@@ -4146,11 +3917,9 @@ manage_db_init (const gchar *name)
 {
   if (strcasecmp (name, "cert") == 0)
     {
-      if (access (CERT_DB_FILE, R_OK)
-          && errno != ENOENT)
+      if (access (CERT_DB_FILE, R_OK) && errno != ENOENT)
         {
-          g_warning ("%s: failed to stat CERT database: %s",
-                     __FUNCTION__,
+          g_warning ("%s: failed to stat CERT database: %s", __FUNCTION__,
                      strerror (errno));
           return -1;
         }
@@ -4158,12 +3927,10 @@ manage_db_init (const gchar *name)
         {
           /* Ensure the parent directory exists. */
 
-          if (g_mkdir_with_parents (CERT_DB_DIR, 0755 /* "rwxr-xr-x" */)
-              == -1)
+          if (g_mkdir_with_parents (CERT_DB_DIR, 0755 /* "rwxr-xr-x" */) == -1)
             {
               g_warning ("%s: failed to create CERT directory: %s",
-                         __FUNCTION__,
-                         strerror (errno));
+                         __FUNCTION__, strerror (errno));
               abort ();
             }
 
@@ -4255,11 +4022,9 @@ manage_db_init (const gchar *name)
     }
   else if (strcasecmp (name, "scap") == 0)
     {
-      if (access (SCAP_DB_FILE, R_OK)
-          && errno != ENOENT)
+      if (access (SCAP_DB_FILE, R_OK) && errno != ENOENT)
         {
-          g_warning ("%s: failed to stat SCAP database: %s",
-                     __FUNCTION__,
+          g_warning ("%s: failed to stat SCAP database: %s", __FUNCTION__,
                      strerror (errno));
           return -1;
         }
@@ -4267,12 +4032,10 @@ manage_db_init (const gchar *name)
         {
           /* Ensure the parent directory exists. */
 
-          if (g_mkdir_with_parents (SCAP_DB_DIR, 0755 /* "rwxr-xr-x" */)
-              == -1)
+          if (g_mkdir_with_parents (SCAP_DB_DIR, 0755 /* "rwxr-xr-x" */) == -1)
             {
               g_warning ("%s: failed to create SCAP directory: %s",
-                         __FUNCTION__,
-                         strerror (errno));
+                         __FUNCTION__, strerror (errno));
               abort ();
             }
 
@@ -4359,13 +4122,13 @@ manage_db_init (const gchar *name)
       sql ("CREATE TABLE scap.ovaldefs"
            " (id INTEGER PRIMARY KEY AUTOINCREMENT,"
            "  uuid UNIQUE,"
-           "  name,"                        /* OVAL identifier. */
+           "  name," /* OVAL identifier. */
            "  comment,"
            "  creation_time DATE,"
            "  modification_time DATE,"
            "  version INTEGER,"
            "  deprecated BOOLEAN,"
-           "  def_class TEXT,"              /* enum */
+           "  def_class TEXT," /* enum */
            "  title TEXT,"
            "  description TEXT,"
            "  xml_file TEXT,"
@@ -4469,8 +4232,7 @@ manage_db_check (const gchar *name)
           if (errno == ENOENT)
             return 0;
 
-          g_warning ("%s: failed to stat CERT database: %s",
-                     __FUNCTION__,
+          g_warning ("%s: failed to stat CERT database: %s", __FUNCTION__,
                      strerror (errno));
           return -1;
         }
@@ -4492,8 +4254,7 @@ manage_db_check (const gchar *name)
           if (errno == ENOENT)
             return 0;
 
-          g_warning ("%s: failed to stat SCAP database: %s",
-                     __FUNCTION__,
+          g_warning ("%s: failed to stat SCAP database: %s", __FUNCTION__,
                      strerror (errno));
           return -1;
         }
@@ -4524,14 +4285,13 @@ manage_cert_loaded ()
   if (access (CERT_DB_FILE, R_OK))
     switch (errno)
       {
-        case ENOENT:
-          return 0;
-          break;
-        default:
-          g_warning ("%s: failed to stat CERT database: %s",
-                     __FUNCTION__,
-                     strerror (errno));
-          return 0;
+      case ENOENT:
+        return 0;
+        break;
+      default:
+        g_warning ("%s: failed to stat CERT database: %s", __FUNCTION__,
+                   strerror (errno));
+        return 0;
       }
 
   if (sql_error ("SELECT count(*) FROM cert.sqlite_master"
@@ -4560,14 +4320,13 @@ manage_scap_loaded ()
   if (access (SCAP_DB_FILE, R_OK))
     switch (errno)
       {
-        case ENOENT:
-          return 0;
-          break;
-        default:
-          g_warning ("%s: failed to stat SCAP database: %s",
-                     __FUNCTION__,
-                     strerror (errno));
-          return 0;
+      case ENOENT:
+        return 0;
+        break;
+      default:
+        g_warning ("%s: failed to stat SCAP database: %s", __FUNCTION__,
+                   strerror (errno));
+        return 0;
       }
 
   if (sql_error ("SELECT count(*) FROM scap.sqlite_master"
@@ -4591,14 +4350,13 @@ manage_cert_db_exists ()
   if (access (CERT_DB_FILE, R_OK))
     switch (errno)
       {
-        case ENOENT:
-          return 0;
-          break;
-        default:
-          g_warning ("%s: failed to stat CERT database: %s",
-                     __FUNCTION__,
-                     strerror (errno));
-          return 1;
+      case ENOENT:
+        return 0;
+        break;
+      default:
+        g_warning ("%s: failed to stat CERT database: %s", __FUNCTION__,
+                   strerror (errno));
+        return 1;
       }
   return 1;
 }
@@ -4614,14 +4372,13 @@ manage_scap_db_exists ()
   if (access (SCAP_DB_FILE, R_OK))
     switch (errno)
       {
-        case ENOENT:
-          return 0;
-          break;
-        default:
-          g_warning ("%s: failed to stat SCAP database: %s",
-                     __FUNCTION__,
-                     strerror (errno));
-          return 1;
+      case ENOENT:
+        return 0;
+        break;
+      default:
+        g_warning ("%s: failed to stat SCAP database: %s", __FUNCTION__,
+                   strerror (errno));
+        return 1;
       }
   return 1;
 }
@@ -4634,28 +4391,22 @@ manage_scap_db_exists ()
 int
 manage_update_cert_db_init ()
 {
-  if (sqlite3_create_function (gvmd_db,
-                               "merge_dfn_cert_adv",
-                               6,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_merge_dfn_cert_adv,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "merge_dfn_cert_adv",
+                               6,                 /* Number of args. */
+                               SQLITE_UTF8, NULL, /* Callback data. */
+                               sql_merge_dfn_cert_adv, NULL, /* xStep. */
+                               NULL)                         /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create merge_dfn_cert_adv", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "merge_bund_adv",
-                               6,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_merge_bund_adv,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "merge_bund_adv",
+                               6,                        /* Number of args. */
+                               SQLITE_UTF8, NULL,        /* Callback data. */
+                               sql_merge_bund_adv, NULL, /* xStep. */
+                               NULL)                     /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create merge_bund_adv", __FUNCTION__);
@@ -4673,25 +4424,19 @@ manage_update_cert_db_init ()
 void
 manage_update_cert_db_cleanup ()
 {
-  if (sqlite3_create_function (gvmd_db,
-                               "merge_dfn_cert_adv",
-                               6,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               NULL,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "merge_dfn_cert_adv",
+                               6,                 /* Number of args. */
+                               SQLITE_UTF8, NULL, /* Callback data. */
+                               NULL, NULL,        /* xStep. */
+                               NULL)              /* xFinal. */
       != SQLITE_OK)
     g_warning ("%s: failed to remove merge_dfn_cert_adv", __FUNCTION__);
 
-  if (sqlite3_create_function (gvmd_db,
-                               "merge_bund_adv",
-                               6,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               NULL,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "merge_bund_adv",
+                               6,                 /* Number of args. */
+                               SQLITE_UTF8, NULL, /* Callback data. */
+                               NULL, NULL,        /* xStep. */
+                               NULL)              /* xFinal. */
       != SQLITE_OK)
     g_warning ("%s: failed to remove merge_bund_adv", __FUNCTION__);
 }
@@ -4704,70 +4449,53 @@ manage_update_cert_db_cleanup ()
 int
 manage_update_scap_db_init ()
 {
-  if (sqlite3_create_function (gvmd_db,
-                               "merge_cpe",
-                               7,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_merge_cpe,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "merge_cpe", 7, /* Number of args. */
+                               SQLITE_UTF8, NULL,       /* Callback data. */
+                               sql_merge_cpe, NULL,     /* xStep. */
+                               NULL)                    /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create merge_cpe", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "merge_cve",
-                               13,              /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_merge_cve,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "merge_cve", 13, /* Number of args. */
+                               SQLITE_UTF8, NULL,        /* Callback data. */
+                               sql_merge_cve, NULL,      /* xStep. */
+                               NULL)                     /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create merge_cpe", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "merge_cpe_name",
-                               4,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_merge_cpe_name,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "merge_cpe_name",
+                               4,                        /* Number of args. */
+                               SQLITE_UTF8, NULL,        /* Callback data. */
+                               sql_merge_cpe_name, NULL, /* xStep. */
+                               NULL)                     /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create merge_cpe_name", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "merge_affected_product",
-                               2,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_merge_affected_product,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "merge_affected_product",
+                               2,                 /* Number of args. */
+                               SQLITE_UTF8, NULL, /* Callback data. */
+                               sql_merge_affected_product, NULL, /* xStep. */
+                               NULL)                             /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create merge_affected_product", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db,
-                               "merge_ovaldef",
-                               13,              /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               sql_merge_ovaldef,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "merge_ovaldef",
+                               13,                      /* Number of args. */
+                               SQLITE_UTF8, NULL,       /* Callback data. */
+                               sql_merge_ovaldef, NULL, /* xStep. */
+                               NULL)                    /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create merge_ovaldef", __FUNCTION__);
@@ -4785,63 +4513,45 @@ manage_update_scap_db_init ()
 void
 manage_update_scap_db_cleanup ()
 {
-  if (sqlite3_create_function (gvmd_db,
-                               "merge_cpe",
-                               8,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               NULL,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "merge_cpe", 8, /* Number of args. */
+                               SQLITE_UTF8, NULL,       /* Callback data. */
+                               NULL, NULL,              /* xStep. */
+                               NULL)                    /* xFinal. */
       != SQLITE_OK)
     g_warning ("%s: failed to remove merge_cpe", __FUNCTION__);
 
-  if (sqlite3_create_function (gvmd_db,
-                               "merge_cve",
-                               13,              /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               NULL,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "merge_cve", 13, /* Number of args. */
+                               SQLITE_UTF8, NULL,        /* Callback data. */
+                               NULL, NULL,               /* xStep. */
+                               NULL)                     /* xFinal. */
       != SQLITE_OK)
     g_warning ("%s: failed to remove merge_cve", __FUNCTION__);
 
-  if (sqlite3_create_function (gvmd_db,
-                               "merge_cpe_name",
-                               4,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               NULL,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "merge_cpe_name",
+                               4,                 /* Number of args. */
+                               SQLITE_UTF8, NULL, /* Callback data. */
+                               NULL, NULL,        /* xStep. */
+                               NULL)              /* xFinal. */
       != SQLITE_OK)
     g_warning ("%s: failed to remove merge_cpe_name", __FUNCTION__);
 
-  if (sqlite3_create_function (gvmd_db,
-                               "merge_affected_product",
-                               2,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               NULL,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "merge_affected_product",
+                               2,                 /* Number of args. */
+                               SQLITE_UTF8, NULL, /* Callback data. */
+                               NULL, NULL,        /* xStep. */
+                               NULL)              /* xFinal. */
       != SQLITE_OK)
     g_warning ("%s: failed to remove merge_affected_product", __FUNCTION__);
 
-  if (sqlite3_create_function (gvmd_db,
-                               "merge_ovaldef",
-                               14,              /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               NULL,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "merge_ovaldef",
+                               14,                /* Number of args. */
+                               SQLITE_UTF8, NULL, /* Callback data. */
+                               NULL, NULL,        /* xStep. */
+                               NULL)              /* xFinal. */
       != SQLITE_OK)
     g_warning ("%s: failed to remove merge_ovaldef", __FUNCTION__);
 }
 
-
 /* Backup. */
 
 /**
@@ -4864,8 +4574,7 @@ backup_db (const gchar *database, gchar **backup_file_arg)
 
   if (sqlite3_open (backup_file, &backup_db) != SQLITE_OK)
     {
-      g_warning ("%s: sqlite3_open failed: %s",
-                 __FUNCTION__,
+      g_warning ("%s: sqlite3_open failed: %s", __FUNCTION__,
                  sqlite3_errmsg (gvmd_db));
       goto fail;
     }
@@ -4879,8 +4588,7 @@ backup_db (const gchar *database, gchar **backup_file_arg)
   backup = sqlite3_backup_init (backup_db, "main", gvmd_db, "main");
   if (backup == NULL)
     {
-      g_warning ("%s: sqlite3_backup_init failed: %s",
-                 __FUNCTION__,
+      g_warning ("%s: sqlite3_backup_init failed: %s", __FUNCTION__,
                  sqlite3_errmsg (backup_db));
       goto fail;
     }
@@ -4899,8 +4607,7 @@ backup_db (const gchar *database, gchar **backup_file_arg)
           sqlite3_sleep (250);
           continue;
         }
-      g_warning ("%s: sqlite3_backup_step failed: %s",
-                 __FUNCTION__,
+      g_warning ("%s: sqlite3_backup_step failed: %s", __FUNCTION__,
                  sqlite3_errmsg (backup_db));
       sqlite3_backup_finish (backup);
       goto fail;
@@ -4914,7 +4621,7 @@ backup_db (const gchar *database, gchar **backup_file_arg)
     g_free (backup_file);
   return 0;
 
- fail:
+fail:
   sqlite3_close (backup_db);
   g_free (backup_file);
   return -1;
@@ -4942,7 +4649,6 @@ manage_backup_db (const gchar *database)
   return ret;
 }
 
-
 /* Migrator helper. */
 
 /**
@@ -4956,7 +4662,7 @@ manage_backup_db (const gchar *database)
  */
 void
 migrate_51_to_52_sql_convert (sqlite3_context *context, int argc,
-                              sqlite3_value** argv)
+                              sqlite3_value **argv)
 {
   const unsigned char *text_time;
   int epoch_time;
@@ -4969,7 +4675,8 @@ migrate_51_to_52_sql_convert (sqlite3_context *context, int argc,
     {
       /* Scanner uses ctime: "Wed Jun 30 21:49:08 1993".
        *
-       * The dates being converted are in the timezone that the Scanner was using.
+       * The dates being converted are in the timezone that the Scanner was
+       * using.
        *
        * As a special case for this migrator, gvmd.c uses the timezone
        * from the environment, instead of forcing UTC.  This allows the user
@@ -4978,10 +4685,11 @@ migrate_51_to_52_sql_convert (sqlite3_context *context, int argc,
        * the user just leaves the timezone as is, it is likely to be the same
        * timezone she/he is running the Scanner under.
        */
-      if (text_time && (strlen ((char*) text_time) > 0))
+      if (text_time && (strlen ((char *) text_time) > 0))
         {
           memset (&tm, 0, sizeof (struct tm));
-          if (strptime ((char*) text_time, "%a %b %d %H:%M:%S %Y", &tm) == NULL)
+          if (strptime ((char *) text_time, "%a %b %d %H:%M:%S %Y", &tm)
+              == NULL)
             {
               sqlite3_result_error (context, "Failed to parse time", -1);
               return;
@@ -5009,14 +4717,10 @@ migrate_51_to_52_sql_convert (sqlite3_context *context, int argc,
 int
 manage_create_migrate_51_to_52_convert ()
 {
-  if (sqlite3_create_function (gvmd_db,
-                               "convert",
-                               1,               /* Number of args. */
-                               SQLITE_UTF8,
-                               NULL,            /* Callback data. */
-                               migrate_51_to_52_sql_convert,
-                               NULL,            /* xStep. */
-                               NULL)            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db, "convert", 1, /* Number of args. */
+                               SQLITE_UTF8, NULL,     /* Callback data. */
+                               migrate_51_to_52_sql_convert, NULL, /* xStep. */
+                               NULL)                               /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create convert", __FUNCTION__);

--- a/src/manage_sqlite3.c
+++ b/src/manage_sqlite3.c
@@ -284,7 +284,8 @@ sql_order_inet (sqlite3_context *context, int argc, sqlite3_value **argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_order_message_type (sqlite3_context *context, int argc,
+sql_order_message_type (sqlite3_context *context,
+                        int argc,
                         sqlite3_value **argv)
 {
   const char *type;
@@ -503,7 +504,8 @@ sql_clean_hosts (sqlite3_context *context, int argc, sqlite3_value **argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_merge_dfn_cert_adv (sqlite3_context *context, int argc,
+sql_merge_dfn_cert_adv (sqlite3_context *context,
+                        int argc,
                         sqlite3_value **argv)
 {
   const unsigned char *refnum, *title, *summary;
@@ -927,7 +929,8 @@ sql_merge_cpe_name (sqlite3_context *context, int argc, sqlite3_value **argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_merge_affected_product (sqlite3_context *context, int argc,
+sql_merge_affected_product (sqlite3_context *context,
+                            int argc,
                             sqlite3_value **argv)
 {
   int cve, cpe;
@@ -1415,8 +1418,10 @@ sql_max_hosts (sqlite3_context *context, int argc, sqlite3_value **argv)
  * @param[in]  new_name   Name of column in new table.
  */
 void
-sql_rename_column (const char *old_table, const char *new_table,
-                   const char *old_name, const char *new_name)
+sql_rename_column (const char *old_table,
+                   const char *new_table,
+                   const char *old_name,
+                   const char *new_name)
 {
   iterator_t rows;
 
@@ -1724,7 +1729,9 @@ clear_cache (void *cache_arg)
  * @return Severity.
  */
 static char *
-cached_task_severity (sqlite3_context *context, task_t task, int overrides,
+cached_task_severity (sqlite3_context *context,
+                      task_t task,
+                      int overrides,
                       int min_qod)
 {
   static sql_severity_t static_cache = {.task = 0,
@@ -1973,7 +1980,8 @@ report_severity_count (report_t report, int overrides, int min_qod, char *level)
  * @param[in]  argv     Argument array.
  */
 void
-sql_report_severity_count (sqlite3_context *context, int argc,
+sql_report_severity_count (sqlite3_context *context,
+                           int argc,
                            sqlite3_value **argv)
 {
   report_t report;
@@ -2051,7 +2059,8 @@ sql_report_host_count (sqlite3_context *context, int argc, sqlite3_value **argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_report_result_host_count (sqlite3_context *context, int argc,
+sql_report_result_host_count (sqlite3_context *context,
+                              int argc,
                               sqlite3_value **argv)
 {
   report_t report;
@@ -2167,7 +2176,8 @@ sql_task_last_report (sqlite3_context *context, int argc, sqlite3_value **argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_severity_matches_ov (sqlite3_context *context, int argc,
+sql_severity_matches_ov (sqlite3_context *context,
+                         int argc,
                          sqlite3_value **argv)
 {
   double severity, ov_severity;
@@ -2508,7 +2518,8 @@ sql_target_credential (sqlite3_context *context, int argc, sqlite3_value **argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_trash_target_credential_location (sqlite3_context *context, int argc,
+sql_trash_target_credential_location (sqlite3_context *context,
+                                      int argc,
                                       sqlite3_value **argv)
 {
   target_t target;
@@ -2576,7 +2587,8 @@ sql_target_login_port (sqlite3_context *context, int argc, sqlite3_value **argv)
  * @param[in]  argv     Argument array.
  */
 void
-sql_user_can_everything (sqlite3_context *context, int argc,
+sql_user_can_everything (sqlite3_context *context,
+                         int argc,
                          sqlite3_value **argv)
 {
   const unsigned char *uuid;
@@ -2603,7 +2615,8 @@ sql_user_can_everything (sqlite3_context *context, int argc,
  * @param[in]  argv     Argument array.
  */
 void
-sql_user_has_access_uuid (sqlite3_context *context, int argc,
+sql_user_has_access_uuid (sqlite3_context *context,
+                          int argc,
                           sqlite3_value **argv)
 {
   const unsigned char *type, *uuid, *permission;
@@ -4966,7 +4979,8 @@ manage_backup_db (const gchar *database)
  * @param[in]  argv     Argument array.
  */
 void
-migrate_51_to_52_sql_convert (sqlite3_context *context, int argc,
+migrate_51_to_52_sql_convert (sqlite3_context *context,
+                              int argc,
                               sqlite3_value **argv)
 {
   const unsigned char *text_time;

--- a/src/manage_sqlite3.c
+++ b/src/manage_sqlite3.c
@@ -548,8 +548,13 @@ sql_merge_dfn_cert_adv (sqlite3_context *context, int argc,
        "  title, summary, cve_refs)"
        " VALUES"
        " ('%s', '%s', '', %i, %i, '%s', '%s', %i);",
-       quoted_refnum, quoted_refnum, published, updated, quoted_title,
-       quoted_summary, cve_refs);
+       quoted_refnum,
+       quoted_refnum,
+       published,
+       updated,
+       quoted_title,
+       quoted_summary,
+       cve_refs);
 
   g_free (quoted_refnum);
   g_free (quoted_title);
@@ -610,8 +615,13 @@ sql_merge_bund_adv (sqlite3_context *context, int argc, sqlite3_value **argv)
        "  title, summary, cve_refs)"
        " VALUES"
        " ('%s', '%s', '', %i, %i, '%s', '%s', %i);",
-       quoted_refnum, quoted_refnum, published, updated, quoted_title,
-       quoted_summary, cve_refs);
+       quoted_refnum,
+       quoted_refnum,
+       published,
+       updated,
+       quoted_title,
+       quoted_summary,
+       cve_refs);
 
   g_free (quoted_refnum);
   g_free (quoted_title);
@@ -679,8 +689,14 @@ sql_merge_cpe (sqlite3_context *context, int argc, sqlite3_value **argv)
        "  deprecated_by_id, nvd_id)"
        " VALUES"
        " ('%s', '%s', '%s', %i, %i, '%s', %i, '%s');",
-       quoted_name, quoted_name, quoted_title, created, modified, quoted_status,
-       deprecated_by_id, quoted_nvd_id);
+       quoted_name,
+       quoted_name,
+       quoted_title,
+       created,
+       modified,
+       quoted_status,
+       deprecated_by_id,
+       quoted_nvd_id);
 
   g_free (quoted_name);
   g_free (quoted_title);
@@ -772,8 +788,8 @@ sql_merge_cve (sqlite3_context *context, int argc, sqlite3_value **argv)
   authentication = sqlite3_value_text (argv[8]);
   if (authentication == NULL)
     {
-      sqlite3_result_error (context, "Failed to get authentication argument",
-                            -1);
+      sqlite3_result_error (
+        context, "Failed to get authentication argument", -1);
       return;
     }
 
@@ -824,9 +840,18 @@ sql_merge_cve (sqlite3_context *context, int argc, sqlite3_value **argv)
        " VALUES"
        " ('%s', '%s', %i, %i, %s, '%s', '%s', '%s', '%s', '%s', '%s', '%s',"
        "  '%s');",
-       quoted_uuid, quoted_name, created, modified, cvss, quoted_description,
-       quoted_vector, quoted_complexity, quoted_authentication,
-       quoted_confidentiality, quoted_integrity, quoted_availability,
+       quoted_uuid,
+       quoted_name,
+       created,
+       modified,
+       cvss,
+       quoted_description,
+       quoted_vector,
+       quoted_complexity,
+       quoted_authentication,
+       quoted_confidentiality,
+       quoted_integrity,
+       quoted_availability,
        quoted_products);
 
   g_free (quoted_uuid);
@@ -883,7 +908,10 @@ sql_merge_cpe_name (sqlite3_context *context, int argc, sqlite3_value **argv)
        " (uuid, name, creation_time, modification_time)"
        " VALUES"
        " ('%s', '%s', %i, %i);",
-       quoted_uuid, quoted_name, creation_time, modification_time);
+       quoted_uuid,
+       quoted_name,
+       creation_time,
+       modification_time);
 
   g_free (quoted_uuid);
   g_free (quoted_name);
@@ -913,7 +941,8 @@ sql_merge_affected_product (sqlite3_context *context, int argc,
        " (cve, cpe)"
        " VALUES"
        " (%i, %i);",
-       cve, cpe);
+       cve,
+       cpe);
 }
 
 /**
@@ -1017,9 +1046,19 @@ sql_merge_ovaldef (sqlite3_context *context, int argc, sqlite3_value **argv)
        " VALUES"
        " ('%s', '%s', '%s', %i, %i, %i, %i, '%s', '%s', '%s', '%s', '%s',"
        "  0.0, %i);",
-       quoted_uuid, quoted_name, quoted_comment, created, modified, version,
-       deprecated, quoted_def_class, quoted_title, quoted_description,
-       quoted_xml_file, quoted_status, cve_refs);
+       quoted_uuid,
+       quoted_name,
+       quoted_comment,
+       created,
+       modified,
+       version,
+       deprecated,
+       quoted_def_class,
+       quoted_title,
+       quoted_description,
+       quoted_xml_file,
+       quoted_status,
+       cve_refs);
 
   g_free (quoted_uuid);
   g_free (quoted_name);
@@ -1062,8 +1101,8 @@ sql_uniquify (sqlite3_context *context, int argc, sqlite3_value **argv)
   proposed_name = sqlite3_value_text (argv[1]);
   if (proposed_name == NULL)
     {
-      sqlite3_result_error (context, "Failed to get proposed name argument",
-                            -1);
+      sqlite3_result_error (
+        context, "Failed to get proposed name argument", -1);
       return;
     }
 
@@ -1077,20 +1116,27 @@ sql_uniquify (sqlite3_context *context, int argc, sqlite3_value **argv)
     }
 
   number = 0;
-  candidate_name =
-    g_strdup_printf ("%s%s%c%i", proposed_name, suffix,
-                     strcmp ((char *) type, "user") ? ' ' : '_', ++number);
+  candidate_name = g_strdup_printf ("%s%s%c%i",
+                                    proposed_name,
+                                    suffix,
+                                    strcmp ((char *) type, "user") ? ' ' : '_',
+                                    ++number);
   quoted_candidate_name = sql_quote (candidate_name);
 
   while (sql_int ("SELECT COUNT (*) FROM %ss WHERE name = '%s'"
                   " AND ((owner IS NULL) OR (owner = %llu));",
-                  type, quoted_candidate_name, owner))
+                  type,
+                  quoted_candidate_name,
+                  owner))
     {
       g_free (candidate_name);
       g_free (quoted_candidate_name);
       candidate_name =
-        g_strdup_printf ("%s%s%c%u", proposed_name, suffix,
-                         strcmp ((char *) type, "user") ? ' ' : '_', ++number);
+        g_strdup_printf ("%s%s%c%u",
+                         proposed_name,
+                         suffix,
+                         strcmp ((char *) type, "user") ? ' ' : '_',
+                         ++number);
       quoted_candidate_name = sql_quote (candidate_name);
     }
 
@@ -1191,8 +1237,8 @@ sql_parse_time (sqlite3_context *context, int argc, sqlite3_value **argv)
       sqlite3_result_int (context, 0);
       break;
     case -3:
-      g_warning ("%s: Failed to parse timezone offset: %s", __FUNCTION__,
-                 string);
+      g_warning (
+        "%s: Failed to parse timezone offset: %s", __FUNCTION__, string);
       sqlite3_result_int (context, 0);
       break;
     default:
@@ -1233,8 +1279,9 @@ sql_next_time (sqlite3_context *context, int argc, sqlite3_value **argv)
   else
     periods_offset = sqlite3_value_int (argv[5]);
 
-  sqlite3_result_int (context, next_time (first, period, period_months, byday,
-                                          zone, periods_offset));
+  sqlite3_result_int (
+    context,
+    next_time (first, period, period_months, byday, zone, periods_offset));
 }
 
 /**
@@ -1395,7 +1442,9 @@ sql_rename_column (const char *old_table, const char *new_table,
           const char *name;
           name = iterator_column_name (&rows, column);
           g_string_append_printf (
-            one, "%s%s", (first ? "" : ", "),
+            one,
+            "%s%s",
+            (first ? "" : ", "),
             (strcmp (name, old_name) == 0 ? new_name : name));
           if (first)
             first = 0;
@@ -1459,7 +1508,9 @@ sql_common_cve (sqlite3_context *context, int argc, sqlite3_value **argv)
     {
       while (*point_2)
         {
-          g_debug ("   %s: %s vs %s", __FUNCTION__, g_strstrip (*point_1),
+          g_debug ("   %s: %s vs %s",
+                   __FUNCTION__,
+                   g_strstrip (*point_1),
                    g_strstrip (*point_2));
           if (strcmp (g_strstrip (*point_1), g_strstrip (*point_2)) == 0)
             {
@@ -1550,13 +1601,15 @@ sql_credential_value (sqlite3_context *context, int argc, sqlite3_value **argv)
     {
       result = sql_string ("SELECT value FROM credentials_trash_data"
                            " WHERE credential = %llu AND type = '%s';",
-                           credential, quoted_type);
+                           credential,
+                           quoted_type);
     }
   else
     {
       result = sql_string ("SELECT value FROM credentials_data"
                            " WHERE credential = %llu AND type = '%s';",
-                           credential, quoted_type);
+                           credential,
+                           quoted_type);
     }
 
   if (result)
@@ -1580,8 +1633,9 @@ void
 sql_current_offset (sqlite3_context *context, int argc, sqlite3_value **argv)
 {
   assert (argc == 1);
-  sqlite3_result_int (context, (int) current_offset (
-                                 (const char *) sqlite3_value_text (argv[0])));
+  sqlite3_result_int (
+    context,
+    (int) current_offset ((const char *) sqlite3_value_text (argv[0])));
 }
 
 /**
@@ -1616,8 +1670,8 @@ sql_task_trend (sqlite3_context *context, int argc, sqlite3_value **argv)
   else
     min_qod = sqlite3_value_int (argv[2]);
 
-  sqlite3_result_text (context, task_trend (task, overrides, min_qod), -1,
-                       SQLITE_TRANSIENT);
+  sqlite3_result_text (
+    context, task_trend (task, overrides, min_qod), -1, SQLITE_TRANSIENT);
 }
 
 /**
@@ -1643,8 +1697,8 @@ clear_cache (void *cache_arg)
   sql_severity_t *cache;
 
   cache = (sql_severity_t *) cache_arg;
-  g_debug ("   %s: %llu, %llu", __FUNCTION__, cache->task,
-           cache->overrides_task);
+  g_debug (
+    "   %s: %llu, %llu", __FUNCTION__, cache->task, cache->overrides_task);
   cache->task = 0;
   cache->overrides_task = 0;
   free (cache->severity);
@@ -1875,11 +1929,21 @@ report_severity_count (report_t report, int overrides, int min_qod, char *level)
   if (current_credentials.uuid == NULL
       || strcmp (current_credentials.uuid, "") == 0)
     return 0;
-  get = report_results_get_data (1 /* first */, -1, /* rows */
-                                 overrides, 0,      /* autofp */
+  get = report_results_get_data (1 /* first */,
+                                 -1, /* rows */
+                                 overrides,
+                                 0, /* autofp */
                                  min_qod);
-  report_counts_id (report, &debugs, &highs, &lows, &logs, &mediums,
-                    &false_positives, NULL, get, NULL);
+  report_counts_id (report,
+                    &debugs,
+                    &highs,
+                    &lows,
+                    &logs,
+                    &mediums,
+                    &false_positives,
+                    NULL,
+                    get,
+                    NULL);
   get_data_reset (get);
   g_free (get);
 
@@ -2160,8 +2224,8 @@ sql_severity_to_level (sqlite3_context *context, int argc, sqlite3_value **argv)
 
   severity = sqlite3_value_double (argv[0]);
 
-  sqlite3_result_text (context, severity_to_level (severity, mode), -1,
-                       SQLITE_TRANSIENT);
+  sqlite3_result_text (
+    context, severity_to_level (severity, mode), -1, SQLITE_TRANSIENT);
   return;
 }
 
@@ -2190,8 +2254,8 @@ sql_severity_to_type (sqlite3_context *context, int argc, sqlite3_value **argv)
 
   severity = sqlite3_value_double (argv[0]);
 
-  sqlite3_result_text (context, severity_to_type (severity), -1,
-                       SQLITE_TRANSIENT);
+  sqlite3_result_text (
+    context, severity_to_type (severity), -1, SQLITE_TRANSIENT);
   return;
 }
 
@@ -2571,8 +2635,8 @@ sql_user_has_access_uuid (sqlite3_context *context, int argc,
 
   trash = sqlite3_value_int (argv[3]);
 
-  ret = acl_user_has_access_uuid ((char *) type, (char *) uuid,
-                                  (char *) permission, trash);
+  ret = acl_user_has_access_uuid (
+    (char *) type, (char *) uuid, (char *) permission, trash);
 
   sqlite3_result_int (context, ret);
 }
@@ -2665,7 +2729,12 @@ sql_vuln_results (sqlite3_context *context, int argc, sqlite3_value **argv)
                       "                             (SELECT uuid"
                       "                              FROM current_credentials))"
                       "           AND task = results.task)",
-    nvt_oid_quoted, report_null, report, task_null, task, host == NULL,
+    nvt_oid_quoted,
+    report_null,
+    report,
+    task_null,
+    task,
+    host == NULL,
     host ? (char *) host : "");
 
   g_free (nvt_oid_quoted);
@@ -2682,538 +2751,714 @@ sql_vuln_results (sqlite3_context *context, int argc, sqlite3_value **argv)
 int
 manage_create_sql_functions ()
 {
-  if (sqlite3_create_function (gvmd_db, "t", 0,   /* Number of args. */
-                               SQLITE_UTF8, NULL, /* Callback data. */
-                               sql_t, NULL,       /* xStep. */
-                               NULL)              /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "t",
+                               0, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_t,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to t", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "strpos", 2, /* Number of args. */
-                               SQLITE_UTF8, NULL,    /* Callback data. */
-                               sql_strpos, NULL,     /* xStep. */
-                               NULL)                 /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "strpos",
+                               2, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_strpos,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create strpos", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "order_inet", 1, /* Number of args. */
-                               SQLITE_UTF8, NULL,        /* Callback data. */
-                               sql_order_inet, NULL,     /* xStep. */
-                               NULL)                     /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "order_inet",
+                               1, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_order_inet,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create order_inet", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "order_message_type",
-                               1,                 /* Number of args. */
-                               SQLITE_UTF8, NULL, /* Callback data. */
-                               sql_order_message_type, NULL, /* xStep. */
-                               NULL)                         /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "order_message_type",
+                               1, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_order_message_type,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create order_message_type", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "order_port", 1, /* Number of args. */
-                               SQLITE_UTF8, NULL,        /* Callback data. */
-                               sql_order_port, NULL,     /* xStep. */
-                               NULL)                     /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "order_port",
+                               1, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_order_port,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create order_port", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "order_role", 1, /* Number of args. */
-                               SQLITE_UTF8, NULL,        /* Callback data. */
-                               sql_order_role, NULL,     /* xStep. */
-                               NULL)                     /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "order_role",
+                               1, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_order_role,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create order_role", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "order_threat", 1, /* Number of args. */
-                               SQLITE_UTF8, NULL,          /* Callback data. */
-                               sql_order_threat, NULL,     /* xStep. */
-                               NULL)                       /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "order_threat",
+                               1, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_order_threat,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create order_threat", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "make_uuid", 0, /* Number of args. */
-                               SQLITE_UTF8, NULL,       /* Callback data. */
-                               sql_make_uuid, NULL,     /* xStep. */
-                               NULL)                    /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "make_uuid",
+                               0, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_make_uuid,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create make_uuid", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "hosts_contains",
-                               2,                        /* Number of args. */
-                               SQLITE_UTF8, NULL,        /* Callback data. */
-                               sql_hosts_contains, NULL, /* xStep. */
-                               NULL)                     /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "hosts_contains",
+                               2, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_hosts_contains,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create hosts_contains", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "clean_hosts", 1, /* Number of args. */
-                               SQLITE_UTF8, NULL,         /* Callback data. */
-                               sql_clean_hosts, NULL,     /* xStep. */
-                               NULL)                      /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "clean_hosts",
+                               1, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_clean_hosts,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create clean_hosts", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "iso_time", 1, /* Number of args. */
-                               SQLITE_UTF8, NULL,      /* Callback data. */
-                               sql_iso_time, NULL,     /* xStep. */
-                               NULL)                   /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "iso_time",
+                               1, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_iso_time,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create iso_time", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "days_from_now",
-                               1,                       /* Number of args. */
-                               SQLITE_UTF8, NULL,       /* Callback data. */
-                               sql_days_from_now, NULL, /* xStep. */
-                               NULL)                    /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "days_from_now",
+                               1, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_days_from_now,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create days_from_now", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "parse_time", 1, /* Number of args. */
-                               SQLITE_UTF8, NULL,        /* Callback data. */
-                               sql_parse_time, NULL,     /* xStep. */
-                               NULL)                     /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "parse_time",
+                               1, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_parse_time,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create parse_time", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "tag", 2, /* Number of args. */
-                               SQLITE_UTF8, NULL, /* Callback data. */
-                               sql_tag, NULL,     /* xStep. */
-                               NULL)              /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "tag",
+                               2, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_tag,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create tag", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "uniquify", 4, /* Number of args. */
-                               SQLITE_UTF8, NULL,      /* Callback data. */
-                               sql_uniquify, NULL,     /* xStep. */
-                               NULL)                   /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "uniquify",
+                               4, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_uniquify,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create uniquify", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "next_time", 4, /* Number of args. */
-                               SQLITE_UTF8, NULL,       /* Callback data. */
-                               sql_next_time, NULL,     /* xStep. */
-                               NULL)                    /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "next_time",
+                               4, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_next_time,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create next_time", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "next_time", 5, /* Number of args. */
-                               SQLITE_UTF8, NULL,       /* Callback data. */
-                               sql_next_time, NULL,     /* xStep. */
-                               NULL)                    /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "next_time",
+                               5, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_next_time,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create next_time", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "next_time", 6, /* Number of args. */
-                               SQLITE_UTF8, NULL,       /* Callback data. */
-                               sql_next_time, NULL,     /* xStep. */
-                               NULL)                    /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "next_time",
+                               6, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_next_time,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create next_time", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "next_time_ical",
-                               2,                        /* Number of args. */
-                               SQLITE_UTF8, NULL,        /* Callback data. */
-                               sql_next_time_ical, NULL, /* xStep. */
-                               NULL)                     /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "next_time_ical",
+                               2, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_next_time_ical,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create next_time_ical", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "next_time_ical",
-                               3,                        /* Number of args. */
-                               SQLITE_UTF8, NULL,        /* Callback data. */
-                               sql_next_time_ical, NULL, /* xStep. */
-                               NULL)                     /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "next_time_ical",
+                               3, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_next_time_ical,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create next_time_ical", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "m_now", 0, /* Number of args. */
-                               SQLITE_UTF8, NULL,   /* Callback data. */
-                               sql_now, NULL,       /* xStep. */
-                               NULL)                /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "m_now",
+                               0, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_now,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create m_now", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "max_hosts", 2, /* Number of args. */
-                               SQLITE_UTF8, NULL,       /* Callback data. */
-                               sql_max_hosts, NULL,     /* xStep. */
-                               NULL)                    /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "max_hosts",
+                               2, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_max_hosts,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create max_hosts", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "common_cve", 2, /* Number of args. */
-                               SQLITE_UTF8, NULL,        /* Callback data. */
-                               sql_common_cve, NULL,     /* xStep. */
-                               NULL)                     /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "common_cve",
+                               2, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_common_cve,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create common_cve", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "cpe_title", 1, /* Number of args. */
-                               SQLITE_UTF8, NULL,       /* Callback data. */
-                               sql_cpe_title, NULL,     /* xStep. */
-                               NULL)                    /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "cpe_title",
+                               1, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_cpe_title,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create cpe_title", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "credential_value",
-                               3,                          /* Number of args. */
-                               SQLITE_UTF8, NULL,          /* Callback data. */
-                               sql_credential_value, NULL, /* xStep. */
-                               NULL)                       /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "credential_value",
+                               3, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_credential_value,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create credential_value", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "current_offset",
-                               1,                        /* Number of args. */
-                               SQLITE_UTF8, NULL,        /* Callback data. */
-                               sql_current_offset, NULL, /* xStep. */
-                               NULL)                     /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "current_offset",
+                               1, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_current_offset,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create current_offset", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "task_trend", 3, /* Number of args. */
-                               SQLITE_UTF8, NULL,        /* Callback data. */
-                               sql_task_trend, NULL,     /* xStep. */
-                               NULL)                     /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "task_trend",
+                               3, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_task_trend,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create task_trend", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "task_threat_level",
-                               3,                 /* Number of args. */
-                               SQLITE_UTF8, NULL, /* Callback data. */
-                               sql_task_threat_level, NULL, /* xStep. */
-                               NULL)                        /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "task_threat_level",
+                               3, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_task_threat_level,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create task_threat_level", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "report_progress",
-                               1,                         /* Number of args. */
-                               SQLITE_UTF8, NULL,         /* Callback data. */
-                               sql_report_progress, NULL, /* xStep. */
-                               NULL)                      /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "report_progress",
+                               1, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_report_progress,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create report_progress", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "report_severity",
-                               3,                         /* Number of args. */
-                               SQLITE_UTF8, NULL,         /* Callback data. */
-                               sql_report_severity, NULL, /* xStep. */
-                               NULL)                      /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "report_severity",
+                               3, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_report_severity,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create report_severity", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "report_severity_count",
-                               4,                 /* Number of args. */
-                               SQLITE_UTF8, NULL, /* Callback data. */
-                               sql_report_severity_count, NULL, /* xStep. */
-                               NULL)                            /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "report_severity_count",
+                               4, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_report_severity_count,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create report_severity_count", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "report_host_count",
-                               1,                 /* Number of args. */
-                               SQLITE_UTF8, NULL, /* Callback data. */
-                               sql_report_host_count, NULL, /* xStep. */
-                               NULL)                        /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "report_host_count",
+                               1, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_report_host_count,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create report_result_host_count", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "report_result_host_count",
-                               2,                 /* Number of args. */
-                               SQLITE_UTF8, NULL, /* Callback data. */
-                               sql_report_result_host_count, NULL, /* xStep. */
-                               NULL)                               /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "report_result_host_count",
+                               2, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_report_result_host_count,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create report_result_host_count", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "task_severity",
-                               3,                       /* Number of args. */
-                               SQLITE_UTF8, NULL,       /* Callback data. */
-                               sql_task_severity, NULL, /* xStep. */
-                               NULL)                    /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "task_severity",
+                               3, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_task_severity,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create task_severity", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "task_last_report",
-                               1,                          /* Number of args. */
-                               SQLITE_UTF8, NULL,          /* Callback data. */
-                               sql_task_last_report, NULL, /* xStep. */
-                               NULL)                       /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "task_last_report",
+                               1, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_task_last_report,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create task_last_report", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "severity_matches_ov",
-                               2,                 /* Number of args. */
-                               SQLITE_UTF8, NULL, /* Callback data. */
-                               sql_severity_matches_ov, NULL, /* xStep. */
-                               NULL)                          /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "severity_matches_ov",
+                               2, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_severity_matches_ov,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create severity_matches_ov", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "severity_to_level",
-                               1,                 /* Number of args. */
-                               SQLITE_UTF8, NULL, /* Callback data. */
-                               sql_severity_to_level, NULL, /* xStep. */
-                               NULL)                        /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "severity_to_level",
+                               1, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_severity_to_level,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create severity_to_level", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "severity_to_level",
-                               2,                 /* Number of args. */
-                               SQLITE_UTF8, NULL, /* Callback data. */
-                               sql_severity_to_level, NULL, /* xStep. */
-                               NULL)                        /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "severity_to_level",
+                               2, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_severity_to_level,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create severity_to_level", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "severity_to_type",
-                               1,                          /* Number of args. */
-                               SQLITE_UTF8, NULL,          /* Callback data. */
-                               sql_severity_to_type, NULL, /* xStep. */
-                               NULL)                       /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "severity_to_type",
+                               1, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_severity_to_type,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create severity_to_type", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "run_status_name",
-                               1,                         /* Number of args. */
-                               SQLITE_UTF8, NULL,         /* Callback data. */
-                               sql_run_status_name, NULL, /* xStep. */
-                               NULL)                      /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "run_status_name",
+                               1, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_run_status_name,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create run_status_name", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "resource_exists",
-                               3,                         /* Number of args. */
-                               SQLITE_UTF8, NULL,         /* Callback data. */
-                               sql_resource_exists, NULL, /* xStep. */
-                               NULL)                      /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "resource_exists",
+                               3, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_resource_exists,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create resource_exists", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "regexp", 2, /* Number of args. */
-                               SQLITE_UTF8, NULL,    /* Callback data. */
-                               sql_regexp, NULL,     /* xStep. */
-                               NULL)                 /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "regexp",
+                               2, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_regexp,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create regexp", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "resource_name",
-                               3,                       /* Number of args. */
-                               SQLITE_UTF8, NULL,       /* Callback data. */
-                               sql_resource_name, NULL, /* xStep. */
-                               NULL)                    /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "resource_name",
+                               3, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_resource_name,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create resource_name", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "severity_in_level",
-                               2,                 /* Number of args. */
-                               SQLITE_UTF8, NULL, /* Callback data. */
-                               sql_severity_in_level, NULL, /* xStep. */
-                               NULL)                        /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "severity_in_level",
+                               2, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_severity_in_level,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create severity_in_level", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "target_credential",
-                               3,                 /* Number of args. */
-                               SQLITE_UTF8, NULL, /* Callback data. */
-                               sql_target_credential, NULL, /* xStep. */
-                               NULL)                        /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "target_credential",
+                               3, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_target_credential,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create target_login_data", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (
-        gvmd_db, "trash_target_credential_location", 2, /* Number of args. */
-        SQLITE_UTF8, NULL,                              /* Callback data. */
-        sql_trash_target_credential_location, NULL,     /* xStep. */
-        NULL)                                           /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "trash_target_credential_location",
+                               2, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_trash_target_credential_location,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create target_login_data", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "target_login_port",
-                               3,                 /* Number of args. */
-                               SQLITE_UTF8, NULL, /* Callback data. */
-                               sql_target_login_port, NULL, /* xStep. */
-                               NULL)                        /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "target_login_port",
+                               3, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_target_login_port,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create target_login_data", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "user_can_everything",
-                               1,                 /* Number of args. */
-                               SQLITE_UTF8, NULL, /* Callback data. */
-                               sql_user_can_everything, NULL, /* xStep. */
-                               NULL)                          /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "user_can_everything",
+                               1, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_user_can_everything,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create user_can_everything", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "user_has_access_uuid",
-                               4,                 /* Number of args. */
-                               SQLITE_UTF8, NULL, /* Callback data. */
-                               sql_user_has_access_uuid, NULL, /* xStep. */
-                               NULL)                           /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "user_has_access_uuid",
+                               4, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_user_has_access_uuid,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create user_has_access_uuid", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "user_owns", 2, /* Number of args. */
-                               SQLITE_UTF8, NULL,       /* Callback data. */
-                               sql_user_owns, NULL,     /* xStep. */
-                               NULL)                    /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "user_owns",
+                               2, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_user_owns,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create user_owns", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "vuln_results", 4, /* Number of args. */
-                               SQLITE_UTF8, NULL,          /* Callback data. */
-                               sql_vuln_results, NULL,     /* xStep. */
-                               NULL)                       /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "vuln_results",
+                               4, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_vuln_results,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create user_has_access_uuid", __FUNCTION__);
@@ -3862,7 +4107,8 @@ manage_attach_databases ()
       case ENOENT:
         break;
       default:
-        g_warning ("%s: failed to stat SCAP database: %s", __FUNCTION__,
+        g_warning ("%s: failed to stat SCAP database: %s",
+                   __FUNCTION__,
                    strerror (errno));
         break;
       }
@@ -3878,7 +4124,8 @@ manage_attach_databases ()
       case ENOENT:
         break;
       default:
-        g_warning ("%s: failed to stat CERT database: %s", __FUNCTION__,
+        g_warning ("%s: failed to stat CERT database: %s",
+                   __FUNCTION__,
                    strerror (errno));
         break;
       }
@@ -3919,7 +4166,8 @@ manage_db_init (const gchar *name)
     {
       if (access (CERT_DB_FILE, R_OK) && errno != ENOENT)
         {
-          g_warning ("%s: failed to stat CERT database: %s", __FUNCTION__,
+          g_warning ("%s: failed to stat CERT database: %s",
+                     __FUNCTION__,
                      strerror (errno));
           return -1;
         }
@@ -3930,7 +4178,8 @@ manage_db_init (const gchar *name)
           if (g_mkdir_with_parents (CERT_DB_DIR, 0755 /* "rwxr-xr-x" */) == -1)
             {
               g_warning ("%s: failed to create CERT directory: %s",
-                         __FUNCTION__, strerror (errno));
+                         __FUNCTION__,
+                         strerror (errno));
               abort ();
             }
 
@@ -4024,7 +4273,8 @@ manage_db_init (const gchar *name)
     {
       if (access (SCAP_DB_FILE, R_OK) && errno != ENOENT)
         {
-          g_warning ("%s: failed to stat SCAP database: %s", __FUNCTION__,
+          g_warning ("%s: failed to stat SCAP database: %s",
+                     __FUNCTION__,
                      strerror (errno));
           return -1;
         }
@@ -4035,7 +4285,8 @@ manage_db_init (const gchar *name)
           if (g_mkdir_with_parents (SCAP_DB_DIR, 0755 /* "rwxr-xr-x" */) == -1)
             {
               g_warning ("%s: failed to create SCAP directory: %s",
-                         __FUNCTION__, strerror (errno));
+                         __FUNCTION__,
+                         strerror (errno));
               abort ();
             }
 
@@ -4232,7 +4483,8 @@ manage_db_check (const gchar *name)
           if (errno == ENOENT)
             return 0;
 
-          g_warning ("%s: failed to stat CERT database: %s", __FUNCTION__,
+          g_warning ("%s: failed to stat CERT database: %s",
+                     __FUNCTION__,
                      strerror (errno));
           return -1;
         }
@@ -4254,7 +4506,8 @@ manage_db_check (const gchar *name)
           if (errno == ENOENT)
             return 0;
 
-          g_warning ("%s: failed to stat SCAP database: %s", __FUNCTION__,
+          g_warning ("%s: failed to stat SCAP database: %s",
+                     __FUNCTION__,
                      strerror (errno));
           return -1;
         }
@@ -4289,7 +4542,8 @@ manage_cert_loaded ()
         return 0;
         break;
       default:
-        g_warning ("%s: failed to stat CERT database: %s", __FUNCTION__,
+        g_warning ("%s: failed to stat CERT database: %s",
+                   __FUNCTION__,
                    strerror (errno));
         return 0;
       }
@@ -4324,7 +4578,8 @@ manage_scap_loaded ()
         return 0;
         break;
       default:
-        g_warning ("%s: failed to stat SCAP database: %s", __FUNCTION__,
+        g_warning ("%s: failed to stat SCAP database: %s",
+                   __FUNCTION__,
                    strerror (errno));
         return 0;
       }
@@ -4354,7 +4609,8 @@ manage_cert_db_exists ()
         return 0;
         break;
       default:
-        g_warning ("%s: failed to stat CERT database: %s", __FUNCTION__,
+        g_warning ("%s: failed to stat CERT database: %s",
+                   __FUNCTION__,
                    strerror (errno));
         return 1;
       }
@@ -4376,7 +4632,8 @@ manage_scap_db_exists ()
         return 0;
         break;
       default:
-        g_warning ("%s: failed to stat SCAP database: %s", __FUNCTION__,
+        g_warning ("%s: failed to stat SCAP database: %s",
+                   __FUNCTION__,
                    strerror (errno));
         return 1;
       }
@@ -4391,22 +4648,28 @@ manage_scap_db_exists ()
 int
 manage_update_cert_db_init ()
 {
-  if (sqlite3_create_function (gvmd_db, "merge_dfn_cert_adv",
-                               6,                 /* Number of args. */
-                               SQLITE_UTF8, NULL, /* Callback data. */
-                               sql_merge_dfn_cert_adv, NULL, /* xStep. */
-                               NULL)                         /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "merge_dfn_cert_adv",
+                               6, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_merge_dfn_cert_adv,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create merge_dfn_cert_adv", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "merge_bund_adv",
-                               6,                        /* Number of args. */
-                               SQLITE_UTF8, NULL,        /* Callback data. */
-                               sql_merge_bund_adv, NULL, /* xStep. */
-                               NULL)                     /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "merge_bund_adv",
+                               6, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_merge_bund_adv,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create merge_bund_adv", __FUNCTION__);
@@ -4424,19 +4687,25 @@ manage_update_cert_db_init ()
 void
 manage_update_cert_db_cleanup ()
 {
-  if (sqlite3_create_function (gvmd_db, "merge_dfn_cert_adv",
-                               6,                 /* Number of args. */
-                               SQLITE_UTF8, NULL, /* Callback data. */
-                               NULL, NULL,        /* xStep. */
-                               NULL)              /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "merge_dfn_cert_adv",
+                               6, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               NULL,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     g_warning ("%s: failed to remove merge_dfn_cert_adv", __FUNCTION__);
 
-  if (sqlite3_create_function (gvmd_db, "merge_bund_adv",
-                               6,                 /* Number of args. */
-                               SQLITE_UTF8, NULL, /* Callback data. */
-                               NULL, NULL,        /* xStep. */
-                               NULL)              /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "merge_bund_adv",
+                               6, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               NULL,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     g_warning ("%s: failed to remove merge_bund_adv", __FUNCTION__);
 }
@@ -4449,53 +4718,70 @@ manage_update_cert_db_cleanup ()
 int
 manage_update_scap_db_init ()
 {
-  if (sqlite3_create_function (gvmd_db, "merge_cpe", 7, /* Number of args. */
-                               SQLITE_UTF8, NULL,       /* Callback data. */
-                               sql_merge_cpe, NULL,     /* xStep. */
-                               NULL)                    /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "merge_cpe",
+                               7, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_merge_cpe,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create merge_cpe", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "merge_cve", 13, /* Number of args. */
-                               SQLITE_UTF8, NULL,        /* Callback data. */
-                               sql_merge_cve, NULL,      /* xStep. */
-                               NULL)                     /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "merge_cve",
+                               13, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_merge_cve,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create merge_cpe", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "merge_cpe_name",
-                               4,                        /* Number of args. */
-                               SQLITE_UTF8, NULL,        /* Callback data. */
-                               sql_merge_cpe_name, NULL, /* xStep. */
-                               NULL)                     /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "merge_cpe_name",
+                               4, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_merge_cpe_name,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create merge_cpe_name", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "merge_affected_product",
-                               2,                 /* Number of args. */
-                               SQLITE_UTF8, NULL, /* Callback data. */
-                               sql_merge_affected_product, NULL, /* xStep. */
-                               NULL)                             /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "merge_affected_product",
+                               2, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_merge_affected_product,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create merge_affected_product", __FUNCTION__);
       return -1;
     }
 
-  if (sqlite3_create_function (gvmd_db, "merge_ovaldef",
-                               13,                      /* Number of args. */
-                               SQLITE_UTF8, NULL,       /* Callback data. */
-                               sql_merge_ovaldef, NULL, /* xStep. */
-                               NULL)                    /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "merge_ovaldef",
+                               13, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               sql_merge_ovaldef,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create merge_ovaldef", __FUNCTION__);
@@ -4513,41 +4799,58 @@ manage_update_scap_db_init ()
 void
 manage_update_scap_db_cleanup ()
 {
-  if (sqlite3_create_function (gvmd_db, "merge_cpe", 8, /* Number of args. */
-                               SQLITE_UTF8, NULL,       /* Callback data. */
-                               NULL, NULL,              /* xStep. */
-                               NULL)                    /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "merge_cpe",
+                               8, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               NULL,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     g_warning ("%s: failed to remove merge_cpe", __FUNCTION__);
 
-  if (sqlite3_create_function (gvmd_db, "merge_cve", 13, /* Number of args. */
-                               SQLITE_UTF8, NULL,        /* Callback data. */
-                               NULL, NULL,               /* xStep. */
-                               NULL)                     /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "merge_cve",
+                               13, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               NULL,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     g_warning ("%s: failed to remove merge_cve", __FUNCTION__);
 
-  if (sqlite3_create_function (gvmd_db, "merge_cpe_name",
-                               4,                 /* Number of args. */
-                               SQLITE_UTF8, NULL, /* Callback data. */
-                               NULL, NULL,        /* xStep. */
-                               NULL)              /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "merge_cpe_name",
+                               4, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               NULL,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     g_warning ("%s: failed to remove merge_cpe_name", __FUNCTION__);
 
-  if (sqlite3_create_function (gvmd_db, "merge_affected_product",
-                               2,                 /* Number of args. */
-                               SQLITE_UTF8, NULL, /* Callback data. */
-                               NULL, NULL,        /* xStep. */
-                               NULL)              /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "merge_affected_product",
+                               2, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               NULL,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     g_warning ("%s: failed to remove merge_affected_product", __FUNCTION__);
 
-  if (sqlite3_create_function (gvmd_db, "merge_ovaldef",
-                               14,                /* Number of args. */
-                               SQLITE_UTF8, NULL, /* Callback data. */
-                               NULL, NULL,        /* xStep. */
-                               NULL)              /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "merge_ovaldef",
+                               14, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               NULL,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     g_warning ("%s: failed to remove merge_ovaldef", __FUNCTION__);
 }
@@ -4574,8 +4877,8 @@ backup_db (const gchar *database, gchar **backup_file_arg)
 
   if (sqlite3_open (backup_file, &backup_db) != SQLITE_OK)
     {
-      g_warning ("%s: sqlite3_open failed: %s", __FUNCTION__,
-                 sqlite3_errmsg (gvmd_db));
+      g_warning (
+        "%s: sqlite3_open failed: %s", __FUNCTION__, sqlite3_errmsg (gvmd_db));
       goto fail;
     }
 
@@ -4588,7 +4891,8 @@ backup_db (const gchar *database, gchar **backup_file_arg)
   backup = sqlite3_backup_init (backup_db, "main", gvmd_db, "main");
   if (backup == NULL)
     {
-      g_warning ("%s: sqlite3_backup_init failed: %s", __FUNCTION__,
+      g_warning ("%s: sqlite3_backup_init failed: %s",
+                 __FUNCTION__,
                  sqlite3_errmsg (backup_db));
       goto fail;
     }
@@ -4607,7 +4911,8 @@ backup_db (const gchar *database, gchar **backup_file_arg)
           sqlite3_sleep (250);
           continue;
         }
-      g_warning ("%s: sqlite3_backup_step failed: %s", __FUNCTION__,
+      g_warning ("%s: sqlite3_backup_step failed: %s",
+                 __FUNCTION__,
                  sqlite3_errmsg (backup_db));
       sqlite3_backup_finish (backup);
       goto fail;
@@ -4717,10 +5022,14 @@ migrate_51_to_52_sql_convert (sqlite3_context *context, int argc,
 int
 manage_create_migrate_51_to_52_convert ()
 {
-  if (sqlite3_create_function (gvmd_db, "convert", 1, /* Number of args. */
-                               SQLITE_UTF8, NULL,     /* Callback data. */
-                               migrate_51_to_52_sql_convert, NULL, /* xStep. */
-                               NULL)                               /* xFinal. */
+  if (sqlite3_create_function (gvmd_db,
+                               "convert",
+                               1, /* Number of args. */
+                               SQLITE_UTF8,
+                               NULL, /* Callback data. */
+                               migrate_51_to_52_sql_convert,
+                               NULL, /* xStep. */
+                               NULL) /* xFinal. */
       != SQLITE_OK)
     {
       g_warning ("%s: failed to create convert", __FUNCTION__);

--- a/src/manage_tickets.h
+++ b/src/manage_tickets.h
@@ -26,8 +26,8 @@
 #ifndef _GVMD_MANAGE_TICKETS_H
 #define _GVMD_MANAGE_TICKETS_H
 
-#include "manage.h"
 #include "iterator.h"
+#include "manage.h"
 
 int
 ticket_count (const get_data_t *);
@@ -35,99 +35,94 @@ ticket_count (const get_data_t *);
 int
 init_ticket_iterator (iterator_t *, const get_data_t *);
 
-const char*
-ticket_iterator_user_id (iterator_t*);
+const char *
+ticket_iterator_user_id (iterator_t *);
 
-const char*
-ticket_iterator_user_name (iterator_t*);
+const char *
+ticket_iterator_user_name (iterator_t *);
 
-const char*
-ticket_iterator_task_id (iterator_t*);
+const char *
+ticket_iterator_task_id (iterator_t *);
 
-const char*
-ticket_iterator_task_name (iterator_t*);
+const char *
+ticket_iterator_task_name (iterator_t *);
 
-const char*
-ticket_iterator_report_id (iterator_t*);
+const char *
+ticket_iterator_report_id (iterator_t *);
 
 double
-ticket_iterator_severity (iterator_t*);
+ticket_iterator_severity (iterator_t *);
 
-const char*
-ticket_iterator_host (iterator_t*);
+const char *
+ticket_iterator_host (iterator_t *);
 
-const char*
-ticket_iterator_location (iterator_t*);
+const char *
+ticket_iterator_location (iterator_t *);
 
-const char*
-ticket_iterator_solution_type (iterator_t*);
+const char *
+ticket_iterator_solution_type (iterator_t *);
 
-const char*
-ticket_iterator_status (iterator_t*);
+const char *
+ticket_iterator_status (iterator_t *);
 
-const char*
-ticket_iterator_open_time (iterator_t*);
+const char *
+ticket_iterator_open_time (iterator_t *);
 
-const char*
-ticket_iterator_fixed_time (iterator_t*);
+const char *
+ticket_iterator_fixed_time (iterator_t *);
 
-const char*
-ticket_iterator_closed_time (iterator_t*);
+const char *
+ticket_iterator_closed_time (iterator_t *);
 
-const char*
-ticket_iterator_fix_verified_time (iterator_t*);
+const char *
+ticket_iterator_fix_verified_time (iterator_t *);
 
-const char*
-ticket_iterator_open_note (iterator_t*);
+const char *
+ticket_iterator_open_note (iterator_t *);
 
-const char*
-ticket_iterator_fixed_note (iterator_t*);
+const char *
+ticket_iterator_fixed_note (iterator_t *);
 
-const char*
-ticket_iterator_closed_note (iterator_t*);
+const char *
+ticket_iterator_closed_note (iterator_t *);
 
-const char*
-ticket_iterator_fix_verified_report_id (iterator_t*);
+const char *
+ticket_iterator_fix_verified_report_id (iterator_t *);
 
-const char*
-ticket_iterator_nvt_oid (iterator_t*);
+const char *
+ticket_iterator_nvt_oid (iterator_t *);
 
 int
 init_ticket_result_iterator (iterator_t *, const gchar *, int);
 
-const char*
-ticket_result_iterator_result_id (iterator_t*);
+const char *
+ticket_result_iterator_result_id (iterator_t *);
 
 int
 init_result_ticket_iterator (iterator_t *, result_t);
 
-const char*
-result_ticket_iterator_ticket_id (iterator_t*);
+const char *
+result_ticket_iterator_ticket_id (iterator_t *);
+
+int ticket_in_use (ticket_t);
+
+int trash_ticket_in_use (ticket_t);
+
+int ticket_writable (ticket_t);
+
+int trash_ticket_writable (ticket_t);
 
 int
-ticket_in_use (ticket_t);
-
-int
-trash_ticket_in_use (ticket_t);
-
-int
-ticket_writable (ticket_t);
-
-int
-trash_ticket_writable (ticket_t);
-
-int
-create_ticket (const char *, const char *, const char *, const char *, ticket_t *);
+create_ticket (const char *, const char *, const char *, const char *,
+               ticket_t *);
 
 int
 copy_ticket (const char *, const char *, ticket_t *);
 
-char*
-ticket_uuid (ticket_t);
+char *ticket_uuid (ticket_t);
 
 int
-modify_ticket (const gchar *, const gchar *, const gchar *,
-               const gchar *, const gchar *, const gchar *,
-               const gchar *);
+modify_ticket (const gchar *, const gchar *, const gchar *, const gchar *,
+               const gchar *, const gchar *, const gchar *);
 
 #endif /* not _GVMD_MANAGE_TICKETS_H */

--- a/src/manage_tickets.h
+++ b/src/manage_tickets.h
@@ -113,7 +113,10 @@ int ticket_writable (ticket_t);
 int trash_ticket_writable (ticket_t);
 
 int
-create_ticket (const char *, const char *, const char *, const char *,
+create_ticket (const char *,
+               const char *,
+               const char *,
+               const char *,
                ticket_t *);
 
 int
@@ -122,7 +125,12 @@ copy_ticket (const char *, const char *, ticket_t *);
 char *ticket_uuid (ticket_t);
 
 int
-modify_ticket (const gchar *, const gchar *, const gchar *, const gchar *,
-               const gchar *, const gchar *, const gchar *);
+modify_ticket (const gchar *,
+               const gchar *,
+               const gchar *,
+               const gchar *,
+               const gchar *,
+               const gchar *,
+               const gchar *);
 
 #endif /* not _GVMD_MANAGE_TICKETS_H */

--- a/src/manage_utils.c
+++ b/src/manage_utils.c
@@ -375,8 +375,12 @@ next_day (int day_of_week, int byday)
  * @return  the next time a schedule with the given times is due.
  */
 time_t
-next_time (time_t first, int period, int period_months, int byday,
-           const char *zone, int periods_offset)
+next_time (time_t first,
+           int period,
+           int period_months,
+           int byday,
+           const char *zone,
+           int periods_offset)
 {
   int periods_diff;
   time_t now;
@@ -605,7 +609,8 @@ parse_time (const gchar *string, int *seconds)
  * @return Number of hosts, or -1 on error.
  */
 int
-manage_count_hosts_max (const char *given_hosts, const char *exclude_hosts,
+manage_count_hosts_max (const char *given_hosts,
+                        const char *exclude_hosts,
                         int max_hosts)
 {
   int count;
@@ -720,7 +725,8 @@ level_max_severity (const char *level, const char *class)
  * @return 1 if host has equal in hosts_str, 0 otherwise.
  */
 int
-hosts_str_contains (const char *hosts_str, const char *find_host_str,
+hosts_str_contains (const char *hosts_str,
+                    const char *find_host_str,
                     int max_hosts)
 {
   gvm_hosts_t *hosts, *find_hosts;
@@ -832,9 +838,12 @@ icalendar_timezone_from_tzid (const char *tzid)
  * @return  The generated iCalendar component.
  */
 icalcomponent *
-icalendar_from_old_schedule_data (time_t first_time, time_t period,
-                                  time_t period_months, time_t duration,
-                                  int byday_mask, const char *zone)
+icalendar_from_old_schedule_data (time_t first_time,
+                                  time_t period,
+                                  time_t period_months,
+                                  time_t duration,
+                                  int byday_mask,
+                                  const char *zone)
 {
   gchar *uid;
   icalcomponent *ical_new, *vevent;
@@ -970,8 +979,10 @@ icalendar_from_old_schedule_data (time_t first_time, time_t period,
  * @return  A newly allocated, simplified VEVENT component.
  */
 static icalcomponent *
-icalendar_simplify_vevent (icalcomponent *vevent, GHashTable *used_tzids,
-                           gchar **error, GString *warnings_buffer)
+icalendar_simplify_vevent (icalcomponent *vevent,
+                           GHashTable *used_tzids,
+                           gchar **error,
+                           GString *warnings_buffer)
 {
   icalproperty *error_prop;
   gchar *uid;
@@ -1492,8 +1503,10 @@ icalendar_time_matches_array (icaltimetype time, GPtrArray *times_array)
  * @return  The next or previous time as time_t.
  */
 static time_t
-icalendar_next_time_from_rdates (GPtrArray *rdates, icaltimetype ref_time_ical,
-                                 icaltimezone *tz, int periods_offset)
+icalendar_next_time_from_rdates (GPtrArray *rdates,
+                                 icaltimetype ref_time_ical,
+                                 icaltimezone *tz,
+                                 int periods_offset)
 {
   int index;
   time_t ref_time, closest_time;
@@ -1546,8 +1559,10 @@ static time_t
 icalendar_next_time_from_recurrence (struct icalrecurrencetype recurrence,
                                      icaltimetype dtstart,
                                      icaltimetype reference_time,
-                                     icaltimezone *tz, GPtrArray *exdates,
-                                     GPtrArray *rdates, int periods_offset)
+                                     icaltimezone *tz,
+                                     GPtrArray *exdates,
+                                     GPtrArray *rdates,
+                                     int periods_offset)
 {
   icalrecur_iterator *recur_iter;
   icaltimetype recur_time, prev_time, next_time;
@@ -1709,7 +1724,8 @@ icalendar_next_time_from_vcalendar (icalcomponent *vcalendar,
  */
 time_t
 icalendar_next_time_from_string (const char *ical_string,
-                                 const char *default_tzid, int periods_offset)
+                                 const char *default_tzid,
+                                 int periods_offset)
 {
   time_t next_time;
   icalcomponent *ical_parsed;

--- a/src/manage_utils.c
+++ b/src/manage_utils.c
@@ -419,11 +419,14 @@ next_time (time_t first, int period, int period_months, int byday,
        * Simply: the next possible time on a daily schedule. */
       next_day_multiple = now + (SECS_PER_DAY - ((now - first) % SECS_PER_DAY));
 
-      g_debug ("%s: next_day_multiple: %lli", __FUNCTION__,
+      g_debug ("%s: next_day_multiple: %lli",
+               __FUNCTION__,
                (long long) next_day_multiple);
-      g_debug ("%s: day_of_week (next_day_multiple): %i", __FUNCTION__,
+      g_debug ("%s: day_of_week (next_day_multiple): %i",
+               __FUNCTION__,
                day_of_week (next_day_multiple));
-      g_debug ("%s: next_day (^, byday): %i", __FUNCTION__,
+      g_debug ("%s: next_day (^, byday): %i",
+               __FUNCTION__,
                next_day (day_of_week (next_day_multiple), byday));
 
       /* Return the next possible daily time, offset according the next day of
@@ -531,12 +534,12 @@ parse_time (const gchar *string, int *seconds)
                   == NULL)
                 {
                   memset (&tm, 0, sizeof (struct tm));
-                  if (strptime ((char *) string, "$Date: %a %b %d %T %Y %z",
-                                &tm)
+                  if (strptime (
+                        (char *) string, "$Date: %a %b %d %T %Y %z", &tm)
                       == NULL)
                     {
-                      g_warning ("%s: Failed to parse time: %s", __FUNCTION__,
-                                 string);
+                      g_warning (
+                        "%s: Failed to parse time: %s", __FUNCTION__, string);
                       return -1;
                     }
                 }
@@ -554,21 +557,23 @@ parse_time (const gchar *string, int *seconds)
 
   if ((sscanf ((char *) string, "%*u-%*u-%*u %*u:%*u:%*u %d%*[^]]", &offset)
        != 1)
-      && (sscanf ((char *) string, "$Date: %*u-%*u-%*u %*u:%*u:%*u %d%*[^]]",
-                  &offset)
+      && (sscanf (
+            (char *) string, "$Date: %*u-%*u-%*u %*u:%*u:%*u %d%*[^]]", &offset)
           != 1)
-      && (sscanf ((char *) string, "%*s %*s %*s %*u:%*u:%*u %*u %d%*[^]]",
+      && (sscanf (
+            (char *) string, "%*s %*s %*s %*u:%*u:%*u %*u %d%*[^]]", &offset)
+          != 1)
+      && (sscanf ((char *) string,
+                  "$Date: %*s %*s %*s %*u %*u:%*u:%*u %d%*[^]]",
                   &offset)
           != 1)
       && (sscanf ((char *) string,
-                  "$Date: %*s %*s %*s %*u %*u:%*u:%*u %d%*[^]]", &offset)
-          != 1)
-      && (sscanf ((char *) string,
-                  "$Date: %*s %*s %*s %*u:%*u:%*u %*u %d%*[^]]", &offset)
+                  "$Date: %*s %*s %*s %*u:%*u:%*u %*u %d%*[^]]",
+                  &offset)
           != 1))
     {
-      g_warning ("%s: Failed to parse timezone offset: %s", __FUNCTION__,
-                 string);
+      g_warning (
+        "%s: Failed to parse timezone offset: %s", __FUNCTION__, string);
       return -3;
     }
 
@@ -1192,8 +1197,8 @@ icalendar_from_string (const char *ical_string, gchar **error)
               //  following ones.
               if (vevent_count == 0)
                 {
-                  new_vevent = icalendar_simplify_vevent (subcomp, tzids, error,
-                                                          warnings_buffer);
+                  new_vevent = icalendar_simplify_vevent (
+                    subcomp, tzids, error, warnings_buffer);
                   if (new_vevent == NULL)
                     ICAL_RETURN_ERROR (*error);
                   icalcomponent_add_component (ical_new, new_vevent);
@@ -1247,8 +1252,8 @@ icalendar_from_string (const char *ical_string, gchar **error)
       {
         icalcomponent *new_vevent;
 
-        new_vevent = icalendar_simplify_vevent (ical_parsed, tzids, error,
-                                                warnings_buffer);
+        new_vevent = icalendar_simplify_vevent (
+          ical_parsed, tzids, error, warnings_buffer);
         if (new_vevent == NULL)
           ICAL_RETURN_ERROR (*error);
         icalcomponent_add_component (ical_new, new_vevent);
@@ -1590,8 +1595,8 @@ icalendar_next_time_from_recurrence (struct icalrecurrencetype recurrence,
   next_time = recur_time;
 
   // Get time from RDATEs
-  rdates_time = icalendar_next_time_from_rdates (rdates, reference_time, tz,
-                                                 periods_offset);
+  rdates_time = icalendar_next_time_from_rdates (
+    rdates, reference_time, tz, periods_offset);
 
   // Select appropriate time as the RRULE time, compare it to the RDATEs time
   //  and return the appropriate time.
@@ -1710,8 +1715,8 @@ icalendar_next_time_from_string (const char *ical_string,
   icalcomponent *ical_parsed;
 
   ical_parsed = icalcomponent_new_from_string (ical_string);
-  next_time = icalendar_next_time_from_vcalendar (ical_parsed, default_tzid,
-                                                  periods_offset);
+  next_time = icalendar_next_time_from_vcalendar (
+    ical_parsed, default_tzid, periods_offset);
   icalcomponent_free (ical_parsed);
   return next_time;
 }

--- a/src/manage_utils.c
+++ b/src/manage_utils.c
@@ -25,12 +25,11 @@
 #include "manage_utils.h"
 
 #include <assert.h> /* for assert */
-#include <stdlib.h> /* for getenv */
-#include <stdio.h>  /* for sscanf */
-#include <string.h> /* for strcmp */
-
 #include <gvm/base/hosts.h>
 #include <gvm/util/uuidutils.h>
+#include <stdio.h>  /* for sscanf */
+#include <stdlib.h> /* for getenv */
+#include <string.h> /* for strcmp */
 
 #undef G_LOG_DOMAIN
 /**
@@ -179,7 +178,7 @@ current_offset (const char *zone)
       return 0;
     }
   tzset ();
-  offset = - (now - mktime (now_broken));
+  offset = -(now - mktime (now_broken));
 
   /* Revert to stored TZ. */
   if (tz)
@@ -198,23 +197,20 @@ current_offset (const char *zone)
   return offset;
 }
 
-
 /**
  * @brief Code fragment for months_between.
  */
-#define MONTHS_WITHIN_YEAR()                                 \
-  (same_month                                                \
-    ? 0                                                      \
-    : ((broken2->tm_mon - broken1.tm_mon)                    \
-       - (same_day                                           \
-           ? (same_hour                                      \
-               ? (same_minute                                \
-                   ? (same_second                            \
-                       ? 0                                   \
-                       : (broken2->tm_sec < broken1.tm_sec)) \
-                   : (broken2->tm_min < broken1.tm_min))     \
-               : (broken2->tm_hour < broken1.tm_hour))       \
-           : (broken2->tm_mday < broken1.tm_mday))))
+#define MONTHS_WITHIN_YEAR()                                                   \
+  (same_month                                                                  \
+     ? 0                                                                       \
+     : ((broken2->tm_mon - broken1.tm_mon)                                     \
+        - (same_day                                                            \
+             ? (same_hour ? (same_minute ? (same_second ? 0                    \
+                                                        : (broken2->tm_sec     \
+                                                           < broken1.tm_sec))  \
+                                         : (broken2->tm_min < broken1.tm_min)) \
+                          : (broken2->tm_hour < broken1.tm_hour))              \
+             : (broken2->tm_mday < broken1.tm_mday))))
 
 /**
  * @brief Count number of full months between two times.
@@ -239,8 +235,7 @@ months_between (time_t time1, time_t time2)
   assert (time1 <= time2);
 
   broken2 = localtime (&time2);
-  if ((localtime_r (&time1, &broken1) == NULL)
-      || (broken2 == NULL))
+  if ((localtime_r (&time1, &broken1) == NULL) || (broken2 == NULL))
     {
       g_warning ("%s: localtime failed", __FUNCTION__);
       return 0;
@@ -259,8 +254,8 @@ months_between (time_t time1, time_t time2)
   minute1_less = (broken1.tm_min < broken2->tm_min);
   second1_less = (broken1.tm_sec < broken2->tm_sec);
 
-  return
-    (same_year
+  return (
+    same_year
       ? MONTHS_WITHIN_YEAR ()
       : ((month1_less
           || (same_month
@@ -269,25 +264,23 @@ months_between (time_t time1, time_t time2)
                       && (hour1_less
                           || (same_hour
                               && (minute1_less
-                                  || (same_minute
-                                      && second1_less))))))))
-         ? (/* time1 is earlier in the year than time2. */
-            ((broken2->tm_year - broken1.tm_year) * 12)
-            + MONTHS_WITHIN_YEAR ())
-         : (/* time1 is later in the year than time2. */
-            ((broken2->tm_year - broken1.tm_year - 1) * 12)
-            /* Months left in year of time1. */
-            + (11 - broken1.tm_mon)
-            /* Months past in year of time2. */
-            + broken2->tm_mon
-            /* Possible extra month due to position in month of each time. */
-            + (day1_less
-               || (same_day
-                   && (hour1_less
-                       || (same_hour
-                           && (minute1_less
-                               || (same_minute
-                                   && second1_less)))))))));
+                                  || (same_minute && second1_less))))))))
+           ? (/* time1 is earlier in the year than time2. */
+              ((broken2->tm_year - broken1.tm_year) * 12)
+              + MONTHS_WITHIN_YEAR ())
+           : (/* time1 is later in the year than time2. */
+              ((broken2->tm_year - broken1.tm_year - 1) * 12)
+              /* Months left in year of time1. */
+              + (11 - broken1.tm_mon)
+              /* Months past in year of time2. */
+              + broken2->tm_mon
+              /* Possible extra month due to position in month of each time. */
+              + (day1_less
+                 || (same_day
+                     && (hour1_less
+                         || (same_hour
+                             && (minute1_less
+                                 || (same_minute && second1_less)))))))));
 }
 
 /**
@@ -331,7 +324,7 @@ day_of_week (time_t time)
       return 0;
     }
 
-  sunday_first = tm->tm_wday;     /* Sunday 0, Monday 1, ... */
+  sunday_first = tm->tm_wday; /* Sunday 0, Monday 1, ... */
   return 1 << ((sunday_first + 6) % 7);
 }
 
@@ -383,7 +376,7 @@ next_day (int day_of_week, int byday)
  */
 time_t
 next_time (time_t first, int period, int period_months, int byday,
-           const char* zone, int periods_offset)
+           const char *zone, int periods_offset)
 {
   int periods_diff;
   time_t now;
@@ -426,29 +419,26 @@ next_time (time_t first, int period, int period_months, int byday,
        * Simply: the next possible time on a daily schedule. */
       next_day_multiple = now + (SECS_PER_DAY - ((now - first) % SECS_PER_DAY));
 
-      g_debug ("%s: next_day_multiple: %lli",
-               __FUNCTION__,
+      g_debug ("%s: next_day_multiple: %lli", __FUNCTION__,
                (long long) next_day_multiple);
-      g_debug ("%s: day_of_week (next_day_multiple): %i",
-               __FUNCTION__,
+      g_debug ("%s: day_of_week (next_day_multiple): %i", __FUNCTION__,
                day_of_week (next_day_multiple));
-      g_debug ("%s: next_day (^, byday): %i",
-               __FUNCTION__,
+      g_debug ("%s: next_day (^, byday): %i", __FUNCTION__,
                next_day (day_of_week (next_day_multiple), byday));
 
       /* Return the next possible daily time, offset according the next day of
        * the week that the schedule must run on. */
       return next_day_multiple
              + next_day (day_of_week (next_day_multiple), byday)
-               * SECONDS_PER_DAY;
+                 * SECONDS_PER_DAY;
     }
 
   if (period > 0)
     {
       return first
-              + ((((now - first + offset_diff) / period) + 1 + periods_offset)
-                 * period)
-              - offset_diff;
+             + ((((now - first + offset_diff) / period) + 1 + periods_offset)
+                * period)
+             - offset_diff;
     }
   else if (period_months > 0)
     {
@@ -510,12 +500,12 @@ parse_time (const gchar *string, int *seconds)
   int epoch_time, offset;
   struct tm tm;
 
-  if ((strcmp ((char*) string, "") == 0)
-      || (strcmp ((char*) string, "$Date: $") == 0)
-      || (strcmp ((char*) string, "$Date$") == 0)
-      || (strcmp ((char*) string, "$Date:$") == 0)
-      || (strcmp ((char*) string, "$Date") == 0)
-      || (strcmp ((char*) string, "$$") == 0))
+  if ((strcmp ((char *) string, "") == 0)
+      || (strcmp ((char *) string, "$Date: $") == 0)
+      || (strcmp ((char *) string, "$Date$") == 0)
+      || (strcmp ((char *) string, "$Date:$") == 0)
+      || (strcmp ((char *) string, "$Date") == 0)
+      || (strcmp ((char *) string, "$$") == 0))
     {
       if (seconds)
         *seconds = 0;
@@ -528,24 +518,25 @@ parse_time (const gchar *string, int *seconds)
   /* $Date: 2012-02-17 16:05:26 +0100 (Fr, 17. Feb 2012) $ */
   /* $Date: Fri, 11 Nov 2011 14:42:28 +0100 $ */
   memset (&tm, 0, sizeof (struct tm));
-  if (strptime ((char*) string, "%F %T %z", &tm) == NULL)
+  if (strptime ((char *) string, "%F %T %z", &tm) == NULL)
     {
       memset (&tm, 0, sizeof (struct tm));
-      if (strptime ((char*) string, "$Date: %F %T %z", &tm) == NULL)
+      if (strptime ((char *) string, "$Date: %F %T %z", &tm) == NULL)
         {
           memset (&tm, 0, sizeof (struct tm));
-          if (strptime ((char*) string, "%a %b %d %T %Y %z", &tm) == NULL)
+          if (strptime ((char *) string, "%a %b %d %T %Y %z", &tm) == NULL)
             {
               memset (&tm, 0, sizeof (struct tm));
-              if (strptime ((char*) string, "$Date: %a, %d %b %Y %T %z", &tm)
+              if (strptime ((char *) string, "$Date: %a, %d %b %Y %T %z", &tm)
                   == NULL)
                 {
                   memset (&tm, 0, sizeof (struct tm));
-                  if (strptime ((char*) string, "$Date: %a %b %d %T %Y %z", &tm)
+                  if (strptime ((char *) string, "$Date: %a %b %d %T %Y %z",
+                                &tm)
                       == NULL)
                     {
-                      g_warning ("%s: Failed to parse time: %s",
-                                 __FUNCTION__, string);
+                      g_warning ("%s: Failed to parse time: %s", __FUNCTION__,
+                                 string);
                       return -1;
                     }
                 }
@@ -561,20 +552,19 @@ parse_time (const gchar *string, int *seconds)
 
   /* Get the timezone offset from the string. */
 
-  if ((sscanf ((char*) string, "%*u-%*u-%*u %*u:%*u:%*u %d%*[^]]", &offset)
-               != 1)
-      && (sscanf ((char*) string, "$Date: %*u-%*u-%*u %*u:%*u:%*u %d%*[^]]",
+  if ((sscanf ((char *) string, "%*u-%*u-%*u %*u:%*u:%*u %d%*[^]]", &offset)
+       != 1)
+      && (sscanf ((char *) string, "$Date: %*u-%*u-%*u %*u:%*u:%*u %d%*[^]]",
                   &offset)
           != 1)
-      && (sscanf ((char*) string, "%*s %*s %*s %*u:%*u:%*u %*u %d%*[^]]",
+      && (sscanf ((char *) string, "%*s %*s %*s %*u:%*u:%*u %*u %d%*[^]]",
                   &offset)
           != 1)
-      && (sscanf ((char*) string,
-                  "$Date: %*s %*s %*s %*u %*u:%*u:%*u %d%*[^]]",
-                  &offset)
+      && (sscanf ((char *) string,
+                  "$Date: %*s %*s %*s %*u %*u:%*u:%*u %d%*[^]]", &offset)
           != 1)
-      && (sscanf ((char*) string, "$Date: %*s %*s %*s %*u:%*u:%*u %*u %d%*[^]]",
-                  &offset)
+      && (sscanf ((char *) string,
+                  "$Date: %*s %*s %*s %*u:%*u:%*u %*u %d%*[^]]", &offset)
           != 1))
     {
       g_warning ("%s: Failed to parse timezone offset: %s", __FUNCTION__,
@@ -622,10 +612,7 @@ manage_count_hosts_max (const char *given_hosts, const char *exclude_hosts,
 
   if (exclude_hosts)
     {
-      if (gvm_hosts_exclude_with_max (hosts,
-                                      exclude_hosts,
-                                      max_hosts)
-          < 0)
+      if (gvm_hosts_exclude_with_max (hosts, exclude_hosts, max_hosts) < 0)
         return -1;
     }
 
@@ -728,7 +715,7 @@ level_max_severity (const char *level, const char *class)
  * @return 1 if host has equal in hosts_str, 0 otherwise.
  */
 int
-hosts_str_contains (const char* hosts_str, const char* find_host_str,
+hosts_str_contains (const char *hosts_str, const char *find_host_str,
                     int max_hosts)
 {
   gvm_hosts_t *hosts, *find_hosts;
@@ -757,13 +744,12 @@ hosts_str_contains (const char* hosts_str, const char* find_host_str,
  * @return 1 yes, 0 no.
  */
 int
-valid_db_resource_type (const char* type)
+valid_db_resource_type (const char *type)
 {
   if (type == NULL)
     return 0;
 
-  return (strcasecmp (type, "agent") == 0)
-         || (strcasecmp (type, "alert") == 0)
+  return (strcasecmp (type, "agent") == 0) || (strcasecmp (type, "alert") == 0)
          || (strcasecmp (type, "config") == 0)
          || (strcasecmp (type, "cpe") == 0)
          || (strcasecmp (type, "credential") == 0)
@@ -772,10 +758,8 @@ valid_db_resource_type (const char* type)
          || (strcasecmp (type, "dfn_cert_adv") == 0)
          || (strcasecmp (type, "filter") == 0)
          || (strcasecmp (type, "group") == 0)
-         || (strcasecmp (type, "host") == 0)
-         || (strcasecmp (type, "os") == 0)
-         || (strcasecmp (type, "note") == 0)
-         || (strcasecmp (type, "nvt") == 0)
+         || (strcasecmp (type, "host") == 0) || (strcasecmp (type, "os") == 0)
+         || (strcasecmp (type, "note") == 0) || (strcasecmp (type, "nvt") == 0)
          || (strcasecmp (type, "ovaldef") == 0)
          || (strcasecmp (type, "override") == 0)
          || (strcasecmp (type, "port_list") == 0)
@@ -786,8 +770,7 @@ valid_db_resource_type (const char* type)
          || (strcasecmp (type, "role") == 0)
          || (strcasecmp (type, "scanner") == 0)
          || (strcasecmp (type, "schedule") == 0)
-         || (strcasecmp (type, "slave") == 0)
-         || (strcasecmp (type, "tag") == 0)
+         || (strcasecmp (type, "slave") == 0) || (strcasecmp (type, "tag") == 0)
          || (strcasecmp (type, "target") == 0)
          || (strcasecmp (type, "task") == 0)
          || (strcasecmp (type, "ticket") == 0)
@@ -797,8 +780,8 @@ valid_db_resource_type (const char* type)
 /**
  * @brief GVM product ID.
  */
-#define GVM_PRODID "-//Greenbone.net//NONSGML Greenbone Security Manager " \
-                   GVMD_VERSION "//EN"
+#define GVM_PRODID \
+  "-//Greenbone.net//NONSGML Greenbone Security Manager " GVMD_VERSION "//EN"
 
 /**
  * @brief Try to get a built-in libical timezone from a tzid or city name.
@@ -807,7 +790,7 @@ valid_db_resource_type (const char* type)
  *
  * @return The built-in timezone if found or UTC otherwise.
  */
-static icaltimezone*
+static icaltimezone *
 icalendar_timezone_from_tzid (const char *tzid)
 {
   icaltimezone *tz;
@@ -844,11 +827,9 @@ icalendar_timezone_from_tzid (const char *tzid)
  * @return  The generated iCalendar component.
  */
 icalcomponent *
-icalendar_from_old_schedule_data (time_t first_time,
-                                  time_t period, time_t period_months,
-                                  time_t duration,
-                                  int byday_mask,
-                                  const char *zone)
+icalendar_from_old_schedule_data (time_t first_time, time_t period,
+                                  time_t period_months, time_t duration,
+                                  int byday_mask, const char *zone)
 {
   gchar *uid;
   icalcomponent *ical_new, *vevent;
@@ -861,8 +842,7 @@ icalendar_from_old_schedule_data (time_t first_time,
   // Setup base calendar component
   ical_new = icalcomponent_new_vcalendar ();
   icalcomponent_add_property (ical_new, icalproperty_new_version ("2.0"));
-  icalcomponent_add_property (ical_new,
-                              icalproperty_new_prodid (GVM_PRODID));
+  icalcomponent_add_property (ical_new, icalproperty_new_prodid (GVM_PRODID));
 
   // Create event component
   vevent = icalcomponent_new_vevent ();
@@ -956,13 +936,12 @@ icalendar_from_old_schedule_data (time_t first_time,
               if (byday_mask & (1 << mask_bit))
                 {
                   recurrence.by_day[array_pos] = ical_day;
-                  array_pos ++;
+                  array_pos++;
                 }
             }
         }
 
-      icalcomponent_add_property (vevent,
-                                  icalproperty_new_rrule (recurrence));
+      icalcomponent_add_property (vevent, icalproperty_new_rrule (recurrence));
     }
 
   // Add duration
@@ -1002,8 +981,8 @@ icalendar_simplify_vevent (icalcomponent *vevent, GHashTable *used_tzids,
 
   // Check for errors
   icalrestriction_check (vevent);
-  error_prop = icalcomponent_get_first_property (vevent,
-                                                 ICAL_XLICERROR_PROPERTY);
+  error_prop =
+    icalcomponent_get_first_property (vevent, ICAL_XLICERROR_PROPERTY);
   if (error_prop)
     {
       if (error)
@@ -1048,12 +1027,10 @@ icalendar_simplify_vevent (icalcomponent *vevent, GHashTable *used_tzids,
    * Technically there can be multiple ones but behavior is undefined in
    *  the iCalendar specification.
    */
-  rrule_prop = icalcomponent_get_first_property (vevent,
-                                                 ICAL_RRULE_PROPERTY);
+  rrule_prop = icalcomponent_get_first_property (vevent, ICAL_RRULE_PROPERTY);
 
   // Warn about EXRULE being deprecated
-  exrule_prop = icalcomponent_get_first_property (vevent,
-                                                  ICAL_EXRULE_PROPERTY);
+  exrule_prop = icalcomponent_get_first_property (vevent, ICAL_EXRULE_PROPERTY);
   if (exrule_prop)
     {
       g_string_append_printf (warnings_buffer,
@@ -1074,8 +1051,7 @@ icalendar_simplify_vevent (icalcomponent *vevent, GHashTable *used_tzids,
     }
 
   // Simplify and copy RDATE properties
-  rdate_prop = icalcomponent_get_first_property (vevent,
-                                                 ICAL_RDATE_PROPERTY);
+  rdate_prop = icalcomponent_get_first_property (vevent, ICAL_RDATE_PROPERTY);
   while (rdate_prop)
     {
       struct icaldatetimeperiodtype old_datetimeperiod, new_datetimeperiod;
@@ -1096,13 +1072,12 @@ icalendar_simplify_vevent (icalcomponent *vevent, GHashTable *used_tzids,
       new_rdate = icalproperty_new_rdate (new_datetimeperiod);
       icalcomponent_add_property (vevent_simplified, new_rdate);
 
-      rdate_prop
-        = icalcomponent_get_next_property (vevent, ICAL_RDATE_PROPERTY);
+      rdate_prop =
+        icalcomponent_get_next_property (vevent, ICAL_RDATE_PROPERTY);
     }
 
   // Copy EXDATE properties
-  exdate_prop = icalcomponent_get_first_property (vevent,
-                                                  ICAL_EXDATE_PROPERTY);
+  exdate_prop = icalcomponent_get_first_property (vevent, ICAL_EXDATE_PROPERTY);
   while (exdate_prop)
     {
       icalproperty *prop_clone;
@@ -1110,8 +1085,8 @@ icalendar_simplify_vevent (icalcomponent *vevent, GHashTable *used_tzids,
       prop_clone = icalproperty_new_clone (exdate_prop);
       icalcomponent_add_property (vevent_simplified, prop_clone);
 
-      exdate_prop
-        = icalcomponent_get_next_property (vevent, ICAL_EXDATE_PROPERTY);
+      exdate_prop =
+        icalcomponent_get_next_property (vevent, ICAL_EXDATE_PROPERTY);
     }
 
   // Generate UID for event
@@ -1130,17 +1105,17 @@ icalendar_simplify_vevent (icalcomponent *vevent, GHashTable *used_tzids,
 /**
  * @brief Error return for icalendar_from_string.
  */
-#define ICAL_RETURN_ERROR(message)              \
-  do                                            \
-    {                                           \
-      if (error)                                \
-        *error = message;                       \
-      icalcomponent_free (ical_parsed);         \
-      icalcomponent_free (ical_new);            \
-      g_string_free (warnings_buffer, TRUE);    \
-      g_hash_table_destroy (tzids);             \
-      return NULL;                              \
-    }                                           \
+#define ICAL_RETURN_ERROR(message)           \
+  do                                         \
+    {                                        \
+      if (error)                             \
+        *error = message;                    \
+      icalcomponent_free (ical_parsed);      \
+      icalcomponent_free (ical_new);         \
+      g_string_free (warnings_buffer, TRUE); \
+      g_hash_table_destroy (tzids);          \
+      return NULL;                           \
+    }                                        \
   while (0)
 
 /**
@@ -1175,8 +1150,8 @@ icalendar_from_string (const char *ical_string, gchar **error)
 
   // Check for errors
   icalrestriction_check (ical_parsed);
-  error_prop = icalcomponent_get_first_property (ical_parsed,
-                                                 ICAL_XLICERROR_PROPERTY);
+  error_prop =
+    icalcomponent_get_first_property (ical_parsed, ICAL_XLICERROR_PROPERTY);
   if (error_prop)
     {
       if (error)
@@ -1192,104 +1167,102 @@ icalendar_from_string (const char *ical_string, gchar **error)
 
   ical_new = icalcomponent_new_vcalendar ();
   icalcomponent_add_property (ical_new, icalproperty_new_version ("2.0"));
-  icalcomponent_add_property (ical_new,
-                              icalproperty_new_prodid (GVM_PRODID));
+  icalcomponent_add_property (ical_new, icalproperty_new_prodid (GVM_PRODID));
 
   switch (icalcomponent_isa (ical_parsed))
     {
-      case ICAL_NO_COMPONENT:
-        // The text must contain valid iCalendar component
-        ICAL_RETURN_ERROR
-            (g_strdup_printf ("String contains no iCalendar component"));
-        break;
-      case ICAL_XROOT_COMPONENT:
-      case ICAL_VCALENDAR_COMPONENT:
-        // Check multiple components
-        ical_iter = icalcomponent_begin_component (ical_parsed,
-                                                   ICAL_ANY_COMPONENT);
-        icalcomponent *subcomp;
-        while ((subcomp = icalcompiter_deref (&ical_iter)))
-          {
-            icalcomponent *new_vevent;
-            switch (icalcomponent_isa (subcomp))
-              {
-                case ICAL_VEVENT_COMPONENT:
-                  // Copy and simplify only the first VEVENT, ignoring all
-                  //  following ones.
-                  if (vevent_count == 0)
-                    {
-                      new_vevent = icalendar_simplify_vevent
-                                      (subcomp, tzids, error, warnings_buffer);
-                      if (new_vevent == NULL)
-                        ICAL_RETURN_ERROR (*error);
-                      icalcomponent_add_component (ical_new, new_vevent);
-                    }
-                  vevent_count ++;
-                  break;
-                case ICAL_VTIMEZONE_COMPONENT:
-                  // Timezones are collected separately
-                  break;
-                case ICAL_VJOURNAL_COMPONENT:
-                case ICAL_VTODO_COMPONENT:
-                  // VJOURNAL and VTODO components are ignored
-                  other_component_count ++;
-                  break;
-                default:
-                  // Unexpected components
-                  ICAL_RETURN_ERROR
-                      (g_strdup_printf ("Unexpected component type: %s",
-                                        icalcomponent_kind_to_string
-                                            (icalcomponent_isa (subcomp))));
-              }
-            icalcompiter_next (&ical_iter);
-          }
-
-        if (vevent_count == 0)
-          {
-            ICAL_RETURN_ERROR
-                (g_strdup_printf ("iCalendar string must contain a VEVENT"));
-          }
-        else if (vevent_count > 1)
-          {
-            g_string_append_printf (warnings_buffer,
-                                    "<warning>"
-                                    "iCalendar contains %d VEVENT components"
-                                    " but only the first one will be used"
-                                    "</warning>",
-                                    vevent_count);
-          }
-
-        if (other_component_count)
-          {
-            g_string_append_printf (warnings_buffer,
-                                    "<warning>"
-                                    "iCalendar contains %d VTODO and/or"
-                                    " VJOURNAL component(s) which will be"
-                                    " ignored"
-                                    "</warning>",
-                                    other_component_count);
-          }
-        break;
-      case ICAL_VEVENT_COMPONENT:
+    case ICAL_NO_COMPONENT:
+      // The text must contain valid iCalendar component
+      ICAL_RETURN_ERROR (
+        g_strdup_printf ("String contains no iCalendar component"));
+      break;
+    case ICAL_XROOT_COMPONENT:
+    case ICAL_VCALENDAR_COMPONENT:
+      // Check multiple components
+      ical_iter =
+        icalcomponent_begin_component (ical_parsed, ICAL_ANY_COMPONENT);
+      icalcomponent *subcomp;
+      while ((subcomp = icalcompiter_deref (&ical_iter)))
         {
           icalcomponent *new_vevent;
-
-          new_vevent = icalendar_simplify_vevent (ical_parsed, tzids,
-                                                  error, warnings_buffer);
-          if (new_vevent == NULL)
-            ICAL_RETURN_ERROR (*error);
-          icalcomponent_add_component (ical_new, new_vevent);
+          switch (icalcomponent_isa (subcomp))
+            {
+            case ICAL_VEVENT_COMPONENT:
+              // Copy and simplify only the first VEVENT, ignoring all
+              //  following ones.
+              if (vevent_count == 0)
+                {
+                  new_vevent = icalendar_simplify_vevent (subcomp, tzids, error,
+                                                          warnings_buffer);
+                  if (new_vevent == NULL)
+                    ICAL_RETURN_ERROR (*error);
+                  icalcomponent_add_component (ical_new, new_vevent);
+                }
+              vevent_count++;
+              break;
+            case ICAL_VTIMEZONE_COMPONENT:
+              // Timezones are collected separately
+              break;
+            case ICAL_VJOURNAL_COMPONENT:
+            case ICAL_VTODO_COMPONENT:
+              // VJOURNAL and VTODO components are ignored
+              other_component_count++;
+              break;
+            default:
+              // Unexpected components
+              ICAL_RETURN_ERROR (g_strdup_printf (
+                "Unexpected component type: %s",
+                icalcomponent_kind_to_string (icalcomponent_isa (subcomp))));
+            }
+          icalcompiter_next (&ical_iter);
         }
-        break;
-      default:
-        ICAL_RETURN_ERROR
-            (g_strdup_printf ("iCalendar string must be a VCALENDAR or VEVENT"
-                              " component or consist of multiple elements."));
-        break;
+
+      if (vevent_count == 0)
+        {
+          ICAL_RETURN_ERROR (
+            g_strdup_printf ("iCalendar string must contain a VEVENT"));
+        }
+      else if (vevent_count > 1)
+        {
+          g_string_append_printf (warnings_buffer,
+                                  "<warning>"
+                                  "iCalendar contains %d VEVENT components"
+                                  " but only the first one will be used"
+                                  "</warning>",
+                                  vevent_count);
+        }
+
+      if (other_component_count)
+        {
+          g_string_append_printf (warnings_buffer,
+                                  "<warning>"
+                                  "iCalendar contains %d VTODO and/or"
+                                  " VJOURNAL component(s) which will be"
+                                  " ignored"
+                                  "</warning>",
+                                  other_component_count);
+        }
+      break;
+    case ICAL_VEVENT_COMPONENT:
+      {
+        icalcomponent *new_vevent;
+
+        new_vevent = icalendar_simplify_vevent (ical_parsed, tzids, error,
+                                                warnings_buffer);
+        if (new_vevent == NULL)
+          ICAL_RETURN_ERROR (*error);
+        icalcomponent_add_component (ical_new, new_vevent);
+      }
+      break;
+    default:
+      ICAL_RETURN_ERROR (
+        g_strdup_printf ("iCalendar string must be a VCALENDAR or VEVENT"
+                         " component or consist of multiple elements."));
+      break;
     }
 
   g_hash_table_iter_init (&tzids_iter, tzids);
-  while (g_hash_table_iter_next (&tzids_iter, (gpointer*)(&tzid), NULL))
+  while (g_hash_table_iter_next (&tzids_iter, (gpointer *) (&tzid), NULL))
     {
       icaltimezone *tz;
       tz = icalcomponent_get_timezone (ical_parsed, tzid);
@@ -1339,7 +1312,6 @@ icalendar_approximate_rrule_from_vcalendar (icalcomponent *vcalendar,
   icalcomponent *vevent;
   icalproperty *rrule_prop;
 
-
   assert (period);
   assert (period_months);
   assert (byday_mask);
@@ -1355,14 +1327,12 @@ icalendar_approximate_rrule_from_vcalendar (icalcomponent *vcalendar,
 
   // Process only the first VEVENT
   // Others should be removed by icalendar_from_string
-  vevent = icalcomponent_get_first_component (vcalendar,
-                                              ICAL_VEVENT_COMPONENT);
+  vevent = icalcomponent_get_first_component (vcalendar, ICAL_VEVENT_COMPONENT);
   if (vevent == NULL)
     return -1;
 
   // Process only first RRULE.
-  rrule_prop = icalcomponent_get_first_property (vevent,
-                                                 ICAL_RRULE_PROPERTY);
+  rrule_prop = icalcomponent_get_first_property (vevent, ICAL_RRULE_PROPERTY);
   if (rrule_prop)
     {
       struct icalrecurrencetype recurrence;
@@ -1372,30 +1342,30 @@ icalendar_approximate_rrule_from_vcalendar (icalcomponent *vcalendar,
       // Get period or period_months
       switch (recurrence.freq)
         {
-          case ICAL_YEARLY_RECURRENCE:
-            *period_months = recurrence.interval * 12;
-            break;
-          case ICAL_MONTHLY_RECURRENCE:
-            *period_months = recurrence.interval;
-            break;
-          case ICAL_WEEKLY_RECURRENCE:
-            *period = recurrence.interval * 604800;
-            break;
-          case ICAL_DAILY_RECURRENCE:
-            *period = recurrence.interval * 86400;
-            break;
-          case ICAL_HOURLY_RECURRENCE:
-            *period = recurrence.interval * 3600;
-            break;
-          case ICAL_MINUTELY_RECURRENCE:
-            *period = recurrence.interval * 60;
-            break;
-          case ICAL_SECONDLY_RECURRENCE:
-            *period = recurrence.interval;
-          case ICAL_NO_RECURRENCE:
-            break;
-          default:
-            return -1;
+        case ICAL_YEARLY_RECURRENCE:
+          *period_months = recurrence.interval * 12;
+          break;
+        case ICAL_MONTHLY_RECURRENCE:
+          *period_months = recurrence.interval;
+          break;
+        case ICAL_WEEKLY_RECURRENCE:
+          *period = recurrence.interval * 604800;
+          break;
+        case ICAL_DAILY_RECURRENCE:
+          *period = recurrence.interval * 86400;
+          break;
+        case ICAL_HOURLY_RECURRENCE:
+          *period = recurrence.interval * 3600;
+          break;
+        case ICAL_MINUTELY_RECURRENCE:
+          *period = recurrence.interval * 60;
+          break;
+        case ICAL_SECONDLY_RECURRENCE:
+          *period = recurrence.interval;
+        case ICAL_NO_RECURRENCE:
+          break;
+        default:
+          return -1;
         }
 
       /*
@@ -1406,8 +1376,8 @@ icalendar_approximate_rrule_from_vcalendar (icalcomponent *vcalendar,
       array_pos = 0;
       while (recurrence.by_day[array_pos] != ICAL_RECURRENCE_ARRAY_MAX)
         {
-          int ical_day = icalrecurrencetype_day_day_of_week
-                            (recurrence.by_day[array_pos]);
+          int ical_day =
+            icalrecurrencetype_day_day_of_week (recurrence.by_day[array_pos]);
           int mask_bit = -1;
 
           if (ical_day == 1)
@@ -1419,7 +1389,7 @@ icalendar_approximate_rrule_from_vcalendar (icalcomponent *vcalendar,
             {
               *byday_mask |= (1 << mask_bit);
             }
-          array_pos ++;
+          array_pos++;
         }
     }
 
@@ -1436,10 +1406,10 @@ icalendar_approximate_rrule_from_vcalendar (icalcomponent *vcalendar,
  *
  * @return  GPtrArray with pointers to collected times or NULL on error.
  */
-static GPtrArray*
+static GPtrArray *
 icalendar_times_from_vevent (icalcomponent *vevent, icalproperty_kind type)
 {
-  GPtrArray* times;
+  GPtrArray *times;
   icalproperty *date_prop;
 
   if (icalcomponent_isa (vevent) != ICAL_VEVENT_COMPONENT
@@ -1490,9 +1460,7 @@ icalendar_time_matches_array (icaltimetype time, GPtrArray *times_array)
   if (times_array == NULL)
     return FALSE;
 
-  for (index = 0;
-       found == FALSE && index < times_array->len;
-       index++)
+  for (index = 0; found == FALSE && index < times_array->len; index++)
     {
       int compare_result;
       icaltimetype *array_time = g_ptr_array_index (times_array, index);
@@ -1519,10 +1487,8 @@ icalendar_time_matches_array (icaltimetype time, GPtrArray *times_array)
  * @return  The next or previous time as time_t.
  */
 static time_t
-icalendar_next_time_from_rdates (GPtrArray *rdates,
-                                 icaltimetype ref_time_ical,
-                                 icaltimezone *tz,
-                                 int periods_offset)
+icalendar_next_time_from_rdates (GPtrArray *rdates, icaltimetype ref_time_ical,
+                                 icaltimezone *tz, int periods_offset)
 {
   int index;
   time_t ref_time, closest_time;
@@ -1575,10 +1541,8 @@ static time_t
 icalendar_next_time_from_recurrence (struct icalrecurrencetype recurrence,
                                      icaltimetype dtstart,
                                      icaltimetype reference_time,
-                                     icaltimezone *tz,
-                                     GPtrArray *exdates,
-                                     GPtrArray *rdates,
-                                     int periods_offset)
+                                     icaltimezone *tz, GPtrArray *exdates,
+                                     GPtrArray *rdates, int periods_offset)
 {
   icalrecur_iterator *recur_iter;
   icaltimetype recur_time, prev_time, next_time;
@@ -1684,8 +1648,7 @@ icalendar_next_time_from_vcalendar (icalcomponent *vcalendar,
 
   // Process only the first VEVENT
   // Others should be removed by icalendar_from_string
-  vevent = icalcomponent_get_first_component (vcalendar,
-                                              ICAL_VEVENT_COMPONENT);
+  vevent = icalcomponent_get_first_component (vcalendar, ICAL_VEVENT_COMPONENT);
   if (vevent == NULL)
     return 0;
 
@@ -1694,7 +1657,7 @@ icalendar_next_time_from_vcalendar (icalcomponent *vcalendar,
   if (icaltime_is_null_time (dtstart))
     return 0;
 
-  tz = (icaltimezone*)(icaltime_get_timezone (dtstart));
+  tz = (icaltimezone *) (icaltime_get_timezone (dtstart));
   if (tz == NULL)
     tz = icalendar_timezone_from_tzid (default_tzid);
 
@@ -1718,10 +1681,8 @@ icalendar_next_time_from_vcalendar (icalcomponent *vcalendar,
     icalrecurrencetype_clear (&recurrence);
 
   // Calculate next time.
-  next_time = icalendar_next_time_from_recurrence (recurrence,
-                                                   dtstart, ical_now, tz,
-                                                   exdates, rdates,
-                                                   periods_offset);
+  next_time = icalendar_next_time_from_recurrence (
+    recurrence, dtstart, ical_now, tz, exdates, rdates, periods_offset);
 
   // Cleanup
   g_ptr_array_free (exdates, TRUE);
@@ -1743,8 +1704,7 @@ icalendar_next_time_from_vcalendar (icalcomponent *vcalendar,
  */
 time_t
 icalendar_next_time_from_string (const char *ical_string,
-                                 const char *default_tzid,
-                                 int periods_offset)
+                                 const char *default_tzid, int periods_offset)
 {
   time_t next_time;
   icalcomponent *ical_parsed;
@@ -1778,8 +1738,7 @@ icalendar_duration_from_vcalendar (icalcomponent *vcalendar)
 
   // Process only the first VEVENT
   // Others should be removed by icalendar_from_string
-  vevent = icalcomponent_get_first_component (vcalendar,
-                                              ICAL_VEVENT_COMPONENT);
+  vevent = icalcomponent_get_first_component (vcalendar, ICAL_VEVENT_COMPONENT);
   if (vevent == NULL)
     return 0;
 
@@ -1815,8 +1774,7 @@ icalendar_first_time_from_vcalendar (icalcomponent *vcalendar,
 
   // Process only the first VEVENT
   // Others should be removed by icalendar_from_string
-  vevent = icalcomponent_get_first_component (vcalendar,
-                                              ICAL_VEVENT_COMPONENT);
+  vevent = icalcomponent_get_first_component (vcalendar, ICAL_VEVENT_COMPONENT);
   if (vevent == NULL)
     return 0;
 
@@ -1825,7 +1783,7 @@ icalendar_first_time_from_vcalendar (icalcomponent *vcalendar,
   if (icaltime_is_null_time (dtstart))
     return 0;
 
-  tz = (icaltimezone*)(icaltime_get_timezone (dtstart));
+  tz = (icaltimezone *) (icaltime_get_timezone (dtstart));
   if (tz == NULL)
     tz = icalendar_timezone_from_tzid (default_tzid);
 

--- a/src/manage_utils.h
+++ b/src/manage_utils.h
@@ -77,14 +77,20 @@ int
 hosts_str_contains (const char *, const char *, int);
 
 icalcomponent *
-icalendar_from_old_schedule_data (time_t, time_t, time_t, time_t, int,
+icalendar_from_old_schedule_data (time_t,
+                                  time_t,
+                                  time_t,
+                                  time_t,
+                                  int,
                                   const char *);
 
 icalcomponent *
 icalendar_from_string (const char *, gchar **);
 
 int
-icalendar_approximate_rrule_from_vcalendar (icalcomponent *, time_t *, time_t *,
+icalendar_approximate_rrule_from_vcalendar (icalcomponent *,
+                                            time_t *,
+                                            time_t *,
                                             int *);
 
 time_t

--- a/src/manage_utils.h
+++ b/src/manage_utils.h
@@ -28,9 +28,9 @@
 /* For strptime in time.h. */
 #undef _XOPEN_SOURCE
 #define _XOPEN_SOURCE
-#include <time.h>
 #include <glib.h>
 #include <libical/ical.h>
+#include <time.h>
 
 // Log message severity constant
 #define SEVERITY_LOG 0.0
@@ -52,10 +52,11 @@
 long
 current_offset (const char *);
 
-time_t add_months (time_t, int);
+time_t
+add_months (time_t, int);
 
 time_t
-next_time (time_t, int, int, int, const char*, int);
+next_time (time_t, int, int, int, const char *, int);
 
 int
 parse_time (const gchar *, int *);
@@ -64,17 +65,16 @@ int
 manage_count_hosts_max (const char *, const char *, int);
 
 double
-level_min_severity (const char*, const char*);
+level_min_severity (const char *, const char *);
 
 double
-level_max_severity (const char*, const char*);
+level_max_severity (const char *, const char *);
 
 int
-valid_db_resource_type (const char*);
-
+valid_db_resource_type (const char *);
 
 int
-hosts_str_contains (const char*, const char*, int);
+hosts_str_contains (const char *, const char *, int);
 
 icalcomponent *
 icalendar_from_old_schedule_data (time_t, time_t, time_t, time_t, int,
@@ -84,21 +84,19 @@ icalcomponent *
 icalendar_from_string (const char *, gchar **);
 
 int
-icalendar_approximate_rrule_from_vcalendar (icalcomponent *,
-                                            time_t *, time_t *, int *);
+icalendar_approximate_rrule_from_vcalendar (icalcomponent *, time_t *, time_t *,
+                                            int *);
 
 time_t
-icalendar_next_time_from_vcalendar (icalcomponent*, const char*, int);
+icalendar_next_time_from_vcalendar (icalcomponent *, const char *, int);
 
 time_t
-icalendar_next_time_from_string (const char *, const char*, int);
+icalendar_next_time_from_string (const char *, const char *, int);
 
 int
 icalendar_duration_from_vcalendar (icalcomponent *);
 
 time_t
 icalendar_first_time_from_vcalendar (icalcomponent *, const char *);
-
-
 
 #endif /* not _GVMD_MANAGE_UTILS_H */

--- a/src/otp.c
+++ b/src/otp.c
@@ -237,9 +237,13 @@ write_message (task_t task, message_t *message, char *type)
   assert (global_current_report);
 
   manage_transaction_start ();
-  result =
-    make_result (task, message->host, message->hostname, message->port.string,
-                 message->oid, type, message->description);
+  result = make_result (task,
+                        message->host,
+                        message->hostname,
+                        message->port.string,
+                        message->oid,
+                        type,
+                        message->description);
   if (global_current_report)
     report_add_result (global_current_report, result);
 }
@@ -289,10 +293,12 @@ append_log_message (task_t task, message_t *message)
           && (message->description[len - 2] == '\\'))
         message->description[len - 2] = '\0';
       /* Add detail to report. */
-      if (manage_report_host_detail (global_current_report, message->host,
-                                     message->description))
+      if (manage_report_host_detail (
+            global_current_report, message->host, message->description))
         g_warning ("%s: Failed to add report detail for host '%s': %s",
-                   __FUNCTION__, message->host, message->description);
+                   __FUNCTION__,
+                   message->host,
+                   message->description);
     }
   else
     write_message (task, message, "Log Message");
@@ -827,11 +833,14 @@ process_otp_scanner_input ()
         {
           parse_scanner_loading (messages);
           if (scanner_current_loading && scanner_total_loading)
-            g_log (G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE,
+            g_log (G_LOG_DOMAIN,
+                   G_LOG_LEVEL_MESSAGE,
                    "Waiting for scanner to load NVTs: %d / %d",
-                   scanner_current_loading, scanner_total_loading);
+                   scanner_current_loading,
+                   scanner_total_loading);
           else
-            g_log (G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE,
+            g_log (G_LOG_DOMAIN,
+                   G_LOG_LEVEL_MESSAGE,
                    "Waiting for scanner to load: No information provided. "
                    "(Message: %s)",
                    messages);
@@ -853,7 +862,8 @@ process_otp_scanner_input ()
         {
           g_debug ("   scanner fail: expected \"%s\""
                    "   got \"%.12s\"",
-                   ver_str, messages);
+                   ver_str,
+                   messages);
           return -1;
         }
       from_scanner_start += ver_len;
@@ -1039,7 +1049,8 @@ process_otp_scanner_input ()
                     protocol[0] = '\0';
                   }
                 g_debug ("   scanner got debug port, number: %i, protocol: %s",
-                         number, protocol);
+                         number,
+                         protocol);
 
                 set_message_port_number (current_message, number);
                 set_message_port_protocol (current_message, protocol);
@@ -1119,7 +1130,8 @@ process_otp_scanner_input ()
                     protocol[0] = '\0';
                   }
                 g_debug ("   scanner got alarm port, number: %i, protocol: %s",
-                         number, protocol);
+                         number,
+                         protocol);
 
                 set_message_port_number (current_message, number);
                 set_message_port_protocol (current_message, protocol);
@@ -1199,7 +1211,8 @@ process_otp_scanner_input ()
                     protocol[0] = '\0';
                   }
                 g_debug ("   scanner got log port, number: %i, protocol: %s",
-                         number, protocol);
+                         number,
+                         protocol);
 
                 set_message_port_number (current_message, number);
                 set_message_port_protocol (current_message, protocol);
@@ -1386,8 +1399,11 @@ process_otp_scanner_input ()
                   int value_start = -1, value_end = -1, count;
                   char name[21];
                   /* LDAPsearch[entry]:Timeout value */
-                  count = sscanf (field, "%20[^[][%*[^]]]:%n%*[ -~]%n", name,
-                                  &value_start, &value_end);
+                  count = sscanf (field,
+                                  "%20[^[][%*[^]]]:%n%*[ -~]%n",
+                                  name,
+                                  &value_start,
+                                  &value_end);
                   if (count == 1 && value_start > 0 && value_end > 0
                       && ((strcmp (name, "SSH Authorization") == 0)
                           || (strcmp (name, "SNMP Authorization") == 0)
@@ -1474,8 +1490,8 @@ process_otp_scanner_input ()
                     unsigned int current, max;
                     g_debug ("   scanner got ports: %s", field);
                     if (sscanf (field, "%u/%u", &current, &max) == 2)
-                      set_scan_ports (global_current_report, current_host,
-                                      current, max);
+                      set_scan_ports (
+                        global_current_report, current_host, current, max);
                   }
                 if (current_host)
                   {
@@ -1524,8 +1540,8 @@ process_otp_scanner_input ()
                     assert (current_host);
                     assert (global_current_report);
 
-                    set_scan_host_start_time_otp (global_current_report,
-                                                  current_host, field);
+                    set_scan_host_start_time_otp (
+                      global_current_report, current_host, field);
                     g_free (current_host);
                     current_host = NULL;
                   }
@@ -1559,16 +1575,21 @@ process_otp_scanner_input ()
                   {
                     char *uuid;
                     uuid = report_uuid (global_current_report);
-                    host_notice (current_host, "ip", current_host,
-                                 "Report Host", uuid, 1, 0);
+                    host_notice (current_host,
+                                 "ip",
+                                 current_host,
+                                 "Report Host",
+                                 uuid,
+                                 1,
+                                 0);
                     free (uuid);
                   }
 
                 if (current_scanner_task)
                   {
                     assert (current_host);
-                    set_scan_host_end_time_otp (global_current_report,
-                                                current_host, field);
+                    set_scan_host_end_time_otp (
+                      global_current_report, current_host, field);
                     g_free (current_host);
                     current_host = NULL;
                   }
@@ -1628,8 +1649,8 @@ process_otp_scanner_input ()
                     if (global_current_report)
                       {
                         hosts_set_identifiers (global_current_report);
-                        hosts_set_max_severity (global_current_report, NULL,
-                                                NULL);
+                        hosts_set_max_severity (
+                          global_current_report, NULL, NULL);
                         hosts_set_details (global_current_report);
                         set_scan_end_time_otp (global_current_report, field);
                       }

--- a/src/otp.c
+++ b/src/otp.c
@@ -37,6 +37,7 @@
  */
 
 #include "otp.h"
+
 #include "manage.h"
 #include "scanner.h"
 #include "types.h"
@@ -44,12 +45,11 @@
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>
+#include <gvm/base/strings.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-
-#include <gvm/base/strings.h>
 
 #undef G_LOG_DOMAIN
 /**
@@ -61,7 +61,6 @@
  *        the client in a data structure like an otp_parser_t. */
 extern buffer_size_t from_buffer_size;
 
-
 /* Helper functions. */
 
 /** @brief Replace any control characters in string with spaces.
@@ -72,21 +71,21 @@ static void
 blank_control_chars (char *string)
 {
   for (; *string; string++)
-    if (iscntrl (*string) && *string != '\n') *string = ' ';
+    if (iscntrl (*string) && *string != '\n')
+      *string = ' ';
 }
 
-
 /* Messages. */
 
 /**
  * @brief Current message during OTP SERVER message commands.
  */
-static message_t* current_message = NULL;
+static message_t *current_message = NULL;
 
 /**
  * @brief Current host during OTP SERVER message commands.
  */
-static gchar* current_host = NULL;
+static gchar *current_host = NULL;
 
 /**
  * @brief The version of the NVT feed.
@@ -100,12 +99,12 @@ static char *plugins_feed_version = NULL;
  *
  * @return A pointer to the new message.
  */
-static message_t*
-make_message (const char* host)
+static message_t *
+make_message (const char *host)
 {
-  message_t* message;
+  message_t *message;
 
-  message = (message_t*) g_malloc0 (sizeof (message_t));
+  message = (message_t *) g_malloc0 (sizeof (message_t));
   message->host = g_strdup (host);
   message->port.protocol = PORT_PROTOCOL_OTHER;
 
@@ -118,13 +117,18 @@ make_message (const char* host)
  * @param[in]  message       Pointer to the message.
  */
 static void
-free_message (message_t* message)
+free_message (message_t *message)
 {
-  if (message->host) free (message->host);
-  if (message->hostname) free (message->hostname);
-  if (message->description) free (message->description);
-  if (message->oid) free (message->oid);
-  if (message->port.string) free (message->port.string);
+  if (message->host)
+    free (message->host);
+  if (message->hostname)
+    free (message->hostname);
+  if (message->description)
+    free (message->description);
+  if (message->oid)
+    free (message->oid);
+  if (message->port.string)
+    free (message->port.string);
   free (message);
 }
 
@@ -136,9 +140,10 @@ free_message (message_t* message)
  * @param[in]  hostname     Hostname.
  */
 static void
-set_message_hostname (message_t* message, char* hostname)
+set_message_hostname (message_t *message, char *hostname)
 {
-  if (message->hostname) free (message->hostname);
+  if (message->hostname)
+    free (message->hostname);
   message->hostname = hostname;
 }
 
@@ -150,7 +155,7 @@ set_message_hostname (message_t* message, char* hostname)
  * @param[in]  number       Port number.
  */
 static void
-set_message_port_number (message_t* message, int number)
+set_message_port_number (message_t *message, int number)
 {
   message->port.number = number;
 }
@@ -163,7 +168,7 @@ set_message_port_number (message_t* message, int number)
  * @param[in]  protocol     Name of protocol on port.
  */
 static void
-set_message_port_protocol (message_t* message, const char* protocol)
+set_message_port_protocol (message_t *message, const char *protocol)
 {
   if (strcasecmp ("udp", protocol) == 0)
     message->port.protocol = PORT_PROTOCOL_UDP;
@@ -180,9 +185,10 @@ set_message_port_protocol (message_t* message, const char* protocol)
  * @param[in]  string       Port string.
  */
 static void
-set_message_port_string (message_t* message, char* string)
+set_message_port_string (message_t *message, char *string)
 {
-  if (message->port.string) free (message->port.string);
+  if (message->port.string)
+    free (message->port.string);
   message->port.string = string;
 }
 
@@ -194,9 +200,10 @@ set_message_port_string (message_t* message, char* string)
  * @param[in]  description  Description.
  */
 static void
-set_message_description (message_t* message, char* description)
+set_message_description (message_t *message, char *description)
 {
-  if (message->description) free (message->description);
+  if (message->description)
+    free (message->description);
   message->description = description;
 }
 
@@ -208,9 +215,10 @@ set_message_description (message_t* message, char* description)
  * @param[in]  oid          OID.
  */
 static void
-set_message_oid (message_t* message, char* oid)
+set_message_oid (message_t *message, char *oid)
 {
-  if (message->oid) free (message->oid);
+  if (message->oid)
+    free (message->oid);
   message->oid = oid;
 }
 
@@ -222,16 +230,16 @@ set_message_oid (message_t* message, char* oid)
  * @param[in]  type     The message type (for example "Security Warning").
  */
 static void
-write_message (task_t task, message_t* message, char* type)
+write_message (task_t task, message_t *message, char *type)
 {
   result_t result;
 
   assert (global_current_report);
 
   manage_transaction_start ();
-  result = make_result (task, message->host, message->hostname,
-                        message->port.string, message->oid,
-                        type, message->description);
+  result =
+    make_result (task, message->host, message->hostname, message->port.string,
+                 message->oid, type, message->description);
   if (global_current_report)
     report_add_result (global_current_report, result);
 }
@@ -243,7 +251,7 @@ write_message (task_t task, message_t* message, char* type)
  * @param[in]  message      Message.
  */
 static void
-append_error_message (task_t task, message_t* message)
+append_error_message (task_t task, message_t *message)
 {
   write_message (task, message, "Error Message");
 }
@@ -255,7 +263,7 @@ append_error_message (task_t task, message_t* message)
  * @param[in]  message      Message.
  */
 static void
-append_alarm_message (task_t task, message_t* message)
+append_alarm_message (task_t task, message_t *message)
 {
   write_message (task, message, "Alarm");
 }
@@ -267,7 +275,7 @@ append_alarm_message (task_t task, message_t* message)
  * @param[in]  message      Message.
  */
 static void
-append_log_message (task_t task, message_t* message)
+append_log_message (task_t task, message_t *message)
 {
   assert (global_current_report);
 
@@ -277,50 +285,43 @@ append_log_message (task_t task, message_t* message)
       int len;
       /* Strip trailing \n. */
       len = strlen (message->description);
-      if ((len > 2)
-          && (message->description[len - 1] == 'n')
+      if ((len > 2) && (message->description[len - 1] == 'n')
           && (message->description[len - 2] == '\\'))
         message->description[len - 2] = '\0';
       /* Add detail to report. */
-      if (manage_report_host_detail (global_current_report,
-                                     message->host,
+      if (manage_report_host_detail (global_current_report, message->host,
                                      message->description))
         g_warning ("%s: Failed to add report detail for host '%s': %s",
-                   __FUNCTION__,
-                   message->host,
-                   message->description);
+                   __FUNCTION__, message->host, message->description);
     }
   else
     write_message (task, message, "Log Message");
 }
 
-
 /* Scanner preferences. */
 
 /**
  * @brief The current scanner preference, during reading of scanner preferences.
  */
-static char* current_scanner_preference = NULL;
+static char *current_scanner_preference = NULL;
 
-
 /* Scanner plugins. */
 
 /**
  * @brief The current plugin, during reading of scanner plugin list.
  */
-static nvti_t* current_plugin = NULL;
+static nvti_t *current_plugin = NULL;
 
 /**
  * @brief The full plugins list, during reading of scanner plugin list.
  */
-static GList* scanner_plugins_list = NULL;
+static GList *scanner_plugins_list = NULL;
 
 /**
  * @brief The full preferences list, during reading of scanner plugin list.
  */
-static GList* scanner_preferences_list = NULL;
+static GList *scanner_preferences_list = NULL;
 
-
 /* Scanner state. */
 
 /**
@@ -443,7 +444,6 @@ reset_scanner_states ()
   scanner_total_loading = 0;
 }
 
-
 /* OTP input processor. */
 
 /** @todo As with the GMP version, these should most likely be passed to and
@@ -480,7 +480,7 @@ sync_buffer ()
       /* Move the remaining partial line to the front of the buffer.  This
        * ensures that there is space after the partial line into which
        * serve_gmp can read the rest of the line. */
-      char* start = from_scanner + from_scanner_start;
+      char *start = from_scanner + from_scanner_start;
       from_scanner_end -= from_scanner_start;
       memmove (from_scanner, start, from_scanner_end);
       from_scanner_start = 0;
@@ -501,11 +501,14 @@ sync_buffer ()
  * @return 0 success, -1 fail, -2 too few characters (need more input).
  */
 static int
-parse_scanner_done (char** messages)
+parse_scanner_done (char **messages)
 {
   char *end = *messages + from_scanner_end - from_scanner_start;
   while (*messages < end && ((*messages)[0] == ' ' || (*messages)[0] == '\n'))
-    { (*messages)++; from_scanner_start++; }
+    {
+      (*messages)++;
+      from_scanner_start++;
+    }
   if ((int) (end - *messages) < 6)
     /* Too few characters to be the end marker, return to select to
      * wait for more input. */
@@ -529,15 +532,17 @@ parse_scanner_done (char** messages)
  * @return 0 if there is a bad login response, else 1.
  */
 static int
-parse_scanner_bad_login (char** messages)
+parse_scanner_bad_login (char **messages)
 {
   char *end, *match;
   end = *messages + from_scanner_end - from_scanner_start;
   while (*messages < end && ((*messages)[0] == ' '))
-    { (*messages)++; from_scanner_start++; }
-  if ((match = memchr (*messages,
-                       (int) '\n',
-                       from_scanner_end - from_scanner_start)))
+    {
+      (*messages)++;
+      from_scanner_start++;
+    }
+  if ((match =
+         memchr (*messages, (int) '\n', from_scanner_end - from_scanner_start)))
     {
       /** @todo Are there 19 characters available? */
       if (strncasecmp ("Bad login attempt !", *messages, 19) == 0)
@@ -560,15 +565,17 @@ parse_scanner_bad_login (char** messages)
  * @return 0 success, -2 too few characters (need more input).
  */
 static int
-parse_scanner_preference_value (char** messages)
+parse_scanner_preference_value (char **messages)
 {
   char *value, *end, *match;
   end = *messages + from_scanner_end - from_scanner_start;
   while (*messages < end && ((*messages)[0] == ' '))
-    { (*messages)++; from_scanner_start++; }
-  if ((match = memchr (*messages,
-                       (int) '\n',
-                       from_scanner_end - from_scanner_start)))
+    {
+      (*messages)++;
+      from_scanner_start++;
+    }
+  if ((match =
+         memchr (*messages, (int) '\n', from_scanner_end - from_scanner_start)))
     {
       match[0] = '\0';
       if (current_scanner_preference)
@@ -582,8 +589,8 @@ parse_scanner_preference_value (char** messages)
           preference->value = value;
           /* Add the preference to the_list which will be bulk-inserted
            * in DB later in manage_complete_nvt_cache_update. */
-          scanner_preferences_list = g_list_prepend (scanner_preferences_list,
-                                                     preference);
+          scanner_preferences_list =
+            g_list_prepend (scanner_preferences_list, preference);
         }
       set_scanner_state (SCANNER_PREFERENCE_NAME);
       from_scanner_start += match + 1 - *messages;
@@ -601,23 +608,25 @@ parse_scanner_preference_value (char** messages)
  * @return 0 success, -2 too few characters (need more input).
  */
 static int
-parse_scanner_plugin_list_tags (char** messages)
+parse_scanner_plugin_list_tags (char **messages)
 {
   char *value, *end, *match;
   assert (current_plugin != NULL);
   end = *messages + from_scanner_end - from_scanner_start;
   while (*messages < end && ((*messages)[0] == ' '))
-    { (*messages)++; from_scanner_start++; }
-  if ((match = memchr (*messages,
-                       (int) '\n',
-                       from_scanner_end - from_scanner_start)))
+    {
+      (*messages)++;
+      from_scanner_start++;
+    }
+  if ((match =
+         memchr (*messages, (int) '\n', from_scanner_end - from_scanner_start)))
     {
       match[0] = '\0';
       value = g_strdup (*messages);
       blank_control_chars (value);
       if (value != NULL)
         {
-          char* pos = value;
+          char *pos = value;
           while (*pos)
             {
               if (*pos == ';')
@@ -636,8 +645,8 @@ parse_scanner_plugin_list_tags (char** messages)
 
           /* Add the plugin to scanner_plugins_list which will be bulk-inserted
            * in DB later in manage_complete_nvt_cache_update. */
-          scanner_plugins_list = g_list_prepend (scanner_plugins_list,
-                                                 current_plugin);
+          scanner_plugins_list =
+            g_list_prepend (scanner_plugins_list, current_plugin);
           current_plugin = NULL;
         }
       set_scanner_state (SCANNER_PLUGIN_LIST_OID);
@@ -659,23 +668,28 @@ parse_scanner_plugin_list_tags (char** messages)
  *         field follows), -4 failed to find a newline (may be a <|>)
  */
 static int
-parse_scanner_server (char** messages)
+parse_scanner_server (char **messages)
 {
   char *end, *match;
   end = *messages + from_scanner_end - from_scanner_start;
   while (*messages < end && ((*messages)[0] == ' '))
-    { (*messages)++; from_scanner_start++; }
-  if ((match = memchr (*messages,
-                       (int) '\n',
-                       from_scanner_end - from_scanner_start)))
     {
-      char* newline;
-      char* input;
+      (*messages)++;
+      from_scanner_start++;
+    }
+  if ((match =
+         memchr (*messages, (int) '\n', from_scanner_end - from_scanner_start)))
+    {
+      char *newline;
+      char *input;
       buffer_size_t from_start, from_end;
       match[0] = '\0';
       /** @todo Is there ever whitespace before the newline? */
       while (*messages < end && ((*messages)[0] == ' '))
-        { (*messages)++; from_scanner_start++; }
+        {
+          (*messages)++;
+          from_scanner_start++;
+        }
       /** @todo Are there 20 characters available? */
       /** @todo Are there 12 characters available? */
       newline = match;
@@ -684,16 +698,13 @@ parse_scanner_server (char** messages)
       input = *messages;
       from_start = from_scanner_start;
       from_end = from_scanner_end;
-      while (from_start < from_end
-             && ((match = memchr (input,
-                                  (int) '<',
-                                  from_end - from_start))
-                 != NULL))
+      while (
+        from_start < from_end
+        && ((match = memchr (input, (int) '<', from_end - from_start)) != NULL))
         {
           assert (match >= input);
           if ((((match - input) + from_start + 1) < from_end)
-              && (match[1] == '|')
-              && (match[2] == '>'))
+              && (match[1] == '|') && (match[2] == '>'))
             {
               if (match > newline)
                 /* The next <|> is after the newline, which is an error. */
@@ -780,13 +791,14 @@ parse_scanner_loading (char *messages)
 int
 process_otp_scanner_input ()
 {
-  char* match = NULL;
-  char* messages = from_scanner + from_scanner_start;
-  char* input;
+  char *match = NULL;
+  char *messages = from_scanner + from_scanner_start;
+  char *input;
   const char *ver_str = "< OTP/2.0 >\n";
   size_t ver_len = strlen (ver_str);
   buffer_size_t from_start, from_end;
-  //g_debug ("   consider %.*s\n", from_scanner_end - from_scanner_start, messages);
+  // g_debug ("   consider %.*s\n", from_scanner_end - from_scanner_start,
+  // messages);
 
   /* Before processing the input, check if another manager process has stopped
    * the current task.  If so, send the stop request to the scanner.  This is
@@ -805,108 +817,123 @@ process_otp_scanner_input ()
 
   switch (scanner_init_state)
     {
-      case SCANNER_INIT_SENT_VERSION:
-        /* Read over any whitespace left by the previous session. */
-        while (from_scanner_start < from_scanner_end
-               && (messages[0] == ' ' || messages[0] == '\n'))
-          from_scanner_start++, messages++;
+    case SCANNER_INIT_SENT_VERSION:
+      /* Read over any whitespace left by the previous session. */
+      while (from_scanner_start < from_scanner_end
+             && (messages[0] == ' ' || messages[0] == '\n'))
+        from_scanner_start++, messages++;
 
-        if (scanner_is_loading (messages))
+      if (scanner_is_loading (messages))
+        {
+          parse_scanner_loading (messages);
+          if (scanner_current_loading && scanner_total_loading)
+            g_log (G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE,
+                   "Waiting for scanner to load NVTs: %d / %d",
+                   scanner_current_loading, scanner_total_loading);
+          else
+            g_log (G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE,
+                   "Waiting for scanner to load: No information provided. "
+                   "(Message: %s)",
+                   messages);
+          return 3;
+        }
+      /* If message is empty we assume the scanner is still loading. */
+      if (!*messages)
+        {
+          return 5;
+        }
+      if (from_scanner_end - from_scanner_start < ver_len)
+        {
+          /* Need more input. */
+          if (sync_buffer ())
+            return -1;
+          return 0;
+        }
+      if (strncasecmp (ver_str, messages, ver_len))
+        {
+          g_debug ("   scanner fail: expected \"%s\""
+                   "   got \"%.12s\"",
+                   ver_str, messages);
+          return -1;
+        }
+      from_scanner_start += ver_len;
+      set_scanner_init_state (SCANNER_INIT_DONE);
+      return 0;
+    case SCANNER_INIT_GOT_FEED_VERSION:
+      /* Nothing to parse. */
+      return 0;
+    case SCANNER_INIT_GOT_PLUGINS:
+      /* Nothing to parse. */
+      return 0;
+    case SCANNER_INIT_CONNECTED:
+      /* Input from scanner before version string sent. */
+      return -1;
+    case SCANNER_INIT_SENT_COMPLETE_LIST:
+    case SCANNER_INIT_SENT_COMPLETE_LIST_UPDATE:
+    case SCANNER_INIT_DONE:
+    case SCANNER_INIT_DONE_CACHE_MODE:
+    case SCANNER_INIT_DONE_CACHE_MODE_UPDATE:
+    case SCANNER_INIT_TOP:
+      if (scanner_state == SCANNER_TOP)
+        switch (parse_scanner_bad_login (&messages))
           {
-            parse_scanner_loading (messages);
-            if (scanner_current_loading && scanner_total_loading)
-              g_log (G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE,
-                     "Waiting for scanner to load NVTs: %d / %d",
-                     scanner_current_loading, scanner_total_loading);
-            else
-              g_log (G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE,
-                     "Waiting for scanner to load: No information provided. (Message: %s)", messages);
-            return 3;
+          case 0:
+            return 2; /* Found bad login response. */
+          case 1:
+            break;
           }
-        /* If message is empty we assume the scanner is still loading. */
-        if (!*messages)
+      else if (scanner_state == SCANNER_DONE)
+        switch (parse_scanner_done (&messages))
           {
-            return 5;
-          }
-        if (from_scanner_end - from_scanner_start < ver_len)
-          {
+          case -1:
+            return -1;
+          case -2:
             /* Need more input. */
-            if (sync_buffer ()) return -1;
+            if (sync_buffer ())
+              return -1;
             return 0;
           }
-        if (strncasecmp (ver_str, messages, ver_len))
+      else if (scanner_state == SCANNER_PLUGIN_LIST_TAGS)
+        switch (parse_scanner_plugin_list_tags (&messages))
           {
-            g_debug ("   scanner fail: expected \"%s\""
-                     "   got \"%.12s\"", ver_str, messages);
-            return -1;
+          case -2:
+            /* Need more input. */
+            if (sync_buffer ())
+              return -1;
+            return 0;
           }
-        from_scanner_start += ver_len;
-        set_scanner_init_state (SCANNER_INIT_DONE);
-        return 0;
-      case SCANNER_INIT_GOT_FEED_VERSION:
-        /* Nothing to parse. */
-        return 0;
-      case SCANNER_INIT_GOT_PLUGINS:
-        /* Nothing to parse. */
-        return 0;
-      case SCANNER_INIT_CONNECTED:
-        /* Input from scanner before version string sent. */
-        return -1;
-      case SCANNER_INIT_SENT_COMPLETE_LIST:
-      case SCANNER_INIT_SENT_COMPLETE_LIST_UPDATE:
-      case SCANNER_INIT_DONE:
-      case SCANNER_INIT_DONE_CACHE_MODE:
-      case SCANNER_INIT_DONE_CACHE_MODE_UPDATE:
-      case SCANNER_INIT_TOP:
-        if (scanner_state == SCANNER_TOP)
-          switch (parse_scanner_bad_login (&messages))
+      else if (scanner_state == SCANNER_PREFERENCE_VALUE)
+        {
+          switch (parse_scanner_preference_value (&messages))
             {
-              case 0: return 2;    /* Found bad login response. */
-              case 1: break;
+            case -2:
+              /* Need more input. */
+              if (sync_buffer ())
+                return -1;
+              return 0;
             }
-        else if (scanner_state == SCANNER_DONE)
-          switch (parse_scanner_done (&messages))
-            {
-              case -1: return -1;
-              case -2:
-                /* Need more input. */
-                if (sync_buffer ()) return -1;
-                return 0;
-            }
-        else if (scanner_state == SCANNER_PLUGIN_LIST_TAGS)
-          switch (parse_scanner_plugin_list_tags (&messages))
-            {
-              case -2:
-                /* Need more input. */
-                if (sync_buffer ()) return -1;
-                return 0;
-            }
-        else if (scanner_state == SCANNER_PREFERENCE_VALUE)
+          g_free (current_scanner_preference);
+          current_scanner_preference = NULL;
+        }
+      else if (scanner_state == SCANNER_SERVER)
+        /* Look for any newline delimited scanner commands. */
+        switch (parse_scanner_server (&messages))
           {
-            switch (parse_scanner_preference_value (&messages))
-              {
-                case -2:
-                  /* Need more input. */
-                  if (sync_buffer ()) return -1;
-                  return 0;
-              }
-            g_free (current_scanner_preference);
-            current_scanner_preference = NULL;
+          case 0:
+            break; /* Found newline delimited command. */
+          case -1:
+            return -1; /* Error. */
+          case -2:
+            /* Need more input. */
+            if (sync_buffer ())
+              return -1;
+            return 0;
+          case -3:
+            break; /* Next <|> is before next \n. */
+          case -4:
+            break; /* Failed to find \n, try for <|>. */
           }
-        else if (scanner_state == SCANNER_SERVER)
-          /* Look for any newline delimited scanner commands. */
-          switch (parse_scanner_server (&messages))
-            {
-              case  0: break;        /* Found newline delimited command. */
-              case -1: return -1;    /* Error. */
-              case -2:
-                /* Need more input. */
-                if (sync_buffer ()) return -1;
-                return 0;
-              case -3: break;        /* Next <|> is before next \n. */
-              case -4: break;        /* Failed to find \n, try for <|>. */
-            }
-        break;
+      break;
     } /* switch (scanner_init_state) */
 
   /* Parse and handle any fields ending in <|>. */
@@ -914,11 +941,9 @@ process_otp_scanner_input ()
   input = messages;
   from_start = from_scanner_start;
   from_end = from_scanner_end;
-  while (from_start < from_end
-         && ((match = memchr (input,
-                              (int) '<',
-                              from_end - from_start))
-             != NULL))
+  while (
+    from_start < from_end
+    && ((match = memchr (input, (int) '<', from_end - from_start)) != NULL))
     {
       assert (match >= input);
 
@@ -929,12 +954,11 @@ process_otp_scanner_input ()
        * write (settings) to the db. */
       manage_transaction_stop (FALSE);
 
-      if ((((match - input) + from_start + 1) < from_end)
-          && (match[1] == '|')
+      if ((((match - input) + from_start + 1) < from_end) && (match[1] == '|')
           && (match[2] == '>'))
         {
-          char* message;
-          char* field;
+          char *message;
+          char *field;
           /* Found a full field, process the field. */
           message = messages;
           *match = '\0';
@@ -951,725 +975,749 @@ process_otp_scanner_input ()
           g_debug ("   scanner field: %s", field);
           switch (scanner_state)
             {
-              case SCANNER_BYE:
-                if (strcasecmp ("BYE", field))
+            case SCANNER_BYE:
+              if (strcasecmp ("BYE", field))
+                goto return_error;
+              /* It's up to the caller to set the init state, as the
+               * caller must flush the ACK. */
+              set_scanner_state (SCANNER_DONE);
+              switch (parse_scanner_done (&messages))
+                {
+                case 0:
+                  if (sync_buffer ())
+                    goto return_error;
+                  if (acknowledge_bye ())
+                    goto return_error;
+                  goto return_bye;
+                case -1:
                   goto return_error;
-                /* It's up to the caller to set the init state, as the
-                 * caller must flush the ACK. */
+                case -2:
+                  /* Need more input. */
+                  if (sync_buffer ())
+                    goto return_error;
+                  goto return_need_more;
+                }
+              break;
+            case SCANNER_ERRMSG_DESCRIPTION:
+              {
+                if (current_message)
+                  {
+                    /** @todo Replace "\n" with newline in description. */
+                    char *description = g_strdup (field);
+                    set_message_description (current_message, description);
+                  }
+                set_scanner_state (SCANNER_ERRMSG_OID);
+                break;
+              }
+            case SCANNER_ERRMSG_HOST:
+              {
+                assert (current_message == NULL);
+                current_message = make_message (field);
+                set_scanner_state (SCANNER_ERRMSG_HOSTNAME);
+                break;
+              }
+            case SCANNER_ERRMSG_HOSTNAME:
+              {
+                if (current_message)
+                  set_message_hostname (current_message, g_strdup (field));
+                set_scanner_state (SCANNER_ERRMSG_NUMBER);
+                break;
+              }
+            case SCANNER_ERRMSG_NUMBER:
+              {
+                /** @todo Field could be "general". */
+                int number;
+                char *protocol, *formatted;
+
+                assert (current_message);
+
+                protocol = g_newa (char, strlen (field));
+
+                if (sscanf (field, "%i/%s", &number, protocol) != 2)
+                  {
+                    number = atoi (field);
+                    protocol[0] = '\0';
+                  }
+                g_debug ("   scanner got debug port, number: %i, protocol: %s",
+                         number, protocol);
+
+                set_message_port_number (current_message, number);
+                set_message_port_protocol (current_message, protocol);
+
+                formatted = port_name_formatted (field);
+                if (formatted == NULL)
+                  formatted = g_strdup (field);
+                set_message_port_string (current_message, formatted);
+
+                set_scanner_state (SCANNER_ERRMSG_DESCRIPTION);
+                break;
+              }
+            case SCANNER_ERRMSG_OID:
+              {
+                if (current_message != NULL
+                    && current_scanner_task != (task_t) 0)
+                  {
+                    char *oid = g_strdup (field);
+                    set_message_oid (current_message, oid);
+
+                    append_error_message (current_scanner_task,
+                                          current_message);
+                    free_message (current_message);
+                    current_message = NULL;
+                  }
                 set_scanner_state (SCANNER_DONE);
                 switch (parse_scanner_done (&messages))
                   {
-                    case  0:
-                      if (sync_buffer ()) goto return_error;
-                      if (acknowledge_bye ()) goto return_error;
-                      goto return_bye;
-                    case -1: goto return_error;
-                    case -2:
-                      /* Need more input. */
-                      if (sync_buffer ()) goto return_error;
-                      goto return_need_more;
+                  case -1:
+                    goto return_error;
+                  case -2:
+                    /* Need more input. */
+                    if (sync_buffer ())
+                      goto return_error;
+                    goto return_need_more;
                   }
                 break;
-              case SCANNER_ERRMSG_DESCRIPTION:
-                {
-                  if (current_message)
-                    {
-                      /** @todo Replace "\n" with newline in description. */
-                      char* description = g_strdup (field);
-                      set_message_description (current_message, description);
-                    }
-                  set_scanner_state (SCANNER_ERRMSG_OID);
-                  break;
-                }
-              case SCANNER_ERRMSG_HOST:
-                {
-                  assert (current_message == NULL);
-                  current_message = make_message (field);
-                  set_scanner_state (SCANNER_ERRMSG_HOSTNAME);
-                  break;
-                }
-              case SCANNER_ERRMSG_HOSTNAME:
-                {
-                  if (current_message)
-                    set_message_hostname (current_message, g_strdup (field));
-                  set_scanner_state (SCANNER_ERRMSG_NUMBER);
-                  break;
-                }
-              case SCANNER_ERRMSG_NUMBER:
-                {
-                  /** @todo Field could be "general". */
-                  int number;
-                  char *protocol, *formatted;
-
-                  assert (current_message);
-
-                  protocol = g_newa (char, strlen (field));
-
-                  if (sscanf (field, "%i/%s",
-                              &number, protocol)
-                      != 2)
-                    {
-                      number = atoi (field);
-                      protocol[0] = '\0';
-                    }
-                  g_debug ("   scanner got debug port, number: %i, protocol: %s",
-                           number, protocol);
-
-                  set_message_port_number (current_message, number);
-                  set_message_port_protocol (current_message, protocol);
-
-                  formatted = port_name_formatted (field);
-                  if (formatted == NULL)
-                    formatted = g_strdup (field);
-                  set_message_port_string (current_message, formatted);
-
-                  set_scanner_state (SCANNER_ERRMSG_DESCRIPTION);
-                  break;
-                }
-              case SCANNER_ERRMSG_OID:
-                {
-                  if (current_message != NULL
-                      && current_scanner_task != (task_t) 0)
-                    {
-                      char* oid = g_strdup (field);
-                      set_message_oid (current_message, oid);
-
-                      append_error_message (current_scanner_task, current_message);
-                      free_message (current_message);
-                      current_message = NULL;
-                    }
-                  set_scanner_state (SCANNER_DONE);
-                  switch (parse_scanner_done (&messages))
-                    {
-                      case -1: goto return_error;
-                      case -2:
-                        /* Need more input. */
-                        if (sync_buffer ()) goto return_error;
-                        goto return_need_more;
-                    }
-                  break;
-                }
-              case SCANNER_ALARM_DESCRIPTION:
-                {
-                  if (current_message)
-                    {
-                      /** @todo Replace "\n" with newline in description. */
-                      char* description = g_strdup (field);
-                      set_message_description (current_message, description);
-                    }
-                  set_scanner_state (SCANNER_ALARM_OID);
-                  break;
-                }
-              case SCANNER_ALARM_HOST:
-                {
-                  assert (current_message == NULL);
-                  current_message = make_message (field);
-                  set_scanner_state (SCANNER_ALARM_HOSTNAME);
-                  break;
-                }
-              case SCANNER_ALARM_HOSTNAME:
-                {
-                  if (current_message)
-                    set_message_hostname (current_message, g_strdup (field));
-                  set_scanner_state (SCANNER_ALARM_NUMBER);
-                  break;
-                }
-              case SCANNER_ALARM_NUMBER:
-                {
-                  /** @todo Field could be "general". */
-                  int number;
-                  char *protocol, *formatted;
-
-                  assert (current_message);
-
-                  protocol = g_newa (char, strlen (field));
-
-                  if (sscanf (field, "%i/%s",
-                              &number, protocol)
-                      != 2)
-                    {
-                      number = atoi (field);
-                      protocol[0] = '\0';
-                    }
-                  g_debug ("   scanner got alarm port, number: %i, protocol: %s",
-                           number, protocol);
-
-                  set_message_port_number (current_message, number);
-                  set_message_port_protocol (current_message, protocol);
-
-                  formatted = port_name_formatted (field);
-                  if (formatted == NULL)
-                    formatted = g_strdup (field);
-                  set_message_port_string (current_message, formatted);
-
-                  set_scanner_state (SCANNER_ALARM_DESCRIPTION);
-                  break;
-                }
-              case SCANNER_ALARM_OID:
-                {
-                  if (current_message != NULL
-                      && current_scanner_task != (task_t) 0)
-                    {
-                      char* oid = g_strdup (field);
-                      set_message_oid (current_message, oid);
-
-                      append_alarm_message (current_scanner_task, current_message);
-                      free_message (current_message);
-                      current_message = NULL;
-                    }
-                  set_scanner_state (SCANNER_DONE);
-                  switch (parse_scanner_done (&messages))
-                    {
-                      case -1: goto return_error;
-                      case -2:
-                        /* Need more input. */
-                        if (sync_buffer ()) goto return_error;
-                        goto return_need_more;
-                    }
-                  break;
-                }
-              case SCANNER_LOG_DESCRIPTION:
-                {
-                  if (current_message)
-                    {
-                      /** @todo Replace "\n" with newline in description. */
-                      char* description = g_strdup (field);
-                      set_message_description (current_message, description);
-                    }
-                  set_scanner_state (SCANNER_LOG_OID);
-                  break;
-                }
-              case SCANNER_LOG_HOST:
-                {
-                  assert (current_message == NULL);
-                  current_message = make_message (field);
-                  set_scanner_state (SCANNER_LOG_HOSTNAME);
-                  break;
-                }
-              case SCANNER_LOG_HOSTNAME:
-                {
-                  if (current_message)
-                    set_message_hostname (current_message, g_strdup (field));
-                  set_scanner_state (SCANNER_LOG_NUMBER);
-                  break;
-                }
-              case SCANNER_LOG_NUMBER:
-                {
-                  /** @todo Field could be "general". */
-                  int number;
-                  char *protocol, *formatted;
-
-                  assert (current_message);
-
-                  protocol = g_newa (char, strlen (field));
-
-                  if (sscanf (field, "%i/%s",
-                              &number, protocol)
-                      != 2)
-                    {
-                      number = atoi (field);
-                      protocol[0] = '\0';
-                    }
-                  g_debug ("   scanner got log port, number: %i, protocol: %s",
-                           number, protocol);
-
-                  set_message_port_number (current_message, number);
-                  set_message_port_protocol (current_message, protocol);
-
-                  formatted = port_name_formatted (field);
-                  if (formatted == NULL)
-                    formatted = g_strdup (field);
-                  set_message_port_string (current_message, formatted);
-
-                  set_scanner_state (SCANNER_LOG_DESCRIPTION);
-                  break;
-                }
-              case SCANNER_LOG_OID:
-                {
-                  if (current_message != NULL
-                      && current_scanner_task != (task_t) 0)
-                    {
-                      char* oid = g_strdup (field);
-                      set_message_oid (current_message, oid);
-
-                      append_log_message (current_scanner_task, current_message);
-                      free_message (current_message);
-                      current_message = NULL;
-                    }
-                  set_scanner_state (SCANNER_DONE);
-                  switch (parse_scanner_done (&messages))
-                    {
-                      case -1: goto return_error;
-                      case -2:
-                        /* Need more input. */
-                        if (sync_buffer ()) goto return_error;
-                        goto return_need_more;
-                    }
-                  break;
-                }
-              case SCANNER_PLUGIN_LIST_OID:
-                {
-                  /* Use match[1] instead of field[1] for UTF-8 hack. */
-                  if (strlen (field) == 0 && match[1] == '|')
-                    {
-                      set_scanner_state (SCANNER_DONE);
-                      switch (parse_scanner_done (&messages))
-                        {
-                          case  0:
-                            if (scanner_init_state
-                                == SCANNER_INIT_SENT_COMPLETE_LIST
-                                || scanner_init_state
-                                   == SCANNER_INIT_SENT_COMPLETE_LIST_UPDATE)
-                              {
-                                set_scanner_init_state (SCANNER_INIT_GOT_PLUGINS);
-                                set_nvts_feed_version (plugins_feed_version);
-                              }
-                            break;
-                          case -1: goto return_error;
-                          case -2:
-                            /* Need more input. */
-                            if (sync_buffer ()) goto return_error;
-                            goto return_need_more;
-                        }
-                      break;
-                    }
-                  assert (current_plugin == NULL);
-                  current_plugin = nvti_new ();
-                  if (current_plugin == NULL) abort ();
-                  nvti_set_oid (current_plugin, field);
-                  set_scanner_state (SCANNER_PLUGIN_LIST_NAME);
-                  break;
-                }
-              case SCANNER_PLUGIN_LIST_NAME:
-                {
-                  nvti_set_name (current_plugin, field);
-                  set_scanner_state (SCANNER_PLUGIN_LIST_CATEGORY);
-                  break;
-                }
-              case SCANNER_PLUGIN_LIST_CATEGORY:
-                {
-                  nvti_set_category (current_plugin, atoi (field));
-                  set_scanner_state (SCANNER_PLUGIN_LIST_FAMILY);
-                  break;
-                }
-              case SCANNER_PLUGIN_LIST_FAMILY:
-                {
-                  nvti_set_family (current_plugin, field);
-                  set_scanner_state (SCANNER_PLUGIN_LIST_CVE_ID);
-                  break;
-                }
-              case SCANNER_PLUGIN_LIST_CVE_ID:
-                {
-                  nvti_set_cve (current_plugin, field);
-                  set_scanner_state (SCANNER_PLUGIN_LIST_BUGTRAQ_ID);
-                  break;
-                }
-              case SCANNER_PLUGIN_LIST_BUGTRAQ_ID:
-                {
-                  nvti_set_bid (current_plugin, field);
-                  set_scanner_state (SCANNER_PLUGIN_LIST_XREFS);
-                  break;
-                }
-              case SCANNER_PLUGIN_LIST_XREFS:
-                {
-                  nvti_set_xref (current_plugin, field);
-                  set_scanner_state (SCANNER_PLUGIN_LIST_TAGS);
-                  switch (parse_scanner_plugin_list_tags (&messages))
-                    {
-                      case -2:
-                        /* Need more input. */
-                        if (sync_buffer ()) goto return_error;
-                        goto return_need_more;
-                    }
-                  break;
-                }
-              case SCANNER_NVT_INFO:
-                {
-                  char *feed_version, *db_feed_version;
-
-                  feed_version = g_strdup (field);
-                  g_debug ("   scanner got nvti_info: %s", feed_version);
-                  if (plugins_feed_version)
-                    g_free (plugins_feed_version);
-                  plugins_feed_version = feed_version;
-                  db_feed_version = nvts_feed_version ();
-                  if (db_feed_version
-                      && (strcmp (plugins_feed_version, db_feed_version) == 0))
-                    /* NVTs are at this version already. */
-                    return 4;
-                  g_info ("   Updating NVT cache");
-                  set_scanner_state (SCANNER_DONE);
-                  switch (parse_scanner_done (&messages))
-                    {
-                      case  0:
-                        if (scanner_init_state == SCANNER_INIT_DONE)
-                          set_scanner_init_state (SCANNER_INIT_GOT_FEED_VERSION);
-                        else if (acknowledge_feed_version_info ())
-                          goto return_error;
-                        break;
-                      case -1: goto return_error;
-                      case -2:
-                        /* Need more input. */
-                        if (sync_buffer ()) goto return_error;
-                        goto return_need_more;
-                    }
-                  break;
-                }
-              case SCANNER_PREFERENCE_NAME:
-                {
-                  /* Use match[1] instead of field[1] for UTF-8 hack. */
-                  if (strlen (field) == 0 && match[1] == '|')
-                    {
-                      set_scanner_state (SCANNER_DONE);
-                      switch (parse_scanner_done (&messages))
-                        {
-                          case -1: goto return_error;
-                          case -2:
-                            /* Need more input. */
-                            if (sync_buffer ()) goto return_error;
-                            goto return_need_more;
-                        }
-                      if (scanner_init_state == SCANNER_INIT_DONE_CACHE_MODE
-                          || scanner_init_state
-                             == SCANNER_INIT_DONE_CACHE_MODE_UPDATE)
-                        {
-                          manage_complete_nvt_cache_update
-                           (scanner_plugins_list,
-                            scanner_preferences_list);
-                          set_scanner_init_state (SCANNER_INIT_DONE);
-                          manage_nvt_preferences_enable ();
-                          /* Return 1, as though the scanner sent BYE. */
-                          /** @todo Exit more formally with Scanner? */
-                          goto return_bye;
-                        }
-                      break;
-                    }
-
+              }
+            case SCANNER_ALARM_DESCRIPTION:
+              {
+                if (current_message)
                   {
-                    int value_start = -1, value_end = -1, count;
-                    char name[21];
-                    /* LDAPsearch[entry]:Timeout value */
-                    count = sscanf (field, "%20[^[][%*[^]]]:%n%*[ -~]%n",
-                                    name, &value_start, &value_end);
-                    if (count == 1 && value_start > 0 && value_end > 0
-                        && ((strcmp (name, "SSH Authorization") == 0)
-                            || (strcmp (name, "SNMP Authorization") == 0)
-                            || (strcmp (name, "ESXi Authorization") == 0)
-                            || (strcmp (name, "SMB Authorization") == 0)))
-                      current_scanner_preference = NULL;
-                    else
-                      current_scanner_preference = g_strdup (field);
-                    set_scanner_state (SCANNER_PREFERENCE_VALUE);
-                    switch (parse_scanner_preference_value (&messages))
-                      {
-                        case -2:
-                          /* Need more input. */
-                          if (sync_buffer ()) goto return_error;
-                          goto return_need_more;
-                      }
-                    g_free (current_scanner_preference);
-                    current_scanner_preference = NULL;
+                    /** @todo Replace "\n" with newline in description. */
+                    char *description = g_strdup (field);
+                    set_message_description (current_message, description);
                   }
-                  break;
-                }
-              case SCANNER_SERVER:
-                if (strcasecmp ("BYE", field) == 0)
-                  set_scanner_state (SCANNER_BYE);
-                else if (strcasecmp ("ERRMSG", field) == 0)
-                  set_scanner_state (SCANNER_ERRMSG_HOST);
-                else if (strcasecmp ("FILE_ACCEPTED", field) == 0)
+                set_scanner_state (SCANNER_ALARM_OID);
+                break;
+              }
+            case SCANNER_ALARM_HOST:
+              {
+                assert (current_message == NULL);
+                current_message = make_message (field);
+                set_scanner_state (SCANNER_ALARM_HOSTNAME);
+                break;
+              }
+            case SCANNER_ALARM_HOSTNAME:
+              {
+                if (current_message)
+                  set_message_hostname (current_message, g_strdup (field));
+                set_scanner_state (SCANNER_ALARM_NUMBER);
+                break;
+              }
+            case SCANNER_ALARM_NUMBER:
+              {
+                /** @todo Field could be "general". */
+                int number;
+                char *protocol, *formatted;
+
+                assert (current_message);
+
+                protocol = g_newa (char, strlen (field));
+
+                if (sscanf (field, "%i/%s", &number, protocol) != 2)
+                  {
+                    number = atoi (field);
+                    protocol[0] = '\0';
+                  }
+                g_debug ("   scanner got alarm port, number: %i, protocol: %s",
+                         number, protocol);
+
+                set_message_port_number (current_message, number);
+                set_message_port_protocol (current_message, protocol);
+
+                formatted = port_name_formatted (field);
+                if (formatted == NULL)
+                  formatted = g_strdup (field);
+                set_message_port_string (current_message, formatted);
+
+                set_scanner_state (SCANNER_ALARM_DESCRIPTION);
+                break;
+              }
+            case SCANNER_ALARM_OID:
+              {
+                if (current_message != NULL
+                    && current_scanner_task != (task_t) 0)
+                  {
+                    char *oid = g_strdup (field);
+                    set_message_oid (current_message, oid);
+
+                    append_alarm_message (current_scanner_task,
+                                          current_message);
+                    free_message (current_message);
+                    current_message = NULL;
+                  }
+                set_scanner_state (SCANNER_DONE);
+                switch (parse_scanner_done (&messages))
+                  {
+                  case -1:
+                    goto return_error;
+                  case -2:
+                    /* Need more input. */
+                    if (sync_buffer ())
+                      goto return_error;
+                    goto return_need_more;
+                  }
+                break;
+              }
+            case SCANNER_LOG_DESCRIPTION:
+              {
+                if (current_message)
+                  {
+                    /** @todo Replace "\n" with newline in description. */
+                    char *description = g_strdup (field);
+                    set_message_description (current_message, description);
+                  }
+                set_scanner_state (SCANNER_LOG_OID);
+                break;
+              }
+            case SCANNER_LOG_HOST:
+              {
+                assert (current_message == NULL);
+                current_message = make_message (field);
+                set_scanner_state (SCANNER_LOG_HOSTNAME);
+                break;
+              }
+            case SCANNER_LOG_HOSTNAME:
+              {
+                if (current_message)
+                  set_message_hostname (current_message, g_strdup (field));
+                set_scanner_state (SCANNER_LOG_NUMBER);
+                break;
+              }
+            case SCANNER_LOG_NUMBER:
+              {
+                /** @todo Field could be "general". */
+                int number;
+                char *protocol, *formatted;
+
+                assert (current_message);
+
+                protocol = g_newa (char, strlen (field));
+
+                if (sscanf (field, "%i/%s", &number, protocol) != 2)
+                  {
+                    number = atoi (field);
+                    protocol[0] = '\0';
+                  }
+                g_debug ("   scanner got log port, number: %i, protocol: %s",
+                         number, protocol);
+
+                set_message_port_number (current_message, number);
+                set_message_port_protocol (current_message, protocol);
+
+                formatted = port_name_formatted (field);
+                if (formatted == NULL)
+                  formatted = g_strdup (field);
+                set_message_port_string (current_message, formatted);
+
+                set_scanner_state (SCANNER_LOG_DESCRIPTION);
+                break;
+              }
+            case SCANNER_LOG_OID:
+              {
+                if (current_message != NULL
+                    && current_scanner_task != (task_t) 0)
+                  {
+                    char *oid = g_strdup (field);
+                    set_message_oid (current_message, oid);
+
+                    append_log_message (current_scanner_task, current_message);
+                    free_message (current_message);
+                    current_message = NULL;
+                  }
+                set_scanner_state (SCANNER_DONE);
+                switch (parse_scanner_done (&messages))
+                  {
+                  case -1:
+                    goto return_error;
+                  case -2:
+                    /* Need more input. */
+                    if (sync_buffer ())
+                      goto return_error;
+                    goto return_need_more;
+                  }
+                break;
+              }
+            case SCANNER_PLUGIN_LIST_OID:
+              {
+                /* Use match[1] instead of field[1] for UTF-8 hack. */
+                if (strlen (field) == 0 && match[1] == '|')
                   {
                     set_scanner_state (SCANNER_DONE);
                     switch (parse_scanner_done (&messages))
                       {
-                        case -1: goto return_error;
-                        case -2:
-                          /* Need more input. */
-                          if (sync_buffer ()) goto return_error;
-                          goto return_need_more;
+                      case 0:
+                        if (scanner_init_state
+                              == SCANNER_INIT_SENT_COMPLETE_LIST
+                            || scanner_init_state
+                                 == SCANNER_INIT_SENT_COMPLETE_LIST_UPDATE)
+                          {
+                            set_scanner_init_state (SCANNER_INIT_GOT_PLUGINS);
+                            set_nvts_feed_version (plugins_feed_version);
+                          }
+                        break;
+                      case -1:
+                        goto return_error;
+                      case -2:
+                        /* Need more input. */
+                        if (sync_buffer ())
+                          goto return_error;
+                        goto return_need_more;
                       }
+                    break;
                   }
-                else if (strcasecmp ("ALARM", field) == 0)
-                  set_scanner_state (SCANNER_ALARM_HOST);
-                else if (strcasecmp ("LOG", field) == 0)
-                  set_scanner_state (SCANNER_LOG_HOST);
-                else if (strcasecmp ("NVT_INFO", field) == 0)
-                  set_scanner_state (SCANNER_NVT_INFO);
-                else if (strcasecmp ("PLUGIN_LIST", field) == 0)
+                assert (current_plugin == NULL);
+                current_plugin = nvti_new ();
+                if (current_plugin == NULL)
+                  abort ();
+                nvti_set_oid (current_plugin, field);
+                set_scanner_state (SCANNER_PLUGIN_LIST_NAME);
+                break;
+              }
+            case SCANNER_PLUGIN_LIST_NAME:
+              {
+                nvti_set_name (current_plugin, field);
+                set_scanner_state (SCANNER_PLUGIN_LIST_CATEGORY);
+                break;
+              }
+            case SCANNER_PLUGIN_LIST_CATEGORY:
+              {
+                nvti_set_category (current_plugin, atoi (field));
+                set_scanner_state (SCANNER_PLUGIN_LIST_FAMILY);
+                break;
+              }
+            case SCANNER_PLUGIN_LIST_FAMILY:
+              {
+                nvti_set_family (current_plugin, field);
+                set_scanner_state (SCANNER_PLUGIN_LIST_CVE_ID);
+                break;
+              }
+            case SCANNER_PLUGIN_LIST_CVE_ID:
+              {
+                nvti_set_cve (current_plugin, field);
+                set_scanner_state (SCANNER_PLUGIN_LIST_BUGTRAQ_ID);
+                break;
+              }
+            case SCANNER_PLUGIN_LIST_BUGTRAQ_ID:
+              {
+                nvti_set_bid (current_plugin, field);
+                set_scanner_state (SCANNER_PLUGIN_LIST_XREFS);
+                break;
+              }
+            case SCANNER_PLUGIN_LIST_XREFS:
+              {
+                nvti_set_xref (current_plugin, field);
+                set_scanner_state (SCANNER_PLUGIN_LIST_TAGS);
+                switch (parse_scanner_plugin_list_tags (&messages))
                   {
-                    set_scanner_state (SCANNER_PLUGIN_LIST_OID);
-                  }
-                else if (strcasecmp ("PREFERENCES", field) == 0)
-                  {
-                    assert (current_scanner_preference == NULL);
-                    set_scanner_state (SCANNER_PREFERENCE_NAME);
-                  }
-                else if (strcasecmp ("TIME", field) == 0)
-                  {
-                    set_scanner_state (SCANNER_TIME);
-                  }
-                else if (strcasecmp ("STATUS", field) == 0)
-                  {
-                    set_scanner_state (SCANNER_STATUS_HOST);
-                  }
-                else
-                  {
-                    g_debug ("New scanner command to implement: %s",
-                             field);
-                    goto return_error;
+                  case -2:
+                    /* Need more input. */
+                    if (sync_buffer ())
+                      goto return_error;
+                    goto return_need_more;
                   }
                 break;
-              case SCANNER_STATUS_HOST:
-                {
-                  assert (current_host == NULL);
-                  current_host = g_strdup (field);
-                  set_scanner_state (SCANNER_STATUS_PROGRESS);
-                  break;
-                }
-              case SCANNER_STATUS_PROGRESS:
-                {
-                  /* Store the progress in the ports slots in the db. */
-                  assert (global_current_report);
-                  if (global_current_report && current_host)
-                    {
-                      unsigned int current, max;
-                      g_debug ("   scanner got ports: %s", field);
-                      if (sscanf (field, "%u/%u", &current, &max) == 2)
-                        set_scan_ports (global_current_report,
-                                        current_host,
-                                        current,
-                                        max);
-                    }
-                  if (current_host)
-                    {
-                      g_free (current_host);
-                      current_host = NULL;
-                    }
-                  set_scanner_state (SCANNER_DONE);
-                  switch (parse_scanner_done (&messages))
-                    {
-                      case -1: goto return_error;
-                      case -2:
-                        /* Need more input. */
-                        if (sync_buffer ()) goto return_error;
-                        goto return_need_more;
-                    }
-                  break;
-                }
-              case SCANNER_TIME:
-                {
-                  if (strcasecmp ("HOST_START", field) == 0)
-                    set_scanner_state (SCANNER_TIME_HOST_START_HOST);
-                  else if (strcasecmp ("HOST_END", field) == 0)
-                    set_scanner_state (SCANNER_TIME_HOST_END_HOST);
-                  else if (strcasecmp ("SCAN_START", field) == 0)
-                    set_scanner_state (SCANNER_TIME_SCAN_START);
-                  else if (strcasecmp ("SCAN_END", field) == 0)
-                    set_scanner_state (SCANNER_TIME_SCAN_END);
-                  else
-                    /** @todo Consider reading all fields up to <|> SERVER? */
-                    abort ();
-                  break;
-                }
-              case SCANNER_TIME_HOST_START_HOST:
-                {
-                  assert (current_host == NULL);
-                  current_host = g_strdup (field);
-                  set_scanner_state (SCANNER_TIME_HOST_START_TIME);
-                  break;
-                }
-              case SCANNER_TIME_HOST_START_TIME:
-                {
-                  if (current_scanner_task)
-                    {
-                      assert (current_host);
-                      assert (global_current_report);
+              }
+            case SCANNER_NVT_INFO:
+              {
+                char *feed_version, *db_feed_version;
 
-                      set_scan_host_start_time_otp (global_current_report,
-                                                    current_host,
-                                                    field);
-                      g_free (current_host);
-                      current_host = NULL;
-                    }
-                  set_scanner_state (SCANNER_DONE);
-                  switch (parse_scanner_done (&messages))
-                    {
-                      case -1: goto return_error;
-                      case -2:
-                        /* Need more input. */
-                        if (sync_buffer ()) goto return_error;
-                        goto return_need_more;
-                    }
-                  break;
-                }
-              case SCANNER_TIME_HOST_END_HOST:
-                {
-                  assert (current_host == NULL);
-                  current_host = g_strdup (field);
-                  set_scanner_state (SCANNER_TIME_HOST_END_TIME);
-                  break;
-                }
-              case SCANNER_TIME_HOST_END_TIME:
-                {
-                  assert (current_host);
-                  assert (global_current_report);
-
-                  if (report_host_noticeable (global_current_report,
-                                              current_host))
-                    {
-                      char *uuid;
-                      uuid = report_uuid (global_current_report);
-                      host_notice (current_host, "ip", current_host,
-                                   "Report Host", uuid, 1, 0);
-                      free (uuid);
-                    }
-
-                  if (current_scanner_task)
-                    {
-                      assert (current_host);
-                      set_scan_host_end_time_otp (global_current_report,
-                                                  current_host,
-                                                  field);
-                      g_free (current_host);
-                      current_host = NULL;
-                    }
-                  set_scanner_state (SCANNER_DONE);
-                  switch (parse_scanner_done (&messages))
-                    {
-                      case -1: goto return_error;
-                      case -2:
-                        /* Need more input. */
-                        if (sync_buffer ()) goto return_error;
-                        goto return_need_more;
-                    }
-                  break;
-                }
-              case SCANNER_TIME_SCAN_START:
-                {
-                  if (current_scanner_task)
-                    {
-                      if (task_run_status (current_scanner_task)
-                          == TASK_STATUS_REQUESTED)
-                        {
-                          set_task_run_status (current_scanner_task,
-                                               TASK_STATUS_RUNNING);
-                          /* If the scan has been started before, then leave
-                           * the start time alone. */
-                          if (scan_start_time_epoch (global_current_report)
-                              == 0)
-                            {
-                              set_task_start_time_otp (current_scanner_task,
-                                                       g_strdup (field));
-                              set_scan_start_time_otp (global_current_report,
-                                                       field);
-                            }
-                        }
-                    }
-                  set_scanner_state (SCANNER_DONE);
-                  switch (parse_scanner_done (&messages))
-                    {
-                      case -1: goto return_error;
-                      case -2:
-                        /* Need more input. */
-                        if (sync_buffer ()) goto return_error;
-                        goto return_need_more;
-                    }
-                  break;
-                }
-              case SCANNER_TIME_SCAN_END:
-                {
-                  if (current_scanner_task)
-                    {
-                      /* Stop transaction now, because delete_task_lock and
-                       * set_scan_end_time_otp run transactions themselves. */
-                      manage_transaction_stop (TRUE);
-                      if (global_current_report)
-                        {
-                          hosts_set_identifiers (global_current_report);
-                          hosts_set_max_severity (global_current_report,
-                                                  NULL,
-                                                  NULL);
-                          hosts_set_details (global_current_report);
-                          set_scan_end_time_otp (global_current_report, field);
-                        }
-                      switch (task_run_status (current_scanner_task))
-                        {
-                          case TASK_STATUS_INTERRUPTED:
-                            break;
-                          case TASK_STATUS_STOP_REQUESTED:
-                          case TASK_STATUS_STOP_WAITING:
-                            set_task_run_status (current_scanner_task,
-                                                 TASK_STATUS_STOPPED);
-                            break;
-                          case TASK_STATUS_DELETE_REQUESTED:
-                          case TASK_STATUS_DELETE_WAITING:
-                            set_task_run_status (current_scanner_task,
-                                                 TASK_STATUS_STOPPED);
-                            delete_task_lock (current_scanner_task, 0);
-                            global_current_report = (report_t) 0;
-                            break;
-                          case TASK_STATUS_DELETE_ULTIMATE_REQUESTED:
-                          case TASK_STATUS_DELETE_ULTIMATE_WAITING:
-                            set_task_run_status (current_scanner_task,
-                                                 TASK_STATUS_STOPPED);
-                            delete_task_lock (current_scanner_task, 1);
-                            global_current_report = (report_t) 0;
-                            break;
-                          default:
-                            set_task_end_time (current_scanner_task,
-                                               g_strdup (field));
-                            set_task_run_status (current_scanner_task,
-                                                 TASK_STATUS_DONE);
-                        }
-                      clear_duration_schedules (current_scanner_task);
-                      update_duration_schedule_periods (current_scanner_task);
-                      global_current_report = (report_t) 0;
-                      current_scanner_task = (task_t) 0;
-                    }
-                  set_scanner_state (SCANNER_DONE);
-                  switch (parse_scanner_done (&messages))
-                    {
-                      case -1: goto return_error;
-                      case -2:
-                        /* Need more input. */
-                        if (sync_buffer ()) goto return_error;
-                        goto return_need_more;
-                    }
-                  break;
-                }
-              case SCANNER_TOP:
-              default:
-                g_debug ("   switch t");
-                g_debug ("   cmp %i", strcasecmp ("SERVER", field));
-                if (strcasecmp ("SERVER", field))
-                  goto return_error;
-                set_scanner_state (SCANNER_SERVER);
-                /* Look for any newline delimited scanner commands. */
-                switch (parse_scanner_server (&messages))
+                feed_version = g_strdup (field);
+                g_debug ("   scanner got nvti_info: %s", feed_version);
+                if (plugins_feed_version)
+                  g_free (plugins_feed_version);
+                plugins_feed_version = feed_version;
+                db_feed_version = nvts_feed_version ();
+                if (db_feed_version
+                    && (strcmp (plugins_feed_version, db_feed_version) == 0))
+                  /* NVTs are at this version already. */
+                  return 4;
+                g_info ("   Updating NVT cache");
+                set_scanner_state (SCANNER_DONE);
+                switch (parse_scanner_done (&messages))
                   {
-                    case  0: break;        /* Found newline delimited command. */
-                    case -1: goto return_error;    /* Error. */
+                  case 0:
+                    if (scanner_init_state == SCANNER_INIT_DONE)
+                      set_scanner_init_state (SCANNER_INIT_GOT_FEED_VERSION);
+                    else if (acknowledge_feed_version_info ())
+                      goto return_error;
+                    break;
+                  case -1:
+                    goto return_error;
+                  case -2:
+                    /* Need more input. */
+                    if (sync_buffer ())
+                      goto return_error;
+                    goto return_need_more;
+                  }
+                break;
+              }
+            case SCANNER_PREFERENCE_NAME:
+              {
+                /* Use match[1] instead of field[1] for UTF-8 hack. */
+                if (strlen (field) == 0 && match[1] == '|')
+                  {
+                    set_scanner_state (SCANNER_DONE);
+                    switch (parse_scanner_done (&messages))
+                      {
+                      case -1:
+                        goto return_error;
+                      case -2:
+                        /* Need more input. */
+                        if (sync_buffer ())
+                          goto return_error;
+                        goto return_need_more;
+                      }
+                    if (scanner_init_state == SCANNER_INIT_DONE_CACHE_MODE
+                        || scanner_init_state
+                             == SCANNER_INIT_DONE_CACHE_MODE_UPDATE)
+                      {
+                        manage_complete_nvt_cache_update (
+                          scanner_plugins_list, scanner_preferences_list);
+                        set_scanner_init_state (SCANNER_INIT_DONE);
+                        manage_nvt_preferences_enable ();
+                        /* Return 1, as though the scanner sent BYE. */
+                        /** @todo Exit more formally with Scanner? */
+                        goto return_bye;
+                      }
+                    break;
+                  }
+
+                {
+                  int value_start = -1, value_end = -1, count;
+                  char name[21];
+                  /* LDAPsearch[entry]:Timeout value */
+                  count = sscanf (field, "%20[^[][%*[^]]]:%n%*[ -~]%n", name,
+                                  &value_start, &value_end);
+                  if (count == 1 && value_start > 0 && value_end > 0
+                      && ((strcmp (name, "SSH Authorization") == 0)
+                          || (strcmp (name, "SNMP Authorization") == 0)
+                          || (strcmp (name, "ESXi Authorization") == 0)
+                          || (strcmp (name, "SMB Authorization") == 0)))
+                    current_scanner_preference = NULL;
+                  else
+                    current_scanner_preference = g_strdup (field);
+                  set_scanner_state (SCANNER_PREFERENCE_VALUE);
+                  switch (parse_scanner_preference_value (&messages))
+                    {
                     case -2:
                       /* Need more input. */
-                      if (sync_buffer ()) goto return_error;
+                      if (sync_buffer ())
+                        goto return_error;
                       goto return_need_more;
-                    case -3: break;        /* Next <|> is before next \n. */
-                    case -4: break;        /* Failed to find \n, try for <|>. */
+                    }
+                  g_free (current_scanner_preference);
+                  current_scanner_preference = NULL;
+                }
+                break;
+              }
+            case SCANNER_SERVER:
+              if (strcasecmp ("BYE", field) == 0)
+                set_scanner_state (SCANNER_BYE);
+              else if (strcasecmp ("ERRMSG", field) == 0)
+                set_scanner_state (SCANNER_ERRMSG_HOST);
+              else if (strcasecmp ("FILE_ACCEPTED", field) == 0)
+                {
+                  set_scanner_state (SCANNER_DONE);
+                  switch (parse_scanner_done (&messages))
+                    {
+                    case -1:
+                      goto return_error;
+                    case -2:
+                      /* Need more input. */
+                      if (sync_buffer ())
+                        goto return_error;
+                      goto return_need_more;
+                    }
+                }
+              else if (strcasecmp ("ALARM", field) == 0)
+                set_scanner_state (SCANNER_ALARM_HOST);
+              else if (strcasecmp ("LOG", field) == 0)
+                set_scanner_state (SCANNER_LOG_HOST);
+              else if (strcasecmp ("NVT_INFO", field) == 0)
+                set_scanner_state (SCANNER_NVT_INFO);
+              else if (strcasecmp ("PLUGIN_LIST", field) == 0)
+                {
+                  set_scanner_state (SCANNER_PLUGIN_LIST_OID);
+                }
+              else if (strcasecmp ("PREFERENCES", field) == 0)
+                {
+                  assert (current_scanner_preference == NULL);
+                  set_scanner_state (SCANNER_PREFERENCE_NAME);
+                }
+              else if (strcasecmp ("TIME", field) == 0)
+                {
+                  set_scanner_state (SCANNER_TIME);
+                }
+              else if (strcasecmp ("STATUS", field) == 0)
+                {
+                  set_scanner_state (SCANNER_STATUS_HOST);
+                }
+              else
+                {
+                  g_debug ("New scanner command to implement: %s", field);
+                  goto return_error;
+                }
+              break;
+            case SCANNER_STATUS_HOST:
+              {
+                assert (current_host == NULL);
+                current_host = g_strdup (field);
+                set_scanner_state (SCANNER_STATUS_PROGRESS);
+                break;
+              }
+            case SCANNER_STATUS_PROGRESS:
+              {
+                /* Store the progress in the ports slots in the db. */
+                assert (global_current_report);
+                if (global_current_report && current_host)
+                  {
+                    unsigned int current, max;
+                    g_debug ("   scanner got ports: %s", field);
+                    if (sscanf (field, "%u/%u", &current, &max) == 2)
+                      set_scan_ports (global_current_report, current_host,
+                                      current, max);
+                  }
+                if (current_host)
+                  {
+                    g_free (current_host);
+                    current_host = NULL;
+                  }
+                set_scanner_state (SCANNER_DONE);
+                switch (parse_scanner_done (&messages))
+                  {
+                  case -1:
+                    goto return_error;
+                  case -2:
+                    /* Need more input. */
+                    if (sync_buffer ())
+                      goto return_error;
+                    goto return_need_more;
                   }
                 break;
+              }
+            case SCANNER_TIME:
+              {
+                if (strcasecmp ("HOST_START", field) == 0)
+                  set_scanner_state (SCANNER_TIME_HOST_START_HOST);
+                else if (strcasecmp ("HOST_END", field) == 0)
+                  set_scanner_state (SCANNER_TIME_HOST_END_HOST);
+                else if (strcasecmp ("SCAN_START", field) == 0)
+                  set_scanner_state (SCANNER_TIME_SCAN_START);
+                else if (strcasecmp ("SCAN_END", field) == 0)
+                  set_scanner_state (SCANNER_TIME_SCAN_END);
+                else
+                  /** @todo Consider reading all fields up to <|> SERVER? */
+                  abort ();
+                break;
+              }
+            case SCANNER_TIME_HOST_START_HOST:
+              {
+                assert (current_host == NULL);
+                current_host = g_strdup (field);
+                set_scanner_state (SCANNER_TIME_HOST_START_TIME);
+                break;
+              }
+            case SCANNER_TIME_HOST_START_TIME:
+              {
+                if (current_scanner_task)
+                  {
+                    assert (current_host);
+                    assert (global_current_report);
+
+                    set_scan_host_start_time_otp (global_current_report,
+                                                  current_host, field);
+                    g_free (current_host);
+                    current_host = NULL;
+                  }
+                set_scanner_state (SCANNER_DONE);
+                switch (parse_scanner_done (&messages))
+                  {
+                  case -1:
+                    goto return_error;
+                  case -2:
+                    /* Need more input. */
+                    if (sync_buffer ())
+                      goto return_error;
+                    goto return_need_more;
+                  }
+                break;
+              }
+            case SCANNER_TIME_HOST_END_HOST:
+              {
+                assert (current_host == NULL);
+                current_host = g_strdup (field);
+                set_scanner_state (SCANNER_TIME_HOST_END_TIME);
+                break;
+              }
+            case SCANNER_TIME_HOST_END_TIME:
+              {
+                assert (current_host);
+                assert (global_current_report);
+
+                if (report_host_noticeable (global_current_report,
+                                            current_host))
+                  {
+                    char *uuid;
+                    uuid = report_uuid (global_current_report);
+                    host_notice (current_host, "ip", current_host,
+                                 "Report Host", uuid, 1, 0);
+                    free (uuid);
+                  }
+
+                if (current_scanner_task)
+                  {
+                    assert (current_host);
+                    set_scan_host_end_time_otp (global_current_report,
+                                                current_host, field);
+                    g_free (current_host);
+                    current_host = NULL;
+                  }
+                set_scanner_state (SCANNER_DONE);
+                switch (parse_scanner_done (&messages))
+                  {
+                  case -1:
+                    goto return_error;
+                  case -2:
+                    /* Need more input. */
+                    if (sync_buffer ())
+                      goto return_error;
+                    goto return_need_more;
+                  }
+                break;
+              }
+            case SCANNER_TIME_SCAN_START:
+              {
+                if (current_scanner_task)
+                  {
+                    if (task_run_status (current_scanner_task)
+                        == TASK_STATUS_REQUESTED)
+                      {
+                        set_task_run_status (current_scanner_task,
+                                             TASK_STATUS_RUNNING);
+                        /* If the scan has been started before, then leave
+                         * the start time alone. */
+                        if (scan_start_time_epoch (global_current_report) == 0)
+                          {
+                            set_task_start_time_otp (current_scanner_task,
+                                                     g_strdup (field));
+                            set_scan_start_time_otp (global_current_report,
+                                                     field);
+                          }
+                      }
+                  }
+                set_scanner_state (SCANNER_DONE);
+                switch (parse_scanner_done (&messages))
+                  {
+                  case -1:
+                    goto return_error;
+                  case -2:
+                    /* Need more input. */
+                    if (sync_buffer ())
+                      goto return_error;
+                    goto return_need_more;
+                  }
+                break;
+              }
+            case SCANNER_TIME_SCAN_END:
+              {
+                if (current_scanner_task)
+                  {
+                    /* Stop transaction now, because delete_task_lock and
+                     * set_scan_end_time_otp run transactions themselves. */
+                    manage_transaction_stop (TRUE);
+                    if (global_current_report)
+                      {
+                        hosts_set_identifiers (global_current_report);
+                        hosts_set_max_severity (global_current_report, NULL,
+                                                NULL);
+                        hosts_set_details (global_current_report);
+                        set_scan_end_time_otp (global_current_report, field);
+                      }
+                    switch (task_run_status (current_scanner_task))
+                      {
+                      case TASK_STATUS_INTERRUPTED:
+                        break;
+                      case TASK_STATUS_STOP_REQUESTED:
+                      case TASK_STATUS_STOP_WAITING:
+                        set_task_run_status (current_scanner_task,
+                                             TASK_STATUS_STOPPED);
+                        break;
+                      case TASK_STATUS_DELETE_REQUESTED:
+                      case TASK_STATUS_DELETE_WAITING:
+                        set_task_run_status (current_scanner_task,
+                                             TASK_STATUS_STOPPED);
+                        delete_task_lock (current_scanner_task, 0);
+                        global_current_report = (report_t) 0;
+                        break;
+                      case TASK_STATUS_DELETE_ULTIMATE_REQUESTED:
+                      case TASK_STATUS_DELETE_ULTIMATE_WAITING:
+                        set_task_run_status (current_scanner_task,
+                                             TASK_STATUS_STOPPED);
+                        delete_task_lock (current_scanner_task, 1);
+                        global_current_report = (report_t) 0;
+                        break;
+                      default:
+                        set_task_end_time (current_scanner_task,
+                                           g_strdup (field));
+                        set_task_run_status (current_scanner_task,
+                                             TASK_STATUS_DONE);
+                      }
+                    clear_duration_schedules (current_scanner_task);
+                    update_duration_schedule_periods (current_scanner_task);
+                    global_current_report = (report_t) 0;
+                    current_scanner_task = (task_t) 0;
+                  }
+                set_scanner_state (SCANNER_DONE);
+                switch (parse_scanner_done (&messages))
+                  {
+                  case -1:
+                    goto return_error;
+                  case -2:
+                    /* Need more input. */
+                    if (sync_buffer ())
+                      goto return_error;
+                    goto return_need_more;
+                  }
+                break;
+              }
+            case SCANNER_TOP:
+            default:
+              g_debug ("   switch t");
+              g_debug ("   cmp %i", strcasecmp ("SERVER", field));
+              if (strcasecmp ("SERVER", field))
+                goto return_error;
+              set_scanner_state (SCANNER_SERVER);
+              /* Look for any newline delimited scanner commands. */
+              switch (parse_scanner_server (&messages))
+                {
+                case 0:
+                  break; /* Found newline delimited command. */
+                case -1:
+                  goto return_error; /* Error. */
+                case -2:
+                  /* Need more input. */
+                  if (sync_buffer ())
+                    goto return_error;
+                  goto return_need_more;
+                case -3:
+                  break; /* Next <|> is before next \n. */
+                case -4:
+                  break; /* Failed to find \n, try for <|>. */
+                }
+              break;
             }
 
           g_debug ("   scanner new state: %i", scanner_state);
 
           continue;
 
-         return_error:
+        return_error:
           return -1;
 
-         return_need_more:
+        return_need_more:
           return 0;
 
-         return_bye:
+        return_bye:
           return 1;
         }
       else
@@ -1679,6 +1727,7 @@ process_otp_scanner_input ()
         }
     }
 
-  if (sync_buffer ()) return -1;
+  if (sync_buffer ())
+    return -1;
   return 0;
 }

--- a/src/otp.h
+++ b/src/otp.h
@@ -26,6 +26,7 @@
 #define _GVMD_OTP_H
 
 #include "manage.h"
+
 #include <glib.h>
 
 void

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -151,7 +151,8 @@ write_string_to_server (char *const string)
                 continue;
               else
                 {
-                  g_warning ("%s: Failed to write to scanner: %s", __FUNCTION__,
+                  g_warning ("%s: Failed to write to scanner: %s",
+                             __FUNCTION__,
                              strerror (errno));
                   return -1;
                 }
@@ -159,8 +160,8 @@ write_string_to_server (char *const string)
         }
       else
         {
-          count = gnutls_record_send (openvas_scanner_session, point,
-                                      (size_t) (end - point));
+          count = gnutls_record_send (
+            openvas_scanner_session, point, (size_t) (end - point));
           if (count < 0)
             {
               if (count == GNUTLS_E_AGAIN)
@@ -172,7 +173,8 @@ write_string_to_server (char *const string)
               if (count == GNUTLS_E_REHANDSHAKE)
                 /** @todo Rehandshake. */
                 continue;
-              g_warning ("%s: failed to write to server: %s", __FUNCTION__,
+              g_warning ("%s: failed to write to server: %s",
+                         __FUNCTION__,
                          gnutls_strerror ((int) count));
               return -1;
             }
@@ -201,8 +203,10 @@ write_to_server_buffer ()
 
       if (openvas_scanner_unix_path)
         {
-          count = send (openvas_scanner_socket, to_server + to_server_start,
-                        to_server_end - to_server_start, 0);
+          count = send (openvas_scanner_socket,
+                        to_server + to_server_start,
+                        to_server_end - to_server_start,
+                        0);
           if (count < 0)
             {
               if (errno == EAGAIN)
@@ -211,7 +215,8 @@ write_to_server_buffer ()
                 return -3;
               else
                 {
-                  g_warning ("%s: Failed to write to scanner: %s", __FUNCTION__,
+                  g_warning ("%s: Failed to write to scanner: %s",
+                             __FUNCTION__,
                              strerror (errno));
                   return -1;
                 }
@@ -233,7 +238,8 @@ write_to_server_buffer ()
               if (count == GNUTLS_E_REHANDSHAKE)
                 /** @todo Rehandshake. */
                 continue;
-              g_warning ("%s: failed to write to server: %s", __FUNCTION__,
+              g_warning ("%s: failed to write to server: %s",
+                         __FUNCTION__,
                          gnutls_strerror ((int) count));
               return -1;
             }
@@ -267,8 +273,10 @@ openvas_scanner_read ()
 
       if (openvas_scanner_unix_path)
         {
-          count = recv (openvas_scanner_socket, from_scanner + from_scanner_end,
-                        from_scanner_size - from_scanner_end, 0);
+          count = recv (openvas_scanner_socket,
+                        from_scanner + from_scanner_end,
+                        from_scanner_size - from_scanner_end,
+                        0);
           if (count < 0)
             {
               if (errno == EINTR)
@@ -278,7 +286,8 @@ openvas_scanner_read ()
               else
                 {
                   g_warning ("%s: Failed to read from scanner: %s",
-                             __FUNCTION__, strerror (errno));
+                             __FUNCTION__,
+                             strerror (errno));
                   return -1;
                 }
             }
@@ -308,10 +317,11 @@ openvas_scanner_read ()
                 {
                   int alert = gnutls_alert_get (openvas_scanner_session);
                   const char *alert_name = gnutls_alert_get_name (alert);
-                  g_warning ("%s: TLS Alert %d: %s", __FUNCTION__, alert,
-                             alert_name);
+                  g_warning (
+                    "%s: TLS Alert %d: %s", __FUNCTION__, alert, alert_name);
                 }
-              g_warning ("%s: failed to read from server: %s", __FUNCTION__,
+              g_warning ("%s: failed to read from server: %s",
+                         __FUNCTION__,
                          gnutls_strerror (count));
               return -1;
             }
@@ -380,7 +390,8 @@ openvas_scanner_write (int nvt_cache_mode)
           if (fcntl (openvas_scanner_socket, F_SETFL, O_NONBLOCK) == -1)
             {
               g_warning ("%s: failed to set scanner socket flag: %s",
-                         __FUNCTION__, strerror (errno));
+                         __FUNCTION__,
+                         strerror (errno));
               return -1;
             }
           /* Fall through to SCANNER_INIT_CONNECTED case below, to write
@@ -506,8 +517,8 @@ openvas_scanner_wait ()
         {
           if (errno == EINTR)
             continue;
-          g_warning ("%s: select failed (connect): %s", __FUNCTION__,
-                     strerror (errno));
+          g_warning (
+            "%s: select failed (connect): %s", __FUNCTION__, strerror (errno));
           return -1;
         }
 
@@ -535,7 +546,8 @@ load_cas (gnutls_certificate_credentials_t *scanner_credentials)
     {
       if (errno != ENOENT)
         {
-          g_warning ("%s: failed to open " CA_DIR ": %s", __FUNCTION__,
+          g_warning ("%s: failed to open " CA_DIR ": %s",
+                     __FUNCTION__,
                      strerror (errno));
           return -1;
         }
@@ -558,7 +570,8 @@ load_cas (gnutls_certificate_credentials_t *scanner_credentials)
                 < 0))
           {
             g_warning ("%s: gnutls_certificate_set_x509_trust_file failed: %s",
-                       __FUNCTION__, name);
+                       __FUNCTION__,
+                       name);
             g_free (name);
             closedir (dir);
             return -1;
@@ -584,7 +597,8 @@ openvas_scanner_close ()
   if (openvas_scanner_unix_path)
     close (openvas_scanner_socket);
   else
-    rc = gvm_server_free (openvas_scanner_socket, openvas_scanner_session,
+    rc = gvm_server_free (openvas_scanner_socket,
+                          openvas_scanner_session,
                           openvas_scanner_credentials);
   openvas_scanner_socket = -1;
   openvas_scanner_session = NULL;
@@ -626,7 +640,8 @@ openvas_scanner_connect_unix ()
   openvas_scanner_socket = socket (AF_UNIX, SOCK_STREAM, 0);
   if (openvas_scanner_socket == -1)
     {
-      g_warning ("%s: failed to create scanner socket: %s", __FUNCTION__,
+      g_warning ("%s: failed to create scanner socket: %s",
+                 __FUNCTION__,
                  strerror (errno));
       return -1;
     }
@@ -636,8 +651,10 @@ openvas_scanner_connect_unix ()
   len = strlen (addr.sun_path) + sizeof (addr.sun_family);
   if (connect (openvas_scanner_socket, (struct sockaddr *) &addr, len) == -1)
     {
-      g_warning ("%s: Failed to connect to scanner (%s): %s", __FUNCTION__,
-                 openvas_scanner_unix_path, strerror (errno));
+      g_warning ("%s: Failed to connect to scanner (%s): %s",
+                 __FUNCTION__,
+                 openvas_scanner_unix_path,
+                 strerror (errno));
       return -1;
     }
 
@@ -659,14 +676,17 @@ openvas_scanner_connect ()
   openvas_scanner_socket = socket (PF_INET, SOCK_STREAM, 0);
   if (openvas_scanner_socket == -1)
     {
-      g_warning ("%s: failed to create scanner socket: %s", __FUNCTION__,
+      g_warning ("%s: failed to create scanner socket: %s",
+                 __FUNCTION__,
                  strerror (errno));
       return -1;
     }
 
   /* Make the scanner socket. */
-  if (gvm_server_new_mem (GNUTLS_CLIENT, openvas_scanner_ca_pub,
-                          openvas_scanner_key_pub, openvas_scanner_key_priv,
+  if (gvm_server_new_mem (GNUTLS_CLIENT,
+                          openvas_scanner_ca_pub,
+                          openvas_scanner_key_pub,
+                          openvas_scanner_key_priv,
                           &openvas_scanner_session,
                           &openvas_scanner_credentials))
     {

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -905,7 +905,8 @@ openvas_scanner_set_unix (const char *path)
  * @param[in]  key_priv     Scanner private key.
  */
 void
-openvas_scanner_set_certs (const char *ca_pub, const char *key_pub,
+openvas_scanner_set_certs (const char *ca_pub,
+                           const char *key_pub,
                            const char *key_priv)
 {
   if (openvas_scanner_unix_path)

--- a/src/sql.c
+++ b/src/sql.c
@@ -41,19 +41,17 @@
  */
 #define G_LOG_DOMAIN "md manage"
 
-
 /* Headers of internal symbols defined in backend files. */
 
 int
-sql_prepare_internal (int, int, const char*, va_list, sql_stmt_t **);
+sql_prepare_internal (int, int, const char *, va_list, sql_stmt_t **);
 
 int
 sql_exec_internal (int, sql_stmt_t *);
 
 int
-sql_explain_internal (const char*, va_list);
+sql_explain_internal (const char *, va_list);
 
-
 /* Variables. */
 
 /**
@@ -63,7 +61,6 @@ sql_explain_internal (const char*, va_list);
  */
 int log_errors = 1;
 
-
 /* Helpers. */
 
 /**
@@ -74,8 +71,8 @@ int log_errors = 1;
  *
  * @return Freshly allocated, quoted string. Free with g_free.
  */
-gchar*
-sql_nquote (const char* string, size_t length)
+gchar *
+sql_nquote (const char *string, size_t length)
 {
   gchar *new, *new_start;
   const gchar *start, *end;
@@ -86,7 +83,8 @@ sql_nquote (const char* string, size_t length)
   /* Count number of apostrophes. */
 
   start = string;
-  while ((start = strchr (start, '\''))) start++, count++;
+  while ((start = strchr (start, '\'')))
+    start++, count++;
 
   /* Allocate new string. */
 
@@ -96,13 +94,13 @@ sql_nquote (const char* string, size_t length)
 
   start = string;
   end = string + length;
-  for (; start < end; start++, new++)
+  for (; start < end; start++, new ++)
     {
       char ch = *start;
       if (ch == '\'')
         {
           *new = '\'';
-          new++;
+          new ++;
           *new = '\'';
         }
       else
@@ -119,8 +117,8 @@ sql_nquote (const char* string, size_t length)
  *
  * @return Freshly allocated, quoted string. Free with g_free.
  */
-gchar*
-sql_quote (const char* string)
+gchar *
+sql_quote (const char *string)
 {
   assert (string);
   return sql_nquote (string, strlen (string));
@@ -157,12 +155,12 @@ sql_insert (const char *string)
  * @return 0 success, 1 gave up (even when retry given), -1 error.
  */
 int
-sqlv (int retry, char* sql, va_list args)
+sqlv (int retry, char *sql, va_list args)
 {
   while (1)
     {
       int ret;
-      sql_stmt_t* stmt;
+      sql_stmt_t *stmt;
       va_list args_copy;
 
       /* Prepare statement.
@@ -178,7 +176,8 @@ sqlv (int retry, char* sql, va_list args)
 
       /* Run statement. */
 
-      while ((ret = sql_exec_internal (retry, stmt)) == 1);
+      while ((ret = sql_exec_internal (retry, stmt)) == 1)
+        ;
       if ((ret == -1) && log_errors)
         g_warning ("%s: sql_exec_internal failed", __FUNCTION__);
       sql_finalize (stmt);
@@ -200,7 +199,7 @@ sqlv (int retry, char* sql, va_list args)
  * @param[in]  ...    Arguments for format string.
  */
 void
-sql (char* sql, ...)
+sql (char *sql, ...)
 {
   while (1)
     {
@@ -230,7 +229,7 @@ sql (char* sql, ...)
  * @return 0 success, -1 error.
  */
 int
-sql_error (char* sql, ...)
+sql_error (char *sql, ...)
 {
   int ret;
 
@@ -258,7 +257,7 @@ sql_error (char* sql, ...)
  * @return 0 success, 1 gave up, -1 error.
  */
 int
-sql_giveup (char* sql, ...)
+sql_giveup (char *sql, ...)
 {
   int ret;
   va_list args;
@@ -280,7 +279,7 @@ sql_giveup (char* sql, ...)
  * @return 0 success, 1 too few rows, -1 error.
  */
 static int
-sql_x_internal (int log, char* sql, va_list args, sql_stmt_t** stmt_return)
+sql_x_internal (int log, char *sql, va_list args, sql_stmt_t **stmt_return)
 {
   int ret;
 
@@ -340,7 +339,7 @@ sql_x_internal (int log, char* sql, va_list args, sql_stmt_t** stmt_return)
  * @return 0 success, 1 too few rows, -1 error.
  */
 int
-sql_x (char* sql, va_list args, sql_stmt_t** stmt_return)
+sql_x (char *sql, va_list args, sql_stmt_t **stmt_return)
 {
   return sql_x_internal (1, sql, args, stmt_return);
 }
@@ -359,9 +358,9 @@ sql_x (char* sql, va_list args, sql_stmt_t** stmt_return)
  * @return Result of the query as an integer.
  */
 double
-sql_double (char* sql, ...)
+sql_double (char *sql, ...)
 {
-  sql_stmt_t* stmt;
+  sql_stmt_t *stmt;
   va_list args;
   double ret;
 
@@ -393,9 +392,9 @@ sql_double (char* sql, ...)
  * @return Result of the query as an integer.
  */
 int
-sql_int (char* sql, ...)
+sql_int (char *sql, ...)
 {
-  sql_stmt_t* stmt;
+  sql_stmt_t *stmt;
   va_list args;
   int ret;
 
@@ -423,12 +422,12 @@ sql_int (char* sql, ...)
  *         NULL means that either the selected value was NULL or there were
  *         no rows in the result.
  */
-char*
-sql_string (char* sql, ...)
+char *
+sql_string (char *sql, ...)
 {
-  sql_stmt_t* stmt;
-  const char* ret2;
-  char* ret;
+  sql_stmt_t *stmt;
+  const char *ret2;
+  char *ret;
   int sql_x_ret;
 
   va_list args;
@@ -456,9 +455,9 @@ sql_string (char* sql, ...)
  * @return 0 success, 1 too few rows, -1 error.
  */
 int
-sql_int64 (long long int* ret, char* sql, ...)
+sql_int64 (long long int *ret, char *sql, ...)
 {
-  sql_stmt_t* stmt;
+  sql_stmt_t *stmt;
   int sql_x_ret;
   va_list args;
 
@@ -467,19 +466,19 @@ sql_int64 (long long int* ret, char* sql, ...)
   va_end (args);
   switch (sql_x_ret)
     {
-      case  0:
-        break;
-      case  1:
-        sql_finalize (stmt);
-        return 1;
-        break;
-      default:
-        assert (0);
-        /* Fall through. */
-      case -1:
-        sql_finalize (stmt);
-        return -1;
-        break;
+    case 0:
+      break;
+    case 1:
+      sql_finalize (stmt);
+      return 1;
+      break;
+    default:
+      assert (0);
+      /* Fall through. */
+    case -1:
+      sql_finalize (stmt);
+      return -1;
+      break;
     }
   *ret = sql_column_int64 (stmt, 0);
   sql_finalize (stmt);
@@ -497,9 +496,9 @@ sql_int64 (long long int* ret, char* sql, ...)
  * @return 0 success, 1 too few rows, -1 error.
  */
 long long int
-sql_int64_0 (char* sql, ...)
+sql_int64_0 (char *sql, ...)
 {
-  sql_stmt_t* stmt;
+  sql_stmt_t *stmt;
   int sql_x_ret;
   long long int ret;
   va_list args;
@@ -537,7 +536,6 @@ sql_explain (const char *sql, ...)
   return ret;
 }
 
-
 /* Iterators. */
 
 /**
@@ -547,7 +545,7 @@ sql_explain (const char *sql, ...)
  * @param[in]  stmt      Statement.
  */
 void
-init_prepared_iterator (iterator_t* iterator, sql_stmt_t* stmt)
+init_prepared_iterator (iterator_t *iterator, sql_stmt_t *stmt)
 {
   iterator->done = FALSE;
   iterator->stmt = stmt;
@@ -563,10 +561,10 @@ init_prepared_iterator (iterator_t* iterator, sql_stmt_t* stmt)
  * @param[in]  sql       Format string for SQL.
  */
 void
-init_iterator (iterator_t* iterator, const char* sql, ...)
+init_iterator (iterator_t *iterator, const char *sql, ...)
 {
   int ret;
-  sql_stmt_t* stmt;
+  sql_stmt_t *stmt;
   va_list args;
 
   iterator->done = FALSE;
@@ -593,9 +591,10 @@ init_iterator (iterator_t* iterator, const char* sql, ...)
  * @return Value of given column.
  */
 double
-iterator_double (iterator_t* iterator, int col)
+iterator_double (iterator_t *iterator, int col)
 {
-  if (iterator->done) abort ();
+  if (iterator->done)
+    abort ();
   return sql_column_double (iterator->stmt, col);
 }
 
@@ -608,9 +607,10 @@ iterator_double (iterator_t* iterator, int col)
  * @return Value of given column.
  */
 int
-iterator_int (iterator_t* iterator, int col)
+iterator_int (iterator_t *iterator, int col)
 {
-  if (iterator->done) abort ();
+  if (iterator->done)
+    abort ();
   return sql_column_int (iterator->stmt, col);
 }
 
@@ -623,9 +623,10 @@ iterator_int (iterator_t* iterator, int col)
  * @return Value of given column.
  */
 long long int
-iterator_int64 (iterator_t* iterator, int col)
+iterator_int64 (iterator_t *iterator, int col)
 {
-  if (iterator->done) abort ();
+  if (iterator->done)
+    abort ();
   return sql_column_int64 (iterator->stmt, col);
 }
 
@@ -637,10 +638,11 @@ iterator_int64 (iterator_t* iterator, int col)
  *
  * @return Value of given column.
  */
-const char*
-iterator_string (iterator_t* iterator, int col)
+const char *
+iterator_string (iterator_t *iterator, int col)
 {
-  if (iterator->done) abort ();
+  if (iterator->done)
+    abort ();
   return sql_column_text (iterator->stmt, col);
 }
 
@@ -650,7 +652,7 @@ iterator_string (iterator_t* iterator, int col)
  * @param[in]  iterator  Iterator.
  */
 void
-cleanup_iterator (iterator_t* iterator)
+cleanup_iterator (iterator_t *iterator)
 {
   if (iterator == NULL)
     {
@@ -675,11 +677,12 @@ cleanup_iterator (iterator_t* iterator)
  * @return TRUE if there was a next item, else FALSE.
  */
 gboolean
-next (iterator_t* iterator)
+next (iterator_t *iterator)
 {
   int ret;
 
-  if (iterator->done) return FALSE;
+  if (iterator->done)
+    return FALSE;
 
   if (iterator->crypt_ctx)
     lsc_crypt_flush (iterator->crypt_ctx);
@@ -729,7 +732,6 @@ next (iterator_t* iterator)
   return TRUE;
 }
 
-
 /* Prepared statements. */
 
 /**
@@ -740,10 +742,10 @@ next (iterator_t* iterator)
  * @return Statement on success, NULL on error.
  */
 sql_stmt_t *
-sql_prepare (const char* sql, ...)
+sql_prepare (const char *sql, ...)
 {
   int ret;
-  sql_stmt_t* stmt;
+  sql_stmt_t *stmt;
   va_list args;
 
   va_start (args, sql);

--- a/src/sql.h
+++ b/src/sql.h
@@ -29,7 +29,6 @@
 
 #include <glib.h>
 
-
 /* Helpers. */
 
 int
@@ -87,22 +86,22 @@ gchar *
 sql_insert (const char *);
 
 void
-sql (char * sql, ...);
+sql (char *sql, ...);
 
 void
 sqli (resource_t *, char *, ...);
 
 int
-sql_error (char* sql, ...);
+sql_error (char *sql, ...);
 
 int
-sql_giveup (char * sql, ...);
+sql_giveup (char *sql, ...);
 
 void
-sql_quiet (char * sql, ...);
+sql_quiet (char *sql, ...);
 
 double
-sql_double (char* sql, ...);
+sql_double (char *sql, ...);
 
 int
 sql_int (char *, ...);
@@ -111,15 +110,14 @@ char *
 sql_string (char *, ...);
 
 int
-sql_int64 (long long int * ret, char *, ...);
+sql_int64 (long long int *ret, char *, ...);
 
 long long int
-sql_int64_0 (char* sql, ...);
+sql_int64_0 (char *sql, ...);
 
 void
 sql_rename_column (const char *, const char *, const char *, const char *);
 
-
 /* Transactions. */
 
 void
@@ -140,44 +138,42 @@ sql_commit ();
 void
 sql_rollback ();
 
-
 /* Iterators. */
 
 /* These functions are for "internal" use.  They may only be accessed by code
  * that is allowed to run SQL statements directly. */
 
 void
-init_prepared_iterator (iterator_t*, sql_stmt_t*);
+init_prepared_iterator (iterator_t *, sql_stmt_t *);
 
 void
-init_iterator (iterator_t*, const char*, ...);
+init_iterator (iterator_t *, const char *, ...);
 
 double
-iterator_double (iterator_t*, int);
+iterator_double (iterator_t *, int);
 
 int
-iterator_int (iterator_t*, int);
+iterator_int (iterator_t *, int);
 
 long long int
-iterator_int64 (iterator_t*, int);
+iterator_int64 (iterator_t *, int);
 
 int
-iterator_null (iterator_t*, int);
+iterator_null (iterator_t *, int);
 
-const char*
-iterator_string (iterator_t*, int);
+const char *
+iterator_string (iterator_t *, int);
 
-const char*
-iterator_column_name (iterator_t*, int);
+const char *
+iterator_column_name (iterator_t *, int);
 
 int
-iterator_column_count (iterator_t*);
+iterator_column_count (iterator_t *);
 
-
 /* Prepared statements. */
 
 sql_stmt_t *
-sql_prepare (const char* sql, ...);
+sql_prepare (const char *sql, ...);
 
 int
 sql_bind_blob (sql_stmt_t *, int, const void *, int);

--- a/src/sql_pg.c
+++ b/src/sql_pg.c
@@ -146,7 +146,9 @@ sql_select_limit (int max)
  * @param[in]  param_format  0 text, 1 binary.
  */
 static void
-sql_stmt_param_add (sql_stmt_t *stmt, const char *param_value, int param_size,
+sql_stmt_param_add (sql_stmt_t *stmt,
+                    const char *param_value,
+                    int param_size,
                     int param_format)
 {
   array_add (stmt->param_values, g_strndup (param_value, param_size));
@@ -466,7 +468,10 @@ sqli (resource_t *resource, char *sql, ...)
  * @return 0 success, 1 gave up, -1 error.
  */
 int
-sql_prepare_internal (int retry, int log, const char *sql, va_list args,
+sql_prepare_internal (int retry,
+                      int log,
+                      const char *sql,
+                      va_list args,
                       sql_stmt_t **stmt)
 {
   assert (stmt);
@@ -708,8 +713,11 @@ iterator_null (iterator_t *iterator, int col)
  * @param[in]  param_format  0 text, 1 binary.
  */
 static void
-bind_param (sql_stmt_t *stmt, int position, const void *param_value,
-            int param_size, int param_format)
+bind_param (sql_stmt_t *stmt,
+            int position,
+            const void *param_value,
+            int param_size,
+            int param_format)
 {
   if (position > stmt->param_values->len + 1)
     {
@@ -733,7 +741,9 @@ bind_param (sql_stmt_t *stmt, int position, const void *param_value,
  * @return 0 success, -1 error.
  */
 int
-sql_bind_blob (sql_stmt_t *stmt, int position, const void *value,
+sql_bind_blob (sql_stmt_t *stmt,
+               int position,
+               const void *value,
                int value_size)
 {
   bind_param (stmt, position, value, value_size, 1);
@@ -751,7 +761,9 @@ sql_bind_blob (sql_stmt_t *stmt, int position, const void *value,
  * @return 0 success, -1 error.
  */
 int
-sql_bind_text (sql_stmt_t *stmt, int position, const gchar *value,
+sql_bind_text (sql_stmt_t *stmt,
+               int position,
+               const gchar *value,
                gsize value_size)
 {
   bind_param (

--- a/src/sql_pg.c
+++ b/src/sql_pg.c
@@ -263,9 +263,9 @@ sql_open (const char *database)
   PostgresPollingStatusType poll_status;
   int socket;
 
-  conn_info =
-    g_strdup_printf ("dbname='%s' application_name='%s'",
-                     database ? database : sql_default_database (), "gvmd");
+  conn_info = g_strdup_printf ("dbname='%s' application_name='%s'",
+                               database ? database : sql_default_database (),
+                               "gvmd");
   conn = PQconnectStart (conn_info);
   g_free (conn_info);
   if (conn == NULL)
@@ -275,7 +275,8 @@ sql_open (const char *database)
     }
   if (PQstatus (conn) == CONNECTION_BAD)
     {
-      g_warning ("%s: PQconnectStart to '%s' failed: %s", __FUNCTION__,
+      g_warning ("%s: PQconnectStart to '%s' failed: %s",
+                 __FUNCTION__,
                  database ? database : sql_default_database (),
                  PQerrorMessage (conn));
       goto fail;
@@ -307,8 +308,8 @@ sql_open (const char *database)
             continue;
           if (ret < 0)
             {
-              g_warning ("%s: write select failed: %s", __FUNCTION__,
-                         strerror (errno));
+              g_warning (
+                "%s: write select failed: %s", __FUNCTION__, strerror (errno));
               goto fail;
             }
           /* Poll again. */
@@ -326,8 +327,8 @@ sql_open (const char *database)
             continue;
           if (ret < 0)
             {
-              g_warning ("%s: read select failed: %s", __FUNCTION__,
-                         strerror (errno));
+              g_warning (
+                "%s: read select failed: %s", __FUNCTION__, strerror (errno));
               goto fail;
             }
           /* Poll again. */
@@ -335,7 +336,8 @@ sql_open (const char *database)
       else if (poll_status == PGRES_POLLING_FAILED)
         {
           g_warning ("%s: PQconnectPoll failed", __FUNCTION__);
-          g_warning ("%s: PQerrorMessage (conn): %s", __FUNCTION__,
+          g_warning ("%s: PQerrorMessage (conn): %s",
+                     __FUNCTION__,
                      PQerrorMessage (conn));
           goto fail;
         }
@@ -499,7 +501,9 @@ sql_exec_internal (int retry, sql_stmt_t *stmt)
     {
       // FIX retry?
 
-      result = PQexecParams (conn, stmt->sql, stmt->param_values->len,
+      result = PQexecParams (conn,
+                             stmt->sql,
+                             stmt->param_values->len,
                              NULL, /* Default param types. */
                              (const char *const *) stmt->param_values->pdata,
                              (const int *) stmt->param_lengths->data,
@@ -520,14 +524,16 @@ sql_exec_internal (int retry, sql_stmt_t *stmt)
             }
           else if (sqlstate && (strcmp (sqlstate, "55P03") == 0))
             {
-              g_debug ("%s: lock unavailable: %s", __FUNCTION__,
+              g_debug ("%s: lock unavailable: %s",
+                       __FUNCTION__,
                        PQresultErrorMessage (result));
               return -3;
             }
 
           if (log_errors)
             {
-              g_warning ("%s: PQexec failed: %s (%i)", __FUNCTION__,
+              g_warning ("%s: PQexec failed: %s (%i)",
+                         __FUNCTION__,
                          PQresultErrorMessage (result),
                          PQresultStatus (result));
               g_warning ("%s: SQL: %s", __FUNCTION__, stmt->sql);
@@ -582,7 +588,8 @@ sql_explain_internal (const char *sql, va_list args)
       explain_ret = sql_exec_internal (1, explain_stmt);
       if (explain_ret == 1)
         g_debug (
-          "%s : %s", __FUNCTION__,
+          "%s : %s",
+          __FUNCTION__,
           PQgetvalue (explain_stmt->result, explain_stmt->current_row, 0));
       else if (explain_ret == 0)
         break;
@@ -707,7 +714,9 @@ bind_param (sql_stmt_t *stmt, int position, const void *param_value,
   if (position > stmt->param_values->len + 1)
     {
       g_critical ("%s: binding out of order: parameter %i after %i",
-                  __FUNCTION__, position, stmt->param_values->len);
+                  __FUNCTION__,
+                  position,
+                  stmt->param_values->len);
       abort ();
     }
   sql_stmt_param_add (stmt, param_value, param_size, param_format);
@@ -745,8 +754,8 @@ int
 sql_bind_text (sql_stmt_t *stmt, int position, const gchar *value,
                gsize value_size)
 {
-  bind_param (stmt, position, value,
-              value_size == -1 ? strlen (value) : value_size, 0);
+  bind_param (
+    stmt, position, value, value_size == -1 ? strlen (value) : value_size, 0);
   return 0;
 }
 

--- a/src/sql_pg.c
+++ b/src/sql_pg.c
@@ -26,18 +26,17 @@
 
 #include "sql.h"
 
+#include <arpa/inet.h>
 #include <assert.h>
 #include <endian.h>
 #include <errno.h>
-#include <arpa/inet.h>
 #include <glib.h>
+#include <gvm/base/array.h>
 #include <inttypes.h>
 #include <netinet/in.h>
 #include <postgresql/libpq-fe.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <gvm/base/array.h>
 
 #undef G_LOG_DOMAIN
 /**
@@ -45,13 +44,11 @@
  */
 #define G_LOG_DOMAIN "md manage"
 
-
 /* Headers of sql.c symbols used only here. */
 
 int
-sql_x (char*, va_list args, sql_stmt_t**);
+sql_x (char *, va_list args, sql_stmt_t **);
 
-
 /* Types. */
 
 /**
@@ -59,16 +56,15 @@ sql_x (char*, va_list args, sql_stmt_t**);
  */
 struct sql_stmt
 {
-  gchar *sql;             ///< SQL statement.
-  PGresult *result;       ///< Result set.
-  int current_row;        ///< Row position in results.
-  int executed;           ///< Whether statement has been executed.
-  array_t *param_values;  ///< Parameter values.
-  GArray *param_lengths;  ///< Parameter lengths (int's).
-  GArray *param_formats;  ///< Parameter formats (int's).
+  gchar *sql;            ///< SQL statement.
+  PGresult *result;      ///< Result set.
+  int current_row;       ///< Row position in results.
+  int executed;          ///< Whether statement has been executed.
+  array_t *param_values; ///< Parameter values.
+  GArray *param_lengths; ///< Parameter lengths (int's).
+  GArray *param_formats; ///< Parameter formats (int's).
 };
 
-
 /* Variables. */
 
 /**
@@ -84,7 +80,6 @@ extern int log_errors;
  */
 static PGconn *conn = NULL;
 
-
 /* Helpers. */
 
 /**
@@ -151,8 +146,8 @@ sql_select_limit (int max)
  * @param[in]  param_format  0 text, 1 binary.
  */
 static void
-sql_stmt_param_add (sql_stmt_t *stmt, const char *param_value,
-                    int param_size, int param_format)
+sql_stmt_param_add (sql_stmt_t *stmt, const char *param_value, int param_size,
+                    int param_format)
 {
   array_add (stmt->param_values, g_strndup (param_value, param_size));
   g_array_append_val (stmt->param_lengths, param_size);
@@ -268,23 +263,19 @@ sql_open (const char *database)
   PostgresPollingStatusType poll_status;
   int socket;
 
-  conn_info = g_strdup_printf ("dbname='%s' application_name='%s'",
-                               database
-                                ? database
-                                : sql_default_database (),
-                               "gvmd");
+  conn_info =
+    g_strdup_printf ("dbname='%s' application_name='%s'",
+                     database ? database : sql_default_database (), "gvmd");
   conn = PQconnectStart (conn_info);
   g_free (conn_info);
   if (conn == NULL)
     {
-      g_warning ("%s: PQconnectStart failed to allocate conn",
-                 __FUNCTION__);
+      g_warning ("%s: PQconnectStart failed to allocate conn", __FUNCTION__);
       return -1;
     }
   if (PQstatus (conn) == CONNECTION_BAD)
     {
-      g_warning ("%s: PQconnectStart to '%s' failed: %s",
-                 __FUNCTION__,
+      g_warning ("%s: PQconnectStart to '%s' failed: %s", __FUNCTION__,
                  database ? database : sql_default_database (),
                  PQerrorMessage (conn));
       goto fail;
@@ -316,8 +307,8 @@ sql_open (const char *database)
             continue;
           if (ret < 0)
             {
-              g_warning ("%s: write select failed: %s",
-                         __FUNCTION__, strerror (errno));
+              g_warning ("%s: write select failed: %s", __FUNCTION__,
+                         strerror (errno));
               goto fail;
             }
           /* Poll again. */
@@ -335,16 +326,15 @@ sql_open (const char *database)
             continue;
           if (ret < 0)
             {
-              g_warning ("%s: read select failed: %s",
-                         __FUNCTION__, strerror (errno));
+              g_warning ("%s: read select failed: %s", __FUNCTION__,
+                         strerror (errno));
               goto fail;
             }
           /* Poll again. */
         }
       else if (poll_status == PGRES_POLLING_FAILED)
         {
-          g_warning ("%s: PQconnectPoll failed",
-                     __FUNCTION__);
+          g_warning ("%s: PQconnectPoll failed", __FUNCTION__);
           g_warning ("%s: PQerrorMessage (conn): %s", __FUNCTION__,
                      PQerrorMessage (conn));
           goto fail;
@@ -367,7 +357,7 @@ sql_open (const char *database)
 
   return 0;
 
- fail:
+fail:
   PQfinish (conn);
   conn = NULL;
   return -1;
@@ -424,10 +414,10 @@ sql_last_insert_id ()
  * @param[in]  ...       Arguments for format string.
  */
 void
-sqli (resource_t *resource, char* sql, ...)
+sqli (resource_t *resource, char *sql, ...)
 {
   gchar *new_sql;
-  sql_stmt_t* stmt;
+  sql_stmt_t *stmt;
   int sql_x_ret;
   va_list args;
 
@@ -445,17 +435,17 @@ sqli (resource_t *resource, char* sql, ...)
   g_free (new_sql);
   switch (sql_x_ret)
     {
-      case  0:
-        break;
-      case  1:
-        sql_finalize (stmt);
-        abort ();
-      default:
-        assert (0);
-        /* Fall through. */
-      case -1:
-        sql_finalize (stmt);
-        abort ();
+    case 0:
+      break;
+    case 1:
+      sql_finalize (stmt);
+      abort ();
+    default:
+      assert (0);
+      /* Fall through. */
+    case -1:
+      sql_finalize (stmt);
+      abort ();
     }
   if (resource)
     *resource = sql_column_int64 (stmt, 0);
@@ -474,12 +464,12 @@ sqli (resource_t *resource, char* sql, ...)
  * @return 0 success, 1 gave up, -1 error.
  */
 int
-sql_prepare_internal (int retry, int log, const char* sql, va_list args,
+sql_prepare_internal (int retry, int log, const char *sql, va_list args,
                       sql_stmt_t **stmt)
 {
   assert (stmt);
 
-  *stmt = (sql_stmt_t*) g_malloc (sizeof (sql_stmt_t));
+  *stmt = (sql_stmt_t *) g_malloc (sizeof (sql_stmt_t));
   sql_stmt_init (*stmt);
   (*stmt)->sql = g_strdup_vprintf (sql, args);
 
@@ -509,14 +499,12 @@ sql_exec_internal (int retry, sql_stmt_t *stmt)
     {
       // FIX retry?
 
-      result = PQexecParams (conn,
-                             stmt->sql,
-                             stmt->param_values->len,
-                             NULL,                 /* Default param types. */
-                             (const char* const*) stmt->param_values->pdata,
-                             (const int*) stmt->param_lengths->data,
-                             (const int*) stmt->param_formats->data,
-                             0);                   /* Results as text. */
+      result = PQexecParams (conn, stmt->sql, stmt->param_values->len,
+                             NULL, /* Default param types. */
+                             (const char *const *) stmt->param_values->pdata,
+                             (const int *) stmt->param_lengths->data,
+                             (const int *) stmt->param_formats->data,
+                             0); /* Results as text. */
       if (PQresultStatus (result) != PGRES_TUPLES_OK
           && PQresultStatus (result) != PGRES_COMMAND_OK)
         {
@@ -524,23 +512,22 @@ sql_exec_internal (int retry, sql_stmt_t *stmt)
 
           sqlstate = PQresultErrorField (result, PG_DIAG_SQLSTATE);
           g_debug ("%s: sqlstate: %s", __FUNCTION__, sqlstate);
-          if (sqlstate && (strcmp (sqlstate, "57014") == 0)) /* query_canceled */
+          if (sqlstate
+              && (strcmp (sqlstate, "57014") == 0)) /* query_canceled */
             {
               log_errors = 0;
               g_debug ("%s: canceled SQL: %s", __FUNCTION__, stmt->sql);
             }
           else if (sqlstate && (strcmp (sqlstate, "55P03") == 0))
             {
-              g_debug ("%s: lock unavailable: %s",
-                       __FUNCTION__,
-                       PQresultErrorMessage(result));
+              g_debug ("%s: lock unavailable: %s", __FUNCTION__,
+                       PQresultErrorMessage (result));
               return -3;
             }
 
           if (log_errors)
             {
-              g_warning ("%s: PQexec failed: %s (%i)",
-                         __FUNCTION__,
+              g_warning ("%s: PQexec failed: %s (%i)", __FUNCTION__,
                          PQresultErrorMessage (result),
                          PQresultStatus (result));
               g_warning ("%s: SQL: %s", __FUNCTION__, stmt->sql);
@@ -575,7 +562,7 @@ sql_exec_internal (int retry, sql_stmt_t *stmt)
  * @return 0 success, -1 error.
  */
 int
-sql_explain_internal (const char* sql, va_list args)
+sql_explain_internal (const char *sql, va_list args)
 {
   char *explain_sql;
   sql_stmt_t *explain_stmt;
@@ -594,11 +581,9 @@ sql_explain_internal (const char* sql, va_list args)
     {
       explain_ret = sql_exec_internal (1, explain_stmt);
       if (explain_ret == 1)
-        g_debug ("%s : %s",
-                __FUNCTION__,
-                PQgetvalue (explain_stmt->result,
-                            explain_stmt->current_row,
-                            0));
+        g_debug (
+          "%s : %s", __FUNCTION__,
+          PQgetvalue (explain_stmt->result, explain_stmt->current_row, 0));
       else if (explain_ret == 0)
         break;
       else
@@ -615,7 +600,6 @@ sql_explain_internal (const char* sql, va_list args)
   return 0;
 }
 
-
 /* Transactions. */
 
 /**
@@ -686,7 +670,6 @@ sql_rollback ()
   sql ("ROLLBACK;");
 }
 
-
 /* Iterators. */
 
 /**
@@ -698,14 +681,14 @@ sql_rollback ()
  * @return 1 if NULL, else 0.
  */
 int
-iterator_null (iterator_t* iterator, int col)
+iterator_null (iterator_t *iterator, int col)
 {
-  if (iterator->done) abort ();
+  if (iterator->done)
+    abort ();
   assert (iterator->stmt->result);
   return PQgetisnull (iterator->stmt->result, 0, col);
 }
 
-
 /* Prepared statements. */
 
 /**
@@ -724,9 +707,7 @@ bind_param (sql_stmt_t *stmt, int position, const void *param_value,
   if (position > stmt->param_values->len + 1)
     {
       g_critical ("%s: binding out of order: parameter %i after %i",
-                  __FUNCTION__,
-                  position,
-                  stmt->param_values->len);
+                  __FUNCTION__, position, stmt->param_values->len);
       abort ();
     }
   sql_stmt_param_add (stmt, param_value, param_size, param_format);
@@ -764,11 +745,8 @@ int
 sql_bind_text (sql_stmt_t *stmt, int position, const gchar *value,
                gsize value_size)
 {
-  bind_param (stmt,
-              position,
-              value,
-              value_size == -1 ? strlen (value) : value_size,
-              0);
+  bind_param (stmt, position, value,
+              value_size == -1 ? strlen (value) : value_size, 0);
   return 0;
 }
 
@@ -846,7 +824,7 @@ sql_column_text (sql_stmt_t *stmt, int position)
   if (PQgetisnull (stmt->result, stmt->current_row, position))
     return NULL;
 
-  return (const char*) PQgetvalue (stmt->result, stmt->current_row, position);
+  return (const char *) PQgetvalue (stmt->result, stmt->current_row, position);
 }
 
 /**
@@ -871,11 +849,11 @@ sql_column_int (sql_stmt_t *stmt, int position)
 
   switch (PQftype (stmt->result, position))
     {
-      case 16:  /* BOOLOID */
-        return strcmp (cell, "f") ? 1 : 0;
+    case 16: /* BOOLOID */
+      return strcmp (cell, "f") ? 1 : 0;
 
-      default:
-        return atoi (cell);
+    default:
+      return atoi (cell);
     }
 }
 
@@ -901,11 +879,11 @@ sql_column_int64 (sql_stmt_t *stmt, int position)
 
   switch (PQftype (stmt->result, position))
     {
-      case 16:  /* BOOLOID */
-        return strcmp (cell, "f") ? 1 : 0;
+    case 16: /* BOOLOID */
+      return strcmp (cell, "f") ? 1 : 0;
 
-      default:
-        return atol (cell);
+    default:
+      return atol (cell);
     }
 }
 

--- a/src/sql_sqlite3.c
+++ b/src/sql_sqlite3.c
@@ -352,7 +352,10 @@ sqli (resource_t *resource, char *sql, ...)
  * @return 0 success, 1 gave up, -1 error.
  */
 int
-sql_prepare_internal (int retry, int log, const char *sql, va_list args,
+sql_prepare_internal (int retry,
+                      int log,
+                      const char *sql,
+                      va_list args,
                       sql_stmt_t **stmt)
 {
   const char *tail;
@@ -641,7 +644,9 @@ iterator_column_count (iterator_t *iterator)
  * @return 0 success, -1 error.
  */
 int
-sql_bind_blob (sql_stmt_t *stmt, int position, const void *value,
+sql_bind_blob (sql_stmt_t *stmt,
+               int position,
+               const void *value,
                int value_size)
 {
   unsigned int retries;
@@ -679,7 +684,9 @@ sql_bind_blob (sql_stmt_t *stmt, int position, const void *value,
  * @return 0 success, -1 error.
  */
 int
-sql_bind_text (sql_stmt_t *stmt, int position, const gchar *value,
+sql_bind_text (sql_stmt_t *stmt,
+               int position,
+               const gchar *value,
                gsize value_size)
 {
   unsigned int retries;

--- a/src/sql_sqlite3.c
+++ b/src/sql_sqlite3.c
@@ -214,8 +214,10 @@ sql_open (const char *database)
   ret = g_mkdir_with_parents (GVMD_STATE_DIR, 0755 /* "rwxr-xr-x" */);
   if (ret == -1)
     {
-      g_warning ("%s: failed to create database directory %s: %s", __FUNCTION__,
-                 GVMD_STATE_DIR, strerror (errno));
+      g_warning ("%s: failed to create database directory %s: %s",
+                 __FUNCTION__,
+                 GVMD_STATE_DIR,
+                 strerror (errno));
       abort ();
     }
 
@@ -226,8 +228,8 @@ sql_open (const char *database)
       case ENOENT:
         break;
       default:
-        g_warning ("%s: failed to stat database: %s", __FUNCTION__,
-                   strerror (errno));
+        g_warning (
+          "%s: failed to stat database: %s", __FUNCTION__, strerror (errno));
         abort ();
       }
   else if (state.st_mode & (S_IXUSR | S_IRWXG | S_IRWXO))
@@ -250,14 +252,15 @@ sql_open (const char *database)
 
   if (sqlite3_open (database ? database : sql_default_database (), &gvmd_db))
     {
-      g_warning ("%s: sqlite3_open failed: %s", __FUNCTION__,
-                 sqlite3_errmsg (gvmd_db));
+      g_warning (
+        "%s: sqlite3_open failed: %s", __FUNCTION__, sqlite3_errmsg (gvmd_db));
       return -1;
     }
 
   sqlite3_busy_timeout (gvmd_db, BUSY_TIMEOUT);
 
-  g_debug ("   %s: db open, max retry sleep time is %i", __FUNCTION__,
+  g_debug ("   %s: db open, max retry sleep time is %i",
+           __FUNCTION__,
            GVM_SQLITE_SLEEP_MAX);
 
   sqlite3_file_control (gvmd_db, NULL, SQLITE_FCNTL_CHUNK_SIZE, &chunk_size);
@@ -373,8 +376,8 @@ sql_prepare_internal (int retry, int log, const char *sql, va_list args,
   sqlite_stmt = NULL;
   while (1)
     {
-      ret = sqlite3_prepare_v2 (gvmd_db, (char *) formatted, -1, &sqlite_stmt,
-                                &tail);
+      ret = sqlite3_prepare_v2 (
+        gvmd_db, (char *) formatted, -1, &sqlite_stmt, &tail);
       if (ret == SQLITE_BUSY || ret == SQLITE_LOCKED)
         {
           if (retry)
@@ -398,14 +401,16 @@ sql_prepare_internal (int retry, int log, const char *sql, va_list args,
           if (sqlite_stmt == NULL)
             {
               g_warning ("%s: sqlite3_prepare failed with NULL stmt: %s",
-                         __FUNCTION__, sqlite3_errmsg (gvmd_db));
+                         __FUNCTION__,
+                         sqlite3_errmsg (gvmd_db));
               if (retry == 0)
                 sqlite3_busy_timeout (gvmd_db, BUSY_TIMEOUT);
               return -1;
             }
           break;
         }
-      g_warning ("%s: sqlite3_prepare failed: %s", __FUNCTION__,
+      g_warning ("%s: sqlite3_prepare failed: %s",
+                 __FUNCTION__,
                  sqlite3_errmsg (gvmd_db));
       if (retry == 0)
         sqlite3_busy_timeout (gvmd_db, BUSY_TIMEOUT);
@@ -459,8 +464,8 @@ sql_exec_internal (int retry, sql_stmt_t *stmt)
         return 0;
       if (ret == SQLITE_ROW)
         return 1;
-      g_warning ("%s: sqlite3_step failed: %s", __FUNCTION__,
-                 sqlite3_errmsg (gvmd_db));
+      g_warning (
+        "%s: sqlite3_step failed: %s", __FUNCTION__, sqlite3_errmsg (gvmd_db));
       return -1;
     }
 }
@@ -492,7 +497,8 @@ sql_explain_internal (const char *sql, va_list args)
     {
       explain_ret = sql_exec_internal (1, explain_stmt);
       if (explain_ret == 1)
-        g_debug ("%s : %s|%s|%s|%s", __FUNCTION__,
+        g_debug ("%s : %s|%s|%s|%s",
+                 __FUNCTION__,
                  sqlite3_column_text (explain_stmt->stmt, 0),
                  sqlite3_column_text (explain_stmt->stmt, 1),
                  sqlite3_column_text (explain_stmt->stmt, 2),
@@ -643,8 +649,8 @@ sql_bind_blob (sql_stmt_t *stmt, int position, const void *value,
   while (1)
     {
       int ret;
-      ret = sqlite3_bind_blob (stmt->stmt, position, value, value_size,
-                               SQLITE_TRANSIENT);
+      ret = sqlite3_bind_blob (
+        stmt->stmt, position, value, value_size, SQLITE_TRANSIENT);
       if (ret == SQLITE_BUSY)
         {
           if ((retries > 10) && (GVM_SQLITE_SLEEP_MAX > 0))
@@ -654,7 +660,8 @@ sql_bind_blob (sql_stmt_t *stmt, int position, const void *value,
         }
       if (ret == SQLITE_OK)
         break;
-      g_warning ("%s: sqlite3_bind_blob failed: %s", __FUNCTION__,
+      g_warning ("%s: sqlite3_bind_blob failed: %s",
+                 __FUNCTION__,
                  sqlite3_errmsg (gvmd_db));
       return -1;
     }
@@ -680,8 +687,8 @@ sql_bind_text (sql_stmt_t *stmt, int position, const gchar *value,
   while (1)
     {
       int ret;
-      ret = sqlite3_bind_text (stmt->stmt, position, value, value_size,
-                               SQLITE_TRANSIENT);
+      ret = sqlite3_bind_text (
+        stmt->stmt, position, value, value_size, SQLITE_TRANSIENT);
       if (ret == SQLITE_BUSY)
         {
           if ((retries > 10) && (GVM_SQLITE_SLEEP_MAX > 0))
@@ -691,7 +698,8 @@ sql_bind_text (sql_stmt_t *stmt, int position, const gchar *value,
         }
       if (ret == SQLITE_OK)
         break;
-      g_warning ("%s: sqlite3_bind_text failed: %s", __FUNCTION__,
+      g_warning ("%s: sqlite3_bind_text failed: %s",
+                 __FUNCTION__,
                  sqlite3_errmsg (gvmd_db));
       return -1;
     }
@@ -739,7 +747,8 @@ sql_reset (sql_stmt_t *stmt)
         break;
       if (ret == SQLITE_ERROR || ret == SQLITE_MISUSE)
         {
-          g_warning ("%s: sqlite3_reset failed: %s", __FUNCTION__,
+          g_warning ("%s: sqlite3_reset failed: %s",
+                     __FUNCTION__,
                      sqlite3_errmsg (gvmd_db));
           return -1;
         }

--- a/src/sql_sqlite3.c
+++ b/src/sql_sqlite3.c
@@ -28,12 +28,12 @@
 #include "utils.h"
 
 #include <assert.h>
+#include <errno.h>
 #include <sqlite3.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
-#include <errno.h>
 
 /**
  * @brief Chunk size for SQLite memory allocation.
@@ -51,13 +51,11 @@
  */
 #define BUSY_TIMEOUT 1000
 
-
 /* Headers of sql.c symbols used only here. */
 
 int
-sqlv (int, char*, va_list);
+sqlv (int, char *, va_list);
 
-
 /* Types. */
 
 /**
@@ -65,18 +63,16 @@ sqlv (int, char*, va_list);
  */
 struct sql_stmt
 {
-  sqlite3_stmt *stmt;     ///< The statement.
+  sqlite3_stmt *stmt; ///< The statement.
 };
 
-
 /* Variables. */
 
 /**
  * @brief Handle on the database.
  */
-sqlite3* gvmd_db = NULL;
+sqlite3 *gvmd_db = NULL;
 
-
 /* Helpers. */
 
 /**
@@ -218,25 +214,21 @@ sql_open (const char *database)
   ret = g_mkdir_with_parents (GVMD_STATE_DIR, 0755 /* "rwxr-xr-x" */);
   if (ret == -1)
     {
-      g_warning ("%s: failed to create database directory %s: %s",
-                 __FUNCTION__,
-                 GVMD_STATE_DIR,
-                 strerror (errno));
+      g_warning ("%s: failed to create database directory %s: %s", __FUNCTION__,
+                 GVMD_STATE_DIR, strerror (errno));
       abort ();
     }
 
-  err = stat (database ? database : sql_default_database (),
-              &state);
+  err = stat (database ? database : sql_default_database (), &state);
   if (err)
     switch (errno)
       {
-        case ENOENT:
-          break;
-        default:
-          g_warning ("%s: failed to stat database: %s",
-                     __FUNCTION__,
-                     strerror (errno));
-          abort ();
+      case ENOENT:
+        break;
+      default:
+        g_warning ("%s: failed to stat database: %s", __FUNCTION__,
+                   strerror (errno));
+        abort ();
       }
   else if (state.st_mode & (S_IXUSR | S_IRWXG | S_IRWXO))
     {
@@ -245,38 +237,33 @@ sql_open (const char *database)
       if (chmod (database ? database : sql_default_database (),
                  S_IRUSR | S_IWUSR))
         {
-          g_warning ("%s: chmod failed: %s",
-                     __FUNCTION__,
-                     strerror (errno));
+          g_warning ("%s: chmod failed: %s", __FUNCTION__, strerror (errno));
           abort ();
         }
     }
 
-  /* Workaround for SQLite temp file name conflicts that can occur if
-   * concurrent forked processes have the same PRNG state. */
+    /* Workaround for SQLite temp file name conflicts that can occur if
+     * concurrent forked processes have the same PRNG state. */
 #if SQLITE_VERSION_NUMBER < 3008003
-    sqlite3_test_control (SQLITE_TESTCTRL_PRNG_RESET);
+  sqlite3_test_control (SQLITE_TESTCTRL_PRNG_RESET);
 #endif
 
-  if (sqlite3_open (database ? database : sql_default_database (),
-                    &gvmd_db))
+  if (sqlite3_open (database ? database : sql_default_database (), &gvmd_db))
     {
-      g_warning ("%s: sqlite3_open failed: %s",
-                 __FUNCTION__,
+      g_warning ("%s: sqlite3_open failed: %s", __FUNCTION__,
                  sqlite3_errmsg (gvmd_db));
       return -1;
     }
 
   sqlite3_busy_timeout (gvmd_db, BUSY_TIMEOUT);
 
-  g_debug ("   %s: db open, max retry sleep time is %i",
-           __FUNCTION__,
+  g_debug ("   %s: db open, max retry sleep time is %i", __FUNCTION__,
            GVM_SQLITE_SLEEP_MAX);
 
   sqlite3_file_control (gvmd_db, NULL, SQLITE_FCNTL_CHUNK_SIZE, &chunk_size);
 
   sql ("PRAGMA journal_mode=WAL;");
-  sql ("PRAGMA journal_size_limit=134217728;");  /* 128 MB. */
+  sql ("PRAGMA journal_size_limit=134217728;"); /* 128 MB. */
 
   return 0;
 }
@@ -295,8 +282,7 @@ sql_close ()
      * sqlite3.pVdbe points to.  This is the list of open statements
      * in the current implementation (and subject to change without
      * notice). */
-    g_warning ("%s: attempt to close db with open statement(s)",
-               __FUNCTION__);
+    g_warning ("%s: attempt to close db with open statement(s)", __FUNCTION__);
   gvmd_db = NULL;
 }
 
@@ -339,7 +325,7 @@ sql_last_insert_id ()
  * @param[in]  ...       Arguments for format string.
  */
 void
-sqli (resource_t *resource, char* sql, ...)
+sqli (resource_t *resource, char *sql, ...)
 {
   va_list args;
 
@@ -363,13 +349,13 @@ sqli (resource_t *resource, char* sql, ...)
  * @return 0 success, 1 gave up, -1 error.
  */
 int
-sql_prepare_internal (int retry, int log, const char* sql, va_list args,
+sql_prepare_internal (int retry, int log, const char *sql, va_list args,
                       sql_stmt_t **stmt)
 {
-  const char* tail;
+  const char *tail;
   int ret;
   unsigned int retries;
-  gchar* formatted;
+  gchar *formatted;
   sqlite3_stmt *sqlite_stmt;
 
   assert (stmt);
@@ -383,19 +369,18 @@ sql_prepare_internal (int retry, int log, const char* sql, va_list args,
     sqlite3_busy_timeout (gvmd_db, 0);
 
   retries = 0;
-  *stmt = (sql_stmt_t*) g_malloc0 (sizeof (sql_stmt_t));
+  *stmt = (sql_stmt_t *) g_malloc0 (sizeof (sql_stmt_t));
   sqlite_stmt = NULL;
   while (1)
     {
-      ret = sqlite3_prepare_v2 (gvmd_db, (char*) formatted, -1, &sqlite_stmt,
+      ret = sqlite3_prepare_v2 (gvmd_db, (char *) formatted, -1, &sqlite_stmt,
                                 &tail);
       if (ret == SQLITE_BUSY || ret == SQLITE_LOCKED)
         {
           if (retry)
             {
               if ((retries > 10) && (GVM_SQLITE_SLEEP_MAX > 0))
-                gvm_usleep (MIN ((retries - 10) * 10000,
-                                 GVM_SQLITE_SLEEP_MAX));
+                gvm_usleep (MIN ((retries - 10) * 10000, GVM_SQLITE_SLEEP_MAX));
               retries++;
               continue;
             }
@@ -413,16 +398,14 @@ sql_prepare_internal (int retry, int log, const char* sql, va_list args,
           if (sqlite_stmt == NULL)
             {
               g_warning ("%s: sqlite3_prepare failed with NULL stmt: %s",
-                         __FUNCTION__,
-                         sqlite3_errmsg (gvmd_db));
+                         __FUNCTION__, sqlite3_errmsg (gvmd_db));
               if (retry == 0)
                 sqlite3_busy_timeout (gvmd_db, BUSY_TIMEOUT);
               return -1;
             }
           break;
         }
-      g_warning ("%s: sqlite3_prepare failed: %s",
-                 __FUNCTION__,
+      g_warning ("%s: sqlite3_prepare failed: %s", __FUNCTION__,
                  sqlite3_errmsg (gvmd_db));
       if (retry == 0)
         sqlite3_busy_timeout (gvmd_db, BUSY_TIMEOUT);
@@ -440,8 +423,8 @@ sql_prepare_internal (int retry, int log, const char* sql, va_list args,
  * @param[in]  retry  Whether to keep retrying while database is busy or locked.
  * @param[in]  stmt   Statement.
  *
- * @return 0 complete, 1 row available in results, 2 condition where caller must rerun
- *         prepare (for example schema changed internally after VACUUM), -1 error,
+ * @return 0 complete, 1 row available in results, 2 condition where caller must
+ * rerun prepare (for example schema changed internally after VACUUM), -1 error,
  *         -2 gave up.
  */
 int
@@ -462,8 +445,7 @@ sql_exec_internal (int retry, sql_stmt_t *stmt)
           if (retry)
             {
               if ((retries > 10) && (GVM_SQLITE_SLEEP_MAX > 0))
-                gvm_usleep (MIN ((retries - 10) * 10000,
-                                 GVM_SQLITE_SLEEP_MAX));
+                gvm_usleep (MIN ((retries - 10) * 10000, GVM_SQLITE_SLEEP_MAX));
               retries++;
               continue;
             }
@@ -477,8 +459,7 @@ sql_exec_internal (int retry, sql_stmt_t *stmt)
         return 0;
       if (ret == SQLITE_ROW)
         return 1;
-      g_warning ("%s: sqlite3_step failed: %s",
-                 __FUNCTION__,
+      g_warning ("%s: sqlite3_step failed: %s", __FUNCTION__,
                  sqlite3_errmsg (gvmd_db));
       return -1;
     }
@@ -493,7 +474,7 @@ sql_exec_internal (int retry, sql_stmt_t *stmt)
  * @return 0 success, -1 error.
  */
 int
-sql_explain_internal (const char* sql, va_list args)
+sql_explain_internal (const char *sql, va_list args)
 {
   char *explain_sql;
   sql_stmt_t *explain_stmt;
@@ -511,12 +492,11 @@ sql_explain_internal (const char* sql, va_list args)
     {
       explain_ret = sql_exec_internal (1, explain_stmt);
       if (explain_ret == 1)
-        g_debug ("%s : %s|%s|%s|%s",
-                __FUNCTION__,
-                sqlite3_column_text (explain_stmt->stmt, 0),
-                sqlite3_column_text (explain_stmt->stmt, 1),
-                sqlite3_column_text (explain_stmt->stmt, 2),
-                sqlite3_column_text (explain_stmt->stmt, 3));
+        g_debug ("%s : %s|%s|%s|%s", __FUNCTION__,
+                 sqlite3_column_text (explain_stmt->stmt, 0),
+                 sqlite3_column_text (explain_stmt->stmt, 1),
+                 sqlite3_column_text (explain_stmt->stmt, 2),
+                 sqlite3_column_text (explain_stmt->stmt, 3));
       else if (explain_ret == 0)
         break;
       else
@@ -533,7 +513,6 @@ sql_explain_internal (const char* sql, va_list args)
   return 0;
 }
 
-
 /* Transactions. */
 
 /**
@@ -594,7 +573,6 @@ sql_rollback ()
   sql ("ROLLBACK;");
 }
 
-
 /* Iterators. */
 
 /**
@@ -606,9 +584,10 @@ sql_rollback ()
  * @return 1 if NULL, else 0.
  */
 int
-iterator_null (iterator_t* iterator, int col)
+iterator_null (iterator_t *iterator, int col)
 {
-  if (iterator->done) abort ();
+  if (iterator->done)
+    abort ();
   return sqlite3_column_type (iterator->stmt->stmt, col) == SQLITE_NULL;
 }
 
@@ -620,11 +599,12 @@ iterator_null (iterator_t* iterator, int col)
  *
  * @return Name of given column.
  */
-const char*
-iterator_column_name (iterator_t* iterator, int col)
+const char *
+iterator_column_name (iterator_t *iterator, int col)
 {
-  if (iterator->done) abort ();
-  return (const char*) sqlite3_column_name (iterator->stmt->stmt, col);
+  if (iterator->done)
+    abort ();
+  return (const char *) sqlite3_column_name (iterator->stmt->stmt, col);
 }
 
 /**
@@ -635,13 +615,13 @@ iterator_column_name (iterator_t* iterator, int col)
  * @return Number of columns.
  */
 int
-iterator_column_count (iterator_t* iterator)
+iterator_column_count (iterator_t *iterator)
 {
-  if (iterator->done) abort ();
+  if (iterator->done)
+    abort ();
   return sqlite3_column_count (iterator->stmt->stmt);
 }
 
-
 /* Prepared statements. */
 
 /**
@@ -663,22 +643,18 @@ sql_bind_blob (sql_stmt_t *stmt, int position, const void *value,
   while (1)
     {
       int ret;
-      ret = sqlite3_bind_blob (stmt->stmt,
-                               position,
-                               value,
-                               value_size,
+      ret = sqlite3_bind_blob (stmt->stmt, position, value, value_size,
                                SQLITE_TRANSIENT);
       if (ret == SQLITE_BUSY)
         {
           if ((retries > 10) && (GVM_SQLITE_SLEEP_MAX > 0))
-            gvm_usleep (MIN ((retries - 10) * 10000,
-                             GVM_SQLITE_SLEEP_MAX));
+            gvm_usleep (MIN ((retries - 10) * 10000, GVM_SQLITE_SLEEP_MAX));
           retries++;
           continue;
         }
-      if (ret == SQLITE_OK) break;
-      g_warning ("%s: sqlite3_bind_blob failed: %s",
-                 __FUNCTION__,
+      if (ret == SQLITE_OK)
+        break;
+      g_warning ("%s: sqlite3_bind_blob failed: %s", __FUNCTION__,
                  sqlite3_errmsg (gvmd_db));
       return -1;
     }
@@ -704,22 +680,18 @@ sql_bind_text (sql_stmt_t *stmt, int position, const gchar *value,
   while (1)
     {
       int ret;
-      ret = sqlite3_bind_text (stmt->stmt,
-                               position,
-                               value,
-                               value_size,
+      ret = sqlite3_bind_text (stmt->stmt, position, value, value_size,
                                SQLITE_TRANSIENT);
       if (ret == SQLITE_BUSY)
         {
           if ((retries > 10) && (GVM_SQLITE_SLEEP_MAX > 0))
-            gvm_usleep (MIN ((retries - 10) * 10000,
-                             GVM_SQLITE_SLEEP_MAX));
+            gvm_usleep (MIN ((retries - 10) * 10000, GVM_SQLITE_SLEEP_MAX));
           retries++;
           continue;
         }
-      if (ret == SQLITE_OK) break;
-      g_warning ("%s: sqlite3_bind_text failed: %s",
-                 __FUNCTION__,
+      if (ret == SQLITE_OK)
+        break;
+      g_warning ("%s: sqlite3_bind_text failed: %s", __FUNCTION__,
                  sqlite3_errmsg (gvmd_db));
       return -1;
     }
@@ -759,16 +731,15 @@ sql_reset (sql_stmt_t *stmt)
       if (ret == SQLITE_BUSY)
         {
           if ((retries > 10) && (GVM_SQLITE_SLEEP_MAX > 0))
-            gvm_usleep (MIN ((retries - 10) * 10000,
-                             GVM_SQLITE_SLEEP_MAX));
+            gvm_usleep (MIN ((retries - 10) * 10000, GVM_SQLITE_SLEEP_MAX));
           retries++;
           continue;
         }
-      if (ret == SQLITE_DONE || ret == SQLITE_OK) break;
+      if (ret == SQLITE_DONE || ret == SQLITE_OK)
+        break;
       if (ret == SQLITE_ERROR || ret == SQLITE_MISUSE)
         {
-          g_warning ("%s: sqlite3_reset failed: %s",
-                     __FUNCTION__,
+          g_warning ("%s: sqlite3_reset failed: %s", __FUNCTION__,
                      sqlite3_errmsg (gvmd_db));
           return -1;
         }
@@ -801,7 +772,7 @@ sql_column_double (sql_stmt_t *stmt, int position)
 const char *
 sql_column_text (sql_stmt_t *stmt, int position)
 {
-  return (const char*) sqlite3_column_text (stmt->stmt, position);
+  return (const char *) sqlite3_column_text (stmt->stmt, position);
 }
 
 /**

--- a/src/utils.c
+++ b/src/utils.c
@@ -379,7 +379,8 @@ iso_time_tz (time_t *epoch_time, const char *zone, const char **abbrev)
  * @return 0 success, 1 already locked, -1 error
  */
 static int
-lock_internal (lockfile_t *lockfile, const gchar *lockfile_basename,
+lock_internal (lockfile_t *lockfile,
+               const gchar *lockfile_basename,
                int operation)
 {
   int fd;

--- a/src/utils.c
+++ b/src/utils.c
@@ -389,13 +389,14 @@ lock_internal (lockfile_t *lockfile, const gchar *lockfile_basename,
 
   lockfile_name = g_build_filename (GVM_RUN_DIR, lockfile_basename, NULL);
 
-  fd = open (lockfile_name, O_RDWR | O_CREAT | O_APPEND,
+  fd = open (lockfile_name,
+             O_RDWR | O_CREAT | O_APPEND,
              /* "-rw-r--r--" */
              S_IWUSR | S_IRUSR | S_IROTH | S_IRGRP);
   if (fd == -1)
     {
-      g_warning ("Failed to open lock file '%s': %s", lockfile_name,
-                 strerror (errno));
+      g_warning (
+        "Failed to open lock file '%s': %s", lockfile_name, strerror (errno));
       lockfile->name = NULL;
       g_free (lockfile_name);
       return -1;
@@ -411,7 +412,8 @@ lock_internal (lockfile_t *lockfile, const gchar *lockfile_basename,
       lockfile->name = NULL;
       g_free (lockfile_name);
       if (close (fd))
-        g_warning ("%s: failed to close lock file fd: %s", __FUNCTION__,
+        g_warning ("%s: failed to close lock file fd: %s",
+                   __FUNCTION__,
                    strerror (errno));
       if (flock_errno == EWOULDBLOCK)
         return 1;

--- a/src/utils.c
+++ b/src/utils.c
@@ -45,8 +45,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/file.h>
-#include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #undef G_LOG_DOMAIN
@@ -55,7 +55,6 @@
  */
 #define G_LOG_DOMAIN "md manage"
 
-
 /* Sleep. */
 
 /**
@@ -102,7 +101,6 @@ gvm_sleep (unsigned int seconds)
   return gvm_usleep (seconds * 1000000);
 }
 
-
 /* Time. */
 
 /**
@@ -135,7 +133,7 @@ parse_utc_time (const char *format, const char *text_time)
     }
 
   memset (&tm, 0, sizeof (struct tm));
-  if (strptime ((char*) text_time, format, &tm) == NULL)
+  if (strptime ((char *) text_time, format, &tm) == NULL)
     {
       g_warning ("%s: Failed to parse time", __FUNCTION__);
       if (tz != NULL)
@@ -216,7 +214,7 @@ parse_ctime (const char *text_time)
   /* ctime format: "Wed Jun 30 21:49:08 1993". */
 
   memset (&tm, 0, sizeof (struct tm));
-  if (strptime ((char*) text_time, "%a %b %d %H:%M:%S %Y", &tm) == NULL)
+  if (strptime ((char *) text_time, "%a %b %d %H:%M:%S %Y", &tm) == NULL)
     {
       g_warning ("%s: Failed to parse time '%s'", __FUNCTION__, text_time);
       return 0;
@@ -245,7 +243,8 @@ days_from_now (time_t *epoch_time)
   time_t now = time (NULL);
   int diff = *epoch_time - now;
 
-  if (diff < 0) return -1;
+  if (diff < 0)
+    return -1;
   return diff / 86400; /* 60 sec * 60 min * 24 h */
 }
 
@@ -367,7 +366,6 @@ iso_time_tz (time_t *epoch_time, const char *zone, const char **abbrev)
   return ret;
 }
 
-
 /* Locks. */
 
 /**
@@ -405,7 +403,7 @@ lock_internal (lockfile_t *lockfile, const gchar *lockfile_basename,
 
   /* Lock the lockfile. */
 
-  if (flock (fd, operation))  /* Blocks, unless operation includes LOCK_NB. */
+  if (flock (fd, operation)) /* Blocks, unless operation includes LOCK_NB. */
     {
       int flock_errno;
 
@@ -413,8 +411,7 @@ lock_internal (lockfile_t *lockfile, const gchar *lockfile_basename,
       lockfile->name = NULL;
       g_free (lockfile_name);
       if (close (fd))
-        g_warning ("%s: failed to close lock file fd: %s",
-                   __FUNCTION__,
+        g_warning ("%s: failed to close lock file fd: %s", __FUNCTION__,
                    strerror (errno));
       if (flock_errno == EWOULDBLOCK)
         return 1;

--- a/src/utils.h
+++ b/src/utils.h
@@ -25,8 +25,8 @@
 #ifndef _GVMD_UTILS_H
 #define _GVMD_UTILS_H
 
-#include <time.h>
 #include <glib.h>
+#include <time.h>
 
 int
 gvm_usleep (unsigned int);
@@ -57,8 +57,8 @@ iso_time_tz (time_t *, const char *, const char **);
  */
 typedef struct
 {
-  int fd;         ///< File descriptor.
-  gchar *name;    ///< Name.
+  int fd;      ///< File descriptor.
+  gchar *name; ///< Name.
 } lockfile_t;
 
 int


### PR DESCRIPTION
Not included in this PR are files gmp.c, manage_sql.c and manage_migrators.c due to the long SQL queries strings and/or macro defines of code blocks botching the formatting and making readability harder.

They are better done in separate PRs with disabling/enabling of clang-format where needed.