### PR TITLE
Remove report format special case from send_get_common (8.0)

### DIFF
--- a/src/gmp_get.c
+++ b/src/gmp_get.c
@@ -369,8 +369,7 @@ send_get_common (const char *type,
       /* Or the user has Admin rights and the resource is a permission or a
        * report format... */
       || (current_credentials.uuid
-          && (((strcmp (type, "permission") == 0)
-               || (strcmp (type, "report_format") == 0))
+          && ((strcmp (type, "permission") == 0)
               && get_iterator_uuid (iterator)
               /* ... but not the special Admin permission. */
               && permission_is_admin (get_iterator_uuid (iterator)))


### PR DESCRIPTION
There is no longer a special case for report formats in the permission
checks.  Access is now controlled by permissions that are explicitly
created when the report formats are loaded from disk.  So no need
for the special case when adding permissions to a GET response.