### PR TITLE
Always include notes, overrides in result details (8.0)

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -16756,7 +16756,7 @@ handle_get_results (gmp_parser_t *gmp_parser, GError **error)
                                 NULL, /* No host restriction */
                                 NULL);  /* No extra order SQL. */
 
-      manage_report_filter_controls (filter,
+      manage_report_filter_controls (filter ? filter : "",
                                       NULL, /* first */
                                       NULL, /* max */
                                       NULL, /* sort_field */
@@ -16796,9 +16796,9 @@ handle_get_results (gmp_parser_t *gmp_parser, GError **error)
               buffer_results_xml (buffer,
                                   &results,
                                   task,
-                                  notes,
+                                  (notes || get_results_data->get.details),
                                   get_results_data->notes_details,
-                                  overrides,
+                                  (overrides || get_results_data->get.details),
                                   get_results_data->overrides_details,
                                   1,
                                   /* show tag details if selected by ID */

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -1974,14 +1974,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         </ele>
         <ele>
           <name>notes</name>
-          <summary>Whether notes are included</summary>
+          <summary>Whether notes are included even if details are not requested</summary>
           <pattern>
             <t><alts><alt>0</alt><alt>1</alt></alts></t>
           </pattern>
         </ele>
         <ele>
           <name>overrides</name>
-          <summary>Whether overrides are included</summary>
+          <summary>Whether overrides are included even if details are not requested</summary>
           <pattern>
             <t><alts><alt>0</alt><alt>1</alt></alts></t>
           </pattern>


### PR DESCRIPTION
If details are requested, notes and overrides are always included
in the get_results response, regardless of the filter.