### PR TITLE
Add cleanup-report-formats choice for --optimize (8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [8.0.2] (unreleased)
 
 ### Added
+- Command cleanup-report-formats for --optimize option [#651](https://github.com/greenbone/gvmd/pull/651)
 
 ### Changes
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -291,6 +291,12 @@ supported values for `<name>` are:
   format `telnet (23/tcp)`, reducing it to the new format `23/tcp`.
   This makes filtering results and delta reports more consistent.
 
+- `cleanup-report-formats`
+
+  This cleans up references to report formats that have been removed without
+  using the DELETE_REPORT_FORMAT GMP command, for example after a built-in
+  report format has been removed.
+
 - `cleanup-result-severities`
 
   This cleans up results with no severity by assigning the default

--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -113,7 +113,7 @@ Modify user's password and exit.
 Modify user's password and exit.
 .TP
 \fB--optimize=\fINAME\fB\f1
-Run an optimization: vacuum, analyze, cleanup-config-prefs, cleanup-port-names, cleanup-result-severities, cleanup-schedule-times, rebuild-report-cache or update-report-cache.
+Run an optimization: vacuum, analyze, cleanup-config-prefs, cleanup-port-names, cleanup-report-formats, cleanup-result-severities, cleanup-schedule-times, rebuild-report-cache or update-report-cache.
 .TP
 \fB--osp-vt-update=\fISCANNER-SOCKET\fB\f1
 Unix socket for OSP NVT update. Default is to do an OTP update.

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -257,9 +257,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       <p><opt>--optimize=<arg>NAME</arg></opt></p>
       <optdesc>
         <p>Run an optimization: vacuum, analyze, cleanup-config-prefs,
-           cleanup-port-names, cleanup-result-severities,
-           cleanup-schedule-times, rebuild-report-cache or
-           update-report-cache.</p>
+           cleanup-port-names, cleanup-report-formats,
+           cleanup-result-severities, cleanup-schedule-times,
+           rebuild-report-cache or update-report-cache.</p>
       </optdesc>
     </option>
     <option>

--- a/doc/gvmd.html
+++ b/doc/gvmd.html
@@ -240,9 +240,9 @@
       <p><b>--optimize=<em>NAME</em></b></p>
       
         <p>Run an optimization: vacuum, analyze, cleanup-config-prefs,
-           cleanup-port-names, cleanup-result-severities,
-           cleanup-schedule-times, rebuild-report-cache or
-           update-report-cache.</p>
+           cleanup-port-names, cleanup-report-formats,
+           cleanup-result-severities, cleanup-schedule-times,
+           rebuild-report-cache or update-report-cache.</p>
       
     
     

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1858,7 +1858,7 @@ main (int argc, char **argv)
     { "optimize", '\0', 0, G_OPTION_ARG_STRING,
       &optimize,
       "Run an optimization: vacuum, analyze, cleanup-config-prefs,"
-      " cleanup-port-names, cleanup-result-severities,"
+      " cleanup-port-names, cleanup-report-formats, cleanup-result-severities,"
       " cleanup-schedule-times, rebuild-report-cache or"
       " update-report-cache.",
       "<name>" },

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -70028,6 +70028,77 @@ manage_optimize (GSList *log_config, const gchar *database, const gchar *name)
                                       " removed IANA port names: %d.",
                                       changes_old_format, changes_iana);
     }
+  else if (strcasecmp (name, "cleanup-report-formats") == 0)
+    {
+      iterator_t alert_data;
+      int alert_changes = 0;
+
+      /* Clean up alerts with missing report formats */
+      sql_begin_immediate ();
+
+      init_iterator (&alert_data,
+                     "SELECT id, data,"
+                     "       (SELECT uuid FROM alerts WHERE id = alert)"
+                     "  FROM alert_method_data"
+                     " WHERE (name = 'notice_attach_format'"
+                     "        OR name = 'notice_report_format'"
+                     "        OR name = 'send_report_format')"
+                     "   AND data NOT IN (SELECT uuid"
+                     "                      FROM report_formats)"
+                     "   AND data NOT IN (SELECT uuid"
+                     "                      FROM report_formats_trash)");
+      while (next (&alert_data))
+        {
+          alert_changes ++;
+          g_message ("Alert %s uses a non-existent report format (%s)"
+                     " and will now use the TXT report format (%s)"
+                     " if TXT exists.",
+                     iterator_string (&alert_data, 2),
+                     iterator_string (&alert_data, 1),
+                     "a3810a62-1f62-11e1-9219-406186ea4fc5");
+
+          sql ("UPDATE alert_method_data SET data = '%s'"
+               " WHERE id = %llu",
+               "a3810a62-1f62-11e1-9219-406186ea4fc5",
+               iterator_int64 (&alert_data, 0));
+        }
+      cleanup_iterator(&alert_data);
+
+      init_iterator (&alert_data,
+                     "SELECT id, data,"
+                     "       (SELECT uuid FROM alerts_trash WHERE id = alert)"
+                     "  FROM alert_method_data_trash"
+                     " WHERE (name = 'notice_attach_format'"
+                     "        OR name = 'notice_report_format'"
+                     "        OR name = 'send_report_format')"
+                     "   AND data NOT IN (SELECT uuid"
+                     "                      FROM report_formats)"
+                     "   AND data NOT IN (SELECT uuid"
+                     "                      FROM report_formats_trash)");
+      while (next (&alert_data))
+        {
+          alert_changes ++;
+          g_warning ("Trash Alert %s uses a non-existent report format (%s)"
+                     " and will now use the TXT report format (%s)"
+                     " if TXT exists.",
+                     iterator_string (&alert_data, 2),
+                     iterator_string (&alert_data, 1),
+                     "a3810a62-1f62-11e1-9219-406186ea4fc5");
+
+          sql ("UPDATE alert_method_data_trash SET data = '%s'"
+               " WHERE id = %llu",
+               "a3810a62-1f62-11e1-9219-406186ea4fc5",
+               iterator_int64 (&alert_data, 0));
+        }
+      cleanup_iterator(&alert_data);
+
+      sql_commit ();
+
+      success_text = g_strdup_printf ("Optimized: cleanup-report-formats."
+                                      " Cleaned up report format references in"
+                                      " %d alert(s).",
+                                      alert_changes);
+    }
   else if (strcasecmp (name, "cleanup-result-severities") == 0)
     {
       int missing_severity_changes = 0;


### PR DESCRIPTION
This cleans up references to report formats that have been removed
without using the DELETE_REPORT_FORMAT GMP command, for example after a
built-in report format has been removed.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
