### PR TITLE
GMP: Consolidate NVT references into unified "refs" element

### DIFF
--- a/report_formats/HTML/HTML.xsl
+++ b/report_formats/HTML/HTML.xsl
@@ -13,7 +13,7 @@
               encoding="UTF-8" />
 
 <!--
-Copyright (C) 2010-2018 Greenbone Networks GmbH
+Copyright (C) 2010-2019 Greenbone Networks GmbH
 
 SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -351,13 +351,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </xsl:if>
   </xsl:template>
 
-  <xsl:template name="ref_cert_list">
-    <xsl:param name="certlist"/>
+  <xsl:template name="ref_list">
+    <xsl:param name="reflist"/>
     <xsl:variable name="token" select="/envelope/token"/>
-    <xsl:variable name="certcount" select="count($certlist/cert_ref)"/>
+    <xsl:variable name="refcount" select="count($reflist/ref)"/>
 
-    <xsl:if test="count($certlist/warning)">
-      <xsl:for-each select="$certlist/warning">
+    <xsl:if test="count($reflist/warning)">
+      <xsl:for-each select="$reflist/warning">
         <tr valign="top">
           <td>CERT:</td>
           <td><i>Warning: <xsl:value-of select="text()"/></i></td>
@@ -365,13 +365,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       </xsl:for-each>
     </xsl:if>
 
-    <xsl:if test="$certcount &gt; 0">
+    <xsl:if test="$refcount &gt; 0">
       <tr valign="top">
         <td>CERT:</td>
         <td>
-          <xsl:for-each select="$certlist/cert_ref">
+          <xsl:for-each select="$reflist/ref">
             <xsl:value-of select="@id"/>
-            <xsl:if test="position() &lt; $certcount">
+            <xsl:if test="position() &lt; $refcount">
               <xsl:text>, </xsl:text>
             </xsl:if>
           </xsl:for-each>
@@ -665,14 +665,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <xsl:value-of select="nvt/bid/text()"/>
           </xsl:if>
         </xsl:variable>
-        <xsl:variable name="cert_ref" select="nvt/cert"/>
+        <xsl:variable name="refs" select="nvt/refs"/>
         <xsl:variable name="xref">
           <xsl:if test="nvt/xref != '' and nvt/xref != 'NOXREF'">
             <xsl:value-of select="nvt/xref/text()"/>
           </xsl:if>
         </xsl:variable>
 
-        <xsl:if test="$cve_ref != '' or $bid_ref != '' or $xref != '' or count($cert_ref/cert_ref) > 0">
+        <xsl:if test="$cve_ref != '' or $bid_ref != '' or $xref != '' or count($refs/ref) > 0">
           <div class="result_section">
             <b>References</b><br/>
             <p>
@@ -683,8 +683,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
                 <xsl:call-template name="ref_bid_list">
                   <xsl:with-param name="bidlist" select="$bid_ref"/>
                 </xsl:call-template>
-                <xsl:call-template name="ref_cert_list">
-                  <xsl:with-param name="certlist" select="$cert_ref"/>
+                <xsl:call-template name="ref_list">
+                  <xsl:with-param name="reflist" select="$refs"/>
                 </xsl:call-template>
                 <xsl:call-template name="ref_xref_list">
                   <xsl:with-param name="xreflist" select="$xref"/>

--- a/src/alert_methods/TippingPoint/report-convert.py
+++ b/src/alert_methods/TippingPoint/report-convert.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # coding: utf-8
-# Copyright (C) 2018 Greenbone Networks GmbH
+# Copyright (C) 2019 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -135,9 +135,17 @@ def convert (xml_tree, out_file):
     ip = result_elem.find ('host').text
     description = result_elem.find ('description').text
 
+    nvt_cve = '';
     nvt_elem = result_elem.find ('nvt')
-    nvt_cve = nvt_elem.find ('cve').text;
-    if (nvt_cve == 'NOCVE' or nvt_cve == '' or nvt_cve is None):
+    nvt_refs = nvt_elem.find ('refs');
+    for ref in nvt_refs.findall('ref'):
+      if (ref.attrib['type'] == 'cve'):
+        if (nvt_cve == ''):
+          nvt_cve = ref.attrib['id'];
+        else:
+          nvt_cve = nvt_cve + ', ' + ref.attrib['id'];
+
+    if (nvt_cve == '' or nvt_cve is None):
       continue;
 
     nvt_oid = nvt_elem.attrib['oid']

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -10573,14 +10573,12 @@ results_xml_append_nvt (iterator_t *results, GString *buffer, int cert_loaded)
                                     "<name>%s</name>"
                                     "<family>%s</family>"
                                     "<cvss_base>%s</cvss_base>"
-                                    "<cve>%s</cve>"
                                     "<xref>%s</xref>"
                                     "<tags>%s</tags>",
                                     oid,
                                     result_iterator_nvt_name (results) ?: oid,
                                     result_iterator_nvt_family (results) ?: "",
                                     cvss_base ?: "",
