### PR TITLE
Show HOST_PROGRESS only with GET_TASKS details (8.0)

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -18826,11 +18826,18 @@ handle_get_tasks (gmp_parser_t *gmp_parser, GError **error)
               int progress;
               gchar *host_xml;
 
+              host_xml = NULL;
               running_report = task_iterator_current_report (&tasks);
-              progress
-                = report_progress (running_report, index, &host_xml);
+
+              if ((&get_tasks_data->get)->details)
+                progress
+                  = report_progress (running_report, index, &host_xml);
+              else
+                progress
+                  = report_progress (running_report, index, NULL);
+
               progress_xml
-                = g_strdup_printf ("%i%s", progress, host_xml);
+                = g_strdup_printf ("%i%s", progress, host_xml ? host_xml : "");
               g_free (host_xml);
             }
 

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -20733,7 +20733,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           </pattern>
           <ele>
             <name>host_progress</name>
-            <summary>Percentage complete for a particular host</summary>
+            <summary>
+              Percentage complete for a particular host,
+              only shown when details are active</summary>
             <pattern>
               <t>integer</t>
               <e>host</e>
@@ -26491,6 +26493,17 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 
   <!-- Compatibility changes between versions. -->
 
+  <change>
+    <command>GET_TASKS</command>
+    <summary>HOST_PROGRESS only shown with active details</summary>
+    <description>
+      <p>
+        The GET_TASKS command will only return the progress of individual hosts
+        in HOST_PROGRESS elements when details are requested.
+      </p>
+    </description>
+    <version>8.0</version>
+  </change>
   <change>
     <command>CREATE_FILTER, CREATE_TARGET</command>
     <summary>NAME MAKE_UNIQUE removed</summary>


### PR DESCRIPTION
The GET_TASKS command now only returns the progress of individual hosts
when details are requested.
This will avoid very large responses in case there are active or stopped
scans with many target hosts.