### PR TITLE
[8.0] Add missing cert.db/scap.db migration from GVM-9 to GVM-10

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -161,6 +161,12 @@ properly.
    If the `gsf-access-key` file was already migrated for the `openvas-scanner`
    module it can be removed from the `$prefix/etc/openvas/` directory.
 
+ - move `$prefix/var/lib/openvas/scap-data/scap.db` to
+   `$prefix/var/lib/gvm/gvmd/scap/`
+
+ - move `$prefix/var/lib/openvas/cert-data/cert.db` to
+   `$prefix/var/lib/gvm/gvmd/cert/`
+
  - move `$prefix/var/lib/openvas/scap-data` to
    `$prefix/var/lib/gvm/scap-data`
 


### PR DESCRIPTION
Backport of #660

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [N/A] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
