### PR TITLE
Add cleanup-report-formats choice for --optimize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Document switching between releases when using Postgres. [#563](https://github.com/greenbone/gvmd/pull/563)
 - Cgreen based unit tests for gvmd has been added. [#579](https://github.com/greenbone/gvmd/pull/579)
 - New usage_type property to distinguish normal scan tasks and configs from compliance audits and policies [#613](https://github.com/greenbone/gvmd/pull/613) [#625](https://github.com/greenbone/gvmd/pull/625) [#633](https://github.com/greenbone/gvmd/pull/633)
+- Command cleanup-report-formats for --optimize option [#652](https://github.com/greenbone/gvmd/pull/652)
 
 ### Changes
 - Check if NVT preferences exist before inserting. [#406](https://github.com/greenbone/gvmd/pull/406)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -399,6 +399,12 @@ supported values for `<name>` are:
   format `telnet (23/tcp)`, reducing it to the new format `23/tcp`.
   This makes filtering results and delta reports more consistent.
 
+- `cleanup-report-formats`
+
+  This cleans up references to report formats that have been removed without
+  using the DELETE_REPORT_FORMAT GMP command, for example after a built-in
+  report format has been removed.
+
 - `cleanup-result-severities`
 
   This cleans up results with no severity by assigning the default

--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -110,7 +110,7 @@ Modify user's password and exit.
 Modify user's password and exit.
 .TP
 \fB--optimize=\fINAME\fB\f1
-Run an optimization: vacuum, analyze, cleanup-config-prefs, cleanup-port-names, cleanup-result-severities, cleanup-schedule-times, rebuild-report-cache or update-report-cache.
+Run an optimization: vacuum, analyze, cleanup-config-prefs, cleanup-port-names, cleanup-report-formats, cleanup-result-severities, cleanup-schedule-times, rebuild-report-cache or update-report-cache.
 .TP
 \fB--osp-vt-update=\fISCANNER-SOCKET\fB\f1
 Unix socket for OSP NVT update. Default is to do an OTP update.

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -251,9 +251,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       <p><opt>--optimize=<arg>NAME</arg></opt></p>
       <optdesc>
         <p>Run an optimization: vacuum, analyze, cleanup-config-prefs,
-           cleanup-port-names, cleanup-result-severities,
-           cleanup-schedule-times, rebuild-report-cache or
-           update-report-cache.</p>
+           cleanup-port-names, cleanup-report-formats,
+           cleanup-result-severities, cleanup-schedule-times,
+           rebuild-report-cache or update-report-cache.</p>
       </optdesc>
     </option>
     <option>

--- a/doc/gvmd.html
+++ b/doc/gvmd.html
@@ -234,9 +234,9 @@
       <p><b>--optimize=<em>NAME</em></b></p>
       
         <p>Run an optimization: vacuum, analyze, cleanup-config-prefs,
-           cleanup-port-names, cleanup-result-severities,
-           cleanup-schedule-times, rebuild-report-cache or
-           update-report-cache.</p>
+           cleanup-port-names, cleanup-report-formats,
+           cleanup-result-severities, cleanup-schedule-times,
+           rebuild-report-cache or update-report-cache.</p>
       
     
     

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1791,9 +1791,9 @@ gvmd (int argc, char** argv)
         { "optimize", '\0', 0, G_OPTION_ARG_STRING,
           &optimize,
           "Run an optimization: vacuum, analyze, cleanup-config-prefs,"
-          " cleanup-port-names, cleanup-result-severities,"
-          " cleanup-schedule-times, rebuild-report-cache or"
-          " update-report-cache.",
+          " cleanup-port-names, cleanup-report-formats,"
+          " cleanup-result-severities, cleanup-schedule-times,"
+          " rebuild-report-cache or update-report-cache.",
           "<name>" },
         { "osp-vt-update", '\0', 0, G_OPTION_ARG_STRING,
           &osp_vt_update,


### PR DESCRIPTION
This cleans up references to report formats that have been removed
without using the DELETE_REPORT_FORMAT GMP command, for example after a
built-in report format has been removed.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- N/A Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
