### PR TITLE
Add --slave-commit-size option (8.0)

### DIFF
--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1686,6 +1686,7 @@ main (int argc, char **argv)
   static gchar *scanner_key_priv = NULL;
   static int schedule_timeout = SCHEDULE_TIMEOUT_DEFAULT;
   static int secinfo_commit_size = SECINFO_COMMIT_SIZE_DEFAULT;
+  static int slave_commit_size = SLAVE_COMMIT_SIZE_DEFAULT;
   static gchar *delete_scanner = NULL;
   static gchar *verify_scanner = NULL;
   static gchar *priorities = "NORMAL";
@@ -1885,6 +1886,14 @@ main (int argc, char **argv)
      "During CERT and SCAP sync, commit updates to the database every <number> "
      "items, 0 for unlimited, default: " G_STRINGIFY (
        SECINFO_COMMIT_SIZE_DEFAULT),
+     "<number>"},
+    {"slave-commit-size",
+     '\0',
+     0,
+     G_OPTION_ARG_INT,
+     &secinfo_commit_size,
+     "During slave updates, commit after every <number> updated results and"
+     " hosts, 0 for unlimited",
      "<number>"},
     {"schedule-timeout",
      '\0',
@@ -2137,6 +2146,9 @@ main (int argc, char **argv)
   /* Set schedule_timeout */
 
   set_schedule_timeout (schedule_timeout);
+
+  /* Set slave commit size */
+  set_slave_commit_size (slave_commit_size);
 
   /* Set SecInfo update commit size */
 

--- a/src/manage.h
+++ b/src/manage.h
@@ -2743,6 +2743,14 @@ manage_system_report (const char *,
                       const char *,
                       char **);
 
+
+/* Scanners. */
+
+/**
+ * @brief Default for slave update commit size.
+ */
+#define SLAVE_COMMIT_SIZE_DEFAULT 0
+
 int
 manage_create_scanner (GSList *,
                        const char *,
@@ -2914,6 +2922,9 @@ osp_connection_t *osp_scanner_connect (scanner_t);
 
 int
 verify_scanner (const char *, char **);
+
+void
+set_slave_commit_size (int);
 
 /* Scheduling. */
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -496,6 +496,11 @@ static manage_connection_forker_t manage_fork_connection;
 static int max_hosts = MANAGE_MAX_HOSTS;
 
 /**
+ * @brief Maximum number of SQL queries per transaction in slave updates.
+ */
+static int slave_commit_size = SLAVE_COMMIT_SIZE_DEFAULT;
+
+/**
  * @brief Default max number of bytes of reports included in email alerts.
  */
 #define MAX_CONTENT_LENGTH 20000
@@ -53949,6 +53954,20 @@ verify_report_format (const char *report_format_id)
 /* GMP slave scanners. */
 
 /**
+ * @brief Set the slave update commit size.
+ *
+ * @param new_commit_size The new slave update commit size.
+ */
+void
+set_slave_commit_size (int new_commit_size)
+{
+  if (new_commit_size < 0)
+    slave_commit_size = 0;
+  else
+    slave_commit_size = new_commit_size;
+}
+
+/**
  * @brief Update the local task from the slave task.
  *
  * @param[in]   task         The local task.
@@ -53964,6 +53983,7 @@ update_from_slave (task_t task, entity_t get_report, entity_t *report,
 {
   entity_t entity, host_start, start;
   entities_t results, hosts, entities;
+  int current_commit_size;
 
   entity = entity_child (get_report, "report");
   if (entity == NULL)
@@ -53992,6 +54012,7 @@ update_from_slave (task_t task, entity_t get_report, entity_t *report,
 
   sql_begin_immediate ();
   hosts = (*report)->entities;
+  current_commit_size = 0;
   while ((host_start = first_entity (hosts)))
     {
       if (strcmp (entity_name (host_start), "host") == 0)
@@ -54017,6 +54038,14 @@ update_from_slave (task_t task, entity_t get_report, entity_t *report,
                                     entity_text (start));
         }
       hosts = next_entities (hosts);
+
+      current_commit_size++;
+      if (slave_commit_size && current_commit_size >= slave_commit_size)
+        {
+          sql_commit ();
+          sql_begin_immediate ();
+          current_commit_size = 0;
+        }
     }
   sql_commit ();
 
@@ -54028,6 +54057,7 @@ update_from_slave (task_t task, entity_t get_report, entity_t *report,
 
   sql_begin_immediate ();
   results = entity->entities;
+  current_commit_size = 0;
   while ((entity = first_entity (results)))
     {
       if (strcmp (entity_name (entity), "result") == 0)
@@ -54072,6 +54102,14 @@ update_from_slave (task_t task, entity_t get_report, entity_t *report,
                                   entity_text (description));
             if (global_current_report)
               report_add_result (global_current_report, result);
+
+            current_commit_size++;
+            if (slave_commit_size && current_commit_size >= slave_commit_size)
+              {
+                sql_commit ();
+                sql_begin_immediate ();
+                current_commit_size = 0;
+              }
           }
 
           (*next_result)++;


### PR DESCRIPTION
This option allows splitting large transactions when updating reports
from a slave into multiple smaller ones, for example when resuming a
scan with many hosts and results.