### PR TITLE
Fix --slave-commit-size option

### DIFF
--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1898,7 +1898,7 @@ main (int argc, char **argv)
      '\0',
      0,
      G_OPTION_ARG_INT,
-     &secinfo_commit_size,
+     &slave_commit_size,
      "During slave updates, commit after every <number> updated results and"
      " hosts, 0 for unlimited",
      "<number>"},


### PR DESCRIPTION
The option was using the value from --secinfo-commit-size by
mistake.