### PR TITLE
Exclude orphaned_time when copying data

### DIFF
--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -2171,6 +2171,12 @@ gvmd (int argc, char** argv)
 
   if (osp_vt_update)
     osp_update_socket = osp_vt_update;
+  else
+    {
+      g_critical ("%s: --osp-vt-update required for now",
+                  __FUNCTION__);
+      return EXIT_FAILURE;
+    }
 
   if (backup_database)
     {

--- a/tools/gvm-migrate-to-postgres.in
+++ b/tools/gvm-migrate-to-postgres.in
@@ -1038,6 +1038,13 @@ cleanup_sqlite_db () {
   # table lying around.
   sqlite "DROP TABLE IF EXISTS escalator_condition_data_trash;"
   test_sql_exit "Failed to remove escalator_condition_data_trash"
+
+  HAVE_CACHE=`sqlite "SELECT EXISTS (SELECT FROM sqlite_master WHERE type='table' AND name='permissions_get_tasks');"`
+  if [ "$HAVE_CACHE" != "0" ]
+  then
+    sqlite "UPDATE permissions_get_tasks SET has_permission = 1 WHERE has_permission != '0';"
+    test_sql_exit "Failed to clean permission_get_tasks"
+  fi
 }
 
 # Replace the value of a column if the cast does not work
@@ -1147,7 +1154,7 @@ copy_data () {
     # database.
     #
     log_info "Copying SQLite3 data: copying table $TABLE"
-    COLS=`pg "SELECT string_agg ('\"' || column_name || '\"', ',') from (select column_name from information_schema.columns where table_schema = 'public' and table_name = '$TABLE' order by ordinal_position) as sub;"`
+    COLS=`pg "SELECT string_agg ('\"' || column_name || '\"', ',') FROM (SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = '$TABLE' AND column_name != 'orphaned_time' order by ordinal_position) as sub;"`
     log_debug "COLS: $COLS"
     # Pipe SQLite CSV output into Postgres COPY FROM.
     $SQLITE3 -csv $SQLITE_DB "SELECT $COLS FROM $TABLE;" | pg "COPY $TABLE ($COLS) FROM STDIN DELIMITER ',' CSV";
@@ -2999,7 +3006,7 @@ create () {
       ;;
 
     *)
-      log_notice "Database version not supported: " $DB_VERSION
+      log_notice "Database version not supported: $DB_VERSION"
       exit 1
   esac
 }


### PR DESCRIPTION
This column was not removed in the SQLite3 version of migrate_202_to_203
so hack it here.