### PR TITLE
Fix create_report cache update at end of results (8.0)

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -22531,12 +22531,10 @@ create_report (array_t *results, const char *task_id, const char *task_name,
       g_free (quoted_qod_type);
     }
 
-  report_cache_counts (report, 1, 1, NULL);
-
   if (first == 0)
     {
       sql (insert->str);
-      report_cache_counts (report, 0, 0, NULL);
+      report_cache_counts (report, 1, 1, NULL);
       sql_commit ();
       gvm_usleep (CREATE_REPORT_CHUNK_SLEEP);
       sql_begin_immediate ();


### PR DESCRIPTION
The last cache rebuild was run before the last insert, so the results
from this were not counted.