### PR TITLE
Ensure tickets tables exist during migration

### DIFF
--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -14976,6 +14976,101 @@ migrate_201_to_202 ()
 
   /* Update the database. */
 
+  /* Ensure the various tickets tables exist */
+  if (sql_is_sqlite3 ())
+    {
+      sql ("CREATE TABLE IF NOT EXISTS tickets"
+           " (id INTEGER PRIMARY KEY, uuid UNIQUE, owner INTEGER, name,"
+           "  comment, nvt, task, report, severity, host, location,"
+           "  solution_type, assigned_to, status, open_time, solved_time,"
+           "  solved_comment, confirmed_time, confirmed_report, closed_time,"
+           "  closed_comment, orphaned_time, creation_time,"
+           "  modification_time);");
+      sql ("CREATE TABLE IF NOT EXISTS ticket_results"
+           " (id INTEGER PRIMARY KEY, ticket, result, result_location,"
+           "  result_uuid, report);");
+      sql ("CREATE TABLE IF NOT EXISTS tickets_trash"
+           " (id INTEGER PRIMARY KEY, uuid UNIQUE, owner INTEGER, name,"
+           "  comment, nvt, task, report, severity, host, location,"
+           "  solution_type, assigned_to, status, open_time, solved_time,"
+           "  solved_comment, confirmed_time, confirmed_report, closed_time,"
+           "  closed_comment, orphaned_time, creation_time,"
+           "  modification_time);");
+      sql ("CREATE TABLE IF NOT EXISTS ticket_results_trash"
+           " (id INTEGER PRIMARY KEY, ticket, result, result_location,"
+           "  result_uuid, report);");
+    }
+  else
+    {
+      sql ("CREATE TABLE IF NOT EXISTS tickets"
+           " (id SERIAL PRIMARY KEY,"
+           "  uuid text UNIQUE NOT NULL,"
+           "  owner integer REFERENCES users (id) ON DELETE RESTRICT,"
+           "  name text NOT NULL," /* NVT name.  Aka Vulnerability. */
+           "  comment text,"
+           "  nvt text,"
+           "  task integer," // REFERENCES tasks (id) ON DELETE RESTRICT,"
+           "  report integer," // REFERENCES reports (id) ON DELETE RESTRICT,"
+           "  severity real,"
+           "  host text,"
+           "  location text,"
+           "  solution_type text,"
+           "  assigned_to integer REFERENCES users (id) ON DELETE RESTRICT,"
+           "  status integer,"
+           "  open_time integer,"
+           "  solved_time integer,"
+           "  solved_comment text,"
+           "  confirmed_time integer,"
+           "  confirmed_report integer," // REFERENCES reports (id) ON DELETE RESTRICT,"
+           "  closed_time integer,"
+           "  closed_comment text,"
+           "  orphaned_time integer,"
+           "  creation_time integer,"
+           "  modification_time integer);");
+
+      sql ("CREATE TABLE IF NOT EXISTS ticket_results"
+           " (id SERIAL PRIMARY KEY,"
+           "  ticket integer REFERENCES tickets (id) ON DELETE RESTRICT,"
+           "  result integer,"    // REFERENCES results (id) ON DELETE RESTRICT
+           "  result_location integer,"
+           "  result_uuid text,"
+           "  report integer);"); // REFERENCES reports (id) ON DELETE RESTRICT
+
+      sql ("CREATE TABLE IF NOT EXISTS tickets_trash"
+           " (id SERIAL PRIMARY KEY,"
+           "  uuid text UNIQUE NOT NULL,"
+           "  owner integer REFERENCES users (id) ON DELETE RESTRICT,"
+           "  name text NOT NULL," /* NVT name.  Aka Vulnerability. */
+           "  comment text,"
+           "  nvt text,"
+           "  task integer," // REFERENCES tasks (id) ON DELETE RESTRICT,"
+           "  report integer," // REFERENCES reports (id) ON DELETE RESTRICT,"
+           "  severity real,"
+           "  host text,"
+           "  location text,"
+           "  solution_type text,"
+           "  assigned_to integer REFERENCES users (id) ON DELETE RESTRICT,"
+           "  status integer,"
+           "  open_time integer,"
+           "  solved_time integer,"
+           "  solved_comment text,"
+           "  confirmed_time integer,"
+           "  confirmed_report integer," // REFERENCES reports (id) ON DELETE RESTRICT,"
+           "  closed_time integer,"
+           "  closed_comment text,"
+           "  orphaned_time integer,"
+           "  creation_time integer,"
+          "  modification_time integer);");
+
+      sql ("CREATE TABLE IF NOT EXISTS ticket_results_trash"
+          " (id SERIAL PRIMARY KEY,"
+          "  ticket integer REFERENCES tickets_trash (id) ON DELETE RESTRICT,"
+          "  result integer,"    // REFERENCES results_trash (id) ON DELETE RESTRICT
+          "  result_location integer,"
+          "  result_uuid text,"
+          "  report integer);"); // REFERENCES reports_trash (id) ON DELETE RESTRICT
+    }
+
   /* Ticket orphan state was removed. */
 
   sql ("UPDATE tickets SET status = 3 WHERE status = 4;");


### PR DESCRIPTION
In migrate_201_to_202 the tables tickets, ticket_results,
tickets_trash, ticket_results_trash are created as they were
before DB version 203 so the migrator and the following ones
will work.