### PR TITLE
Fix getting nvt_revision in buffer_insert (8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fix iCalendar recurrence and timezone handling [#653](https://github.com/greenbone/gvmd/pull/653)
 - Fix issues with some scheduled tasks by using iCalendar more instead of old period fields [#655](https://github.com/greenbone/gvmd/pull/655)
-- Fix an issue in getting the reports from GMP scanners [#658](https://github.com/greenbone/gvmd/pull/658)
+- Fix an issue in getting the reports from GMP scanners [#658](https://github.com/greenbone/gvmd/pull/658) [#666](https://github.com/greenbone/gvmd/pull/666)
 
 ### Removed
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -54264,10 +54264,10 @@ buffer_insert (GString *buffer, task_t task, const char* host,
           quoted_qod_type = g_strdup ("");
         }
 
-      nvt_revision = g_strdup_printf ("SELECT iso_time (modification_time)"
-                                      " FROM nvts"
-                                      " WHERE uuid = '%s';",
-                                      nvt);
+      nvt_revision = sql_string ("SELECT iso_time (modification_time)"
+                                 " FROM nvts"
+                                 " WHERE uuid = '%s';",
+                                 nvt);
     }
   else
     {


### PR DESCRIPTION
This addresses another error in #657

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
