### PR TITLE
[7.0] Specify SQLite requirements in INSTALL and CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,7 +226,8 @@ pkg_check_modules (GNUTLS REQUIRED gnutls>=3.2.15)
 pkg_check_modules (GLIB REQUIRED glib-2.0>=2.32)
 
 if (BACKEND STREQUAL SQLITE3)
-  pkg_check_modules (SQLITE3 REQUIRED sqlite3)
+  # sqlite3 3.8.3 is required for WITH syntax
+  pkg_check_modules (SQLITE3 REQUIRED sqlite3>=3.8.3)
 else (BACKEND STREQUAL SQLITE3)
   message (STATUS "Looking for PostgreSQL...")
   find_program (PG_CONFIG_EXECUTABLE pg_config DOC "pg_config")

--- a/INSTALL
+++ b/INSTALL
@@ -14,7 +14,7 @@ Prerequisites:
 * glib-2.0 >= 2.32
 * gnutls >= 3.2.15
 * libopenvas_base, libopenvas_omp, libopenvas_misc, libopenvas_osp >= 9.0.0
-* sqlite3 library or PostgreSQL database
+* sqlite3 library >= 3.8.3 or PostgreSQL database
 * pkg-config
 
 Prerequisites for certificate generation:
@@ -75,7 +75,7 @@ domain socket.
 
 The default is a UNIX domain socket, at
 
-	<install-prefix>/var/run/openvas/openvasmd.sock
+    <install-prefix>/var/run/openvas/openvasmd.sock
 
 This location can be overridden with the --unix-socket option, and the
 permissions of the socket can be specified with the --list-owner,


### PR DESCRIPTION
Backports of f0448207b1c08bcc16f23180b64932ef5d626155 and d20518948fa32bdd9a698c3bedb1dad4fb225b99

To avoid situations like e.g. https://community.greenbone.net/t/openvasmd-not-starting-after-update/1965/5