### PR TITLE
Add UTF-8 validation in modify_setting (8.0)

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -63597,7 +63597,17 @@ modify_setting (const gchar *uuid, const gchar *name,
       gsize value_size;
       gchar *quoted_timezone, *value;
       if (value_64 && strlen (value_64))
-        value = (gchar*) g_base64_decode (value_64, &value_size);
+        {
+          value = (gchar*) g_base64_decode (value_64, &value_size);
+          if (g_utf8_validate (value, value_size, NULL))
+            {
+              if (r_errdesc)
+                *r_errdesc = g_strdup ("Value cannot be decoded to"
+                                       " valid UTF-8");
+              g_free (value);
+              return -1;
+            }
+        }
       else
         {
           value = g_strdup ("");
@@ -63622,7 +63632,17 @@ modify_setting (const gchar *uuid, const gchar *name,
       assert (current_credentials.username);
 
       if (value_64 && strlen (value_64))
-        value = (gchar*) g_base64_decode (value_64, &value_size);
+        {
+          value = (gchar*) g_base64_decode (value_64, &value_size);
+          if (g_utf8_validate (value, value_size, NULL))
+            {
+              if (r_errdesc)
+                *r_errdesc = g_strdup ("Value cannot be decoded to"
+                                       " valid UTF-8");
+              g_free (value);
+              return -1;
+            }
+        }
       else
         {
           value = g_strdup ("");
@@ -63666,7 +63686,17 @@ modify_setting (const gchar *uuid, const gchar *name,
         }
 
       if (value_64 && strlen (value_64))
-        value = (gchar*) g_base64_decode (value_64, &value_size);
+        {
+          value = (gchar*) g_base64_decode (value_64, &value_size);
+          if (g_utf8_validate (value, value_size, NULL))
+            {
+              if (r_errdesc)
+                *r_errdesc = g_strdup ("Value cannot be decoded to"
+                                       " valid UTF-8");
+              g_free (value);
+              return -1;
+            }
+        }
       else
         {
           value = g_strdup ("");
@@ -63831,7 +63861,17 @@ modify_setting (const gchar *uuid, const gchar *name,
         return -1;
 
       if (value_64 && strlen (value_64))
-        value = (gchar*) g_base64_decode (value_64, &value_size);
+        {
+          value = (gchar*) g_base64_decode (value_64, &value_size);
+          if (g_utf8_validate (value, value_size, NULL))
+            {
+              if (r_errdesc)
+                *r_errdesc = g_strdup ("Value cannot be decoded to"
+                                       " valid UTF-8");
+              g_free (value);
+              return -1;
+            }
+        }
       else
         {
           value = g_strdup ("");
@@ -64081,7 +64121,17 @@ modify_setting (const gchar *uuid, const gchar *name,
       assert (current_credentials.username);
 
       if (value_64 && strlen (value_64))
-        value = (gchar*) g_base64_decode (value_64, &value_size);
+        {
+          value = (gchar*) g_base64_decode (value_64, &value_size);
+          if (g_utf8_validate (value, value_size, NULL))
+            {
+              if (r_errdesc)
+                *r_errdesc = g_strdup ("Value cannot be decoded to"
+                                       " valid UTF-8");
+              g_free (value);
+              return -1;
+            }
+        }
       else
         {
           value = g_strdup ("");


### PR DESCRIPTION
The decoded setting value is checked whether it is valid UTF-8 because
it could cause problems if it is not.
A likely cause for this happening is giving the value as plain text
instead of the expected Base64.