### PR TITLE
Trim whole report when resuming slave scans (8.0)

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -4806,6 +4806,7 @@ run_task_setup (task_t task,
  *                          continue if stopped else start from beginning.
  * @param[in]   run_status  The task's run status.
  * @param[in]   last_stopped_report  Last stopped report of task.
+ * @param[in]   for_slave_scan  If the report is for a slave scan.
  *
  * @return 0 success, -1 error, -3 creating the report failed.
  */
@@ -4814,7 +4815,8 @@ run_task_prepare_report (task_t task,
                          char **report_id,
                          int from,
                          task_status_t run_status,
-                         report_t *last_stopped_report)
+                         report_t *last_stopped_report,
+                         gboolean for_slave_scan)
 {
   if ((from == 1)
       || ((from == 2)
@@ -4833,7 +4835,10 @@ run_task_prepare_report (task_t task,
 
       /* Remove partial host information from the report. */
 
-      trim_partial_report (*last_stopped_report);
+      if (for_slave_scan)
+        trim_report (*last_stopped_report);
+      else
+        trim_partial_report (*last_stopped_report);
 
       /* Ensure the report is marked as requested. */
 
@@ -4923,8 +4928,8 @@ run_slave_or_gmp_task (task_t task,
 
   /* Prepare the report. */
 
-  ret = run_task_prepare_report (
-    task, report_id, from, run_status, &last_stopped_report);
+  ret = run_task_prepare_report (task, report_id, from, run_status,
+                                 &last_stopped_report, TRUE);
   if (ret)
     {
       set_task_run_status (task, run_status);
@@ -5186,8 +5191,8 @@ run_otp_task (task_t task, scanner_t scanner, int from, char **report_id)
 
   /* Prepare the report. */
 
-  ret = run_task_prepare_report (
-    task, report_id, from, run_status, &last_stopped_report);
+  ret = run_task_prepare_report (task, report_id, from, run_status,
+                                 &last_stopped_report, FALSE);
   if (ret)
     {
       set_task_run_status (task, run_status);


### PR DESCRIPTION
When a slave task is resumed, the whole report is fetched from the slave
including results from already finished hosts, so these results would be
duplicated on the master if it kept the results from before.

(Port of #499 from openvas-manager-7.0)