### PR TITLE
Rebuild cache for each chunk in CREATE_REPORT (8.0)

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -22504,7 +22504,7 @@ create_report (array_t *results, const char *task_id, const char *task_name,
 
           if (count == CREATE_REPORT_CHUNK_SIZE)
             {
-              report_cache_counts (report, 0, 0, NULL);
+              report_cache_counts (report, 1, 1, NULL);
               sql_commit ();
               gvm_usleep (CREATE_REPORT_CHUNK_SLEEP);
               sql_begin_immediate ();
@@ -22523,6 +22523,8 @@ create_report (array_t *results, const char *task_id, const char *task_name,
       g_free (quoted_qod);
       g_free (quoted_qod_type);
     }
+
+  report_cache_counts (report, 1, 1, NULL);
 
   if (first == 0)
     {


### PR DESCRIPTION
When adding the results of the imported report, delete the cache and
recount before every commit to ensure all results are counted.