### PR TITLE
Fix setting UTF-8 validation (7.0)

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -63669,7 +63669,7 @@ modify_setting (const gchar *uuid, const gchar *name,
       if (value_64 && strlen (value_64))
         {
           value = (gchar*) g_base64_decode (value_64, &value_size);
-          if (g_utf8_validate (value, value_size, NULL))
+          if (g_utf8_validate (value, value_size, NULL) == FALSE)
             {
               if (r_errdesc)
                 *r_errdesc = g_strdup ("Value cannot be decoded to"
@@ -63704,7 +63704,7 @@ modify_setting (const gchar *uuid, const gchar *name,
       if (value_64 && strlen (value_64))
         {
           value = (gchar*) g_base64_decode (value_64, &value_size);
-          if (g_utf8_validate (value, value_size, NULL))
+          if (g_utf8_validate (value, value_size, NULL) == FALSE)
             {
               if (r_errdesc)
                 *r_errdesc = g_strdup ("Value cannot be decoded to"
@@ -63758,7 +63758,7 @@ modify_setting (const gchar *uuid, const gchar *name,
       if (value_64 && strlen (value_64))
         {
           value = (gchar*) g_base64_decode (value_64, &value_size);
-          if (g_utf8_validate (value, value_size, NULL))
+          if (g_utf8_validate (value, value_size, NULL) == FALSE)
             {
               if (r_errdesc)
                 *r_errdesc = g_strdup ("Value cannot be decoded to"
@@ -63933,7 +63933,7 @@ modify_setting (const gchar *uuid, const gchar *name,
       if (value_64 && strlen (value_64))
         {
           value = (gchar*) g_base64_decode (value_64, &value_size);
-          if (g_utf8_validate (value, value_size, NULL))
+          if (g_utf8_validate (value, value_size, NULL) == FALSE)
             {
               if (r_errdesc)
                 *r_errdesc = g_strdup ("Value cannot be decoded to"
@@ -64177,7 +64177,7 @@ modify_setting (const gchar *uuid, const gchar *name,
       if (value_64 && strlen (value_64))
         {
           value = (gchar*) g_base64_decode (value_64, &value_size);
-          if (g_utf8_validate (value, value_size, NULL))
+          if (g_utf8_validate (value, value_size, NULL) == FALSE)
             {
               if (r_errdesc)
                 *r_errdesc = g_strdup ("Value cannot be decoded to"


### PR DESCRIPTION
The g_utf8_validate function returns FALSE if the string is invalid, so
the checks were reversed.