### PR TITLE
Update dead hosts preference in default configs (7.0)

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -1933,6 +1933,9 @@ config_timeout_iterator_nvt_name (iterator_t *);
 const char*
 config_timeout_iterator_value (iterator_t *);
 
+void update_config_preference (const char *, const char *, const char *,
+                               const char *, gboolean);
+
 
 
 /* NVT's. */

--- a/src/manage_config_discovery.c
+++ b/src/manage_config_discovery.c
@@ -970,7 +970,7 @@ make_config_discovery (char *const uuid, char *const selector_name)
 int
 check_config_discovery (const char *uuid)
 {
-  /* Check new preference. */
+  /* Check preferences. */
 
   sql ("UPDATE config_preferences SET value = 'no'"
        " WHERE config = (SELECT id FROM configs WHERE uuid = '%s')"
@@ -978,6 +978,13 @@ check_config_discovery (const char *uuid)
        " AND name = 'Ping Host[checkbox]:Report about unrechable Hosts'"
        " AND value = 'yes';",
        uuid);
+
+  update_config_preference (uuid,
+                            "PLUGINS_PREFS",
+                            "Ping Host[checkbox]:Mark unrechable Hosts as dead"
+                            " (not scanning)",
+                            "yes",
+                            TRUE);
 
   return 0;
 }

--- a/src/manage_config_host_discovery.c
+++ b/src/manage_config_host_discovery.c
@@ -159,5 +159,14 @@ check_config_host_discovery (const char *uuid)
   if (update)
     update_config_cache_init (uuid);
 
+  /* Check preferences. */
+
+  update_config_preference (uuid,
+                            "PLUGINS_PREFS",
+                            "Ping Host[checkbox]:Mark unrechable Hosts as dead"
+                            " (not scanning)",
+                            "yes",
+                            TRUE);
+
   return 0;
 }

--- a/src/manage_config_system_discovery.c
+++ b/src/manage_config_system_discovery.c
@@ -244,5 +244,14 @@ check_config_system_discovery (const char *uuid)
   if (update)
     update_config_cache_init (uuid);
 
+  /* Check preferences. */
+
+  update_config_preference (uuid,
+                            "PLUGINS_PREFS",
+                            "Ping Host[checkbox]:Mark unrechable Hosts as dead"
+                            " (not scanning)",
+                            "yes",
+                            TRUE);
+
   return 0;
 }

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -38323,6 +38323,56 @@ DEF_ACCESS (config_timeout_iterator_nvt_name, 2);
  */
 DEF_ACCESS (config_timeout_iterator_value, 3);
 
+/**
+ * @brief Update or optionally insert a NVT preference.
+ *
+ * @param[in]  config_id        UUID of the config to set the preference in
+ * @param[in]  type             Type of the preference, e.g. "PLUGINS_PREFS"
+ * @param[in]  preference_name  Full name of the preference
+ * @param[in]  new_value        The new value to set
+ * @param[in]  insert           Whether to insert the preference if missing
+ */
+void
+update_config_preference (const char *config_id,
+                          const char *type,
+                          const char *preference_name,
+                          const char *new_value,
+                          gboolean insert)
+{
+  gchar *quoted_config_id = sql_quote (config_id);
+  gchar *quoted_type = sql_quote (type);
+  gchar *quoted_name = sql_quote (preference_name);
+  gchar *quoted_value = sql_quote (new_value);
+
+  if (sql_int ("SELECT count (*) FROM config_preferences"
+               " WHERE config = (SELECT id FROM configs WHERE uuid = '%s')"
+               "   AND type = '%s'"
+               "   AND name = '%s';",
+               quoted_config_id, quoted_type, quoted_name) == 0)
+    {
+      if (insert)
+        {
+          sql ("INSERT INTO config_preferences (config, type, name, value)"
+               " VALUES ((SELECT id FROM configs WHERE uuid = '%s'),"
+               "         '%s', '%s', '%s');",
+               quoted_config_id, quoted_type, quoted_name, quoted_value);
+        }
+    }
+  else
+    {
+      sql ("UPDATE config_preferences SET value = '%s'"
+           " WHERE config = (SELECT id FROM configs WHERE uuid = '%s')"
+           "   AND type = '%s'"
+           "   AND name = '%s';",
+           quoted_value, quoted_config_id, quoted_type, quoted_name);
+    }
+
+  g_free (quoted_config_id);
+  g_free (quoted_type);
+  g_free (quoted_name);
+  g_free (quoted_value);
+}
+
 
 /* NVT's. */
 


### PR DESCRIPTION
The preference for marking unreachable hosts as dead is now set to "yes"
for the built in scan configs "Discovery", "Host Discovery" and
"System Discovery".