### PR TITLE
Add --slave-commit-size option (master)

### DIFF
--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1717,6 +1717,7 @@ main (int argc, char** argv)
   static gchar *scanner_key_priv = NULL;
   static int schedule_timeout = SCHEDULE_TIMEOUT_DEFAULT;
   static int secinfo_commit_size = SECINFO_COMMIT_SIZE_DEFAULT;
+  static int slave_commit_size = SLAVE_COMMIT_SIZE_DEFAULT;
   static gchar *delete_scanner = NULL;
   static gchar *verify_scanner = NULL;
   static gchar *priorities = "NORMAL";
@@ -1790,6 +1791,14 @@ main (int argc, char** argv)
         { "get-scanners", '\0', 0, G_OPTION_ARG_NONE, &get_scanners, "List scanners and exit.", NULL },
         { "secinfo-commit-size", '\0', 0, G_OPTION_ARG_INT, &secinfo_commit_size, "During CERT and SCAP sync, commit updates to the database every <number> items, 0 for unlimited, default: " G_STRINGIFY (SECINFO_COMMIT_SIZE_DEFAULT), "<number>" },
         { "schedule-timeout", '\0', 0, G_OPTION_ARG_INT, &schedule_timeout, "Time out tasks that are more than <time> minutes overdue. -1 to disable, 0 for minimum time, default: " G_STRINGIFY (SCHEDULE_TIMEOUT_DEFAULT), "<time>" },
+        {"slave-commit-size",
+         '\0',
+         0,
+         G_OPTION_ARG_INT,
+         &slave_commit_size,
+         "During slave updates, commit after every <number> updated results and"
+         " hosts, 0 for unlimited",
+         "<number>"},
         { "foreground", 'f', 0, G_OPTION_ARG_NONE, &foreground, "Run in foreground.", NULL },
         { "inheritor", '\0', 0, G_OPTION_ARG_STRING, &inheritor, "Have <username> inherit from deleted user.", "<username>" },
         { "listen", 'a', 0, G_OPTION_ARG_STRING, &manager_address_string, "Listen on <address>.", "<address>" },
@@ -1873,6 +1882,9 @@ main (int argc, char** argv)
   /* Set schedule_timeout */
 
   set_schedule_timeout (schedule_timeout);
+
+  /* Set slave commit size */
+  set_slave_commit_size (slave_commit_size);
 
   /* Set SecInfo update commit size */
 

--- a/src/manage.h
+++ b/src/manage.h
@@ -2657,6 +2657,14 @@ int
 manage_system_report (const char *, const char *, const char *, const char *,
                       const char *, char **);
 
+
+/* Scanners. */
+
+/**
+ * @brief Default for slave update commit size.
+ */
+#define SLAVE_COMMIT_SIZE_DEFAULT 0
+
 int
 manage_create_scanner (GSList *, const char *, const char *, const char *,
                        const char *, const char *, const char *, const char *,
@@ -2816,6 +2824,9 @@ osp_scanner_connect (scanner_t);
 
 int
 verify_scanner (const char *, char **);
+
+void
+set_slave_commit_size (int);
 
 /* Scheduling. */
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -496,6 +496,11 @@ static manage_connection_forker_t manage_fork_connection;
 static int max_hosts = MANAGE_MAX_HOSTS;
 
 /**
+ * @brief Maximum number of SQL queries per transaction in slave updates.
+ */
+static int slave_commit_size = SLAVE_COMMIT_SIZE_DEFAULT;
+
+/**
  * @brief Default max number of bytes of reports included in email alerts.
  */
 #define MAX_CONTENT_LENGTH 20000
@@ -54041,6 +54046,20 @@ verify_report_format (const char *report_format_id)
 /* GMP slave scanners. */
 
 /**
+ * @brief Set the slave update commit size.
+ *
+ * @param new_commit_size The new slave update commit size.
+ */
+void
+set_slave_commit_size (int new_commit_size)
+{
+  if (new_commit_size < 0)
+    slave_commit_size = 0;
+  else
+    slave_commit_size = new_commit_size;
+}
+
+/**
  * @brief Update the local task from the slave task.
  *
  * @param[in]   task         The local task.
@@ -54056,6 +54075,7 @@ update_from_slave (task_t task, entity_t get_report, entity_t *report,
 {
   entity_t entity, host_start, start;
   entities_t results, hosts, entities;
+  int current_commit_size;
 
   entity = entity_child (get_report, "report");
   if (entity == NULL)
@@ -54084,6 +54104,7 @@ update_from_slave (task_t task, entity_t get_report, entity_t *report,
 
   sql_begin_immediate ();
   hosts = (*report)->entities;
+  current_commit_size = 0;
   while ((host_start = first_entity (hosts)))
     {
       if (strcmp (entity_name (host_start), "host") == 0)
@@ -54109,6 +54130,14 @@ update_from_slave (task_t task, entity_t get_report, entity_t *report,
                                     entity_text (start));
         }
       hosts = next_entities (hosts);
+
+      current_commit_size++;
+      if (slave_commit_size && current_commit_size >= slave_commit_size)
+        {
+          sql_commit ();
+          sql_begin_immediate ();
+          current_commit_size = 0;
+        }
     }
   sql_commit ();
 
@@ -54120,6 +54149,7 @@ update_from_slave (task_t task, entity_t get_report, entity_t *report,
 
   sql_begin_immediate ();
   results = entity->entities;
+  current_commit_size = 0;
   while ((entity = first_entity (results)))
     {
       if (strcmp (entity_name (entity), "result") == 0)
@@ -54164,6 +54194,14 @@ update_from_slave (task_t task, entity_t get_report, entity_t *report,
                                   entity_text (description));
             if (global_current_report)
               report_add_result (global_current_report, result);
+
+            current_commit_size++;
+            if (slave_commit_size && current_commit_size >= slave_commit_size)
+              {
+                sql_commit ();
+                sql_begin_immediate ();
+                current_commit_size = 0;
+              }
           }
 
           (*next_result)++;


### PR DESCRIPTION
This option allows splitting large transactions when updating reports
from a slave into multiple smaller ones, for example when resuming a
scan with many hosts and results.

This is a port of #449 with the fix from #555.