-                                    result_iterator_nvt_cve (results) ?: "",
                                     result_iterator_nvt_xref (results) ?: "",
                                     result_iterator_nvt_tag (results) ?: "");
 

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -10452,7 +10452,6 @@ results_xml_append_cert (GString *buffer, const char *oid, int cert_loaded,
 {
   iterator_t cert_refs_iterator;
 
-  buffer_xml_append_printf (buffer, "<refs>");
   if (cert_loaded)
     {
       if (has_cert_bunds)
@@ -10482,7 +10481,6 @@ results_xml_append_cert (GString *buffer, const char *oid, int cert_loaded,
   else
     g_string_append_printf (buffer,
                             "<warning>database not available</warning>");
-  buffer_xml_append_printf (buffer, "</refs>");
 }
 
 /**
@@ -10556,6 +10554,12 @@ results_xml_append_nvt (iterator_t *results, GString *buffer, int cert_loaded)
                                     g_free (cves);
           g_free (get.id);
           cleanup_iterator (&iterator);
+
+          buffer_xml_append_printf (buffer, "<refs>");
+          results_xml_append_cert (buffer, oid, cert_loaded,
+                                   result_iterator_has_cert_bunds (results),
+                                   result_iterator_has_dfn_certs (results));
+          buffer_xml_append_printf (buffer, "</refs>");
         }
       else
         {
@@ -10571,7 +10575,6 @@ results_xml_append_nvt (iterator_t *results, GString *buffer, int cert_loaded)
                                     "<family>%s</family>"
                                     "<cvss_base>%s</cvss_base>"
                                     "<cve>%s</cve>"
-                                    "<bid>%s</bid>"
                                     "<xref>%s</xref>"
                                     "<tags>%s</tags>",
                                     oid,
@@ -10579,14 +10582,17 @@ results_xml_append_nvt (iterator_t *results, GString *buffer, int cert_loaded)
                                     result_iterator_nvt_family (results) ?: "",
                                     cvss_base ?: "",
                                     result_iterator_nvt_cve (results) ?: "",
-                                    result_iterator_nvt_bid (results) ?: "",
                                     result_iterator_nvt_xref (results) ?: "",
                                     result_iterator_nvt_tag (results) ?: "");
+
+          buffer_xml_append_printf (buffer, "<refs>");
+          result_iterator_nvt_refs_append (buffer, results);
+          results_xml_append_cert (buffer, oid, cert_loaded,
+                                   result_iterator_has_cert_bunds (results),
+                                   result_iterator_has_dfn_certs (results));
+          buffer_xml_append_printf (buffer, "</refs>");
         }
 
-      results_xml_append_cert (buffer, oid, cert_loaded,
-                               result_iterator_has_cert_bunds (results),
-                               result_iterator_has_dfn_certs (results));
     }
 
   buffer_xml_append_printf (buffer, "</nvt>");

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -10543,7 +10543,6 @@ results_xml_append_nvt (iterator_t *results, GString *buffer, int cert_loaded)
                                     "<family/>"
                                     "<cvss_base>%s</cvss_base>"
                                     "<cve>%s</cve>"
-                                    "<bid/>"
                                     "<tags>summary=%s</tags>"
                                     "<xref/>",
                                     oid,

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -10543,8 +10543,7 @@ results_xml_append_nvt (iterator_t *results, GString *buffer, int cert_loaded)
                                     "<family/>"
                                     "<cvss_base>%s</cvss_base>"
                                     "<cve>%s</cve>"
-                                    "<tags>summary=%s</tags>"
-                                    "<xref/>",
+                                    "<tags>summary=%s</tags>",
                                     oid,
                                     ovaldef_info_iterator_title (&iterator),
                                     ovaldef_info_iterator_max_cvss (&iterator),
@@ -10573,13 +10572,11 @@ results_xml_append_nvt (iterator_t *results, GString *buffer, int cert_loaded)
                                     "<name>%s</name>"
                                     "<family>%s</family>"
                                     "<cvss_base>%s</cvss_base>"
-                                    "<xref>%s</xref>"
                                     "<tags>%s</tags>",
                                     oid,
                                     result_iterator_nvt_name (results) ?: oid,
                                     result_iterator_nvt_family (results) ?: "",
                                     cvss_base ?: "",
-                                    result_iterator_nvt_xref (results) ?: "",
                                     result_iterator_nvt_tag (results) ?: "");
 
           buffer_xml_append_printf (buffer, "<refs>");

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -10438,7 +10438,7 @@ add_detail (GString *buffer, const gchar *name, const gchar *value)
 }
 
 /**
- * @brief Append a CERT element to an XML buffer.
+ * @brief Append a REFS element to an XML buffer.
  *
  * @param[in]  buffer       Buffer.
  * @param[in]  oid          OID.
@@ -10452,7 +10452,7 @@ results_xml_append_cert (GString *buffer, const char *oid, int cert_loaded,
 {
   iterator_t cert_refs_iterator;
 
-  buffer_xml_append_printf (buffer, "<cert>");
+  buffer_xml_append_printf (buffer, "<refs>");
   if (cert_loaded)
     {
       if (has_cert_bunds)
@@ -10461,7 +10461,7 @@ results_xml_append_cert (GString *buffer, const char *oid, int cert_loaded,
           while (next (&cert_refs_iterator))
             {
               g_string_append_printf
-               (buffer, "<cert_ref type=\"CERT-Bund\" id=\"%s\"/>",
+               (buffer, "<ref type=\"cert-bund\" id=\"%s\"/>",
                 get_iterator_name (&cert_refs_iterator));
             }
           cleanup_iterator (&cert_refs_iterator);
@@ -10473,7 +10473,7 @@ results_xml_append_cert (GString *buffer, const char *oid, int cert_loaded,
           while (next (&cert_refs_iterator))
             {
               g_string_append_printf
-               (buffer, "<cert_ref type=\"DFN-CERT\" id=\"%s\"/>",
+               (buffer, "<ref type=\"dfn-cert\" id=\"%s\"/>",
                 get_iterator_name (&cert_refs_iterator));
             }
           cleanup_iterator (&cert_refs_iterator);
@@ -10482,7 +10482,7 @@ results_xml_append_cert (GString *buffer, const char *oid, int cert_loaded,
   else
     g_string_append_printf (buffer,
                             "<warning>database not available</warning>");
-  buffer_xml_append_printf (buffer, "</cert>");
+  buffer_xml_append_printf (buffer, "</refs>");
 }
 
 /**

--- a/src/manage.c
+++ b/src/manage.c
@@ -8093,7 +8093,7 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count,
   if (details)
     {
       int tag_count;
-      GString *cert_refs_str, *tags_str, *buffer;
+      GString *refs_str, *tags_str, *buffer;
       iterator_t cert_refs_iterator, tags;
       gchar *tag_name_esc, *tag_value_esc, *tag_comment_esc;
       char *default_timeout = nvt_default_timeout (oid);
@@ -8104,14 +8104,15 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count,
 
 #undef DEF
 
-      cert_refs_str = g_string_new ("");
+      refs_str = g_string_new ("");
+
       if (manage_cert_loaded())
         {
           init_nvt_cert_bund_adv_iterator (&cert_refs_iterator, oid, 0, 0);
           while (next (&cert_refs_iterator))
             {
-              g_string_append_printf (cert_refs_str,
-                                      "<cert_ref type=\"CERT-Bund\" id=\"%s\"/>",
+              g_string_append_printf (refs_str,
+                                      "<ref type=\"cert-bund\" id=\"%s\"/>",
                                       get_iterator_name (&cert_refs_iterator));
           }
           cleanup_iterator (&cert_refs_iterator);
@@ -8119,15 +8120,15 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count,
           init_nvt_dfn_cert_adv_iterator (&cert_refs_iterator, oid, 0, 0);
           while (next (&cert_refs_iterator))
             {
-              g_string_append_printf (cert_refs_str,
-                                      "<cert_ref type=\"DFN-CERT\" id=\"%s\"/>",
+              g_string_append_printf (refs_str,
+                                      "<ref type=\"dfn-cert\" id=\"%s\"/>",
                                       get_iterator_name (&cert_refs_iterator));
           }
           cleanup_iterator (&cert_refs_iterator);
         }
       else
         {
-          g_string_append (cert_refs_str, "<warning>database not available</warning>");
+          g_string_append (refs_str, "<warning>database not available</warning>");
         }
 
       tags_str = g_string_new ("");
@@ -8190,9 +8191,9 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count,
                               "<value>%s</value>"
                               "<type>%s</type>"
                               "</qod>"
+                              "<refs>%s</refs>"
                               "<cve_id>%s</cve_id>"
                               "<bugtraq_id>%s</bugtraq_id>"
-                              "<cert_refs>%s</cert_refs>"
                               "<xrefs>%s</xrefs>"
                               "<tags>%s</tags>"
                               "<preference_count>%i</preference_count>"
@@ -8214,9 +8215,9 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count,
                                : "",
                               nvt_iterator_qod (nvts),
                               nvt_iterator_qod_type (nvts),
+                              refs_str->str,
                               nvt_iterator_cve (nvts),
                               nvt_iterator_bid (nvts),
-                              cert_refs_str->str,
                               xref_text,
                               tag_text,
                               pref_count,
@@ -8225,7 +8226,7 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count,
       g_free (family_text);
       g_free (xref_text);
       g_free (tag_text);
-      g_string_free(cert_refs_str, 1);
+      g_string_free(refs_str, 1);
       g_string_free(tags_str, 1);
 
       if (preferences)

--- a/src/manage.c
+++ b/src/manage.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2009-2018 Greenbone Networks GmbH
+/* Copyright (C) 2009-2019 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *
@@ -8099,7 +8099,6 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count,
       char *default_timeout = nvt_default_timeout (oid);
 
       DEF (family);
-      DEF (xref);
       DEF (tag);
 
 #undef DEF
@@ -8130,6 +8129,8 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count,
         {
           g_string_append (refs_str, "<warning>database not available</warning>");
         }
+
+      nvti_refs_append_xml (refs_str, oid);
 
       tags_str = g_string_new ("");
       tag_count = resource_tag_count ("nvt",
@@ -8192,9 +8193,6 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count,
                               "<type>%s</type>"
                               "</qod>"
                               "<refs>%s</refs>"
-                              "<cve_id>%s</cve_id>"
-                              "<bugtraq_id>%s</bugtraq_id>"
-                              "<xrefs>%s</xrefs>"
                               "<tags>%s</tags>"
                               "<preference_count>%i</preference_count>"
                               "<timeout>%s</timeout>"
@@ -8216,15 +8214,11 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count,
                               nvt_iterator_qod (nvts),
                               nvt_iterator_qod_type (nvts),
                               refs_str->str,
-                              nvt_iterator_cve (nvts),
-                              nvt_iterator_bid (nvts),
-                              xref_text,
                               tag_text,
                               pref_count,
                               timeout ? timeout : "",
                               default_timeout ? default_timeout : "");
       g_free (family_text);
-      g_free (xref_text);
       g_free (tag_text);
       g_string_free(refs_str, 1);
       g_string_free(tags_str, 1);

--- a/src/manage.h
+++ b/src/manage.h
@@ -1435,10 +1435,10 @@ const char*
 result_iterator_nvt_cve (iterator_t *);
 
 const char*
-result_iterator_nvt_bid (iterator_t *);
-
-const char*
 result_iterator_nvt_xref (iterator_t *);
+
+void
+result_iterator_nvt_refs_append (GString *, iterator_t *);
 
 const char*
 result_iterator_nvt_tag (iterator_t *);

--- a/src/manage.h
+++ b/src/manage.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2009-2018 Greenbone Networks GmbH
+/* Copyright (C) 2009-2019 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *
@@ -1984,15 +1984,6 @@ nvt_iterator_description (iterator_t*);
 
 const char*
 nvt_iterator_copyright (iterator_t*);
-
-const char*
-nvt_iterator_cve (iterator_t*);
-
-const char*
-nvt_iterator_bid (iterator_t*);
-
-const char*
-nvt_iterator_xref (iterator_t*);
 
 const char*
 nvt_iterator_tag (iterator_t*);

--- a/src/manage.h
+++ b/src/manage.h
@@ -2113,6 +2113,9 @@ nvt_preference_iterator_id (iterator_t*);
 int
 nvt_preference_count (const char *);
 
+void
+nvti_refs_append_xml (GString *, const char *);
+
 gchar*
 get_nvti_xml (iterator_t*, int, int, int, const char*, config_t, int);
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -24657,6 +24657,31 @@ result_iterator_nvt_refs_append (GString *xml, iterator_t *iterator)
       item++;
     }
   g_strfreev (split);
+
+  str = nvti_xref (nvti);
+  split = g_strsplit (str, ",", 0);
+  item = split;
+  while (*item)
+    {
+      gchar *type_and_id;
+      gchar **split2;
+
+      type_and_id = *item;
+      g_strstrip (type_and_id);
+
+      if ((strcmp (type_and_id, "") == 0) || (strcmp (type_and_id, "NOXREF")) == 0)
+        {
+          item++;
+          continue;
+        }
+
+      split2 = g_strsplit (type_and_id, ":", 2);
+      if (split2[0] && split2[1])
+        xml_string_append (xml, "<ref type=\"%s\" id=\"%s\"/>", split2[0], split2[1]);
+
+      item++;
+    }
+  g_strfreev (split);
 }
 
 /**

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -24598,19 +24598,17 @@ result_iterator_nvt_xref (iterator_t *iterator)
 }
 
 /**
- * @brief Get the NVT's references in XML format from a result iterator.
+ * @brief Get the NVT's references in XML format from a nvti object via oid.
  *
  * @param[in]  xml       The buffer where to append to
- * @param[in]  iterator  Iterator.
+ * @param[in]  oid       The oid of the nvti object from where to collect the refs.
  */
 void
-result_iterator_nvt_refs_append (GString *xml, iterator_t *iterator)
+nvti_refs_append_xml (GString *xml, const char *oid)
 {
-  nvti_t *nvti;
   gchar **split, **item, *str;
+  nvti_t *nvti = nvtis_lookup (nvti_cache, oid);
 
-  if (iterator->done) return;
-  nvti = nvtis_lookup (nvti_cache, result_iterator_nvt_oid (iterator));
   if (!nvti)
     return;
 
@@ -24682,6 +24680,20 @@ result_iterator_nvt_refs_append (GString *xml, iterator_t *iterator)
       item++;
     }
   g_strfreev (split);
+}
+
+/**
+ * @brief Get the NVT's references in XML format from a result iterator.
+ *
+ * @param[in]  xml       The buffer where to append to
+ * @param[in]  iterator  Iterator.
+ */
+void
+result_iterator_nvt_refs_append (GString *xml, iterator_t *iterator)
+{
+  if (iterator->done) return;
+
+  nvti_refs_append_xml (xml, result_iterator_nvt_oid (iterator));
 }
 
 /**

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -24580,24 +24580,6 @@ result_iterator_nvt_cve (iterator_t *iterator)
 }
 
 /**
- * @brief Get the NVT BID from a result iterator.
- *
- * @param[in]  iterator  Iterator.
- *
- * @return The BID of the NVT that produced the result, or NULL on error.
- */
-const char*
-result_iterator_nvt_bid (iterator_t *iterator)
-{
-  nvti_t *nvti;
-  if (iterator->done) return NULL;
-  nvti = nvtis_lookup (nvti_cache, result_iterator_nvt_oid (iterator));
-  if (nvti)
-    return nvti_bid (nvti);
-  return NULL;
-}
-
-/**
  * @brief Get the NVT XREF from a result iterator.
  *
  * @param[in]  iterator  Iterator.
@@ -24613,6 +24595,48 @@ result_iterator_nvt_xref (iterator_t *iterator)
   if (nvti)
     return nvti_xref (nvti);
   return NULL;
+}
+
+/**
+ * @brief Get the NVT's references in XML format from a result iterator.
+ *
+ * @param[in]  xml       The buffer where to append to
+ * @param[in]  iterator  Iterator.
+ */
+void
+result_iterator_nvt_refs_append (GString *xml, iterator_t *iterator)
+{
+  nvti_t *nvti;
+  gchar **split, **item, *bid;
+
+  if (iterator->done) return;
+  nvti = nvtis_lookup (nvti_cache, result_iterator_nvt_oid (iterator));
+  if (!nvti)
+    return;
+
+  bid = nvti_bid (nvti);
+
+  split = g_strsplit (bid, ",", 0);
+  item = split;
+  while (*item)
+    {
+      gchar *id;
+
+      id = *item;
+      g_strstrip (id);
+
+      if ((strcmp (id, "") == 0) || (strcmp (id, "NOBID")) == 0)
+        {
+          item++;
+          continue;
+        }
+
+      xml_string_append (xml, "<ref type=\"bid\" id=\"%s\"/>", id);
+
+      item++;
+    }
+
+  g_strfreev (split);
 }
 
 /**

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -24607,16 +24607,15 @@ void
 result_iterator_nvt_refs_append (GString *xml, iterator_t *iterator)
 {
   nvti_t *nvti;
-  gchar **split, **item, *bid;
+  gchar **split, **item, *str;
 
   if (iterator->done) return;
   nvti = nvtis_lookup (nvti_cache, result_iterator_nvt_oid (iterator));
   if (!nvti)
     return;
 
-  bid = nvti_bid (nvti);
-
-  split = g_strsplit (bid, ",", 0);
+  str = nvti_bid (nvti);
+  split = g_strsplit (str, ",", 0);
   item = split;
   while (*item)
     {
@@ -24635,7 +24634,28 @@ result_iterator_nvt_refs_append (GString *xml, iterator_t *iterator)
 
       item++;
     }
+  g_strfreev (split);
 
+  str = nvti_cve (nvti);
+  split = g_strsplit (str, ",", 0);
+  item = split;
+  while (*item)
+    {
+      gchar *id;
+
+      id = *item;
+      g_strstrip (id);
+
+      if ((strcmp (id, "") == 0) || (strcmp (id, "NOCVE")) == 0)
+        {
+          item++;
+          continue;
+        }
+
+      xml_string_append (xml, "<ref type=\"cve\" id=\"%s\"/>", id);
+
+      item++;
+    }
   g_strfreev (split);
 }
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -24600,7 +24600,7 @@ result_iterator_nvt_xref (iterator_t *iterator)
 /**
  * @brief Get the NVT's references in XML format from a nvti object via oid.
  *
- * @param[in]  xml       The buffer where to append to
+ * @param[in]  xml       The buffer where to append to.
  * @param[in]  oid       The oid of the nvti object from where to collect the refs.
  */
 void
@@ -24685,7 +24685,7 @@ nvti_refs_append_xml (GString *xml, const char *oid)
 /**
  * @brief Get the NVT's references in XML format from a result iterator.
  *
- * @param[in]  xml       The buffer where to append to
+ * @param[in]  xml       The buffer where to append to.
  * @param[in]  iterator  Iterator.
  */
 void

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2009-2018 Greenbone Networks GmbH
+/* Copyright (C) 2009-2019 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *
@@ -796,36 +796,6 @@ DEF_ACCESS (nvt_iterator_oid, GET_ITERATOR_COLUMN_COUNT);
  *         cleanup_iterator.
  */
 DEF_ACCESS (nvt_iterator_name, GET_ITERATOR_COLUMN_COUNT + 2);
-
-/**
- * @brief Get the cve from an NVT iterator.
- *
- * @param[in]  iterator  Iterator.
- *
- * @return Cve, or NULL if iteration is complete.  Freed by
- *         cleanup_iterator.
- */
-DEF_ACCESS (nvt_iterator_cve, GET_ITERATOR_COLUMN_COUNT + 3);
-
-/**
- * @brief Get the bid from an NVT iterator.
- *
- * @param[in]  iterator  Iterator.
- *
- * @return Bid, or NULL if iteration is complete.  Freed by
- *         cleanup_iterator.
- */
-DEF_ACCESS (nvt_iterator_bid, GET_ITERATOR_COLUMN_COUNT + 4);
-
-/**
- * @brief Get the xref from an NVT iterator.
- *
- * @param[in]  iterator  Iterator.
- *
- * @return Xref, or NULL if iteration is complete.  Freed by
- *         cleanup_iterator.
- */
-DEF_ACCESS (nvt_iterator_xref, GET_ITERATOR_COLUMN_COUNT + 5);
 
 /**
  * @brief Get the tag from an NVT iterator.

--- a/src/report_formats/CSV_Results/CSV_Results.xsl
+++ b/src/report_formats/CSV_Results/CSV_Results.xsl
@@ -216,10 +216,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   <xsl:variable name="cell_cves">
     <xsl:for-each select="nvt/refs/ref[@type = 'cve']">
       <xsl:value-of select="str:replace (@id, $quote, $two-quotes)"/>
-      <xsl:call-template name="newline"/>
+      <xsl:text>,</xsl:text>
     </xsl:for-each>
   </xsl:variable>
-  <xsl:value-of select="openvas:formula_quote ($cell_cves)"/>
+  <xsl:value-of select="openvas:formula_quote (substring ($cell_cves, 0, string-length($cell_cves)))"/>
 
   <xsl:text>",</xsl:text>
 
@@ -301,34 +301,34 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   <xsl:variable name="cell_bids">
     <xsl:for-each select="nvt/refs/ref[@type = 'bid']">
       <xsl:value-of select="str:replace (@id, $quote, $two-quotes)"/>
-      <xsl:call-template name="newline"/>
+      <xsl:text>,</xsl:text>
     </xsl:for-each>
   </xsl:variable>
-  <xsl:value-of select="openvas:formula_quote ($cell_bids)"/>
+  <xsl:value-of select="openvas:formula_quote (substring ($cell_bids, 0, string-length($cell_bids)))"/>
 
   <xsl:text>","</xsl:text> <!-- column "CERTs" -->
 
   <xsl:variable name="cell_certs">
     <xsl:for-each select="nvt/refs/ref[@type = 'dfn-cert']">
       <xsl:value-of select="@id"/>
-      <xsl:call-template name="newline"/>
+      <xsl:text>,</xsl:text>
     </xsl:for-each>
     <xsl:for-each select="nvt/refs/ref[@type = 'cert-bund']">
       <xsl:value-of select="str:replace (@id, $quote, $two-quotes)"/>
-      <xsl:call-template name="newline"/>
+      <xsl:text>,</xsl:text>
     </xsl:for-each>
   </xsl:variable>
-  <xsl:value-of select="openvas:formula_quote ($cell_certs)"/>
+  <xsl:value-of select="openvas:formula_quote (substring ($cell_certs, 0, string-length($cell_certs)))"/>
 
   <xsl:text>","</xsl:text> <!-- column "Other References" -->
 
   <xsl:variable name="cell_urls">
     <xsl:for-each select="nvt/refs/ref[@type = 'URL']">
       <xsl:value-of select="str:replace (@id, $quote, $two-quotes)"/>
-      <xsl:call-template name="newline"/>
+      <xsl:text>,</xsl:text>
     </xsl:for-each>
   </xsl:variable>
-  <xsl:value-of select="openvas:formula_quote ($cell_urls)"/>
+  <xsl:value-of select="openvas:formula_quote (substring ($cell_urls, 0, string-length($cell_urls)))"/>
 
   <xsl:text>"</xsl:text>
   <xsl:text>

--- a/src/report_formats/CSV_Results/CSV_Results.xsl
+++ b/src/report_formats/CSV_Results/CSV_Results.xsl
@@ -322,25 +322,25 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <xsl:value-of select="openvas:formula_quote ($new_bidlist)"/>
   </xsl:if>
   <xsl:text>","</xsl:text>
-  <xsl:if test="count(nvt/cert/cert_ref) &gt; 0">
-    <xsl:variable name="certlist" select="nvt/cert"/>
-    <xsl:variable name="certcount" select="count ($certlist/cert_ref)"/>
-    <xsl:variable name="new_certlist">
-      <xsl:for-each select="$certlist/warning">
+  <xsl:if test="count(nvt/refs/ref) &gt; 0">
+    <xsl:variable name="reflist" select="nvt/refs"/>
+    <xsl:variable name="refcount" select="count ($reflist/ref)"/>
+    <xsl:variable name="new_reflist">
+      <xsl:for-each select="$reflist/warning">
         <xsl:text>Warning: </xsl:text>
         <xsl:value-of select="str:replace (text(), $quote, $two-quotes)"/>
         <xsl:call-template name="newline"/>
       </xsl:for-each>
-      <xsl:if test="$certcount &gt; 0">
-        <xsl:for-each select="$certlist/cert_ref">
+      <xsl:if test="$refcount &gt; 0">
+        <xsl:for-each select="$reflist/ref">
           <xsl:value-of select="str:replace (@id, $quote, $two-quotes)"/>
-          <xsl:if test="position() &lt; $certcount">
+          <xsl:if test="position() &lt; $refcount">
             <xsl:text>, </xsl:text>
           </xsl:if>
         </xsl:for-each>
       </xsl:if>
     </xsl:variable>
-    <xsl:value-of select="openvas:formula_quote ($new_certlist)"/>
+    <xsl:value-of select="openvas:formula_quote ($new_reflist)"/>
   </xsl:if>
   <xsl:text>","</xsl:text>
   <xsl:if test="nvt/xref != '' and nvt/xref != 'NOXREF'">

--- a/src/report_formats/LaTeX/latex.xsl
+++ b/src/report_formats/LaTeX/latex.xsl
@@ -1024,7 +1024,7 @@ advice given in each description, in order to rectify the issue.
 
       <xsl:for-each select="nvt/refs/ref">
         <xsl:call-template name="text-to-escaped-row">
-		<xsl:with-param name="string" select="concat(@type, ': ', @id)"/>
+          <xsl:with-param name="string" select="concat(@type, ': ', @id)"/>
         </xsl:call-template>
       </xsl:for-each>
     </xsl:if>

--- a/src/report_formats/LaTeX/latex.xsl
+++ b/src/report_formats/LaTeX/latex.xsl
@@ -1016,47 +1016,17 @@ advice given in each description, in order to rectify the issue.
 
   <!-- References box. -->
   <xsl:template name="references">
-    <xsl:variable name="cve_ref">
-      <xsl:if test="nvt/cve != '' and nvt/cve != 'NOCVE'">
-        <xsl:value-of select="nvt/cve/text()"/>
-      </xsl:if>
-    </xsl:variable>
-    <xsl:variable name="bid_ref">
-      <xsl:if test="nvt/bid != '' and nvt/bid != 'NOBID'">
-        <xsl:value-of select="nvt/bid/text()"/>
-      </xsl:if>
-    </xsl:variable>
-    <xsl:variable name="xref_ref">
-      <xsl:if test="nvt/xref != '' and nvt/xref != 'NOXREF'">
-        <xsl:value-of select="nvt/xref/text()"/>
-      </xsl:if>
-    </xsl:variable>
-
-    <xsl:if test="$cve_ref != '' or $bid_ref != '' or $xref_ref != ''">
+    <xsl:if test="count(nvt/refs/ref) &gt; 0">
       \hline
       <xsl:call-template name="latex-newline"/>
       <xsl:text>\textbf{References}</xsl:text>
       <xsl:call-template name="latex-newline"/>
-      <xsl:if test="$cve_ref != ''">
+
+      <xsl:for-each select="nvt/refs/ref">
         <xsl:call-template name="text-to-escaped-row">
-          <xsl:with-param name="string" select="concat('CVE: ', $cve_ref)"/>
+		<xsl:with-param name="string" select="concat(@type, ': ', @id)"/>
         </xsl:call-template>
-      </xsl:if>
-      <xsl:if test="$bid_ref != ''">
-        <xsl:call-template name="text-to-escaped-row">
-          <xsl:with-param name="string" select="concat('BID:', $bid_ref)"/>
-        </xsl:call-template>
-      </xsl:if>
-      <xsl:if test="$xref_ref != ''">
-        <xsl:call-template name="text-to-escaped-row">
-          <xsl:with-param name="string" select="'Other:'"/>
-        </xsl:call-template>
-        <xsl:for-each select="str:split($xref_ref, ',')">
-          <xsl:call-template name="text-to-escaped-row">
-            <xsl:with-param name="string" select="concat('  ', .)"/>
-          </xsl:call-template>
-        </xsl:for-each>
-      </xsl:if>
+      </xsl:for-each>
     </xsl:if>
   </xsl:template>
 

--- a/src/report_formats/NBE/NBE.xsl
+++ b/src/report_formats/NBE/NBE.xsl
@@ -107,87 +107,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   <xsl:value-of select="substring-after('.', 'cvss_base_vector=')"/>
 </xsl:template>
 
-<xsl:template name="ref_cve_list">
-  <xsl:param name="cvelist"/>
-
-  <xsl:variable name="cvecount" select="count(str:split($cvelist, ','))"/>
-  <xsl:if test="$cvecount &gt; 0">
-    <xsl:text>CVE: </xsl:text>
-    <xsl:for-each select="str:split($cvelist, ',')">
-      <xsl:value-of select="str:replace (normalize-space(.), '&#10;', '\n')"/>
-      <xsl:if test="position() &lt; $cvecount">
-        <xsl:text>, </xsl:text>
-      </xsl:if>
-    </xsl:for-each>
-    <xsl:text>\n</xsl:text>
-  </xsl:if>
-</xsl:template>
-
-<xsl:template name="ref_bid_list">
-  <xsl:param name="bidlist"/>
-
-  <xsl:variable name="bidcount" select="count(str:split($bidlist, ','))"/>
-  <xsl:if test="$bidcount &gt; 0">
-    <xsl:text>BID: </xsl:text>
-    <xsl:for-each select="str:split($bidlist, ',')">
-      <xsl:value-of select="str:replace (., '&#10;', '\n')"/>
-      <xsl:if test="position() &lt; $bidcount">
-        <xsl:text>, </xsl:text>
-      </xsl:if>
-    </xsl:for-each>
-    <xsl:text>\n</xsl:text>
-  </xsl:if>
-</xsl:template>
-
-<xsl:template name="ref_cert_list">
-  <xsl:param name="reflist"/>
-
-  <xsl:variable name="refcount" select="count($reflist/ref)"/>
-
-  <xsl:if test="count($reflist/warning)">
-    <xsl:for-each select="$reflist/warning">
-      <xsl:text>CERT: Warning: </xsl:text>
-      <xsl:value-of select="str:replace (text(), '&#10;', '\n')"/>
-      <xsl:text>\n</xsl:text>
-    </xsl:for-each>
-  </xsl:if>
-
-  <xsl:if test="$refcount &gt; 0">
-    <xsl:text>References: </xsl:text>
-    <xsl:for-each select="$reflist/ref">
-      <xsl:value-of select="@id"/>
-      <xsl:if test="position() &lt; $refcount">
-        <xsl:text>, </xsl:text>
-      </xsl:if>
-    </xsl:for-each>
-    <xsl:text>\n</xsl:text>
-  </xsl:if>
-</xsl:template>
-
-<xsl:template name="ref_xref_list">
-  <xsl:param name="xreflist"/>
-
-  <xsl:variable name="xrefcount" select="count(str:split($xreflist, ','))"/>
-  <xsl:if test="$xrefcount &gt; 0">
-    <xsl:for-each select="str:split($xreflist, ',')">
-      <xsl:if test="position()=1">
-        <xsl:text>Other:</xsl:text>
-        <xsl:text>\n</xsl:text>
-      </xsl:if>
-      <xsl:text>    </xsl:text>
-      <xsl:choose>
-        <xsl:when test="contains(., 'URL:')">
-          <xsl:value-of select="str:replace (substring-after(., 'URL:'), '&#10;', '\n')"/>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="str:replace (., '&#10;', '\n')"/>
-        </xsl:otherwise>
-      </xsl:choose>
-      <xsl:text>\n</xsl:text>
-    </xsl:for-each>
-  </xsl:if>
-</xsl:template>
-
 <xsl:template match="result">
   <xsl:variable name="netmask">
     <xsl:call-template name="substring-before-last">
@@ -331,23 +250,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <xsl:text>\n</xsl:text>
   </xsl:if>
 
-  <xsl:variable name="cve_ref">
-    <xsl:if test="nvt/cve != '' and nvt/cve != 'NOCVE'">
-      <xsl:value-of select="nvt/cve/text()"/>
-    </xsl:if>
-  </xsl:variable>
-  <xsl:variable name="bid_ref">
-    <xsl:if test="nvt/bid != '' and nvt/bid != 'NOBID'">
-      <xsl:value-of select="nvt/bid/text()"/>
-    </xsl:if>
-  </xsl:variable>
-  <xsl:variable name="refs" select="nvt/refs"/>
-  <xsl:variable name="xref">
-    <xsl:if test="nvt/xref != '' and nvt/xref != 'NOXREF'">
-      <xsl:value-of select="nvt/xref/text()"/>
-    </xsl:if>
-  </xsl:variable>
-
   <xsl:if test="nvt/cvss_base != ''">
     <xsl:variable name="cvss_base_vector">
       <xsl:for-each select="str:split (nvt/tags, '|')">
@@ -364,21 +266,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <xsl:text>)\n</xsl:text>
   </xsl:if>
 
-  <xsl:if test="$cve_ref != '' or $bid_ref != '' or $xref != '' or count($refs/ref) > 0">
+  <xsl:if test="count(nvt/refs/ref) > 0">
     <xsl:text>References:</xsl:text>
     <xsl:text>\n</xsl:text>
-    <xsl:call-template name="ref_cve_list">
-      <xsl:with-param name="cvelist" select="$cve_ref"/>
-    </xsl:call-template>
-    <xsl:call-template name="ref_bid_list">
-      <xsl:with-param name="bidlist" select="$bid_ref"/>
-    </xsl:call-template>
-    <xsl:call-template name="ref_cert_list">
-      <xsl:with-param name="reflist" select="$refs"/>
-    </xsl:call-template>
-    <xsl:call-template name="ref_xref_list">
-      <xsl:with-param name="xreflist" select="$xref"/>
-    </xsl:call-template>
+    <xsl:for-each select="nvt/refs/ref">
+      <xsl:value-of select="concat(@type, ': ', @id, '\n')"/>
+    </xsl:for-each>
   </xsl:if>
   <xsl:call-template name="newline"/>
 </xsl:template>

--- a/src/report_formats/NBE/NBE.xsl
+++ b/src/report_formats/NBE/NBE.xsl
@@ -11,7 +11,7 @@
   <xsl:strip-space elements="*"/>
 
 <!--
-Copyright (C) 2010-2018 Greenbone Networks GmbH
+Copyright (C) 2010-2019 Greenbone Networks GmbH
 
 SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -140,23 +140,23 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 </xsl:template>
 
 <xsl:template name="ref_cert_list">
-  <xsl:param name="certlist"/>
+  <xsl:param name="reflist"/>
 
-  <xsl:variable name="certcount" select="count($certlist/cert_ref)"/>
+  <xsl:variable name="refcount" select="count($reflist/ref)"/>
 
-  <xsl:if test="count($certlist/warning)">
-    <xsl:for-each select="$certlist/warning">
+  <xsl:if test="count($reflist/warning)">
+    <xsl:for-each select="$reflist/warning">
       <xsl:text>CERT: Warning: </xsl:text>
       <xsl:value-of select="str:replace (text(), '&#10;', '\n')"/>
       <xsl:text>\n</xsl:text>
     </xsl:for-each>
   </xsl:if>
 
-  <xsl:if test="$certcount &gt; 0">
-    <xsl:text>CERT: </xsl:text>
-    <xsl:for-each select="$certlist/cert_ref">
+  <xsl:if test="$refcount &gt; 0">
+    <xsl:text>References: </xsl:text>
+    <xsl:for-each select="$reflist/ref">
       <xsl:value-of select="@id"/>
-      <xsl:if test="position() &lt; $certcount">
+      <xsl:if test="position() &lt; $refcount">
         <xsl:text>, </xsl:text>
       </xsl:if>
     </xsl:for-each>
@@ -341,7 +341,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       <xsl:value-of select="nvt/bid/text()"/>
     </xsl:if>
   </xsl:variable>
-  <xsl:variable name="cert_ref" select="nvt/cert"/>
+  <xsl:variable name="refs" select="nvt/refs"/>
   <xsl:variable name="xref">
     <xsl:if test="nvt/xref != '' and nvt/xref != 'NOXREF'">
       <xsl:value-of select="nvt/xref/text()"/>
@@ -364,7 +364,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <xsl:text>)\n</xsl:text>
   </xsl:if>
 
-  <xsl:if test="$cve_ref != '' or $bid_ref != '' or $xref != '' or count($cert_ref/cert_ref) > 0">
+  <xsl:if test="$cve_ref != '' or $bid_ref != '' or $xref != '' or count($refs/ref) > 0">
     <xsl:text>References:</xsl:text>
     <xsl:text>\n</xsl:text>
     <xsl:call-template name="ref_cve_list">
@@ -374,7 +374,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       <xsl:with-param name="bidlist" select="$bid_ref"/>
     </xsl:call-template>
     <xsl:call-template name="ref_cert_list">
-      <xsl:with-param name="certlist" select="$cert_ref"/>
+      <xsl:with-param name="reflist" select="$refs"/>
     </xsl:call-template>
     <xsl:call-template name="ref_xref_list">
       <xsl:with-param name="xreflist" select="$xref"/>

--- a/src/report_formats/TXT/TXT.xsl
+++ b/src/report_formats/TXT/TXT.xsl
@@ -311,38 +311,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </xsl:choose>
   </xsl:template>
 
-  <xsl:template name="ref_cve_list">
-    <xsl:param name="cvelist"/>
-
-    <xsl:variable name="cvecount" select="count(str:split($cvelist, ','))"/>
-    <xsl:if test="$cvecount &gt; 0">
-      <xsl:text>CVE: </xsl:text>
-      <xsl:for-each select="str:split($cvelist, ',')">
-        <xsl:value-of select="normalize-space(.)"/>
-        <xsl:if test="position() &lt; $cvecount">
-          <xsl:text>, </xsl:text>
-        </xsl:if>
-      </xsl:for-each>
-      <xsl:call-template name="newline"/>
-    </xsl:if>
-  </xsl:template>
-
-  <xsl:template name="ref_bid_list">
-    <xsl:param name="bidlist"/>
-
-    <xsl:variable name="bidcount" select="count(str:split($bidlist, ','))"/>
-    <xsl:if test="$bidcount &gt; 0">
-      <xsl:text>BID: </xsl:text>
-      <xsl:for-each select="str:split($bidlist, ',')">
-        <xsl:value-of select="."/>
-        <xsl:if test="position() &lt; $bidcount">
-          <xsl:text>, </xsl:text>
-        </xsl:if>
-      </xsl:for-each>
-      <xsl:call-template name="newline"/>
-    </xsl:if>
-  </xsl:template>
-
   <xsl:template name="refs_list">
     <xsl:param name="refs"/>
 
@@ -361,34 +329,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       <xsl:call-template name="newline"/>
       <xsl:for-each select="$refs/ref">
         <xsl:text> </xsl:text>
+        <xsl:value-of select="@type"/>
+        <xsl:text>: </xsl:text>
         <xsl:value-of select="@id"/>
         <xsl:call-template name="newline"/>
       </xsl:for-each>
       <xsl:call-template name="newline"/>
-    </xsl:if>
-  </xsl:template>
-
-  <xsl:template name="ref_xref_list">
-    <xsl:param name="xreflist"/>
-
-    <xsl:variable name="xrefcount" select="count(str:split($xreflist, ','))"/>
-    <xsl:if test="$xrefcount &gt; 0">
-      <xsl:for-each select="str:split($xreflist, ',')">
-        <xsl:if test="position()=1">
-          <xsl:text>Other:</xsl:text>
-          <xsl:call-template name="newline"/>
-        </xsl:if>
-        <xsl:text>    </xsl:text>
-        <xsl:choose>
-          <xsl:when test="contains(., 'URL:')">
-            <xsl:value-of select="substring-after(., 'URL:')"/>
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:value-of select="."/>
-          </xsl:otherwise>
-        </xsl:choose>
-        <xsl:call-template name="newline"/>
-      </xsl:for-each>
     </xsl:if>
   </xsl:template>
 
@@ -623,22 +569,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       </xsl:if>
     </xsl:variable>
 
-    <xsl:if test="$cve_ref != '' or $bid_ref != '' or $xref != '' or count($refs/ref) > 0">
-      <xsl:text>References:</xsl:text>
-      <xsl:call-template name="newline"/>
-      <xsl:call-template name="ref_cve_list">
-        <xsl:with-param name="cvelist" select="$cve_ref"/>
-      </xsl:call-template>
-      <xsl:call-template name="ref_bid_list">
-        <xsl:with-param name="bidlist" select="$bid_ref"/>
-      </xsl:call-template>
+    <xsl:if test="count($refs/ref) > 0">
       <xsl:call-template name="refs_list">
         <xsl:with-param name="refs" select="$refs"/>
       </xsl:call-template>
-      <xsl:call-template name="ref_xref_list">
-        <xsl:with-param name="xreflist" select="$xref"/>
-      </xsl:call-template>
-      <xsl:call-template name="newline"/>
     </xsl:if>
 
     <xsl:if test="delta">

--- a/src/report_formats/TXT/TXT.xsl
+++ b/src/report_formats/TXT/TXT.xsl
@@ -552,26 +552,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       <xsl:call-template name="newline"/>
     </xsl:if>
 
-    <xsl:variable name="cve_ref">
-      <xsl:if test="nvt/cve != '' and nvt/cve != 'NOCVE'">
-        <xsl:value-of select="nvt/cve/text()"/>
-      </xsl:if>
-    </xsl:variable>
-    <xsl:variable name="bid_ref">
-      <xsl:if test="nvt/bid != '' and nvt/bid != 'NOBID'">
-        <xsl:value-of select="nvt/bid/text()"/>
-      </xsl:if>
-    </xsl:variable>
-    <xsl:variable name="refs" select="nvt/refs"/>
-    <xsl:variable name="xref">
-      <xsl:if test="nvt/xref != '' and nvt/xref != 'NOXREF'">
-        <xsl:value-of select="nvt/xref/text()"/>
-      </xsl:if>
-    </xsl:variable>
-
-    <xsl:if test="count($refs/ref) > 0">
+    <xsl:if test="count(nvt/refs/ref) > 0">
       <xsl:call-template name="refs_list">
-        <xsl:with-param name="refs" select="$refs"/>
+        <xsl:with-param name="refs" select="nvt/refs"/>
       </xsl:call-template>
     </xsl:if>
 

--- a/src/report_formats/TXT/TXT.xsl
+++ b/src/report_formats/TXT/TXT.xsl
@@ -343,29 +343,26 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </xsl:if>
   </xsl:template>
 
-  <xsl:template name="ref_cert_list">
-    <xsl:param name="certlist"/>
+  <xsl:template name="refs_list">
+    <xsl:param name="refs"/>
 
-    <xsl:variable name="certcount" select="count($certlist/cert_ref)"/>
+    <xsl:variable name="refscount" select="count($refs/ref)"/>
 
-    <xsl:if test="count($certlist/warning)">
-      <xsl:for-each select="$certlist/warning">
+    <xsl:if test="count($refs/warning)">
+      <xsl:for-each select="$refs/warning">
         <xsl:text>CERT: Warning: </xsl:text>
         <xsl:value-of select="text()"/>
         <xsl:call-template name="newline"/>
       </xsl:for-each>
     </xsl:if>
 
-    <xsl:if test="$certcount &gt; 0">
-      <xsl:text>CERT: </xsl:text>
-      <xsl:for-each select="$certlist/cert_ref">
-        <xsl:call-template name="wrap">
-          <xsl:with-param name="string" select="@id"/>
-          <xsl:with-param name="width" select="'55'"/>
-        </xsl:call-template>
-        <xsl:if test="position() &lt; $certcount">
-          <xsl:text>, </xsl:text>
-        </xsl:if>
+    <xsl:if test="$refscount &gt; 0">
+      <xsl:text>References:</xsl:text>
+      <xsl:call-template name="newline"/>
+      <xsl:for-each select="$refs/ref">
+        <xsl:text> </xsl:text>
+        <xsl:value-of select="@id"/>
+        <xsl:call-template name="newline"/>
       </xsl:for-each>
       <xsl:call-template name="newline"/>
     </xsl:if>
@@ -619,14 +616,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         <xsl:value-of select="nvt/bid/text()"/>
       </xsl:if>
     </xsl:variable>
-    <xsl:variable name="cert_ref" select="nvt/cert"/>
+    <xsl:variable name="refs" select="nvt/refs"/>
     <xsl:variable name="xref">
       <xsl:if test="nvt/xref != '' and nvt/xref != 'NOXREF'">
         <xsl:value-of select="nvt/xref/text()"/>
       </xsl:if>
     </xsl:variable>
 
-    <xsl:if test="$cve_ref != '' or $bid_ref != '' or $xref != '' or count($cert_ref/cert_ref) > 0">
+    <xsl:if test="$cve_ref != '' or $bid_ref != '' or $xref != '' or count($refs/ref) > 0">
       <xsl:text>References:</xsl:text>
       <xsl:call-template name="newline"/>
       <xsl:call-template name="ref_cve_list">
@@ -635,8 +632,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       <xsl:call-template name="ref_bid_list">
         <xsl:with-param name="bidlist" select="$bid_ref"/>
       </xsl:call-template>
-      <xsl:call-template name="ref_cert_list">
-        <xsl:with-param name="certlist" select="$cert_ref"/>
+      <xsl:call-template name="refs_list">
+        <xsl:with-param name="refs" select="$refs"/>
       </xsl:call-template>
       <xsl:call-template name="ref_xref_list">
         <xsl:with-param name="xreflist" select="$xref"/>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -13755,8 +13755,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
               <e>family</e>
               <e>cvss_base</e>
               <e>qod</e>
+              <e>refs</e>
               <e>cve_id</e>
-              <e>cert_refs</e>
               <e>bugtraq_id</e>
               <e>xrefs</e>
               <e>tags</e>
@@ -13867,6 +13867,37 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           </ele>
         </ele>
         <ele>
+          <name>refs</name>
+          <summary>List of references of various type for this vulnerability test</summary>
+          <pattern>
+            <any><e>ref</e></any>
+            <o><e>warning</e></o>
+          </pattern>
+          <ele>
+            <name>ref</name>
+            <summary>A reference</summary>
+            <pattern>
+              <attrib>
+                <name>id</name>
+                <summary>ID of the reference</summary>
+                <type>text</type>
+              </attrib>
+              <attrib>
+                <name>type</name>
+                <summary>Type of the advisory, for example "dfn-cert", "cert-bund"</summary>
+                <type>text</type>
+              </attrib>
+            </pattern>
+          </ele>
+          <ele>
+            <name>warning</name>
+            <summary>A warning message, e.g. when the CERT database is not available</summary>
+            <pattern>
+              text
+            </pattern>
+          </ele>
+        </ele>
+        <ele>
           <name>cve_id</name>
           <summary>IDs of the CVEs the NVT addresses</summary>
           <pattern>text</pattern>
@@ -13875,37 +13906,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <name>bugtraq_id</name>
           <summary>List of Bugtraq IDs of the NVT</summary>
           <pattern>text</pattern>
-        </ele>
-        <ele>
-          <name>cert_refs</name>
-          <summary>List of CERT advisories referencing this NVT via CVEs</summary>
-          <pattern>
-            <any><e>cert_ref</e></any>
-            <o><e>warning</e></o>
-          </pattern>
-          <ele>
-            <name>cert_ref</name>
-            <summary>A CERT advisory reference</summary>
-            <pattern>
-              <attrib>
-                <name>id</name>
-                <summary>ID of the advisory</summary>
-                <type>text</type>
-              </attrib>
-              <attrib>
-                <name>type</name>
-                <summary>Type of the advisory (e.g. "DFN-CERT", "CERT-BUND")</summary>
-                <type>text</type>
-              </attrib>
-            </pattern>
-          </ele>
-          <ele>
-            <name>warning</name>
-            <summary>A warning message, e.g. when the database is not</summary>
-            <pattern>
-              text
-            </pattern>
-          </ele>
         </ele>
         <ele>
           <name>xrefs</name>
@@ -14025,7 +14025,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <cvss_base></cvss_base>
             <cve_id>NOCVE</cve_id>
             <bugtraq_id>NOBID</bugtraq_id>
-            <cert_refs/>
+            <refs/>
             <xrefs>NOXREF</xrefs>
             <tags>NOTAG</tags>
             <preference_count>-1</preference_count>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -1410,7 +1410,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         <e>cpe</e>
         <e>bid</e>
         <e>tags</e>
-        <e>cert</e>
+        <e>refs</e>
         <e>xref</e>
       </pattern>
       <ele>
@@ -1454,23 +1454,23 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         <pattern>text</pattern>
       </ele>
       <ele>
-        <name>cert</name>
-        <summary>List of CERT advisories referencing this NVT via CVEs</summary>
+        <name>refs</name>
+        <summary>List of references of various types for this vulnerability test</summary>
         <pattern>
-          <any><e>cert_ref</e></any>
+          <any><e>ref</e></any>
         </pattern>
         <ele>
-          <name>cert_ref</name>
-          <summary>A CERT advisory reference</summary>
+          <name>ref</name>
+          <summary>A reference</summary>
           <pattern>
             <attrib>
               <name>id</name>
-              <summary>ID of the advisory</summary>
+              <summary>ID of the reference</summary>
               <type>text</type>
             </attrib>
             <attrib>
               <name>type</name>
-              <summary>Type of the advisory (e.g. "DFN-CERT", "CERT-BUND")</summary>
+              <summary>Type of the reference, for example "dfn-cert", "cert-bund"</summary>
               <type>text</type>
             </attrib>
           </pattern>
@@ -13868,7 +13868,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         </ele>
         <ele>
           <name>refs</name>
-          <summary>List of references of various type for this vulnerability test</summary>
+          <summary>List of references of various types for this vulnerability test</summary>
           <pattern>
             <any><e>ref</e></any>
             <o><e>warning</e></o>
@@ -13884,7 +13884,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
               </attrib>
               <attrib>
                 <name>type</name>
-                <summary>Type of the advisory, for example "dfn-cert", "cert-bund"</summary>
+                <summary>Type of the reference, for example "dfn-cert", "cert-bund"</summary>
                 <type>text</type>
               </attrib>
             </pattern>
@@ -16402,9 +16402,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
                     <cve>CVE-2013-1406</cve>
                     <bid>51702</bid>
                     <tags>NOTAGS</tags>
-                    <cert>
-                      <cert_ref id="DFN-CERT-2013-0246" type="DFN-CERT"/>
-                    </cert>
+                    <refs>
+                      <ref id="DFN-CERT-2013-0246" type="dfn-cert"/>
+                    </refs>
                     <xref>NOXREF</xref>
                   </nvt>
                   <threat>Medium</threat>
@@ -17454,7 +17454,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
               <cve>CVE-2009-3095</cve>
               <bid>36254</bid>
               <tags>NOTAGS</tags>
-              <cert></cert>
+              <refs></refs>
               <xref>NOXREF</xref>
             </nvt>
             <threat>Medium</threat>
@@ -17512,7 +17512,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
               <cve>CVE-2009-3095</cve>
               <bid>36254</bid>
               <tags>NOTAGS</tags>
-              <cert></cert>
+              <refs></refs>
               <xref>NOXREF</xref>
             </nvt>
             <threat>High</threat>
@@ -26342,6 +26342,18 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </description>
     <version>9.0</version>
   </change>
+  <change>
+    <command>GET_REPORTS, GET_RESULTS</command>
+    <summary>New element RESULT/NVT/REFS replaces RESULT/NVT/CERT</summary>
+    <version>@GMP_VERSION@</version>
+    <description>
+      <p>
+        The former element CERT is now named REFS and the id's for the type
+        are now lower case, ie. "cert-bund" and "dfn-cert" instead of "CERT-Bund" and "DFN-CERT".
+      </p>
+    </description>
+  </change>
+
   <change>
     <command>CREATE_FILTER, CREATE_TARGET</command>
     <summary>NAME MAKE_UNIQUE removed</summary>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -26308,9 +26308,24 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <version>9.0</version>
   </change>
   <change>
+    <command>GET_NVTS, GET_INFO</command>
+    <summary>New element REFS replaces CVE_ID, BUGTRAQ_ID, XREFS and CERT_REFS</summary>
+    <version>9.0</version>
+    <description>
+      <p>
+        The former element CERT_REFS is now named REFS and the id's for the type
+        are now lower case, ie. "cert-bund" and "dfn-cert" instead of "CERT-Bund" and "DFN-CERT".
+      </p>
+      <p>
+        The content of the elements CVE_ID, BUGTRAQ_ID and XREFS is now integrated
+        into the REFS element.
+      </p>
+    </description>
+  </change>
+  <change>
     <command>GET_REPORTS, GET_RESULTS</command>
     <summary>New element RESULT/NVT/REFS replaces RESULT/NVT/CERT</summary>
-    <version>@GMP_VERSION@</version>
+    <version>9.0</version>
     <description>
       <p>
         The former element CERT is now named REFS and the id's for the type
@@ -26321,7 +26336,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   <change>
     <command>GET_REPORTS, GET_RESULTS</command>
     <summary>Elements RESULT/NVT/CVE, RESULT/NVT/BID and RESULT/NVT/XREF consolidated into RESULT/NVT/REFS</summary>
-    <version>@GMP_VERSION@</version>
+    <version>9.0</version>
     <description>
       <p>
         The content of former elements CVE and BID are now also part of REFS and the

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -1406,12 +1406,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         <e>type</e>
         <e>family</e>
         <e>cvss_base</e>
-        <e>cve</e>
         <e>cpe</e>
-        <e>bid</e>
         <e>tags</e>
         <e>refs</e>
-        <e>xref</e>
       </pattern>
       <ele>
         <name>name</name>
@@ -1434,18 +1431,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         <pattern><t>integer</t></pattern>
       </ele>
       <ele>
-        <name>cve</name>
-        <summary>CVE associated with the NVT</summary>
-        <pattern>text</pattern>
-      </ele>
-      <ele>
         <name>cpe</name>
         <summary>The CPE which produced the CVE (for "cve" results)</summary>
-        <pattern>text</pattern>
-      </ele>
-      <ele>
-        <name>bid</name>
-        <summary>BID associated with the NVT</summary>
         <pattern>text</pattern>
       </ele>
       <ele>
@@ -1470,16 +1457,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             </attrib>
             <attrib>
               <name>type</name>
-              <summary>Type of the reference, for example "dfn-cert", "cert-bund"</summary>
+	      <summary>Type of the reference, for example "cve", "bid", "dfn-cert", "cert-bund"
+	      </summary>
               <type>text</type>
             </attrib>
           </pattern>
         </ele>
-      </ele>
-      <ele>
-        <name>xref</name>
-        <summary>XREFs associated with the NVT</summary>
-        <pattern>text</pattern>
       </ele>
     </ele>
     <ele>
@@ -16399,13 +16382,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
                   <nvt oid="1.3.6.1.4.1.25623.1.0.74">
                     <name>Test NVT: fields with ISO-8859-1 chars ()</name>
                     <cvss_base>5.0</cvss_base>
-                    <cve>CVE-2013-1406</cve>
-                    <bid>51702</bid>
                     <tags>NOTAGS</tags>
                     <refs>
+                      <ref id="CVE-2013-1406" type="cve"/>
+                      <ref id="51702" type="bid"/>
                       <ref id="DFN-CERT-2013-0246" type="dfn-cert"/>
                     </refs>
-                    <xref>NOXREF</xref>
                   </nvt>
                   <threat>Medium</threat>
                   <description>Test with  umlaut Warning Port 0.</description>
@@ -17451,11 +17433,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <nvt oid="1.3.6.1.4.1.25623.1.0.74">
               <name>Test NVT: fields with ISO-8859-1 chars</name>
               <cvss_base>5.0</cvss_base>
-              <cve>CVE-2009-3095</cve>
-              <bid>36254</bid>
               <tags>NOTAGS</tags>
-              <refs></refs>
-              <xref>NOXREF</xref>
+              <refs>
+                 <ref type="cve" id="CVE-2009-3095"/>
+                 <ref type="bid" id="36254"/>
+              </refs>
             </nvt>
             <threat>Medium</threat>
             <description>Test with umlaut.</description>
@@ -17509,11 +17491,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <nvt oid="1.3.6.1.4.1.25623.1.0.75">
               <name>Test NVT: long lines</name>
               <cvss_base>9</cvss_base>
-              <cve>CVE-2009-3095</cve>
-              <bid>36254</bid>
               <tags>NOTAGS</tags>
-              <refs></refs>
-              <xref>NOXREF</xref>
+              <refs>
+                 <ref type="cve" id="CVE-2009-3095"/>
+                 <ref type="bid" id="36254"/>
+              </refs>
             </nvt>
             <threat>High</threat>
             <description>Test with very long warning.</description>
@@ -26350,6 +26332,25 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       <p>
         The former element CERT is now named REFS and the id's for the type
         are now lower case, ie. "cert-bund" and "dfn-cert" instead of "CERT-Bund" and "DFN-CERT".
+      </p>
+    </description>
+  </change>
+  <change>
+    <command>GET_REPORTS, GET_RESULTS</command>
+    <summary>Elements RESULT/NVT/CVE, RESULT/NVT/BID and RESULT/NVT/XREF consolidated into RESULT/NVT/REFS</summary>
+    <version>@GMP_VERSION@</version>
+    <description>
+      <p>
+        The content of former elements CVE and BID are now also part of REFS and the
+	respective REF types are "cve" and "bid".
+      </p>
+      <p>
+        The content of former element XREF is now also part of REFS and the
+        respective REF type is the former prefix of the XREF, for example "URL".
+      </p>
+      <p>
+        The "NOCVE", "NOXREF" and "NOBID" strings that previously indicated the absense
+        of a CVE, XREF or BID are not applied anymore.
       </p>
     </description>
   </change>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -12211,7 +12211,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <column>
             <name>cve</name>
             <type>text</type>
-            <summary>List of BIDs of the NVT</summary>
+            <summary>List of CVEs of the NVT</summary>
           </column>
           <column>
             <name>xref</name>
@@ -13739,9 +13739,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
               <e>cvss_base</e>
               <e>qod</e>
               <e>refs</e>
-              <e>cve_id</e>
-              <e>bugtraq_id</e>
-              <e>xrefs</e>
               <e>tags</e>
               <o><e>preference_count</e></o>
               <o><e>timeout</e></o>
@@ -13867,7 +13864,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
               </attrib>
               <attrib>
                 <name>type</name>
-                <summary>Type of the reference, for example "dfn-cert", "cert-bund"</summary>
+                <summary>Type of the reference, for example "cve", "bid", "dfn-cert", "cert-bund"</summary>
                 <type>text</type>
               </attrib>
             </pattern>
@@ -13879,21 +13876,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
               text
             </pattern>
           </ele>
-        </ele>
-        <ele>
-          <name>cve_id</name>
-          <summary>IDs of the CVEs the NVT addresses</summary>
-          <pattern>text</pattern>
-        </ele>
-        <ele>
-          <name>bugtraq_id</name>
-          <summary>List of Bugtraq IDs of the NVT</summary>
-          <pattern>text</pattern>
-        </ele>
-        <ele>
-          <name>xrefs</name>
-          <summary>List of other references of the NVT</summary>
-          <pattern>text</pattern>
         </ele>
         <ele>
           <name>tags</name>
@@ -14006,10 +13988,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <summary>Find what is listening on which port</summary>
             <family>Service detection</family>
             <cvss_base></cvss_base>
-            <cve_id>NOCVE</cve_id>
-            <bugtraq_id>NOBID</bugtraq_id>
             <refs/>
-            <xrefs>NOXREF</xrefs>
             <tags>NOTAG</tags>
             <preference_count>-1</preference_count>
             <timeout></timeout>
@@ -26320,6 +26299,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         contains an ID subelement. The ID should help in identifying
         preferences within the same nvt instead of using the preference name
         which may be changed.
+      </p>
+      <p>
+        The content of the elements CVE_ID, BUGTRAQ_ID and XREFS is now integrated
+        into the REFS element.
       </p>
     </description>
     <version>9.0</version>


### PR DESCRIPTION
The GMP element "nvt" uses various explicit elements for references: "bid", "cve", "xrefs" and "cert".

This is all consolidated into a "refs" section like this:

    <refs>
      <ref type="cve" id="CVE-2010-4480"/>
      <ref type="url" id="http://www.exploit-db.com/exploits/15699/"/>
      <ref type="url" id="http://www.vupen.com/english/advisories/2010/3133">
        Vendor Advisory
      </ref>
      <ref type="dfn-cert" id="DFN-CERT-2011-0467"/>
      <ref type="dfn-cert" id="DFN-CERT-2011-0451"/>
      <ref type="dfn-cert" id="DFN-CERT-2011-0016"/>
      <ref type="dfn-cert" id="DFN-CERT-2011-0002"/>
    </refs>

This affects the commands get_nvts, get_results, get_info and get_reports.
