### PR TITLE
Show HOST_PROGRESS only with GET_TASKS details (7.0)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,8 @@ Main changes since 7.0.3:
   HTML and LaTeX report formats.
 * A new password-only credential type has been added
 * The Sourcefire alert now accepts a password credential for PKCS12 decryption.
+* The GET_TASKS command now only returns the progress of individual hosts
+  when details are requested.
 
 openvas-manager 7.0.3 (2018-03-29)
 

--- a/doc/omp.html
+++ b/doc/omp.html
@@ -30706,7 +30706,7 @@ get_targets_response_target_count_page
               <div style="margin-left: 15px; display: inline;">The percentage of the task that is complete.</div>
 <ul style="list-style: none"><li>
               &lt;<b>host_progress</b>&gt;
-              *<div style="margin-left: 15px; display: inline;">Percentage complete for a particular host.</div>
+              *<div style="margin-left: 15px; display: inline;">Percentage complete for a particular host, only shown when details are active.</div>
 <ul style="list-style: none"><li>
               &lt;<b>host</b>&gt;
               <ul style="list-style: none"></ul>
@@ -38022,6 +38022,16 @@ start_task_response_report_id
       7.0</h2>
 <div>
 <div><h3>8.1
+          Change in <tt>GET_TASKS</tt>
+</h3></div>
+<p>In short: HOST_PROGRESS only shown with active details.</p>
+<p>
+        The GET_TASKS command will only return the progress of individual hosts
+        in HOST_PROGRESS elements when details are requested.
+      </p>
+</div>
+<div>
+<div><h3>8.2
           Change in <tt>GET_NVT_FEED_VERSION</tt>
 </h3></div>
 <p>In short: Command removed.</p>
@@ -38031,7 +38041,7 @@ start_task_response_report_id
       </p>
 </div>
 <div>
-<div><h3>8.2
+<div><h3>8.3
           Change in <tt>GET_TASKS, MODIFY_TASK</tt>
 </h3></div>
 <p>In short: Element SLAVE removed.</p>
@@ -38041,7 +38051,7 @@ start_task_response_report_id
       </p>
 </div>
 <div>
-<div><h3>8.3
+<div><h3>8.4
           Change in <tt>GET_CREDENTIALS</tt>
 </h3></div>
 <p>In short: Attribute "slaves" and element SLAVES removed.</p>
@@ -38052,7 +38062,7 @@ start_task_response_report_id
       </p>
 </div>
 <div>
-<div><h3>8.4
+<div><h3>8.5
           Change in <tt>CREATE_TASK</tt>
 </h3></div>
 <p>In short: Element SLAVE removed.</p>
@@ -38062,7 +38072,7 @@ start_task_response_report_id
       </p>
 </div>
 <div>
-<div><h3>8.5
+<div><h3>8.6
           Change in <tt>CREATE_SLAVE, DELETE_SLAVE, GET_SLAVES, MODIFY_SLAVE</tt>
 </h3></div>
 <p>In short: Commands removed.</p>
@@ -38072,7 +38082,7 @@ start_task_response_report_id
       </p>
 </div>
 <div>
-<div><h3>8.6
+<div><h3>8.7
           Change in <tt>DESCRIBE_FEED, DESCRIBE_SCAP, DESCRIBE_CERT</tt>
 </h3></div>
 <p>In short: Commands replaced with GET_FEEDS.</p>
@@ -38082,7 +38092,7 @@ start_task_response_report_id
       </p>
 </div>
 <div>
-<div><h3>8.7
+<div><h3>8.8
           Change in <tt>GET_REPORT_FORMATS, CREATE_REPORT_FORMAT</tt>
 </h3></div>
 <p>In short: Element GLOBAL removed.</p>
@@ -38092,7 +38102,7 @@ start_task_response_report_id
       </p>
 </div>
 <div>
-<div><h3>8.8
+<div><h3>8.9
           Change in <tt>DESCRIBE_AUTH, MODIFY_AUTH</tt>
 </h3></div>
 <p>In short: Response attributes "key" and "value" moved to elements.</p>
@@ -38103,7 +38113,7 @@ start_task_response_report_id
       </p>
 </div>
 <div>
-<div><h3>8.9
+<div><h3>8.10
           Change in <tt>All GET_... commands</tt>
 </h3></div>
 <p>In short: Limit on number of returned rows introduced.</p>
@@ -38119,7 +38129,7 @@ start_task_response_report_id
       </p>
 </div>
 <div>
-<div><h3>8.10
+<div><h3>8.11
           Change in <tt>GET_RESULTS</tt>
 </h3></div>
 <p>In short: Redundant filtering attributes removed.</p>
