### PR TITLE
Fix getting single unowned resources (8.0)

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -5197,7 +5197,7 @@ init_get_iterator2_with (iterator_t* iterator, const char *type,
     {
       resource = 0;
     }
-  else if (get->id && owned && (current_credentials.uuid == NULL))
+  else if (get->id && (owned == 0 || (current_credentials.uuid == NULL)))
     {
       gchar *quoted_uuid = sql_quote (get->id);
       switch (sql_int64 (&resource,


### PR DESCRIPTION
The init_get_iterator2_with function will now return an iterator for a
single resource as expected even for unowned types like "vuln".