### PR TITLE
Make users "self aware".

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 206)
+set (GVMD_DATABASE_VERSION 207)
 
 set (GVMD_SCAP_DATABASE_VERSION 15)
 

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -15392,7 +15392,14 @@ migrate_206_to_207 ()
        " SELECT make_uuid (), id, 'get_users',"
        "        'Automatically created when adding user', 'user', uuid, id, 0,"
        "        'user', id, 0, m_now (), m_now ()"
-       " FROM users;");
+       " FROM users"
+       " WHERE NOT"
+       "       EXISTS (SELECT * FROM permissions"
+       "               WHERE name = 'get_users'"
+       "               AND resource = users.id"
+       "               AND subject = users.id"
+       "               AND comment"
+       "                   = 'Automatically created when adding user');");
 
   /* Set the database version to 207. */
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -65067,6 +65067,15 @@ create_user (const gchar * name, const gchar * password, const gchar *comment,
   if (new_user)
     *new_user = user;
 
+  /* Every user can see themself. */
+  create_permission_internal ("GET_USERS",
+                              "Automatically created when adding user",
+                              NULL,
+                              user_uuid (user),
+                              "user",
+                              user_uuid (user),
+                              NULL);
+
   cache_users = g_array_new (TRUE, TRUE, sizeof (user_t));
   g_array_append_val (cache_users, user);
   cache_all_permissions_for_users (cache_users);
@@ -65128,6 +65137,15 @@ copy_user (const char* name, const char* comment, const char *user_id,
        quoted_uuid);
 
   g_free (quoted_uuid);
+
+  /* Every user can see themself. */
+  create_permission_internal ("GET_USERS",
+                              "Automatically created when adding user",
+                              NULL,
+                              user_uuid (user),
+                              "user",
+                              user_uuid (user),
+                              NULL);
 
   cache_users = g_array_new (TRUE, TRUE, sizeof (user_t));
   g_array_append_val (cache_users, user);


### PR DESCRIPTION
This ensures that users can see themselves, by creating a permission when the user is created.

Existing users are given the same permission using a migrator.