### PR TITLE
 Fix host selection in various RFPs (master)

### DIFF
--- a/src/report_formats/ARF/ARF.xsl
+++ b/src/report_formats/ARF/ARF.xsl
@@ -133,7 +133,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   <report id="{concat('report_', $ip)}">
     <content>
       <xsl:copy>
-        <xsl:for-each select="openvas:report()/results/result[host = $ip]">
+        <xsl:for-each select="openvas:report()/results/result[host/text() = $ip]">
           <xsl:copy-of select="."/>
         </xsl:for-each>
       </xsl:copy>

--- a/src/report_formats/CSV_Results/CSV_Results.xsl
+++ b/src/report_formats/CSV_Results/CSV_Results.xsl
@@ -182,7 +182,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 
 <!-- MATCH RESULT -->
 <xsl:template match="result">
-  <xsl:variable name="ip" select="host"/>
+  <xsl:variable name="ip" select="host/text()"/>
   <xsl:variable name="summary-tag" select="openvas:get-nvt-tag (nvt/tags, 'summary')"/>
   <xsl:variable name="summary">
     <xsl:choose>

--- a/src/report_formats/LaTeX/latex.xsl
+++ b/src/report_formats/LaTeX/latex.xsl
@@ -568,15 +568,15 @@ advice given in each description, in order to rectify the issue.
       <xsl:with-param name="text" select="$host"/>
     </xsl:call-template>
     <xsl:text>&amp;</xsl:text>
-    <xsl:value-of select="count(../results/result[host=$host][threat/text()='High'])"/>
+    <xsl:value-of select="count(../results/result[host/text()=$host][threat/text()='High'])"/>
     <xsl:text>&amp;</xsl:text>
-    <xsl:value-of select="count(../results/result[host=$host][threat/text()='Medium'])"/>
+    <xsl:value-of select="count(../results/result[host/text()=$host][threat/text()='Medium'])"/>
     <xsl:text>&amp;</xsl:text>
-    <xsl:value-of select="count(../results/result[host=$host][threat/text()='Low'])"/>
+    <xsl:value-of select="count(../results/result[host/text()=$host][threat/text()='Low'])"/>
     <xsl:text>&amp;</xsl:text>
-    <xsl:value-of select="count(../results/result[host=$host][threat/text()='Log'])"/>
+    <xsl:value-of select="count(../results/result[host/text()=$host][threat/text()='Log'])"/>
     <xsl:text>&amp;</xsl:text>
-    <xsl:value-of select="count(../results/result[host=$host][threat/text()='False Positive'])"/>
+    <xsl:value-of select="count(../results/result[host/text()=$host][threat/text()='False Positive'])"/>
     <xsl:call-template name="latex-newline"/>
     <xsl:choose>
       <xsl:when test="$hostname">
@@ -914,9 +914,9 @@ advice given in each description, in order to rectify the issue.
   <xsl:template name="single-host-overview-table-row">
     <xsl:param name="threat"/>
     <xsl:param name="host"/>
-    <xsl:for-each select="openvas:report()/ports/port[host=$host]">
+    <xsl:for-each select="openvas:report()/ports/port[host/text()=$host]">
       <xsl:variable name="port_service" select="text()"/>
-        <xsl:if test="openvas:report()/results/result[host=$host][threat/text()=$threat][port=$port_service]">
+        <xsl:if test="openvas:report()/results/result[host/text()=$host][threat/text()=$threat][port=$port_service]">
           <xsl:call-template name="latex-hyperref">
             <xsl:with-param name="target" select="concat('port:', $host, ' ', $port_service, ' ', $threat)"/>
             <xsl:with-param name="text" select="$port_service"/>
@@ -1155,11 +1155,11 @@ advice given in each description, in order to rectify the issue.
     <xsl:param name="host"/>
     <xsl:param name="port_service"/>
     <xsl:param name="threat"/>
-    <xsl:if test="openvas:report()/results/result[host=$host][threat/text()=$threat][port=$port_service]">
+    <xsl:if test="openvas:report()/results/result[host/text()=$host][threat/text()=$threat][port=$port_service]">
       <xsl:call-template name="latex-subsubsection"><xsl:with-param name="subsubsection_string" select="concat ($threat, ' ', $port_service)"/></xsl:call-template>
       <xsl:call-template name="latex-label"><xsl:with-param name="label_string" select="concat('port:', $host, ' ', $port_service, ' ', $threat)"/></xsl:call-template>
       <xsl:call-template name="newline"/>
