### PR TITLE
Request nvti_cache update only at very end of NVT update (7.0)

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -38456,9 +38456,6 @@ set_nvts_feed_version (const char *feed_version)
        sql_schema (),
        quoted);
   g_free (quoted);
-
-  sql ("UPDATE %s.meta SET value = 1 WHERE name = 'update_nvti_cache';",
-       sql_schema ());
 }
 
 /**
@@ -40367,6 +40364,10 @@ manage_complete_nvt_cache_update (GList *nvts_list, GList *nvt_preferences_list,
 
   if (mode == -2)
     sql_commit ();
+
+  /* Tell the main process to update its NVTi cache. */
+  sql ("UPDATE %s.meta SET value = 1 WHERE name = 'update_nvti_cache';",
+       sql_schema ());
 
   if (progress)
     progress ();


### PR DESCRIPTION
The nvti_cache is Manager's internal memory cache of NVT info. Previously the NVT
update process was flagging the nvti_cache for update in set_nvts_feed_version.
However, this happens at the end of the OTP plugins, before the OTP preferences
are received. This meant that the main process could update its nvti_cache
after the NVT update process had cleared the nvt_preferences table but before
the process had filled the table with the new preferences.

The result was an empty nvti_cache in the main process, which was causing scan
results to be recorded with incorrect information, like all having a 75% QOD.

Now the nvti_cache is flagged for update after the nvt_preferences table has been
updated.

Backport of https://github.com/greenbone/gvmd/pull/426 / https://github.com/greenbone/gvmd/pull/428