### PR TITLE
Optimize osp vt update

### DIFF
--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -1580,7 +1580,7 @@ check_config_families ()
 /* NVT preferences.  This is part of Configs. */
 
 /**
- * @brief Add an NVT preference.
+ * @brief Add/replace an NVT preference.
  *
  * @param[in]  name    The name of the preference.
  * @param[in]  value   The value of the preference.
@@ -1597,16 +1597,11 @@ manage_nvt_preference_add (const char* name, const char* value)
                    "  (SELECT * FROM nvt_preferences"
                    "   WHERE name = '%s')",
                    quoted_name))
-        {
-          g_warning ("%s: preference '%s' already exists",
-                     __FUNCTION__, name);
-        }
-      else
-        {
-          sql ("INSERT into nvt_preferences (name, value)"
-               " VALUES ('%s', '%s');",
-               quoted_name, quoted_value);
-        }
+        sql ("DELETE FROM nvt_preferences WHERE name = '%s';", quoted_name);
+
+      sql ("INSERT into nvt_preferences (name, value)"
+           " VALUES ('%s', '%s');",
+           quoted_name, quoted_value);
     }
 
   g_free (quoted_name);

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -187,7 +187,7 @@ insert_nvt (const nvti_t *nvti)
   gchar *quoted_name, *quoted_cve, *quoted_tag;
   gchar *quoted_cvss_base, *quoted_qod_type, *quoted_family, *value;
   gchar *quoted_solution_type;
-  int creation_time, modification_time, qod;
+  int creation_time, modification_time, qod, i;
 
   cve = nvti_refs (nvti, "cve", "", 0);
 
@@ -316,11 +316,7 @@ insert_nvt (const nvti_t *nvti)
 
   if (sql_int ("SELECT EXISTS (SELECT * FROM nvts WHERE oid = '%s');",
                nvti_oid (nvti)))
-    g_warning ("%s: NVT with OID %s exists already, ignoring", __FUNCTION__,
-               nvti_oid (nvti));
-  else
-    {
-      int i;
+    sql ("DELETE FROM nvts WHERE oid = '%s';", nvti_oid (nvti));
 
       sql ("INSERT into nvts (oid, name,"
            " cve, tag, category, family, cvss_base,"
@@ -351,7 +347,6 @@ insert_nvt (const nvti_t *nvti)
           g_free (quoted_id);
           g_free (quoted_text);
         }
-    }
 
   g_free (quoted_name);
   g_free (quoted_cve);

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -318,35 +318,35 @@ insert_nvt (const nvti_t *nvti)
                nvti_oid (nvti)))
     sql ("DELETE FROM nvts WHERE oid = '%s';", nvti_oid (nvti));
 
-      sql ("INSERT into nvts (oid, name,"
-           " cve, tag, category, family, cvss_base,"
-           " creation_time, modification_time, uuid, solution_type,"
-           " qod, qod_type)"
-           " VALUES ('%s', '%s', '%s',"
-           " '%s', %i, '%s', '%s', %i, %i, '%s', '%s', %d, '%s');",
-           nvti_oid (nvti), quoted_name, quoted_cve, quoted_tag,
-           nvti_category (nvti), quoted_family, quoted_cvss_base, creation_time,
-           modification_time, nvti_oid (nvti), quoted_solution_type,
-           qod, quoted_qod_type);
+  sql ("INSERT into nvts (oid, name,"
+       " cve, tag, category, family, cvss_base,"
+       " creation_time, modification_time, uuid, solution_type,"
+       " qod, qod_type)"
+       " VALUES ('%s', '%s', '%s',"
+       " '%s', %i, '%s', '%s', %i, %i, '%s', '%s', %d, '%s');",
+       nvti_oid (nvti), quoted_name, quoted_cve, quoted_tag,
+       nvti_category (nvti), quoted_family, quoted_cvss_base, creation_time,
+       modification_time, nvti_oid (nvti), quoted_solution_type,
+       qod, quoted_qod_type);
 
-      sql ("DELETE FROM vt_refs where vt_oid = '%s';", nvti_oid (nvti));
+  sql ("DELETE FROM vt_refs where vt_oid = '%s';", nvti_oid (nvti));
 
-      for (i = 0; i < nvti_vtref_len (nvti); i++)
-        {
-          vtref_t *ref;
-          gchar *quoted_id, *quoted_text;
+  for (i = 0; i < nvti_vtref_len (nvti); i++)
+    {
+      vtref_t *ref;
+      gchar *quoted_id, *quoted_text;
 
-          ref = nvti_vtref (nvti, i);
-          quoted_id = sql_quote (vtref_id (ref));
-          quoted_text = sql_quote (vtref_text (ref) ? vtref_text (ref) : "");
+      ref = nvti_vtref (nvti, i);
+      quoted_id = sql_quote (vtref_id (ref));
+      quoted_text = sql_quote (vtref_text (ref) ? vtref_text (ref) : "");
 
-          sql ("INSERT into vt_refs (vt_oid, type, ref_id, ref_text)"
-               " VALUES ('%s', '%s', '%s', '%s');",
-               nvti_oid (nvti), vtref_type (ref), quoted_id, quoted_text);
+      sql ("INSERT into vt_refs (vt_oid, type, ref_id, ref_text)"
+           " VALUES ('%s', '%s', '%s', '%s');",
+           nvti_oid (nvti), vtref_type (ref), quoted_id, quoted_text);
 
-          g_free (quoted_id);
-          g_free (quoted_text);
-        }
+      g_free (quoted_id);
+      g_free (quoted_text);
+    }
 
   g_free (quoted_name);
   g_free (quoted_cve);

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1435,7 +1435,7 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
       || strcmp (scanner_feed_version, db_feed_version))
     {
       entity_t vts;
-      gchar *filter;
+      osp_get_vts_opts_t get_vts_opts;
 
       g_info ("OSP service has newer VT status (version %s) than in database (version %s, %i VTs). Starting update ...",
               scanner_feed_version, db_feed_version, sql_int ("SELECT count (*) FROM nvts;"));
@@ -1448,14 +1448,14 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
           return -1;
         }
 
-      filter = g_strdup_printf ("modification_time>%s", db_feed_version); 
-      if (osp_get_vts_filtered (connection, filter, &vts))
+      get_vts_opts.filter = g_strdup_printf ("modification_time>%s", db_feed_version); 
+      if (osp_get_vts_ext (connection, get_vts_opts, &vts))
         {
           g_warning ("%s: failed to get VTs", __FUNCTION__);
-	  g_free (filter);
+          g_free (get_vts_opts.filter);
           return -1;
         }
-      g_free (filter);
+      g_free (get_vts_opts.filter);
 
       osp_connection_close (connection);
 


### PR DESCRIPTION
This patch speeds up the feed update between OSP service and gvmd
by a factor of 30. The more frequent the update is done (ie the smaller the
set of new/changed VTs), the higher the factor.

Previously a VT update from a OSP service always loaded all of the VTs, then
removed the nvts table and inserted all NVTs into the table anew.

The logs of gvmd showed a duration of about 4 minutes for an update where about
1900 new/changed VTs occured in the NVT feed since the last feed update.
Updating the entire feed anew from OSP service into gvmd also take about
4 minutes. In other words, it did not matter how few VTs changed.

This patch
* retrieves only the VT datasets from the OSP service that have a modification
time newer than the time of the last update.
* does not remove the nvts table anymore
* inserts all of the newly loaded VTs. If it already exists, the old one is removed
and the new one inserted.

The very same scenario was repeated with 1900 new/changed  VTs and with
the patch it took 8 seconds to complete.

Interestingly, when forcing gvmd to rebuild the entire nvts table content, the
measurement shows 3m30s. This is more or less within the range that
was measured without the patch.

This patch depends on https://github.com/greenbone/gvm-libs/pull/251

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
