### PR TITLE
Update gvm-libs version requirements

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,7 +18,7 @@ Prerequisites:
 * cmake >= 3.0
 * glib-2.0 >= 2.42
 * gnutls >= 3.2.15
-* libgvm_base, libgvm_util, libgvm_osp, libgvm_gmp >= 1.0.0
+* libgvm_base, libgvm_util, libgvm_osp, libgvm_gmp >= 11.0.0
 * sqlite3 library >= 3.8.3 or PostgreSQL database
 * pkg-config
 * libical >= 1.0.0

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,10 +27,10 @@ find_package (Threads)
 ## list and throw an error, otherwise long install-cmake-install-cmake cycles
 ## might occur.
 
-pkg_check_modules (LIBGVM_BASE REQUIRED libgvm_base>=1.0.0)
-pkg_check_modules (LIBGVM_UTIL REQUIRED libgvm_util>=1.0.0)
-pkg_check_modules (LIBGVM_OSP REQUIRED libgvm_osp>=1.0.0)
-pkg_check_modules (LIBGVM_GMP REQUIRED libgvm_gmp>=1.0.0)
+pkg_check_modules (LIBGVM_BASE REQUIRED libgvm_base>=11.0.0)
+pkg_check_modules (LIBGVM_UTIL REQUIRED libgvm_util>=11.0.0)
+pkg_check_modules (LIBGVM_OSP REQUIRED libgvm_osp>=11.0.0)
+pkg_check_modules (LIBGVM_GMP REQUIRED libgvm_gmp>=11.0.0)
 pkg_check_modules (GNUTLS REQUIRED gnutls>=3.2.15)
 pkg_check_modules (GLIB REQUIRED glib-2.0>=2.42)
 pkg_check_modules (LIBICAL REQUIRED libical>=1.00)


### PR DESCRIPTION
The version number for gvm-libs master has changed from 1.0 to 11.0,
so the required versions are adjusted accordingly.