-      <xsl:for-each select="openvas:report()/results/result[host=$host][threat/text()=$threat][port=$port_service]">
+      <xsl:for-each select="openvas:report()/results/result[host/text()=$host][threat/text()=$threat][port=$port_service]">
         <xsl:text>\begin{longtable}{|p{\textwidth * 1}|}</xsl:text><xsl:call-template name="newline"/>
         <xsl:call-template name="latex-hline"/>
         <xsl:text>\rowcolor{</xsl:text>
@@ -1457,7 +1457,7 @@ advice given in each description, in order to rectify the issue.
     <xsl:param name="host"/>
 
     <!-- TODO Solve other sorting possibilities. -->
-    <xsl:for-each select="openvas:report()/ports/port[host=$host]">
+    <xsl:for-each select="openvas:report()/ports/port[host/text()=$host]">
       <xsl:call-template name="result-details-host-port-threat">
         <xsl:with-param name="threat">High</xsl:with-param>
         <xsl:with-param name="host" select="$host"/>
@@ -1465,7 +1465,7 @@ advice given in each description, in order to rectify the issue.
       </xsl:call-template>
     </xsl:for-each>
 
-    <xsl:for-each select="openvas:report()/ports/port[host=$host]">
+    <xsl:for-each select="openvas:report()/ports/port[host/text()=$host]">
       <xsl:call-template name="result-details-host-port-threat">
         <xsl:with-param name="threat">Medium</xsl:with-param>
         <xsl:with-param name="host" select="$host"/>
@@ -1473,7 +1473,7 @@ advice given in each description, in order to rectify the issue.
       </xsl:call-template>
     </xsl:for-each>
 
-    <xsl:for-each select="openvas:report()/ports/port[host=$host]">
+    <xsl:for-each select="openvas:report()/ports/port[host/text()=$host]">
       <xsl:call-template name="result-details-host-port-threat">
         <xsl:with-param name="threat">Low</xsl:with-param>
         <xsl:with-param name="host" select="$host"/>
@@ -1481,7 +1481,7 @@ advice given in each description, in order to rectify the issue.
       </xsl:call-template>
     </xsl:for-each>
 
-    <xsl:for-each select="openvas:report()/ports/port[host=$host]">
+    <xsl:for-each select="openvas:report()/ports/port[host/text()=$host]">
       <xsl:call-template name="result-details-host-port-threat">
         <xsl:with-param name="threat">Log</xsl:with-param>
         <xsl:with-param name="host" select="$host"/>
@@ -1489,7 +1489,7 @@ advice given in each description, in order to rectify the issue.
       </xsl:call-template>
     </xsl:for-each>
 
-    <xsl:for-each select="openvas:report()/ports/port[host=$host]">
+    <xsl:for-each select="openvas:report()/ports/port[host/text()=$host]">
       <xsl:call-template name="result-details-host-port-threat">
         <xsl:with-param name="threat">Debug</xsl:with-param>
         <xsl:with-param name="host" select="$host"/>
@@ -1497,7 +1497,7 @@ advice given in each description, in order to rectify the issue.
       </xsl:call-template>
     </xsl:for-each>
 
-    <xsl:for-each select="openvas:report()/ports/port[host=$host]">
+    <xsl:for-each select="openvas:report()/ports/port[host/text()=$host]">
       <xsl:call-template name="result-details-host-port-threat">
         <xsl:with-param name="threat">False Positive</xsl:with-param>
         <xsl:with-param name="host" select="$host"/>

--- a/src/report_formats/NBE/NBE.xsl
+++ b/src/report_formats/NBE/NBE.xsl
@@ -191,7 +191,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 <xsl:template match="result">
   <xsl:variable name="netmask">
     <xsl:call-template name="substring-before-last">
-      <xsl:with-param name="string" select="host"/>
+      <xsl:with-param name="string" select="host/text()"/>
       <xsl:with-param name="delimiter" select="'.'"/>
     </xsl:call-template>
   </xsl:variable>
@@ -201,7 +201,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   <xsl:text>|</xsl:text>
   <xsl:value-of select="$netmask"/>
   <xsl:text>|</xsl:text>
-  <xsl:value-of select="host"/>
+  <xsl:value-of select="host/text()"/>
   <xsl:text>|</xsl:text>
   <xsl:value-of select="port"/>
   <xsl:text>|</xsl:text>

--- a/src/report_formats/Verinice_ITG/Verinice_ITG.xsl
+++ b/src/report_formats/Verinice_ITG/Verinice_ITG.xsl
@@ -262,7 +262,7 @@ transformation with the tool xsltproc.
         </syncAttribute>
         <extId><xsl:value-of select="$task_id"/>-<xsl:value-of select="$addr"/>-results</extId>
         <extObjectType>gsm_itg_result_group</extObjectType>
-        <xsl:for-each select="/report/results/result[port='general/IT-Grundschutz-T'][host=$addr]">
+        <xsl:for-each select="/report/results/result[port='general/IT-Grundschutz-T'][host/text()=$addr]">
           <xsl:apply-templates select="description">
             <xsl:with-param name="task_id">
               <xsl:value-of select="$task_id"/>


### PR DESCRIPTION
With the addition of the hostname in the result hosts GMP XML the XSL
templates need to select the element text directly to compare IP
addresses.
The updated report formats are: ARF, LaTeX, Verinice, NBE, CSV Results.