### PR TITLE
Wrap PostgreSQL exclusive table lock in function (master)

### DIFF
--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -649,6 +649,21 @@ manage_create_sql_functions ()
 
   /* Functions in pl/pgsql. */
 
+  /* Wrapping the "LOCK TABLE ... NOWAIT" like this will prevent
+   *  error messages in the PostgreSQL log if the lock is not available.
+   */
+  sql ("CREATE OR REPLACE FUNCTION try_exclusive_lock (regclass)"
+       " RETURNS integer AS $$"
+       " BEGIN"
+       "   EXECUTE 'LOCK TABLE \"'"
+       "           || $1"
+       "           || '\" IN ACCESS EXCLUSIVE MODE NOWAIT;';"
+       "   RETURN 1;"
+       " EXCEPTION WHEN lock_not_available THEN"
+       "   RETURN 0;"
+       " END;"
+       "$$ language 'plpgsql';");
+
   if (sql_int ("SELECT EXISTS (SELECT * FROM information_schema.tables"
                "               WHERE table_catalog = '%s'"
                "               AND table_schema = 'public'"

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -20541,7 +20541,7 @@ auto_delete_reports ()
 
       /* As in delete_report, this prevents other processes from getting the
        * report ID. */
-      if (sql_error ("LOCK table reports IN ACCESS EXCLUSIVE MODE NOWAIT;"))
+      if (sql_int ("SELECT try_exclusive_lock('reports');") == 0)
         {
           sql_rollback ();
           return;


### PR DESCRIPTION
Wrapping the "LOCK TABLE ... NOWAIT" in a function will prevent error
messages in the PostgreSQL log if the lock is not available.