### PR TITLE
Skip free of context, in case we are in the context

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -30115,8 +30115,9 @@ init_gmp_process (int update_nvt_cache, const gchar *database,
   xml_parser.text = gmp_xml_handle_text;
   xml_parser.passthrough = NULL;
   xml_parser.error = gmp_xml_handle_error;
-  if (xml_context)
-    g_markup_parse_context_free (xml_context);
+  /* Don't free xml_context because we likely are inside the parser that is
+   * the context, which would cause Glib to freak out.  Just leak, the process
+   * is going to exit after this anyway. */
   xml_context = g_markup_parse_context_new
                  (&xml_parser,
                   0,


### PR DESCRIPTION
This can happen, for example, when running TEST_ALERT on a 'Start Task' alert.

Manager forks during the parsing and in the fork it initialises a new parser to serve
GMP to the alert.