### PR TITLE
Drop table nvt_cves

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 208)
+set (GVMD_DATABASE_VERSION 209)
 
 set (GVMD_SCAP_DATABASE_VERSION 15)
 

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -1704,6 +1704,39 @@ migrate_207_to_208 ()
   return 0;
 }
 
+/**
+ * @brief Migrate the database from version 208 to version 209.
+ *
+ * @return 0 success, -1 error.
+ */
+int
+migrate_208_to_209 ()
+{
+  sql_begin_immediate ();
+
+  /* Ensure that the database is currently version 208. */
+
+  if (manage_db_version () != 208)
+    {
+      sql_rollback ();
+      return -1;
+    }
+
+  /* Update the database. */
+
+  /* Drop the now-unused table "nvt_cves". */
+
+  sql ("DROP TABLE IF EXISTS nvt_cves;");
+
+  /* Set the database version to 209. */
+
+  set_db_version (209);
+
+  sql_commit ();
+
+  return 0;
+}
+
 #undef UPDATE_DASHBOARD_SETTINGS
 
 /**
@@ -1739,6 +1772,7 @@ static migrator_t database_migrators[] = {
   {206, migrate_205_to_206},
   {207, migrate_206_to_207},
   {208, migrate_207_to_208},
+  {209, migrate_208_to_209},
   /* End marker. */
   {-1, NULL}};
 

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -2873,12 +2873,6 @@ create_tables ()
        "  qod integer,"
        "  qod_type text);");
 
-  sql ("CREATE TABLE IF NOT EXISTS nvt_cves"
-       " (id SERIAL PRIMARY KEY,"
-       "  nvt integer REFERENCES nvts (id) ON DELETE RESTRICT,"
-       "  oid text,"
-       "  cve_name text);");
-
   sql ("CREATE TABLE IF NOT EXISTS notes"
        " (id SERIAL PRIMARY KEY,"
        "  uuid text UNIQUE NOT NULL,"
@@ -3206,7 +3200,6 @@ create_tables ()
   sql ("SELECT create_index ('host_oss_by_host',"
        "                     'host_oss', 'host');");
 
-  sql ("SELECT create_index ('nvt_cves_by_oid', 'nvt_cves', 'oid');");
   sql ("SELECT create_index ('nvt_selectors_by_family_or_nvt',"
        "                     'nvt_selectors',"
        "                     'type, family_or_nvt');");

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2009-2018 Greenbone Networks GmbH
+/* Copyright (C) 2009-2019 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *
@@ -918,9 +918,10 @@ init_nvt_cert_bund_adv_iterator (iterator_t *iterator, const char *oid,
                  "SELECT %s"
                  " FROM cert_bund_advs"
                  " WHERE id IN (SELECT adv_id FROM cert_bund_cves"
-                 "              WHERE cve_name IN (SELECT cve_name"
-                 "                                 FROM nvt_cves"
-                 "                                 WHERE oid = '%s'))"
+                 "              WHERE cve_name IN (SELECT ref_id"
+                 "                                 FROM vt_refs"
+                 "                                 WHERE vt_oid = '%s'"
+		 "                                   AND type = 'cve'))"
                  " ORDER BY %s %s;",
                  columns,
                  oid,
@@ -1098,9 +1099,10 @@ init_nvt_dfn_cert_adv_iterator (iterator_t *iterator, const char *oid,
                  "SELECT %s"
                  " FROM dfn_cert_advs"
                  " WHERE id IN (SELECT adv_id FROM dfn_cert_cves"
-                 "              WHERE cve_name IN (SELECT cve_name"
-                 "                                 FROM nvt_cves"
-                 "                                 WHERE oid = '%s'))"
+                 "              WHERE cve_name IN (SELECT ref_id"
+                 "                                 FROM vt_refs"
+                 "                                 WHERE vt_oid = '%s'"
+		 "                                   AND type = 'cve'))"
                  " ORDER BY %s %s;",
                  columns,
                  oid,

--- a/src/manage_sql_secinfo.h
+++ b/src/manage_sql_secinfo.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2010-2018 Greenbone Networks GmbH
+/* Copyright (C) 2010-2019 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *
@@ -30,18 +30,20 @@
  */
 #define SECINFO_SQL_RESULT_HAS_CERT_BUNDS                          \
  "(SELECT EXISTS (SELECT * FROM cert_bund_cves"                    \
- "                WHERE cve_name IN (SELECT cve_name"              \
- "                                   FROM nvt_cves"                \
- "                                   WHERE oid = results.nvt)))"
+ "                WHERE cve_name IN (SELECT ref_id"                \
+ "                                   FROM vt_refs"                 \
+ "                                   WHERE vt_oid = results.nvt"   \
+ "                                     AND type = 'cve')))"
 
 /**
  * @brief SQL to check if a result has CERT Bunds.
  */
 #define SECINFO_SQL_RESULT_HAS_DFN_CERTS                           \
  "(SELECT EXISTS (SELECT * FROM dfn_cert_cves"                     \
- "                WHERE cve_name IN (SELECT cve_name"              \
- "                                   FROM nvt_cves"                \
- "                                   WHERE oid = results.nvt)))"
+ "                WHERE cve_name IN (SELECT ref_id"                \
+ "                                   FROM vt_refs"                 \
+ "                                   WHERE vt_oid = results.nvt"   \
+ "                                     AND type = 'cve')))"
 
 /**
  * @brief Filter columns for CVE iterator.

--- a/src/manage_sqlite3.c
+++ b/src/manage_sqlite3.c
@@ -3674,8 +3674,6 @@ create_tables ()
        " ON nvts (name);");
   sql ("CREATE INDEX IF NOT EXISTS nvts_by_family"
        " ON nvts (family);");
-  sql ("CREATE TABLE IF NOT EXISTS nvt_cves"
-       " (nvt, oid, cve_name)");
   sql ("CREATE INDEX IF NOT EXISTS nvts_by_creation_time"
        " ON nvts (creation_time);");
   sql ("CREATE INDEX IF NOT EXISTS nvts_by_modification_time"
@@ -3684,8 +3682,6 @@ create_tables ()
        " ON nvts (cvss_base);");
   sql ("CREATE INDEX IF NOT EXISTS nvts_by_solution_type"
        " ON nvts (solution_type);");
-  sql ("CREATE INDEX IF NOT EXISTS nvt_cves_by_oid"
-       " ON nvt_cves (oid);");
   sql ("CREATE TABLE IF NOT EXISTS overrides"
        " (id INTEGER PRIMARY KEY, uuid UNIQUE, owner INTEGER, nvt, result_nvt,"
        "  creation_time, modification_time, text, hosts, port, severity,"


### PR DESCRIPTION
Assuming we have the new table vt_refs as proposed in
https://github.com/greenbone/gvmd/pull/570
we do not need the table "nvt_cves" anymore.

This PR removes the table and takes care vt_refs is used to achieve the same.
Therefore the above cited PR is mandatory before applying this PR. No conflict for compile time, but at run-time it would fail with SQL errors.

The PR does not include a migrator to remove existing tables. This should be subject to another
PR. 