### PR TITLE
Drop long-unsupported '0' to indicate Open Port result

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 210)
+set (GVMD_DATABASE_VERSION 211)
 
 set (GVMD_SCAP_DATABASE_VERSION 15)
 

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -1738,7 +1738,7 @@ migrate_208_to_209 ()
 }
 
 /**
- * @brief Migrate the database from version 208 to version 209.
+ * @brief Migrate the database from version 209 to version 210.
  *
  * @return 0 success, -1 error.
  */
@@ -1772,6 +1772,42 @@ migrate_209_to_210 ()
   /* Set the database version to 210. */
 
   set_db_version (210);
+
+  sql_commit ();
+
+  return 0;
+}
+
+/**
+ * @brief Migrate the database from version 210 to version 211.
+ *
+ * @return 0 success, -1 error.
+ */
+int
+migrate_210_to_211 ()
+{
+  sql_begin_immediate ();
+
+  /* Ensure that the database is currently version 210. */
+
+  if (manage_db_version () != 210)
+    {
+      sql_rollback ();
+      return -1;
+    }
+
+  /* Update the database. */
+
+  /* Remove any entry in table "results" where field "nvt" is '0'.
+   * The oid '0' was used to inidcate a open port detection in very early
+   * versions. This migration ensures there are no more such
+   * results although it is very unlikely the case. */
+
+  sql ("DELETE FROM results WHERE nvt = '0';");
+
+  /* Set the database version to 211. */
+
+  set_db_version (211);
 
   sql_commit ();
 
@@ -1815,6 +1851,7 @@ static migrator_t database_migrators[] = {
   {208, migrate_207_to_208},
   {209, migrate_208_to_209},
   {210, migrate_209_to_210},
+  {211, migrate_210_to_211},
   /* End marker. */
   {-1, NULL}};
 

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -3093,7 +3093,6 @@ create_tables ()
        "          (CASE WHEN"
        "           (((SELECT family FROM nvts WHERE oid = results.nvt)"
        "             IN (" LSC_FAMILY_LIST "))"
-       "            OR results.nvt = '0'" /* Open ports previously had 0 NVT. */
        "            OR EXISTS"
        "              (SELECT id FROM nvts"
        "               WHERE oid = results.nvt"
@@ -3119,7 +3118,6 @@ create_tables ()
        "          (CASE WHEN"
        "            (((SELECT family FROM nvts WHERE oid = results.nvt)"
        "              IN (" LSC_FAMILY_LIST "))"
-       "             OR results.nvt = '0'" /* Open ports previously had 0 NVT.*/
        "             OR EXISTS"
        "             (SELECT id FROM nvts AS outer_nvts"
        "              WHERE oid = results.nvt"

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -28504,7 +28504,7 @@ static int
 report_vuln_count (report_t report)
 {
   return sql_int ("SELECT count (DISTINCT nvt) FROM results"
-                  " WHERE report = %llu AND nvt != '0'"
+                  " WHERE report = %llu"
                   " AND severity != " G_STRINGIFY (SEVERITY_ERROR) ";",
                   report);
 }

--- a/src/manage_sqlite3.c
+++ b/src/manage_sqlite3.c
@@ -4000,7 +4000,6 @@ create_tables ()
        "          (CASE WHEN"
        "           (((SELECT family FROM nvts WHERE oid = results.nvt)"
        "              IN (" LSC_FAMILY_LIST "))"
-       "            OR results.nvt = '0'" /* Open ports previously had 0 NVT. */
        "            OR EXISTS"
        "              (SELECT id FROM nvts"
        "               WHERE oid = results.nvt"
@@ -4024,7 +4023,6 @@ create_tables ()
        "          (CASE WHEN"
        "            (((SELECT family FROM nvts WHERE oid = results.nvt)"
        "              IN (" LSC_FAMILY_LIST "))"
-       "             OR results.nvt = '0'" /* Open ports previously had 0 NVT.*/
        "             OR EXISTS"
        "             (SELECT id FROM nvts AS outer_nvts"
        "              WHERE oid = results.nvt"

--- a/src/report_formats/CSV_Results/CSV_Results.xsl
+++ b/src/report_formats/CSV_Results/CSV_Results.xsl
@@ -127,16 +127,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   </xsl:choose>
 </xsl:template>
 
-<!-- Substitute "Open Port" if the NVT name is empty -->
 <xsl:template name="nvt_name">
   <xsl:variable name="name_without_single_quotes"
                 select="translate(nvt/name, &quot;&apos;&quot;, '')" />
-  <xsl:choose>
-    <xsl:when test="string-length($name_without_single_quotes) > 0">
-      <xsl:value-of select="openvas:formula_quote (str:replace ($name_without_single_quotes, $quote, $two-quotes))"/>
-    </xsl:when>
-    <xsl:otherwise>Open Port</xsl:otherwise>
-  </xsl:choose>
+  <xsl:value-of select="openvas:formula_quote (str:replace ($name_without_single_quotes, $quote, $two-quotes))"/>
 </xsl:template>
 
 <func:function name="openvas:get-nvt-tag">

--- a/tools/database-statistics-sqlite
+++ b/tools/database-statistics-sqlite
@@ -45,8 +45,6 @@ UNUSED_PAGES_COUNT=$($SQLITE3 "$DATABASE" "PRAGMA freelist_count;")
 
 SUPERFLUOUS_ITG_RESULT_COUNT=$($SQLITE3 "$DATABASE" "SELECT COUNT() FROM results WHERE nvt = '1.3.6.1.4.1.25623.1.0.94000' AND port = 'general/IT-Grundschutz' AND ROWID NOT IN (SELECT ROWID FROM results AS outer_results WHERE length (description) = (SELECT max (length (description)) FROM results WHERE report = outer_results.report AND host = outer_results.host AND nvt = '1.3.6.1.4.1.25623.1.0.94000' AND port = 'general/IT-Grundschutz') AND nvt = '1.3.6.1.4.1.25623.1.0.94000' AND port = 'general/IT-Grundschutz' GROUP BY report, host);")
 
-SUPERFLUOUS_OPEN_PORT_RESULT_COUNT=$($SQLITE3 "$DATABASE" "SELECT COUNT() FROM results WHERE nvt = '0';");
-
 OLD_STYLE_RESULT_LOCATION_COUNT=$($SQLITE3 "$DATABASE" "SELECT COUNT() FROM results WHERE port LIKE '%)';");
 
 DUPLICATE_CONFIG_PREFERENCES_COUNT=$($SQLITE3 "$DATABASE" "SELECT COUNT () FROM (SELECT config, type, name, value FROM config_preferences GROUP BY config, type, name, value HAVING COUNT() > 1);");
@@ -54,8 +52,6 @@ DUPLICATE_CONFIG_PREFERENCES_COUNT=$($SQLITE3 "$DATABASE" "SELECT COUNT () FROM 
 log_write "Unused pages: $UNUSED_PAGES_COUNT"
 
 log_write "Superfluous ITG results: $SUPERFLUOUS_ITG_RESULT_COUNT"
-
-log_write "Superfluous 'Open Port' results: $SUPERFLUOUS_OPEN_PORT_RESULT_COUNT"
 
 log_write "Old style result locations: $OLD_STYLE_RESULT_LOCATION_COUNT"
 


### PR DESCRIPTION
Remove results with nvt = '0' from DB and remove any special handling
or consideration of this case.

The oid '0' was used to indicate a open port detection in very early versions.

Any such results are removed during a migration. It is extremely unlikely that such
results are still in the database. This circumstance of '0' for the  oid isn't supported
in many places since a long time already.

Further, remaining special considerations are finally removed and simplify SQL queries
and XSLT.

Even in the case for some reason a new results get into the database that has nvt = '0',
this '0' will be simply treated like any other oid.   Well, in normal operation mode, this can
not happen, so it is more a theoretical consideration. 

