### PR TITLE
Add Hosts and Operating Systems Filter settings (8.0)

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -12903,17 +12903,17 @@ handle_get_assets (gmp_parser_t *gmp_parser, GError **error)
       return;
     }
 
-  INIT_GET (asset, Asset);
-
   /* Set type specific functions. */
   if (g_strcmp0 ("host", get_assets_data->type) == 0)
     {
+      INIT_GET (asset, Host);
       init_asset_iterator = init_asset_host_iterator;
       asset_count = asset_host_count;
       get_assets_data->get.subtype = g_strdup ("host");
     }
   else if (g_strcmp0 ("os", get_assets_data->type) == 0)
     {
+      INIT_GET (asset, Operating System);
       init_asset_iterator = init_asset_os_iterator;
       asset_count = asset_os_count;
       get_assets_data->get.subtype = g_strdup ("os");

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -64010,8 +64010,12 @@ modify_setting (const gchar *uuid, const gchar *name,
         setting_name = g_strdup ("Credentials Filter");
       else if (strcmp (uuid, "f9691163-976c-47e7-ad9a-38f2d5c81649") == 0)
         setting_name = g_strdup ("Filters Filter");
+      else if (strcmp (uuid, "37562dfe-1f7e-4cae-a7c0-fa95e6f194c5") == 0)
+        setting_name = g_strdup ("Hosts Filter");
       else if (strcmp (uuid, "96abcd5a-9b6d-456c-80b8-c3221bfa499d") == 0)
         setting_name = g_strdup ("Notes Filter");
+      else if (strcmp (uuid, "f608c3ec-ce73-4ff6-8e04-7532749783af") == 0)
+        setting_name = g_strdup ("Operating Systems Filter");
       else if (strcmp (uuid, "eaaaebf1-01ef-4c49-b7bb-955461c78e0a") == 0)
         setting_name = g_strdup ("Overrides Filter");
       else if (strcmp (uuid, "ffb16b28-538c-11e3-b8f9-406186ea4fc5") == 0)


### PR DESCRIPTION
This adds settings for filtering the subtypes of GET_ASSETS and makes
the command use them instead of the "Assets Filter" setting.