### PR TITLE
Handle NULL host in results.

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -10772,7 +10772,7 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
                             "<asset asset_id=\"%s\"/>"
                             "<hostname>%s</hostname>"
                             "</host>",
-                            result_iterator_host (results),
+                            result_iterator_host (results) ?: "",
                             asset_id ? asset_id : "",
                             result_iterator_hostname (results) ?: "");
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -28575,7 +28575,7 @@ print_report_host_details_xml (report_host_t report_host, FILE *stream)
              "<scan_nvt_version>%s</scan_nvt_version>"                     \
              "<severity>%s</severity>"                                     \
              "</error>",                                                   \
-             report_errors_iterator_host (errors),                         \
+             report_errors_iterator_host (errors) ?: "",                   \
              asset_id ? asset_id : "",                                     \
              report_errors_iterator_port (errors),                         \
              report_errors_iterator_desc (errors),                         \


### PR DESCRIPTION
When the host of a result is NULL, leave the XML text empty instead of
inserting "(null)".