### PR TITLE
Fix slave_system_report permission check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix iCalendar recurrence and timezone handling [#654](https://github.com/greenbone/gvmd/pull/654)
 - Fix issues with some scheduled tasks by using iCalendar more instead of old period fields [#656](https://github.com/greenbone/gvmd/pull/655)
 - Fix an issue in getting the reports from GMP scanners [#659](https://github.com/greenbone/gvmd/pull/659) [#665](https://github.com/greenbone/gvmd/pull/665)
+- Fix GET_SYSTEM_REPORTS using slave_id [#668](https://github.com/greenbone/gvmd/pull/668)
 
 ### Removed
 - The handling of NVT updates via OTP has been removed. [#575](https://github.com/greenbone/gvmd/pull/575)

--- a/src/manage.c
+++ b/src/manage.c
@@ -5722,7 +5722,7 @@ slave_system_report (const char *name, const char *duration,
   gmp_get_system_reports_opts_t opts;
   int ret;
 
-  if (find_scanner_with_permission (slave_id, &slave, "get_slaves"))
+  if (find_scanner_with_permission (slave_id, &slave, "get_scanners"))
     return -1;
   if (slave == 0)
     return 2;


### PR DESCRIPTION
The function checked for the removed permission "get_slave" when it
should check "get_scanners".

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
