### PR TITLE
Add --slave-commit-size option (7.0)

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -2696,6 +2696,14 @@ int
 manage_system_report (const char *, const char *, const char *, const char *,
                       const char *, char **);
 
+
+/* Scanners. */
+
+/**
+ * @brief Default for slave update commit size.
+ */
+#define SLAVE_COMMIT_SIZE_DEFAULT 0
+
 int
 manage_create_scanner (GSList *, const char *, const char *, const char *,
                        const char *, const char *, const char *, const char *,
@@ -2843,6 +2851,9 @@ osp_scanner_connect (scanner_t);
 
 int
 verify_scanner (const char *, char **);
+
+void
+set_slave_commit_size (int);
 
 /* Scheduling. */
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -54422,10 +54422,10 @@ update_from_slave (task_t task, entity_t get_report, entity_t *report,
         }
       hosts = next_entities (hosts);
 
-      current_commit_size ++;
+      current_commit_size++;
       if (slave_commit_size && current_commit_size >= slave_commit_size)
         {
-          sql_commit();
+          sql_commit ();
           sql_begin_immediate ();
           current_commit_size = 0;
         }
@@ -54482,10 +54482,10 @@ update_from_slave (task_t task, entity_t get_report, entity_t *report,
                                   entity_text (description));
             if (current_report) report_add_result (current_report, result);
 
-            current_commit_size ++;
+            current_commit_size++;
             if (slave_commit_size && current_commit_size >= slave_commit_size)
               {
-                sql_commit();
+                sql_commit ();
                 sql_begin_immediate ();
                 current_commit_size = 0;
               }

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -360,6 +360,11 @@ void (*progress) () = NULL;
 static int max_hosts = MANAGE_MAX_HOSTS;
 
 /**
+ * @brief Maximum number of SQL queries per transaction in slave updates.
+ */
+static int slave_commit_size = SLAVE_COMMIT_SIZE_DEFAULT;
+
+/**
  * @brief Default max number of bytes of reports included in email alerts.
  */
 #define MAX_CONTENT_LENGTH 20000
@@ -54336,6 +54341,20 @@ check_report_format (const gchar *uuid)
 /* OMP slave scanners. */
 
 /**
+ * @brief Set the slave update commit size.
+ *
+ * @param new_commit_size The new slave update commit size.
+ */
+void
+set_slave_commit_size (int new_commit_size)
+{
+  if (new_commit_size < 0)
+    slave_commit_size = 0;
+  else
+    slave_commit_size = new_commit_size;
+}
+
+/**
  * @brief Update the local task from the slave task.
  *
  * @param[in]   task         The local task.
@@ -54351,6 +54370,7 @@ update_from_slave (task_t task, entity_t get_report, entity_t *report,
 {
   entity_t entity, host_start, start;
   entities_t results, hosts, entities;
+  int current_commit_size;
 
   entity = entity_child (get_report, "report");
   if (entity == NULL)
@@ -54379,6 +54399,7 @@ update_from_slave (task_t task, entity_t get_report, entity_t *report,
 
   sql_begin_immediate ();
   hosts = (*report)->entities;
+  current_commit_size = 0;
   while ((host_start = first_entity (hosts)))
     {
       if (strcmp (entity_name (host_start), "host_start") == 0)
@@ -54400,6 +54421,14 @@ update_from_slave (task_t task, entity_t get_report, entity_t *report,
                                     entity_text (host_start));
         }
       hosts = next_entities (hosts);
+
+      current_commit_size ++;
+      if (slave_commit_size && current_commit_size >= slave_commit_size)
+        {
+          sql_commit();
+          sql_begin_immediate ();
+          current_commit_size = 0;
+        }
     }
   sql_commit ();
 
@@ -54411,6 +54440,7 @@ update_from_slave (task_t task, entity_t get_report, entity_t *report,
 
   sql_begin_immediate ();
   results = entity->entities;
+  current_commit_size = 0;
   while ((entity = first_entity (results)))
     {
       if (strcmp (entity_name (entity), "result") == 0)
@@ -54451,6 +54481,14 @@ update_from_slave (task_t task, entity_t get_report, entity_t *report,
                                   threat_message_type (entity_text (threat)),
                                   entity_text (description));
             if (current_report) report_add_result (current_report, result);
+
+            current_commit_size ++;
+            if (slave_commit_size && current_commit_size >= slave_commit_size)
+              {
+                sql_commit();
+                sql_begin_immediate ();
+                current_commit_size = 0;
+              }
           }
 
           (*next_result)++;

--- a/src/openvasmd.c
+++ b/src/openvasmd.c
@@ -1725,6 +1725,7 @@ main (int argc, char** argv)
   static gchar *scanner_key_pub = NULL;
   static gchar *scanner_key_priv = NULL;
   static int schedule_timeout = SCHEDULE_TIMEOUT_DEFAULT;
+  static int slave_commit_size = SLAVE_COMMIT_SIZE_DEFAULT;
   static gchar *delete_scanner = NULL;
   static gchar *verify_scanner = NULL;
   static gchar *priorities = "NORMAL";
@@ -1797,6 +1798,7 @@ main (int argc, char** argv)
         { "delete-scanner", '\0', 0, G_OPTION_ARG_STRING, &delete_scanner, "Delete scanner <scanner-uuid> and exit.", "<scanner-uuid>" },
         { "get-scanners", '\0', 0, G_OPTION_ARG_NONE, &get_scanners, "List scanners and exit.", NULL },
         { "schedule-timeout", '\0', 0, G_OPTION_ARG_INT, &schedule_timeout, "Time out tasks that are more than <time> minutes overdue. -1 to disable, 0 for minimum time, default: " G_STRINGIFY (SCHEDULE_TIMEOUT_DEFAULT), "<time>" },
+        { "slave-commit-size", '\0', 0, G_OPTION_ARG_INT, &slave_commit_size, "Number of updates per transaction during slave updates, 0 for unlimited" },
         { "foreground", 'f', 0, G_OPTION_ARG_NONE, &foreground, "Run in foreground.", NULL },
         { "inheritor", '\0', 0, G_OPTION_ARG_STRING, &inheritor, "Have <username> inherit from deleted user.", "<username>" },
         { "listen", 'a', 0, G_OPTION_ARG_STRING, &manager_address_string, "Listen on <address>.", "<address>" },
@@ -1880,6 +1882,9 @@ main (int argc, char** argv)
   /* Set schedule_timeout */
 
   set_schedule_timeout (schedule_timeout);
+
+  /* Set slave commit size */
+  set_slave_commit_size (slave_commit_size);
 
   /* Check which type of socket to use. */
 


### PR DESCRIPTION
This option allows splitting large transactions when updating reports
from a slave into multiple smaller ones, for example when resuming a
scan with many hosts and results.