@@ -38131,7 +38141,7 @@ start_task_response_report_id
       </p>
 </div>
 <div>
-<div><h3>8.11
+<div><h3>8.12
           Change in <tt>GET_REPORTS</tt>
 </h3></div>
 <p>In short: Redundant filtering attributes removed.</p>
@@ -38145,7 +38155,7 @@ start_task_response_report_id
       </p>
 </div>
 <div>
-<div><h3>8.12
+<div><h3>8.13
           Change in <tt>GET_REPORTS</tt>
 </h3></div>
 <p>In short: Filter keywords in response changed to common format.</p>
@@ -38158,7 +38168,7 @@ start_task_response_report_id
       </p>
 </div>
 <div>
-<div><h3>8.13
+<div><h3>8.14
           Change in <tt>GET_CREDENTIALS</tt>
 </h3></div>
 <p>In short: Credential types renamed.</p>
@@ -38169,7 +38179,7 @@ start_task_response_report_id
       </p>
 </div>
 <div>
-<div><h3>8.14
+<div><h3>8.15
           Change in <tt>CREATE_LSC_CREDENTIAL, DELETE_LSC_CREDENTIAL, GET_LSC_CREDENTIALS, MODIFY_LSC_CREDENTIAL</tt>
 </h3></div>
 <p>In short: Resource type and commands renamed.</p>
@@ -38180,7 +38190,7 @@ start_task_response_report_id
       </p>
 </div>
 <div>
-<div><h3>8.15
+<div><h3>8.16
           Change in <tt>CREATE_SCANNER, GET_SCANNERS, MODIFY_SCANNER</tt>
 </h3></div>
 <p>In short: key_priv and key_pub replaced by credential.</p>
@@ -38190,7 +38200,7 @@ start_task_response_report_id
       </p>
 </div>
 <div>
-<div><h3>8.16
+<div><h3>8.17
           Change in <tt>CREATE_SLAVE, GET_SLAVES, MODIFY_SLAVE</tt>
 </h3></div>
 <p>In short: username and password replaced by credential.</p>
@@ -38200,7 +38210,7 @@ start_task_response_report_id
       </p>
 </div>
 <div>
-<div><h3>8.17
+<div><h3>8.18
           Change in <tt>GET_TARGETS</tt>
 </h3></div>
 <p>In short: "lsc_" removed from credential element names.</p>

--- a/doc/omp.rnc
+++ b/doc/omp.rnc
@@ -16665,7 +16665,7 @@ get_tasks_response_task_progress
        & get_tasks_response_task_progress_host_progress*
      }
 
-# Percentage complete for a particular host.
+# Percentage complete for a particular host, only shown when details are active.
 get_tasks_response_task_progress_host_progress
  = element host_progress
      {

--- a/src/omp.c
+++ b/src/omp.c
@@ -19226,11 +19226,18 @@ handle_get_tasks (omp_parser_t *omp_parser, GError **error)
               int progress;
               gchar *host_xml;
 
+              host_xml = NULL;
               running_report = task_iterator_current_report (&tasks);
-              progress
-                = report_progress (running_report, index, &host_xml);
+
+              if ((&get_tasks_data->get)->details)
+                progress
+                  = report_progress (running_report, index, &host_xml);
+              else
+                progress
+                  = report_progress (running_report, index, NULL);
+
               progress_xml
-                = g_strdup_printf ("%i%s", progress, host_xml);
+                = g_strdup_printf ("%i%s", progress, host_xml ? host_xml : "");
               g_free (host_xml);
             }
 

--- a/src/schema_formats/XML/OMP.xml.in
+++ b/src/schema_formats/XML/OMP.xml.in
@@ -20546,7 +20546,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           </pattern>
           <ele>
             <name>host_progress</name>
-            <summary>Percentage complete for a particular host</summary>
+            <summary>
+              Percentage complete for a particular host,
+              only shown when details are active</summary>
             <pattern>
               <t>integer</t>
               <e>host</e>
@@ -25377,6 +25379,17 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 
   <!-- Compatibility changes between versions. -->
 
+  <change>
+    <command>GET_TASKS</command>
+    <summary>HOST_PROGRESS only shown with active details</summary>
+    <description>
+      <p>
+        The GET_TASKS command will only return the progress of individual hosts
+        in HOST_PROGRESS elements when details are requested.
+      </p>
+    </description>
+    <version>7.0</version>
+  </change>
   <change>
     <command>GET_NVT_FEED_VERSION</command>
     <summary>Command removed</summary>


### PR DESCRIPTION
The GET_TASKS command now only returns the progress of individual hosts
when details are requested.
This will avoid very large responses in case there are active or stopped
scans with many target hosts.