### PR TITLE
Fix various typos.

### DIFF
--- a/doc/about-cert-feed.txt
+++ b/doc/about-cert-feed.txt
@@ -14,7 +14,7 @@ Response Teams (CERTs). Many CERTs act regional and publish the advisories
 in local languages. The regional focus is a helpful complementation of
 the english CVE publications. In most cases, CERT advisories are
 referring to one or more CVEs and therfore can be linked
-into the vulerability management, for example into scan results.
+into the vulnerability management, for example into scan results.
 
 In the following, relevant aspects on format and structure are documented
 for the integrated CERTs.

--- a/report_formats/simple_map_plot/generate
+++ b/report_formats/simple_map_plot/generate
@@ -21,7 +21,7 @@
 #
 # This mapgenerator creates a PNG image showing hosts on a worldmap.
 # The first step is to create a CSV file from the GMP report using xsltproc.
-# Then the file is merged with the file contianing the location information.
+# Then the file is merged with the file containing the location information.
 # To generate the map, the resulting CSV file is converted into the shape format
 # used by MapServer and then drawn to the image file using shp2img.
 

--- a/src/manage_utils.c
+++ b/src/manage_utils.c
@@ -1545,7 +1545,7 @@ icalendar_next_time_from_rdates (GPtrArray *rdates,
       iter_time = icaltime_as_timet_with_zone (*iter_time_ical, tz);
       time_diff = iter_time - ref_time;
 
-      // Cases: previous (offset -1): lastest before reference
+      // Cases: previous (offset -1): latest before reference
       //        next     (offset  0): earliest after reference
       if ((periods_offset == -1 && time_diff < 0 && time_diff > old_diff)
           || (periods_offset == 0 && time_diff > 0 && time_diff < old_diff))

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -26355,7 +26355,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         respective REF type is the former prefix of the XREF, for example "URL".
       </p>
       <p>
-        The "NOCVE", "NOXREF" and "NOBID" strings that previously indicated the absense
+        The "NOCVE", "NOXREF" and "NOBID" strings that previously indicated the absence
         of a CVE, XREF or BID are not applied anymore.
       </p>
     </description>

--- a/tools/greenbone-certdata-sync.in
+++ b/tools/greenbone-certdata-sync.in
@@ -413,7 +413,7 @@ sync_certdata(){
     log_notice "Synchronization with the Greenbone CERT data Repository successful."
     echo
   else
-    log_notice "No Greenbone Security Feed accees key found, falling back to Greenbone Community Feed"
+    log_notice "No Greenbone Security Feed access key found, falling back to Greenbone Community Feed"
     do_sync_community_feed
   fi
 

--- a/tools/greenbone-scapdata-sync.in
+++ b/tools/greenbone-scapdata-sync.in
@@ -297,7 +297,7 @@ is_feed_current () {
     fi
     remove_tmp_key
   else
-    log_notice "No Greenbone Security Feed accees key found, falling back to Greenbone Community Feed"
+    log_notice "No Greenbone Security Feed access key found, falling back to Greenbone Community Feed"
     eval "$RSYNC -ltvrP \"$COMMUNITY_SCAP_RSYNC_FEED/timestamp\" \"$FEED_INFO_TEMP_DIR\""
     if [ $? -ne 0 ]
     then
@@ -432,7 +432,7 @@ sync_scapdata(){
     done
     log_notice "Synchronization with the Greenbone SCAP data Repository successful."
   else
-    log_notice "No Greenbone Security Feed accees key found, falling back to Greenbone Community Feed"
+    log_notice "No Greenbone Security Feed access key found, falling back to Greenbone Community Feed"
     do_sync_community_feed
   fi
 


### PR DESCRIPTION
Found via codespell 1.15

There is still one left:

```
./src/gmp.c:19602: Vulnerabilitie  ==> Vulnerability
```

where the following is used and where i'm not sure if this is really correct or not:

```
INIT_GET (vuln, Vulnerabilitie);
```