### PR TITLE
 Allow special characters in credential login names (8.0)

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -22264,8 +22264,8 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("create_credential",
                                     "Login may only contain alphanumeric"
-                                    " characters if autogenerating"
-                                    " credential"));
+                                    " characters or the following:"
+                                    " - _ \\ @"));
                 break;
               case 3:
                 SEND_TO_CLIENT_OR_FAIL
@@ -26161,8 +26161,9 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
               case 4:
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("modify_credential",
-                                    "Login name must not be empty and contain"
-                                    " only alphanumeric characters"));
+                                    "Login name must not be empty and may"
+                                    " contain only alphanumeric characters"
+                                    " or the following: - _ \\ @"));
                 log_event_fail ("credential", "Credential",
                                 modify_credential_data->credential_id,
                                 "modified");

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -22265,7 +22265,7 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                  (XML_ERROR_SYNTAX ("create_credential",
                                     "Login may only contain alphanumeric"
                                     " characters or the following:"
-                                    " - _ \\ @"));
+                                    " - _ \\ . @"));
                 break;
               case 3:
                 SEND_TO_CLIENT_OR_FAIL
@@ -26163,7 +26163,7 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                  (XML_ERROR_SYNTAX ("modify_credential",
                                     "Login name must not be empty and may"
                                     " contain only alphanumeric characters"
-                                    " or the following: - _ \\ @"));
+                                    " or the following: - _ \\ . @"));
                 log_event_fail ("credential", "Credential",
                                 modify_credential_data->credential_id,
                                 "modified");

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -41599,7 +41599,7 @@ validate_credential_username (const gchar *username)
   s = username;
   while (*s)
     if (isalnum (*s)
-        || strchr ("-_\\@", *s))
+        || strchr ("-_\\.@", *s))
       s++;
     else
       return 0;

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -41878,6 +41878,10 @@ create_credential (const char* name, const char* comment, const char* login,
       set_credential_data (new_credential,
                            "username", login);
     }
+
+  if (key_public)
+    set_credential_data (new_credential, "public_key", key_public);
+
   if (certificate)
     {
       gchar *certificate_truncated;


### PR DESCRIPTION
The login usernames can now also contain these characters: - _ \ @ .
This is a port of #59.