### PR TITLE
Add missing cert.db/scap.db migration from GVM-9 to GVM-10

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -273,6 +273,12 @@ properly.
    If the `gsf-access-key` file was already migrated for the `openvas-scanner`
    module it can be removed from the `$prefix/etc/openvas/` directory.
 
+ - move `$prefix/var/lib/openvas/scap-data/scap.db` to
+   `$prefix/var/lib/gvm/gvmd/scap/`
+
+ - move `$prefix/var/lib/openvas/cert-data/cert.db` to
+   `$prefix/var/lib/gvm/gvmd/cert/`
+
  - move `$prefix/var/lib/openvas/scap-data` to
    `$prefix/var/lib/gvm/scap-data`
 


### PR DESCRIPTION
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

This is a follow-up of the added migration steps in 36c0e525ef9b53760f075670decf5a332a85d61c.

It seems it was missed there to add the migration step for the new location of the cert.db/scap.db files introduced in 3e3864f7283e870ae7902065cd789439e1929c3f.

This PR describes the additional migration steps of both .db files before the plain/xml files are copied to their new location. It should solve messages after the migration like seen in e.g.:

https://community.greenbone.net/t/sql-prepare-internal-sqlite3-prepare-failed-no-such-table-cert-dfn-cert-advs/2220

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [N/A] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
