### PR TITLE
Fix slave_system_report permission check (8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix iCalendar recurrence and timezone handling [#653](https://github.com/greenbone/gvmd/pull/653)
 - Fix issues with some scheduled tasks by using iCalendar more instead of old period fields [#655](https://github.com/greenbone/gvmd/pull/655)
 - Fix an issue in getting the reports from GMP scanners [#658](https://github.com/greenbone/gvmd/pull/658) [#666](https://github.com/greenbone/gvmd/pull/666)
+- Fix GET_SYSTEM_REPORTS using slave_id [#667](https://github.com/greenbone/gvmd/pull/667)
 
 ### Removed
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -6568,7 +6568,7 @@ slave_system_report (const char *name,
   gmp_get_system_reports_opts_t opts;
   int ret;
 
-  if (find_scanner_with_permission (slave_id, &slave, "get_slaves"))
+  if (find_scanner_with_permission (slave_id, &slave, "get_scanners"))
     return -1;
   if (slave == 0)
     return 2;


### PR DESCRIPTION
The function checked for the removed permission "get_slave" when it
should check "get_scanners".

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
