### PR TITLE
Test if column is NULL in cleanup_keyword (master)

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -1660,6 +1660,9 @@ parse_keyword (keyword_t* keyword)
 static void
 cleanup_keyword (keyword_t *keyword)
 {
+  if (keyword->column == NULL)
+    return;
+
   if (strcasecmp (keyword->column, "first") == 0)
     {
       /* "first" must be >= 1 */


### PR DESCRIPTION
This is required for keywords without a column like "and", "or" or
filtering all columns to work.