### PR TITLE
Fix TippingPoint error handling (7.0)

### DIFF
--- a/src/alert_methods/TippingPoint/alert
+++ b/src/alert_methods/TippingPoint/alert
@@ -103,7 +103,7 @@ elif [ " - Status code 302" = "$HTTP_CODE" ]
 then
   echo "Host returned: $HTTP_CODE - credentials may be incorrect" >&2
   exit 1
-elif [ -n "$HTTP_CODE" ] && [ "- Status code 000" != "$HTTP_CODE" ]
+elif [ -n "$HTTP_CODE" ] && [ " - Status code 000" != "$HTTP_CODE" ]
 then
   echo "Host returned: $HTTP_CODE" >&2
   exit 1


### PR DESCRIPTION
Connection errors in the TippingPoint SMS alert were not handled
correctly due to a typo in the case for handling unexpected HTTP status
codes.