### PR TITLE
Add type filter column to GET_CONFIGS

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -37398,7 +37398,7 @@ sync_config (const char *config_id)
  */
 #define CONFIG_ITERATOR_FILTER_COLUMNS                                        \
  { GET_ITERATOR_FILTER_COLUMNS, "nvt_selector", "families_total",             \
-   "nvts_total", "families_trend", "nvts_trend", NULL }
+   "nvts_total", "families_trend", "nvts_trend", "type", NULL }
 
 /**
  * @brief Scan config iterator columns.

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -8016,6 +8016,15 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <type>boolean</type>
             <summary>Whether new NVTs will be added</summary>
           </column>
+          <column>
+            <name>type</name>
+            <type>
+              <alts>
+                <alt>0</alt>
+                <alt>1</alt>
+              </alts></type>
+            <summary>The type of the config (0 = OpenVAS, 1 OSP)</summary>
+          </column>
         </filter_keywords>
       </attrib>
       <attrib>
@@ -8160,9 +8169,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         </ele>
         <ele>
           <name>type</name>
-          <summary>The type the config.</summary>
+          <summary>The type of the config (0 = OpenVAS, 1 OSP)</summary>
           <pattern>
-            text
+            <t>
+              <alts>
+                <alt>0</alt>
+                <alt>1</alt>
+              </alts>
+            </t>
           </pattern>
         </ele>
         <ele>


### PR DESCRIPTION
This allows filtering and sorting configs by type and also
adds documentation of the numeric values.