### PR TITLE
Add vt_refs table

### DIFF
--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -3225,9 +3225,6 @@ create_tables ()
   sql ("SELECT create_index ('nvts_by_solution_type',"
        "                     'nvts', 'solution_type');");
 
-  sql ("SELECT create_index ('vt_refs_by_vt_oid',"
-       "                     'vt_refs', 'vt_oid');");
-
   sql ("SELECT create_index ('permissions_by_name',"
        "                     'permissions', 'name');");
   sql ("SELECT create_index ('permissions_by_resource',"
@@ -3250,6 +3247,9 @@ create_tables ()
 
   sql ("SELECT create_index ('tag_resources_trash_by_tag',"
        "                     'tag_resources_trash', 'tag');");
+
+  sql ("SELECT create_index ('vt_refs_by_vt_oid',"
+       "                     'vt_refs', 'vt_oid');");
 
 
 #if 0

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -2842,6 +2842,13 @@ create_tables ()
        "  name text,"
        "  value text);");
 
+  sql ("CREATE TABLE IF NOT EXISTS vt_refs"
+       " (id SERIAL PRIMARY KEY,"
+       "  vt_oid text NOT NULL,"
+       "  type text NOT NULL,"
+       "  ref_id text NOT NULL,"
+       "  ref_text text);");
+
   sql ("CREATE TABLE IF NOT EXISTS nvt_preferences"
        " (id SERIAL PRIMARY KEY,"
        "  name text UNIQUE NOT NULL,"
@@ -3217,6 +3224,9 @@ create_tables ()
        "                     'nvts', 'cvss_base');");
   sql ("SELECT create_index ('nvts_by_solution_type',"
        "                     'nvts', 'solution_type');");
+
+  sql ("SELECT create_index ('vt_refs_by_vt_oid',"
+       "                     'vt_refs', 'vt_oid');");
 
   sql ("SELECT create_index ('permissions_by_name',"
        "                     'permissions', 'name');");

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -337,17 +337,37 @@ insert_nvt (const nvti_t *nvti)
     g_warning ("%s: NVT with OID %s exists already, ignoring", __FUNCTION__,
                nvti_oid (nvti));
   else
-    sql ("INSERT into nvts (oid, name,"
-         " cve, bid, xref, tag, category, family, cvss_base,"
-         " creation_time, modification_time, uuid, solution_type,"
-         " qod, qod_type)"
-         " VALUES ('%s', '%s', '%s', '%s', '%s',"
-         " '%s', %i, '%s', '%s', %i, %i, '%s', '%s', %d, '%s');",
-         nvti_oid (nvti), quoted_name,
-         quoted_cve, quoted_bid, quoted_xref, quoted_tag,
-         nvti_category (nvti), quoted_family, quoted_cvss_base, creation_time,
-         modification_time, nvti_oid (nvti), quoted_solution_type,
-         qod, quoted_qod_type);
+    {
+      int i;
+
+      sql ("INSERT into nvts (oid, name,"
+           " cve, bid, xref, tag, category, family, cvss_base,"
+           " creation_time, modification_time, uuid, solution_type,"
+           " qod, qod_type)"
+           " VALUES ('%s', '%s', '%s', '%s', '%s',"
+           " '%s', %i, '%s', '%s', %i, %i, '%s', '%s', %d, '%s');",
+           nvti_oid (nvti), quoted_name,
+           quoted_cve, quoted_bid, quoted_xref, quoted_tag,
+           nvti_category (nvti), quoted_family, quoted_cvss_base, creation_time,
+           modification_time, nvti_oid (nvti), quoted_solution_type,
+           qod, quoted_qod_type);
+
+      sql ("DELETE FROM vt_refs where vt_oid = '%s';", nvti_oid (nvti));
+
+      for (i = 0; i < nvti_vtref_len (nvti); i++)
+        {
+          vtref_t *ref = nvti_vtref (nvti, i);
+          gchar *quoted_id = sql_quote (vtref_id (ref));
+          gchar *quoted_text = sql_quote (vtref_text (ref) ? vtref_text (ref) : "");
+
+          sql ("INSERT into vt_refs (vt_oid, type, ref_id, ref_text)"
+               " VALUES ('%s', '%s', '%s', '%s');",
+               nvti_oid (nvti), vtref_type (ref), quoted_id, quoted_text);
+
+          g_free (quoted_id);
+          g_free (quoted_text);
+        }
+    }
 
   g_free (quoted_name);
   g_free (quoted_cve);

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -356,9 +356,12 @@ insert_nvt (const nvti_t *nvti)
 
       for (i = 0; i < nvti_vtref_len (nvti); i++)
         {
-          vtref_t *ref = nvti_vtref (nvti, i);
-          gchar *quoted_id = sql_quote (vtref_id (ref));
-          gchar *quoted_text = sql_quote (vtref_text (ref) ? vtref_text (ref) : "");
+          vtref_t *ref;
+          gchar *quoted_id, *quoted_text;
+
+          ref = nvti_vtref (nvti, i);
+          quoted_id = sql_quote (vtref_id (ref));
+          quoted_text = sql_quote (vtref_text (ref) ? vtref_text (ref) : "");
 
           sql ("INSERT into vt_refs (vt_oid, type, ref_id, ref_text)"
                " VALUES ('%s', '%s', '%s', '%s');",

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1520,6 +1520,9 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
     {
       entity_t vts;
 
+      g_info ("OSP service has newer VT status (version %s) than in database (version %s, %i VTs). Starting update ...",
+              scanner_feed_version, db_feed_version, sql_int ("SELECT count (*) FROM nvts;"));
+
       connection = osp_connection_new (update_socket, 0, NULL, NULL, NULL);
       if (!connection)
         {
@@ -1543,7 +1546,7 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
       sql ("UPDATE %s.meta SET value = 1 WHERE name = 'update_nvti_cache';",
            sql_schema ());
 
-      g_info ("Updating NVT cache... done (%i NVTs).",
+      g_info ("Updating VTs in database ... done (%i VTs).",
               sql_int ("SELECT count (*) FROM nvts;"));
     }
 


### PR DESCRIPTION
The table "vt_refs" is created and when a next VT update  is running, the table will be filled with the references of the VTs.

In total currently about 370K entries should appear in the table.
A subsequent feed update takes about 4-5 minutes and there is a additional log entry to follow this activity more easily.

The content of the vt_refs table is not used yet. The same information redundantly is still in the nvts table. Switching over to using the vt_refs and removing the redundant data in nvts is subject to subsequent pull requests. 

The new table and index is only implemented for PostgreSQL. SQLite3-based setups will fail during run time.