### PR TITLE
Use correct timezone variable

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -50582,7 +50582,7 @@ modify_schedule (const char *schedule_id, const char *name, const char *comment,
 
   /* Update basic data */
   quoted_comment = comment ? sql_quote (comment) : NULL;
-  quoted_timezone = timezone ? sql_quote (zone) : NULL;
+  quoted_timezone = zone ? sql_quote (zone) : NULL;
 
   sql ("UPDATE schedules SET"
        " name = %s%s%s,"


### PR DESCRIPTION
Use the correct timezone variable when sql quoting the passed argument.
It seems timezone is set in time.h therefore the compiler isn't
complaining here.