### PR TITLE
Check that roles exist earlier (8.0)

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -17778,6 +17778,7 @@ check_db (int check_encryption_key)
   create_tables ();
   check_db_sequences ();
   set_db_version (GVMD_DATABASE_VERSION);
+  check_db_roles ();
   check_db_nvt_selectors ();
   check_db_nvts ();
   check_db_configs ();
@@ -17789,7 +17790,6 @@ check_db (int check_encryption_key)
     goto fail;
   if (check_db_report_formats_trash ())
     goto fail;
-  check_db_roles ();
   check_db_permissions ();
   check_db_settings ();
   cleanup_schedule_times ();


### PR DESCRIPTION
This is so that other checks have access to the roles.  In
particular check_db_report_formats needs the roles to exist.