### PR TITLE
Consider new vt refs in SQL data model.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 208)
+set (GVMD_DATABASE_VERSION 209)
 
 set (GVMD_SCAP_DATABASE_VERSION 15)
 

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -2844,7 +2844,7 @@ create_tables ()
 
   sql ("CREATE TABLE IF NOT EXISTS vt_refs"
        " (id SERIAL PRIMARY KEY,"
-       "  vt_oid text UNIQUE NOT NULL,"
+       "  vt_oid text NOT NULL,"
        "  type text NOT NULL,"
        "  ref_id text NOT NULL,"
        "  ref_text text);");

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -2861,8 +2861,6 @@ create_tables ()
        "  name text,"
        "  comment text,"
        "  cve text,"
-       "  bid text,"
-       "  xref text,"
        "  tag text,"
        "  category text,"
        "  family text,"

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -3216,6 +3216,9 @@ create_tables ()
   sql ("SELECT create_index ('nvts_by_solution_type',"
        "                     'nvts', 'solution_type');");
 
+  sql ("SELECT create_index ('vt_refs_by_vt_oid',"
+       "                     'vt_refs', 'vt_oid');");
+
   sql ("SELECT create_index ('permissions_by_name',"
        "                     'permissions', 'name');");
   sql ("SELECT create_index ('permissions_by_resource',"

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -2842,6 +2842,13 @@ create_tables ()
        "  name text,"
        "  value text);");
 
