### PR TITLE
Avoid race condition if possible

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -20715,10 +20715,17 @@ result_nvt_notice (const gchar *nvt)
 {
   if (nvt == NULL)
     return;
-  sql ("INSERT into result_nvts (nvt)"
-       " SELECT '%s' WHERE NOT EXISTS (SELECT * FROM result_nvts WHERE nvt = '%s');",
-       nvt,
-       nvt);
+  if (sql_is_sqlite3 ()
+      || (sql_int ("SELECT current_setting ('server_version_num')::integer;")
+          < 90500))
+    sql ("INSERT into result_nvts (nvt)"
+         " SELECT '%s' WHERE NOT EXISTS (SELECT * FROM result_nvts"
+         "                               WHERE nvt = '%s');",
+         nvt,
+         nvt);
+  else
+    sql ("INSERT INTO result_nvts (nvt) VALUES ('%s') ON CONFLICT DO NOTHING;",
+         nvt);
 }
 
 /**


### PR DESCRIPTION
There's a race condition using the WHERE NOT EXISTS SQL when
inserting new NVTs into result_nvts.  It should not occur so
easily in practice, but when running random-report-gen.gmp
this happens easily.

Solve only for Postgres, and only versions >= 9.5, for now.