### PR TITLE
Remove -m SMB3 for smbclient in SMB alert (7.0)

### DIFF
--- a/src/alert_methods/SMB/alert
+++ b/src/alert_methods/SMB/alert
@@ -36,7 +36,7 @@ def smb_error_print(message, stdout, stderr):
 
 
 def smb_call(auth_path, share, command):
-    args = ["smbclient", "-m", "SMB3", "-A", auth_path, share, "-c", command]
+    args = ["smbclient", "-A", auth_path, share, "-c", command]
     retries = 10
     stdout = ''
     stderr = ''


### PR DESCRIPTION
This will allow changing the maximum protocol version via the smbclient
config instead of forcing a particular one in the alert script.