+  sql ("CREATE TABLE IF NOT EXISTS vt_refs"
+       " (id SERIAL PRIMARY KEY,"
+       "  vt_oid text UNIQUE NOT NULL,"
+       "  type text NOT NULL,"
+       "  ref_id text NOT NULL,"
+       "  ref_text text);");
+
   sql ("CREATE TABLE IF NOT EXISTS nvt_preferences"
        " (id SERIAL PRIMARY KEY,"
        "  name text UNIQUE NOT NULL,"

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014-2018 Greenbone Networks GmbH
+/* Copyright (C) 2014-2019 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *
@@ -2871,12 +2871,6 @@ create_tables ()
        "  qod integer,"
        "  qod_type text);");
 
-  sql ("CREATE TABLE IF NOT EXISTS nvt_cves"
-       " (id SERIAL PRIMARY KEY,"
-       "  nvt integer REFERENCES nvts (id) ON DELETE RESTRICT,"
-       "  oid text,"
-       "  cve_name text);");
-
   sql ("CREATE TABLE IF NOT EXISTS notes"
        " (id SERIAL PRIMARY KEY,"
        "  uuid text UNIQUE NOT NULL,"
@@ -3204,7 +3198,6 @@ create_tables ()
   sql ("SELECT create_index ('host_oss_by_host',"
        "                     'host_oss', 'host');");
 
-  sql ("SELECT create_index ('nvt_cves_by_oid', 'nvt_cves', 'oid');");
   sql ("SELECT create_index ('nvt_selectors_by_family_or_nvt',"
        "                     'nvt_selectors',"
        "                     'type, family_or_nvt');");

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -15430,19 +15430,33 @@ update_nvti_cache ()
   nvti_cache = nvtis_new ();
 
   init_iterator (&nvts,
-                 "SELECT oid, name, family, cvss_base, cve, bid, xref, tag"
+                 "SELECT oid, name, family, cvss_base, tag"
                  " FROM nvts;");
   while (next (&nvts))
     {
+      iterator_t refs;
       nvti_t *nvti = nvti_new ();
+
       nvti_set_oid (nvti, iterator_string (&nvts, 0));
       nvti_set_name (nvti, iterator_string (&nvts, 1));
       nvti_set_family (nvti, iterator_string (&nvts, 2));
       nvti_set_cvss_base (nvti, iterator_string (&nvts, 3));
-      nvti_add_refs (nvti, "cve", iterator_string (&nvts, 4), "");
-      nvti_add_refs (nvti, "bid", iterator_string (&nvts, 5), "");
-      nvti_add_refs (nvti, NULL, iterator_string (&nvts, 6), "");
-      nvti_set_tag (nvti, iterator_string (&nvts, 7));
+      nvti_set_tag (nvti, iterator_string (&nvts, 4));
+
+      init_iterator (&refs,
+                     "SELECT vt_oid, type, ref_id, ref_text"
+                     " FROM vt_refs"
+		     " WHERE vt_oid = '%s';", iterator_string (&nvts, 0));
+
+      while (next (&refs))
+        {
+          nvti_add_vtref (nvti, vtref_new (iterator_string (&refs, 0),
+                                           iterator_string (&refs, 1),
+                                           iterator_string (&refs, 2)));
+        }
+
+      cleanup_iterator (&refs);
+
       nvtis_add (nvti_cache, nvti);
     }
   cleanup_iterator (&nvts);

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -213,8 +213,8 @@ insert_nvt (const gchar *name, const gchar *cve, const gchar *bid,
             const gchar *xref, const gchar *tags, const gchar *cvss_base,
             const gchar *family, const gchar *oid, int category)
 {
-  gchar *qod_str, *qod_type;
-  gchar *quoted_name, *quoted_tag;
+  gchar *qod_str, *qod_type, *cve;
+  gchar *quoted_name, *quoted_cve, *quoted_tag;
   gchar *quoted_cvss_base, *quoted_qod_type, *quoted_family, *value;
   gchar *quoted_solution_type;
 <<<<<<< HEAD
@@ -239,7 +239,10 @@ insert_nvt (const gchar *name, const gchar *cve, const gchar *bid,
   else
     chunk_count++;
 
+  cve = nvti_refs (nvti, "cve", "", 0);
   quoted_name = sql_quote (nvti_name (nvti) ? nvti_name (nvti) : "");
+  quoted_cve = sql_quote (cve ? cve : "");
+  g_free (cve);
 
   if (nvti_tag (nvti))
 >>>>>>> Do not insert cve, bid and xref anymore into db.
@@ -369,12 +372,12 @@ insert_nvt (const gchar *name, const gchar *cve, const gchar *bid,
       int i;
 
       sql ("INSERT into nvts (oid, name,"
-           " tag, category, family, cvss_base,"
+           " cve, tag, category, family, cvss_base,"
            " creation_time, modification_time, uuid, solution_type,"
            " qod, qod_type)"
-           " VALUES ('%s', '%s', '%s', '%s', '%s',"
+           " VALUES ('%s', '%s', '%s', '%s', '%s', '%s',"
            " '%s', %i, '%s', '%s', %i, %i, '%s', '%s', %d, '%s');",
-           oid, quoted_name, quoted_tag,
+           oid, quoted_name, quoted_cve, quoted_tag,
            category, quoted_family, quoted_cvss_base, creation_time,
            modification_time, oid, quoted_solution_type,
            qod, quoted_qod_type);
@@ -397,6 +400,7 @@ insert_nvt (const gchar *name, const gchar *cve, const gchar *bid,
     }
 
   g_free (quoted_name);
+  g_free (quoted_cve);
   g_free (quoted_tag);
   g_free (quoted_cvss_base);
   g_free (quoted_family);

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -851,7 +851,7 @@ DEF_ACCESS (nvt_iterator_name, GET_ITERATOR_COLUMN_COUNT + 2);
  * @return Tag, or NULL if iteration is complete.  Freed by
  *         cleanup_iterator.
  */
-DEF_ACCESS (nvt_iterator_tag, GET_ITERATOR_COLUMN_COUNT + 6);
+DEF_ACCESS (nvt_iterator_tag, GET_ITERATOR_COLUMN_COUNT + 4);
 
 /**
  * @brief Get the category from an NVT iterator.
@@ -865,7 +865,7 @@ nvt_iterator_category (iterator_t* iterator)
 {
   int ret;
   if (iterator->done) return -1;
-  ret = iterator_int (iterator, GET_ITERATOR_COLUMN_COUNT + 7);
+  ret = iterator_int (iterator, GET_ITERATOR_COLUMN_COUNT + 5);
   return ret;
 }
 
@@ -877,7 +877,7 @@ nvt_iterator_category (iterator_t* iterator)
  * @return Family, or NULL if iteration is complete.  Freed by
  *         cleanup_iterator.
  */
-DEF_ACCESS (nvt_iterator_family, GET_ITERATOR_COLUMN_COUNT + 8);
+DEF_ACCESS (nvt_iterator_family, GET_ITERATOR_COLUMN_COUNT + 6);
 
 /**
  * @brief Get the cvss_base from an NVT iterator.
@@ -887,7 +887,7 @@ DEF_ACCESS (nvt_iterator_family, GET_ITERATOR_COLUMN_COUNT + 8);
  * @return Cvss_base, or NULL if iteration is complete.  Freed by
  *         cleanup_iterator.
  */
-DEF_ACCESS (nvt_iterator_cvss_base, GET_ITERATOR_COLUMN_COUNT + 9);
+DEF_ACCESS (nvt_iterator_cvss_base, GET_ITERATOR_COLUMN_COUNT + 7);
 
 /**
  * @brief Get the qod from an NVT iterator.
@@ -897,7 +897,7 @@ DEF_ACCESS (nvt_iterator_cvss_base, GET_ITERATOR_COLUMN_COUNT + 9);
  * @return QoD, or NULL if iteration is complete.  Freed by
  *         cleanup_iterator.
  */
-DEF_ACCESS (nvt_iterator_qod, GET_ITERATOR_COLUMN_COUNT + 12);
+DEF_ACCESS (nvt_iterator_qod, GET_ITERATOR_COLUMN_COUNT + 10);
 
 /**
  * @brief Get the qod_type from an NVT iterator.
@@ -907,7 +907,7 @@ DEF_ACCESS (nvt_iterator_qod, GET_ITERATOR_COLUMN_COUNT + 12);
  * @return QoD type, or NULL if iteration is complete.  Freed by
  *         cleanup_iterator.
  */
-DEF_ACCESS (nvt_iterator_qod_type, GET_ITERATOR_COLUMN_COUNT + 13);
+DEF_ACCESS (nvt_iterator_qod_type, GET_ITERATOR_COLUMN_COUNT + 11);
 
 /**
  * @brief Get the default timeout of an NVT.

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -214,10 +214,10 @@ insert_nvt (const gchar *name, const gchar *cve, const gchar *bid,
             const gchar *family, const gchar *oid, int category)
 {
   gchar *qod_str, *qod_type;
-  gchar *quoted_name;
-  gchar *quoted_cve, *quoted_bid, *quoted_xref, *quoted_tag;
+  gchar *quoted_name, *quoted_tag;
   gchar *quoted_cvss_base, *quoted_qod_type, *quoted_family, *value;
   gchar *quoted_solution_type;
+<<<<<<< HEAD
   int creation_time, modification_time, qod;
 
   quoted_name = sql_quote (name ? name : "");
@@ -225,6 +225,24 @@ insert_nvt (const gchar *name, const gchar *cve, const gchar *bid,
   quoted_bid = sql_quote (bid ? bid : "");
   quoted_xref = sql_quote (xref ? xref : "");
   if (tags)
+=======
+
+  int creation_time, modification_time, qod;
+
+  if (chunk_count == 0)
+    {
+      sql_begin_immediate ();
+      chunk_count++;
+    }
+  else if (chunk_count == CHUNK_SIZE)
+    chunk_count = 0;
+  else
+    chunk_count++;
+
+  quoted_name = sql_quote (nvti_name (nvti) ? nvti_name (nvti) : "");
+
+  if (nvti_tag (nvti))
+>>>>>>> Do not insert cve, bid and xref anymore into db.
     {
       gchar **split, **point;
       GString *tag;
@@ -351,13 +369,12 @@ insert_nvt (const gchar *name, const gchar *cve, const gchar *bid,
       int i;
 
       sql ("INSERT into nvts (oid, name,"
-           " cve, bid, xref, tag, category, family, cvss_base,"
+           " tag, category, family, cvss_base,"
            " creation_time, modification_time, uuid, solution_type,"
            " qod, qod_type)"
            " VALUES ('%s', '%s', '%s', '%s', '%s',"
            " '%s', %i, '%s', '%s', %i, %i, '%s', '%s', %d, '%s');",
-           oid, quoted_name,
-           quoted_cve, quoted_bid, quoted_xref, quoted_tag,
+           oid, quoted_name, quoted_tag,
            category, quoted_family, quoted_cvss_base, creation_time,
            modification_time, oid, quoted_solution_type,
            qod, quoted_qod_type);
@@ -380,9 +397,6 @@ insert_nvt (const gchar *name, const gchar *cve, const gchar *bid,
     }
 
   g_free (quoted_name);
-  g_free (quoted_cve);
-  g_free (quoted_bid);
-  g_free (quoted_xref);
   g_free (quoted_tag);
   g_free (quoted_cvss_base);
   g_free (quoted_family);

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -342,8 +342,8 @@ insert_nvt (const gchar *name, const gchar *cve, const gchar *tags,
            " cve, tag, category, family, cvss_base,"
            " creation_time, modification_time, uuid, solution_type,"
            " qod, qod_type)"
-           " VALUES ('%s', '%s', '%s', '%s', '%s', '%s',"
-           " '%s', %i, '%s', '%s', %i, %i, '%s', '%s', %d, '%s');",
+           " VALUES ('%s', '%s', '%s', '%s',"
+           " %i, '%s', '%s', %i, %i, '%s', '%s', %d, '%s');",
            oid, quoted_name, quoted_cve, quoted_tag,
            category, quoted_family, quoted_cvss_base, creation_time,
            modification_time, oid, quoted_solution_type,

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -347,17 +347,37 @@ insert_nvt (const gchar *name, const gchar *cve, const gchar *bid,
     g_warning ("%s: NVT with OID %s exists already, ignoring", __FUNCTION__,
                oid);
   else
-    sql ("INSERT into nvts (oid, name,"
-         " cve, bid, xref, tag, category, family, cvss_base,"
-         " creation_time, modification_time, uuid, solution_type,"
-         " qod, qod_type)"
-         " VALUES ('%s', '%s', '%s', '%s', '%s',"
-         " '%s', %i, '%s', '%s', %i, %i, '%s', '%s', %d, '%s');",
-         oid, quoted_name,
-         quoted_cve, quoted_bid, quoted_xref, quoted_tag,
-         category, quoted_family, quoted_cvss_base, creation_time,
-         modification_time, oid, quoted_solution_type,
-         qod, quoted_qod_type);
+    {
+      int i;
+
+      sql ("INSERT into nvts (oid, name,"
+           " cve, bid, xref, tag, category, family, cvss_base,"
+           " creation_time, modification_time, uuid, solution_type,"
+           " qod, qod_type)"
+           " VALUES ('%s', '%s', '%s', '%s', '%s',"
+           " '%s', %i, '%s', '%s', %i, %i, '%s', '%s', %d, '%s');",
+           oid, quoted_name,
+           quoted_cve, quoted_bid, quoted_xref, quoted_tag,
+           category, quoted_family, quoted_cvss_base, creation_time,
+           modification_time, oid, quoted_solution_type,
+           qod, quoted_qod_type);
+
+      sql ("DELETE FROM vt_refs where vt_oid = '%s';", nvti_oid (nvti));
+
+      for (i = 0; i < nvti_vtref_len (nvti); i++)
+        {
+          vtref_t *ref = nvti_vtref (nvti, i);
+          gchar *quoted_id = sql_quote (vtref_id (ref));
+          gchar *quoted_text = sql_quote (vtref_text (ref));
+
+          sql ("INSERT into vt_refs (vt_oid, type, ref_id, ref_text)"
+               " VALUES ('%s', '%s', '%s', '%s');",
+               nvti_oid (nvti), vtref_type (ref), quoted_id, quoted_text);
+
+          g_free (quoted_id);
+          g_free (quoted_text);
+        }
+    }
 
   g_free (quoted_name);
   g_free (quoted_cve);

--- a/src/manage_sql_nvts.h
+++ b/src/manage_sql_nvts.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2010-2018 Greenbone Networks GmbH
+/* Copyright (C) 2010-2019 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *
@@ -29,7 +29,7 @@
  * @brief Filter columns for NVT info iterator.
  */
 #define NVT_INFO_ITERATOR_FILTER_COLUMNS                                    \
- { GET_ITERATOR_FILTER_COLUMNS, "version", "cve", "bid", "xref",            \
+ { GET_ITERATOR_FILTER_COLUMNS, "version", "cve",                           \
    "family", "cvss_base", "severity", "cvss", "script_tags", "qod",         \
    "qod_type", "solution_type", NULL }
 
@@ -45,8 +45,6 @@
    { "modification_time", "version", KEYWORD_TYPE_INTEGER },                \
    { "name", NULL, KEYWORD_TYPE_STRING },                                   \
    { "cve", NULL, KEYWORD_TYPE_STRING },                                    \
-   { "bid", NULL, KEYWORD_TYPE_STRING },                                    \
-   { "xref", NULL, KEYWORD_TYPE_STRING },                                   \
    { "tag", NULL, KEYWORD_TYPE_STRING },                                    \
    { "category", NULL, KEYWORD_TYPE_STRING },                               \
    { "family", NULL, KEYWORD_TYPE_STRING },                                 \
@@ -72,8 +70,6 @@
    { "modification_time", "version", KEYWORD_TYPE_INTEGER },                \
    { "nvts.name", NULL, KEYWORD_TYPE_STRING },                              \
    { "cve", NULL, KEYWORD_TYPE_STRING },                                    \
-   { "bid", NULL, KEYWORD_TYPE_STRING },                                    \
-   { "xref", NULL, KEYWORD_TYPE_STRING },                                   \
    { "tag", NULL, KEYWORD_TYPE_STRING },                                    \
    { "category", NULL, KEYWORD_TYPE_STRING },                               \
    { "nvts.family", NULL, KEYWORD_TYPE_STRING },                            \

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -920,7 +920,7 @@ init_nvt_cert_bund_adv_iterator (iterator_t *iterator, const char *oid,
                  " WHERE id IN (SELECT adv_id FROM cert_bund_cves"
                  "              WHERE cve_name IN (SELECT ref_id"
                  "                                 FROM vt_refs"
-                 "                                 WHERE oid = '%s'"
+                 "                                 WHERE vt_oid = '%s'"
 		 "                                   AND type = 'cve'))"
                  " ORDER BY %s %s;",
                  columns,
@@ -1101,7 +1101,7 @@ init_nvt_dfn_cert_adv_iterator (iterator_t *iterator, const char *oid,
                  " WHERE id IN (SELECT adv_id FROM dfn_cert_cves"
                  "              WHERE cve_name IN (SELECT ref_id"
                  "                                 FROM vt_refs"
-                 "                                 WHERE oid = '%s'"
+                 "                                 WHERE vt_oid = '%s'"
 		 "                                   AND type = 'cve'))"
                  " ORDER BY %s %s;",
                  columns,

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2009-2018 Greenbone Networks GmbH
+/* Copyright (C) 2009-2019 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *
@@ -918,9 +918,10 @@ init_nvt_cert_bund_adv_iterator (iterator_t *iterator, const char *oid,
                  "SELECT %s"
                  " FROM cert_bund_advs"
                  " WHERE id IN (SELECT adv_id FROM cert_bund_cves"
-                 "              WHERE cve_name IN (SELECT cve_name"
-                 "                                 FROM nvt_cves"
-                 "                                 WHERE oid = '%s'))"
+                 "              WHERE cve_name IN (SELECT ref_id"
+                 "                                 FROM vt_refs"
+                 "                                 WHERE oid = '%s'"
+		 "                                   AND type = 'cve'))"
                  " ORDER BY %s %s;",
                  columns,
                  oid,
@@ -1098,9 +1099,10 @@ init_nvt_dfn_cert_adv_iterator (iterator_t *iterator, const char *oid,
                  "SELECT %s"
                  " FROM dfn_cert_advs"
                  " WHERE id IN (SELECT adv_id FROM dfn_cert_cves"
-                 "              WHERE cve_name IN (SELECT cve_name"
-                 "                                 FROM nvt_cves"
-                 "                                 WHERE oid = '%s'))"
+                 "              WHERE cve_name IN (SELECT ref_id"
+                 "                                 FROM vt_refs"
+                 "                                 WHERE oid = '%s'"
+		 "                                   AND type = 'cve'))"
                  " ORDER BY %s %s;",
                  columns,
                  oid,

--- a/src/manage_sql_secinfo.h
+++ b/src/manage_sql_secinfo.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2010-2018 Greenbone Networks GmbH
+/* Copyright (C) 2010-2019 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *
@@ -30,18 +30,20 @@
  */
 #define SECINFO_SQL_RESULT_HAS_CERT_BUNDS                          \
  "(SELECT EXISTS (SELECT * FROM cert_bund_cves"                    \
- "                WHERE cve_name IN (SELECT cve_name"              \
- "                                   FROM nvt_cves"                \
- "                                   WHERE oid = results.nvt)))"
+ "                WHERE cve_name IN (SELECT ref_id"                \
+ "                                   FROM vt_refs"                 \
+ "                                   WHERE oid = results.nvt"      \
+ "                                     AND type = 'cve')))"
 
 /**
  * @brief SQL to check if a result has CERT Bunds.
  */
 #define SECINFO_SQL_RESULT_HAS_DFN_CERTS                           \
  "(SELECT EXISTS (SELECT * FROM dfn_cert_cves"                     \
- "                WHERE cve_name IN (SELECT cve_name"              \
- "                                   FROM nvt_cves"                \
- "                                   WHERE oid = results.nvt)))"
+ "                WHERE cve_name IN (SELECT ref_id"                \
+ "                                   FROM vt_refs"                 \
+ "                                   WHERE oid = results.nvt"      \
+ "                                     AND type = 'cve')))"
 
 /**
  * @brief Filter columns for CVE iterator.

--- a/src/manage_sql_secinfo.h
+++ b/src/manage_sql_secinfo.h
@@ -32,7 +32,7 @@
  "(SELECT EXISTS (SELECT * FROM cert_bund_cves"                    \
  "                WHERE cve_name IN (SELECT ref_id"                \
  "                                   FROM vt_refs"                 \
- "                                   WHERE oid = results.nvt"      \
+ "                                   WHERE vt_oid = results.nvt"   \
  "                                     AND type = 'cve')))"
 
 /**
@@ -42,7 +42,7 @@
  "(SELECT EXISTS (SELECT * FROM dfn_cert_cves"                     \
  "                WHERE cve_name IN (SELECT ref_id"                \
  "                                   FROM vt_refs"                 \
- "                                   WHERE oid = results.nvt"      \
+ "                                   WHERE vt_oid = results.nvt"   \
  "                                     AND type = 'cve')))"
 
 /**


### PR DESCRIPTION
Essentially the columns "bid", "xrefs" and "cve" are removed from table "nvts".
These fields contained comma-separated lists of references where xref
hat a addtional colon-separation to define a type.

A new table "vt_refs" will store all these references with one reference per entry.
This removes the internal syntax of comma/colon-separation and the respective parsing.

Subsequently many places are changed because actually the access to the 
references is now simpler. Even some some helper tables can be removed.

"bid" and "xref" are relatively easy to resolve. But for "cve" many internal logic
algorithms need adjustments.

The changes are not applied for the sqlite3 case, only for PostgreSQL. 

Required:
https://github.com/greenbone/gvm-libs/pull/232