### PR TITLE
 Allow special characters in credential login names (master)

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -22173,8 +22173,8 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("create_credential",
                                     "Login may only contain alphanumeric"
-                                    " characters if autogenerating"
-                                    " credential"));
+                                    " characters or the following:"
+                                    " - _ \\ @"));
                 break;
               case 3:
                 SEND_TO_CLIENT_OR_FAIL
@@ -26070,8 +26070,9 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
               case 4:
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("modify_credential",
-                                    "Login name must not be empty and contain"
-                                    " only alphanumeric characters"));
+                                    "Login name must not be empty and may"
+                                    " contain only alphanumeric characters"
+                                    " or the following: - _ \\ @"));
                 log_event_fail ("credential", "Credential",
                                 modify_credential_data->credential_id,
                                 "modified");

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -22174,7 +22174,7 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                  (XML_ERROR_SYNTAX ("create_credential",
                                     "Login may only contain alphanumeric"
                                     " characters or the following:"
-                                    " - _ \\ @"));
+                                    " - _ \\ . @"));
                 break;
               case 3:
                 SEND_TO_CLIENT_OR_FAIL
@@ -26072,7 +26072,7 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                  (XML_ERROR_SYNTAX ("modify_credential",
                                     "Login name must not be empty and may"
                                     " contain only alphanumeric characters"
-                                    " or the following: - _ \\ @"));
+                                    " or the following: - _ \\ . @"));
                 log_event_fail ("credential", "Credential",
                                 modify_credential_data->credential_id,
                                 "modified");

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -41588,7 +41588,7 @@ validate_credential_username (const gchar *username)
   s = username;
   while (*s)
     if (isalnum (*s)
-        || strchr ("-_\\@", *s))
+        || strchr ("-_\\.@", *s))
       s++;
     else
       return 0;

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -41874,6 +41874,10 @@ create_credential (const char* name, const char* comment, const char* login,
       set_credential_data (new_credential,
                            "username", login);
     }
+
+  if (key_public)
+    set_credential_data (new_credential, "public_key", key_public);
+
   if (certificate)
     {
       gchar *certificate_truncated;

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -41572,6 +41572,31 @@ set_credential_data (credential_t credential,
 }
 
 /**
+ * @brief Test if a username is valid to use in a credential.
+ *
+ * Valid usernames may only contain alphanumeric characters and a few
+ *  special ones to avoid problems with installer package generation.
+ *
+ * @param[in]  username  The username string to test.
+ *
+ * @return Whether the username is valid.
+ */
+static int
+validate_credential_username (const gchar *username)
+{
+  const char *s;
+  s = username;
+  while (*s)
+    if (isalnum (*s)
+        || strchr ("-_\\@", *s))
+      s++;
+    else
+      return 0;
+
+  return 1;
+}
+
+/**
  * @brief Test if a username is valid for a credential export format.
  *
  * @param[in]  username  The username string to test.
@@ -41644,7 +41669,7 @@ validate_credential_username_for_format (const gchar *username,
  * @param[in]  allow_insecure  Whether to allow insecure uses.
  * @param[out] credential      Created Credential.
  *
- * @return 0 success, 1 LSC credential exists already, 2 name contains space,
+ * @return 0 success, 1 LSC credential exists already, 2 invalid username,
  *         3 Failed to create public key from private key/password,
  *         4 Invalid credential type, 5 login username missing,
  *         6 password missing, 7 private key missing, 8 certificate missing,
@@ -41828,11 +41853,20 @@ create_credential (const char* name, const char* comment, const char* login,
 
   /* Add non-secret data */
   if (login)
-    set_credential_data (new_credential,
-                         "username", login);
-  if (key_public)
-    set_credential_data (new_credential, "public_key", key_public);
+    {
+      /*
+       * Ensure the login does not contain characters that cause problems
+       *  with package generation.
+       */
+      if (validate_credential_username (login) == 0)
+        {
+          sql_rollback ();
+          return 2;
+        }
 
+      set_credential_data (new_credential,
+                           "username", login);
+    }
   if (certificate)
     {
       gchar *certificate_truncated;
@@ -41841,7 +41875,10 @@ create_credential (const char* name, const char* comment, const char* login,
         set_credential_data (new_credential,
                              "certificate", certificate_truncated);
       else
-        return 17;
+        {
+          sql_rollback();
+          return 17;
+        }
       g_free (certificate_truncated);
     }
   if (auth_algorithm)
@@ -41997,23 +42034,6 @@ create_credential (const char* name, const char* comment, const char* login,
   /*
    * Auto-generate credential
    */
-
-  /* Ensure the login is alphanumeric, to help the package generation. */
-
-  if (login)
-    {
-      const char *s;
-      s = login;
-      while (*s)
-        if (isalnum (*s))
-          s++;
-        else
-          {
-            g_free (quoted_name);
-            sql_rollback ();
-            return 2;
-          }
-    }
 
   /* Create the keys and packages. */
 
@@ -42221,16 +42241,13 @@ modify_credential (const char *credential_id,
 
   if (login && ret == 0)
     {
-      const char *s;
-      s = login;
-      // Check if login contains only alphanumeric characters
-      if (strcmp (login, "") == 0)
+      /*
+       * Ensure the login is not empty and does not contain characters that
+       *  cause problems with package generation.
+       */
+      if (strcmp (login, "") == 0
+          || validate_credential_username (login) == 0)
         ret = 4;
-      while (*s && ret == 0)
-        if (isalnum (*s))
-          s++;
-        else
-          ret = 4;
 
       if (ret == 0)
         set_credential_login (credential, login);


### PR DESCRIPTION
The login usernames can now also contain these characters: - _ \ @ .
This is a port of #59.
