### PR TITLE
[8.0] Fix log_notice syntax for unsupported database version

### DIFF
--- a/tools/gvm-migrate-to-postgres.in
+++ b/tools/gvm-migrate-to-postgres.in
@@ -2462,7 +2462,7 @@ create () {
       ;;
 
     *)
-      log_notice "Database version not supported: " $DB_VERSION
+      log_notice "Database version not supported: $DB_VERSION"
       exit 1
   esac
 }


### PR DESCRIPTION
Backport of #595 