### PR TITLE
Check and create default permissions individually (8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Command cleanup-report-formats for --optimize option [#651](https://github.com/greenbone/gvmd/pull/651)
 
 ### Changes
+- Check and create default permissions individually [#672](https://github.com/greenbone/gvmd/pull/672)
 
 ### Fixed
 - Fix iCalendar recurrence and timezone handling [#653](https://github.com/greenbone/gvmd/pull/653)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -17541,78 +17541,78 @@ add_permissions_on_globals (const gchar *role_uuid)
            role_uuid);
     }
 
-      /* Global configs. */
-      add_role_permission_resource (role_uuid, "GET_CONFIGS", "config",
-                                    CONFIG_UUID_FULL_AND_FAST);
-      add_role_permission_resource (role_uuid, "GET_CONFIGS", "config",
-                                    CONFIG_UUID_FULL_AND_FAST_ULTIMATE);
-      add_role_permission_resource (role_uuid, "GET_CONFIGS", "config",
-                                    CONFIG_UUID_FULL_AND_VERY_DEEP);
-      add_role_permission_resource (role_uuid, "GET_CONFIGS", "config",
-                                    CONFIG_UUID_FULL_AND_VERY_DEEP_ULTIMATE);
-      add_role_permission_resource (role_uuid, "GET_CONFIGS", "config",
-                                    CONFIG_UUID_EMPTY);
-      add_role_permission_resource (role_uuid, "GET_CONFIGS", "config",
-                                    CONFIG_UUID_DISCOVERY);
-      add_role_permission_resource (role_uuid, "GET_CONFIGS", "config",
-                                    CONFIG_UUID_HOST_DISCOVERY);
-      add_role_permission_resource (role_uuid, "GET_CONFIGS", "config",
-                                    CONFIG_UUID_SYSTEM_DISCOVERY);
+  /* Global configs. */
+  add_role_permission_resource (role_uuid, "GET_CONFIGS", "config",
+                                CONFIG_UUID_FULL_AND_FAST);
+  add_role_permission_resource (role_uuid, "GET_CONFIGS", "config",
+                                CONFIG_UUID_FULL_AND_FAST_ULTIMATE);
+  add_role_permission_resource (role_uuid, "GET_CONFIGS", "config",
+                                CONFIG_UUID_FULL_AND_VERY_DEEP);
+  add_role_permission_resource (role_uuid, "GET_CONFIGS", "config",
+                                CONFIG_UUID_FULL_AND_VERY_DEEP_ULTIMATE);
+  add_role_permission_resource (role_uuid, "GET_CONFIGS", "config",
+                                CONFIG_UUID_EMPTY);
+  add_role_permission_resource (role_uuid, "GET_CONFIGS", "config",
+                                CONFIG_UUID_DISCOVERY);
+  add_role_permission_resource (role_uuid, "GET_CONFIGS", "config",
+                                CONFIG_UUID_HOST_DISCOVERY);
+  add_role_permission_resource (role_uuid, "GET_CONFIGS", "config",
+                                CONFIG_UUID_SYSTEM_DISCOVERY);
 
-      /* Global port lists. */
-      add_role_permission_resource (role_uuid, "GET_PORT_LISTS",
-                                    "port_list", PORT_LIST_UUID_DEFAULT);
-      add_role_permission_resource (role_uuid, "GET_PORT_LISTS",
-                                    "port_list", PORT_LIST_UUID_ALL_TCP);
-      add_role_permission_resource (role_uuid, "GET_PORT_LISTS",
-                                    "port_list",
-                                    PORT_LIST_UUID_ALL_TCP_NMAP_5_51_TOP_100);
-      add_role_permission_resource (role_uuid, "GET_PORT_LISTS",
-                                    "port_list",
-                                    PORT_LIST_UUID_ALL_TCP_NMAP_5_51_TOP_1000);
-      add_role_permission_resource (role_uuid, "GET_PORT_LISTS",
-                                    "port_list",
-                                    PORT_LIST_UUID_ALL_PRIV_TCP);
-      add_role_permission_resource (role_uuid, "GET_PORT_LISTS",
-                                    "port_list",
-                                    PORT_LIST_UUID_ALL_PRIV_TCP_UDP);
-      add_role_permission_resource (role_uuid, "GET_PORT_LISTS",
-                                    "port_list",
-                                    PORT_LIST_UUID_ALL_IANA_TCP_2012);
-      add_role_permission_resource (role_uuid, "GET_PORT_LISTS",
-                                    "port_list",
-                                    PORT_LIST_UUID_ALL_IANA_TCP_UDP_2012);
-      add_role_permission_resource (role_uuid, "GET_PORT_LISTS",
-                                    "port_list",
-                                    PORT_LIST_UUID_NMAP_5_51_TOP_2000_TOP_100);
+  /* Global port lists. */
+  add_role_permission_resource (role_uuid, "GET_PORT_LISTS",
+                                "port_list", PORT_LIST_UUID_DEFAULT);
+  add_role_permission_resource (role_uuid, "GET_PORT_LISTS",
+                                "port_list", PORT_LIST_UUID_ALL_TCP);
+  add_role_permission_resource (role_uuid, "GET_PORT_LISTS",
+                                "port_list",
+                                PORT_LIST_UUID_ALL_TCP_NMAP_5_51_TOP_100);
+  add_role_permission_resource (role_uuid, "GET_PORT_LISTS",
+                                "port_list",
+                                PORT_LIST_UUID_ALL_TCP_NMAP_5_51_TOP_1000);
+  add_role_permission_resource (role_uuid, "GET_PORT_LISTS",
+                                "port_list",
+                                PORT_LIST_UUID_ALL_PRIV_TCP);
+  add_role_permission_resource (role_uuid, "GET_PORT_LISTS",
+                                "port_list",
+                                PORT_LIST_UUID_ALL_PRIV_TCP_UDP);
+  add_role_permission_resource (role_uuid, "GET_PORT_LISTS",
+                                "port_list",
+                                PORT_LIST_UUID_ALL_IANA_TCP_2012);
+  add_role_permission_resource (role_uuid, "GET_PORT_LISTS",
+                                "port_list",
+                                PORT_LIST_UUID_ALL_IANA_TCP_UDP_2012);
+  add_role_permission_resource (role_uuid, "GET_PORT_LISTS",
+                                "port_list",
+                                PORT_LIST_UUID_NMAP_5_51_TOP_2000_TOP_100);
 
-      /* Scanners are global when created from the command line. */
-      init_iterator (&scanners,
-                     "SELECT id, uuid FROM scanners WHERE owner is NULL;");
-      while (next (&scanners))
-        add_role_permission_resource (role_uuid, "GET_SCANNERS",
-                                      "scanner",
-                                      iterator_string (&scanners, 1));
-      cleanup_iterator (&scanners);
+  /* Scanners are global when created from the command line. */
+  init_iterator (&scanners,
+                  "SELECT id, uuid FROM scanners WHERE owner is NULL;");
+  while (next (&scanners))
+    add_role_permission_resource (role_uuid, "GET_SCANNERS",
+                                  "scanner",
+                                  iterator_string (&scanners, 1));
+  cleanup_iterator (&scanners);
 
-      add_role_permission_resource (role_uuid, "GET_ROLES",
-                                    "role",
-                                    ROLE_UUID_ADMIN);
-      add_role_permission_resource (role_uuid, "GET_ROLES",
-                                    "role",
-                                    ROLE_UUID_GUEST);
-      add_role_permission_resource (role_uuid, "GET_ROLES",
-                                    "role",
-                                    ROLE_UUID_INFO);
-      add_role_permission_resource (role_uuid, "GET_ROLES",
-                                    "role",
-                                    ROLE_UUID_MONITOR);
-      add_role_permission_resource (role_uuid, "GET_ROLES",
-                                    "role",
-                                    ROLE_UUID_USER);
-      add_role_permission_resource (role_uuid, "GET_ROLES",
-                                    "role",
-                                    ROLE_UUID_OBSERVER);
+  add_role_permission_resource (role_uuid, "GET_ROLES",
+                                "role",
+                                ROLE_UUID_ADMIN);
+  add_role_permission_resource (role_uuid, "GET_ROLES",
+                                "role",
+                                ROLE_UUID_GUEST);
+  add_role_permission_resource (role_uuid, "GET_ROLES",
+                                "role",
+                                ROLE_UUID_INFO);
+  add_role_permission_resource (role_uuid, "GET_ROLES",
+                                "role",
+                                ROLE_UUID_MONITOR);
+  add_role_permission_resource (role_uuid, "GET_ROLES",
+                                "role",
+                                ROLE_UUID_USER);
+  add_role_permission_resource (role_uuid, "GET_ROLES",
+                                "role",
+                                ROLE_UUID_OBSERVER);
 }
 
 /**
@@ -17672,14 +17672,14 @@ check_db_permissions ()
            " AND subject = (SELECT id FROM roles"
            "                WHERE uuid = '" ROLE_UUID_GUEST "');");
     }
-      add_role_permission (ROLE_UUID_GUEST, "AUTHENTICATE");
-      add_role_permission (ROLE_UUID_GUEST, "COMMANDS");
-      add_role_permission (ROLE_UUID_GUEST, "HELP");
-      add_role_permission (ROLE_UUID_GUEST, "GET_AGGREGATES");
-      add_role_permission (ROLE_UUID_GUEST, "GET_FILTERS");
-      add_role_permission (ROLE_UUID_GUEST, "GET_INFO");
-      add_role_permission (ROLE_UUID_GUEST, "GET_NVTS");
-      add_role_permission (ROLE_UUID_GUEST, "GET_SETTINGS");
+  add_role_permission (ROLE_UUID_GUEST, "AUTHENTICATE");
+  add_role_permission (ROLE_UUID_GUEST, "COMMANDS");
+  add_role_permission (ROLE_UUID_GUEST, "HELP");
+  add_role_permission (ROLE_UUID_GUEST, "GET_AGGREGATES");
+  add_role_permission (ROLE_UUID_GUEST, "GET_FILTERS");
+  add_role_permission (ROLE_UUID_GUEST, "GET_INFO");
+  add_role_permission (ROLE_UUID_GUEST, "GET_NVTS");
+  add_role_permission (ROLE_UUID_GUEST, "GET_SETTINGS");
 
   if (sql_int ("SELECT count(*) FROM permissions"
                " WHERE subject_type = 'role'"
@@ -17693,14 +17693,14 @@ check_db_permissions ()
            " AND subject = (SELECT id FROM roles"
            "                WHERE uuid = '" ROLE_UUID_INFO "');");
     }
-      add_role_permission (ROLE_UUID_INFO, "AUTHENTICATE");
-      add_role_permission (ROLE_UUID_INFO, "COMMANDS");
-      add_role_permission (ROLE_UUID_INFO, "HELP");
-      add_role_permission (ROLE_UUID_INFO, "GET_AGGREGATES");
-      add_role_permission (ROLE_UUID_INFO, "GET_INFO");
-      add_role_permission (ROLE_UUID_INFO, "GET_NVTS");
-      add_role_permission (ROLE_UUID_INFO, "GET_SETTINGS");
-      add_role_permission (ROLE_UUID_INFO, "MODIFY_SETTING");
+  add_role_permission (ROLE_UUID_INFO, "AUTHENTICATE");
+  add_role_permission (ROLE_UUID_INFO, "COMMANDS");
+  add_role_permission (ROLE_UUID_INFO, "HELP");
+  add_role_permission (ROLE_UUID_INFO, "GET_AGGREGATES");
+  add_role_permission (ROLE_UUID_INFO, "GET_INFO");
+  add_role_permission (ROLE_UUID_INFO, "GET_NVTS");
+  add_role_permission (ROLE_UUID_INFO, "GET_SETTINGS");
+  add_role_permission (ROLE_UUID_INFO, "MODIFY_SETTING");
 
   if (sql_int ("SELECT count(*) FROM permissions"
                " WHERE subject_type = 'role'"
@@ -17714,11 +17714,11 @@ check_db_permissions ()
            " AND subject = (SELECT id FROM roles"
            "                WHERE uuid = '" ROLE_UUID_MONITOR "');");
     }
-      add_role_permission (ROLE_UUID_MONITOR, "AUTHENTICATE");
-      add_role_permission (ROLE_UUID_MONITOR, "COMMANDS");
-      add_role_permission (ROLE_UUID_MONITOR, "GET_SETTINGS");
-      add_role_permission (ROLE_UUID_MONITOR, "GET_SYSTEM_REPORTS");
-      add_role_permission (ROLE_UUID_MONITOR, "HELP");
+  add_role_permission (ROLE_UUID_MONITOR, "AUTHENTICATE");
+  add_role_permission (ROLE_UUID_MONITOR, "COMMANDS");
+  add_role_permission (ROLE_UUID_MONITOR, "GET_SETTINGS");
+  add_role_permission (ROLE_UUID_MONITOR, "GET_SYSTEM_REPORTS");
+  add_role_permission (ROLE_UUID_MONITOR, "HELP");
 
   if (sql_int ("SELECT count(*) FROM permissions"
                " WHERE subject_type = 'role'"
@@ -17732,18 +17732,18 @@ check_db_permissions ()
            " AND subject = (SELECT id FROM roles"
            "                WHERE uuid = '" ROLE_UUID_USER "');");
     }
-      command = gmp_commands;
-      while (command[0].name)
-        {
-          if (strstr (command[0].name, "DESCRIBE_AUTH") == NULL
-              && strcmp (command[0].name, "GET_VERSION")
-              && strstr (command[0].name, "GROUP") == NULL
-              && strstr (command[0].name, "ROLE") == NULL
-              && strstr (command[0].name, "SYNC") == NULL
-              && strstr (command[0].name, "USER") == NULL)
-            add_role_permission (ROLE_UUID_USER, command[0].name);
-          command++;
-        }
+  command = gmp_commands;
+  while (command[0].name)
+    {
+      if (strstr (command[0].name, "DESCRIBE_AUTH") == NULL
+          && strcmp (command[0].name, "GET_VERSION")
+          && strstr (command[0].name, "GROUP") == NULL
+          && strstr (command[0].name, "ROLE") == NULL
+          && strstr (command[0].name, "SYNC") == NULL
+          && strstr (command[0].name, "USER") == NULL)
+        add_role_permission (ROLE_UUID_USER, command[0].name);
+      command++;
+    }
 
   if (sql_int ("SELECT count(*) FROM permissions"
                " WHERE subject_type = 'role'"
@@ -17757,20 +17757,20 @@ check_db_permissions ()
            " AND subject = (SELECT id FROM roles"
            "                WHERE uuid = '" ROLE_UUID_OBSERVER "');");
     }
-      command = gmp_commands;
-      while (command[0].name)
-        {
-          if ((strstr (command[0].name, "GET") == command[0].name)
-              && strcmp (command[0].name, "GET_GROUPS")
-              && strcmp (command[0].name, "GET_ROLES")
-              && strcmp (command[0].name, "GET_USERS")
-              && strcmp (command[0].name, "GET_VERSION"))
-            add_role_permission (ROLE_UUID_OBSERVER, command[0].name);
-          command++;
-        }
-      add_role_permission (ROLE_UUID_OBSERVER, "AUTHENTICATE");
-      add_role_permission (ROLE_UUID_OBSERVER, "HELP");
-      add_role_permission (ROLE_UUID_OBSERVER, "MODIFY_SETTING");
+  command = gmp_commands;
+  while (command[0].name)
+    {
+      if ((strstr (command[0].name, "GET") == command[0].name)
+          && strcmp (command[0].name, "GET_GROUPS")
+          && strcmp (command[0].name, "GET_ROLES")
+          && strcmp (command[0].name, "GET_USERS")
+          && strcmp (command[0].name, "GET_VERSION"))
+        add_role_permission (ROLE_UUID_OBSERVER, command[0].name);
+      command++;
+    }
+  add_role_permission (ROLE_UUID_OBSERVER, "AUTHENTICATE");
+  add_role_permission (ROLE_UUID_OBSERVER, "HELP");
+  add_role_permission (ROLE_UUID_OBSERVER, "MODIFY_SETTING");
 
 
   add_permissions_on_globals (ROLE_UUID_ADMIN);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -17514,12 +17514,11 @@ check_db_report_formats_trash ()
  * @brief Add permissions for all global resources.
  *
  * @param[in]  role_uuid  UUID of role.
- * @param[in]  force_add  Whether to always try to add permissions.
  */
 static void
-add_permissions_on_globals (const gchar *role_uuid, gboolean force_add)
+add_permissions_on_globals (const gchar *role_uuid)
 {
-  gboolean must_add = force_add;
+  iterator_t scanners;
 
   if (sql_int ("SELECT count(*) FROM permissions"
                " WHERE owner is NULL"
@@ -17540,13 +17539,7 @@ add_permissions_on_globals (const gchar *role_uuid, gboolean force_add)
            " AND subject = (SELECT id FROM roles"
            "                WHERE uuid = '%s');",
            role_uuid);
-
-      must_add = TRUE;
     }
-
-  if (must_add)
-    {
-      iterator_t scanners;
 
       /* Global configs. */
       add_role_permission_resource (role_uuid, "GET_CONFIGS", "config",
@@ -17620,18 +17613,15 @@ add_permissions_on_globals (const gchar *role_uuid, gboolean force_add)
       add_role_permission_resource (role_uuid, "GET_ROLES",
                                     "role",
                                     ROLE_UUID_OBSERVER);
-    }
 }
 
 /**
  * @brief Ensure the predefined permissions exists.
- *
- * @param[in]  force_add   Whether to always try to create permissions.
  */
 static void
-check_db_permissions (gboolean force_add)
+check_db_permissions ()
 {
-  gboolean must_add;
+  command_t *command;
 
   if (sql_int ("SELECT count(*) FROM permissions"
                " WHERE uuid = '" PERMISSION_UUID_ADMIN_EVERYTHING "';")
@@ -17670,7 +17660,6 @@ check_db_permissions (gboolean force_add)
            "  " G_STRINGIFY (LOCATION_TABLE) ", m_now (), m_now ());");
     }
 
-  must_add = force_add;
   if (sql_int ("SELECT count(*) FROM permissions"
                " WHERE subject_type = 'role'"
                " AND subject = (SELECT id FROM roles"
@@ -17682,10 +17671,7 @@ check_db_permissions (gboolean force_add)
       sql ("DELETE FROM permissions WHERE subject_type = 'role'"
            " AND subject = (SELECT id FROM roles"
            "                WHERE uuid = '" ROLE_UUID_GUEST "');");
-      must_add = TRUE;
     }
-  if (must_add)
-    {
       add_role_permission (ROLE_UUID_GUEST, "AUTHENTICATE");
       add_role_permission (ROLE_UUID_GUEST, "COMMANDS");
       add_role_permission (ROLE_UUID_GUEST, "HELP");
@@ -17694,9 +17680,7 @@ check_db_permissions (gboolean force_add)
       add_role_permission (ROLE_UUID_GUEST, "GET_INFO");
       add_role_permission (ROLE_UUID_GUEST, "GET_NVTS");
       add_role_permission (ROLE_UUID_GUEST, "GET_SETTINGS");
-    }
 
-  must_add = force_add;
   if (sql_int ("SELECT count(*) FROM permissions"
                " WHERE subject_type = 'role'"
                " AND subject = (SELECT id FROM roles"
@@ -17708,10 +17692,7 @@ check_db_permissions (gboolean force_add)
       sql ("DELETE FROM permissions WHERE subject_type = 'role'"
            " AND subject = (SELECT id FROM roles"
            "                WHERE uuid = '" ROLE_UUID_INFO "');");
-      must_add = TRUE;
     }
-  if (must_add)
-    {
       add_role_permission (ROLE_UUID_INFO, "AUTHENTICATE");
       add_role_permission (ROLE_UUID_INFO, "COMMANDS");
       add_role_permission (ROLE_UUID_INFO, "HELP");
@@ -17720,9 +17701,7 @@ check_db_permissions (gboolean force_add)
       add_role_permission (ROLE_UUID_INFO, "GET_NVTS");
       add_role_permission (ROLE_UUID_INFO, "GET_SETTINGS");
       add_role_permission (ROLE_UUID_INFO, "MODIFY_SETTING");
-    }
 
-  must_add = force_add;
   if (sql_int ("SELECT count(*) FROM permissions"
                " WHERE subject_type = 'role'"
                " AND subject = (SELECT id FROM roles"
@@ -17734,18 +17713,13 @@ check_db_permissions (gboolean force_add)
       sql ("DELETE FROM permissions WHERE subject_type = 'role'"
            " AND subject = (SELECT id FROM roles"
            "                WHERE uuid = '" ROLE_UUID_MONITOR "');");
-      must_add = TRUE;
     }
-  if (must_add)
-    {
       add_role_permission (ROLE_UUID_MONITOR, "AUTHENTICATE");
       add_role_permission (ROLE_UUID_MONITOR, "COMMANDS");
       add_role_permission (ROLE_UUID_MONITOR, "GET_SETTINGS");
       add_role_permission (ROLE_UUID_MONITOR, "GET_SYSTEM_REPORTS");
       add_role_permission (ROLE_UUID_MONITOR, "HELP");
-    }
 
-  must_add = force_add;
   if (sql_int ("SELECT count(*) FROM permissions"
                " WHERE subject_type = 'role'"
                " AND subject = (SELECT id FROM roles"
@@ -17757,11 +17731,7 @@ check_db_permissions (gboolean force_add)
       sql ("DELETE FROM permissions WHERE subject_type = 'role'"
            " AND subject = (SELECT id FROM roles"
            "                WHERE uuid = '" ROLE_UUID_USER "');");
-      must_add = TRUE;
     }
-  if (must_add)
-    {
-      command_t *command;
       command = gmp_commands;
       while (command[0].name)
         {
@@ -17774,9 +17744,7 @@ check_db_permissions (gboolean force_add)
             add_role_permission (ROLE_UUID_USER, command[0].name);
           command++;
         }
-    }
 
-  must_add = force_add;
   if (sql_int ("SELECT count(*) FROM permissions"
                " WHERE subject_type = 'role'"
                " AND subject = (SELECT id FROM roles"
@@ -17788,11 +17756,7 @@ check_db_permissions (gboolean force_add)
       sql ("DELETE FROM permissions WHERE subject_type = 'role'"
            " AND subject = (SELECT id FROM roles"
            "                WHERE uuid = '" ROLE_UUID_OBSERVER "');");
-      must_add = TRUE;
     }
-  if (must_add)
-    {
-      command_t *command;
       command = gmp_commands;
       while (command[0].name)
         {
@@ -17807,12 +17771,12 @@ check_db_permissions (gboolean force_add)
       add_role_permission (ROLE_UUID_OBSERVER, "AUTHENTICATE");
       add_role_permission (ROLE_UUID_OBSERVER, "HELP");
       add_role_permission (ROLE_UUID_OBSERVER, "MODIFY_SETTING");
-    }
 
-  add_permissions_on_globals (ROLE_UUID_ADMIN, force_add);
-  add_permissions_on_globals (ROLE_UUID_GUEST, force_add);
-  add_permissions_on_globals (ROLE_UUID_OBSERVER, force_add);
-  add_permissions_on_globals (ROLE_UUID_USER, force_add);
+
+  add_permissions_on_globals (ROLE_UUID_ADMIN);
+  add_permissions_on_globals (ROLE_UUID_GUEST);
+  add_permissions_on_globals (ROLE_UUID_OBSERVER);
+  add_permissions_on_globals (ROLE_UUID_USER);
 
   /* Once only, ensure that all existing users have permission to see
    * themselves.  From Manager 9.0 this will be done in a migrator. */
@@ -17950,7 +17914,7 @@ check_db (int check_encryption_key)
     goto fail;
   if (check_db_report_formats_trash ())
     goto fail;
-  check_db_permissions (TRUE);
+  check_db_permissions ();
   check_db_settings ();
   cleanup_schedule_times ();
   if (check_encryption_key && check_db_encryption_key ())

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -16626,23 +16626,33 @@ check_db_settings ()
  *
  * Caller must ensure args are SQL escaped.
  *
- * @param[in]  role        Role.
+ * @param[in]  role_id     Role.
  * @param[in]  permission  Permission.
  */
 static void
-add_role_permission (const gchar *role, const gchar *permission)
+add_role_permission (const gchar *role_id, const gchar *permission)
 {
-  sql ("INSERT INTO permissions"
-       " (uuid, owner, name, comment, resource_type, resource, resource_uuid,"
-       "  resource_location, subject_type, subject, subject_location,"
-       "  creation_time, modification_time)"
-       " VALUES"
-       " (make_uuid (), NULL, lower ('%s'), '', '',"
-       "  0, '', " G_STRINGIFY (LOCATION_TABLE) ", 'role',"
-       "  (SELECT id FROM roles WHERE uuid = '%s'),"
-       "  " G_STRINGIFY (LOCATION_TABLE) ", m_now (), m_now ());",
-       permission,
-       role);
+  if (sql_int ("SELECT EXISTS (SELECT * FROM permissions"
+               "               WHERE owner IS NULL"
+               "               AND name = lower ('%s')"
+               "               AND resource_type = ''"
+               "               AND resource = 0"
+               "               AND subject_type = 'role'"
+               "               AND subject = (SELECT id FROM roles"
+               "                              WHERE uuid = '%s'));",
+               permission,
+               role_id) == 0)
+    sql ("INSERT INTO permissions"
+         " (uuid, owner, name, comment, resource_type, resource, resource_uuid,"
+         "  resource_location, subject_type, subject, subject_location,"
+         "  creation_time, modification_time)"
+         " VALUES"
+         " (make_uuid (), NULL, lower ('%s'), '', '',"
+         "  0, '', " G_STRINGIFY (LOCATION_TABLE) ", 'role',"
+         "  (SELECT id FROM roles WHERE uuid = '%s'),"
+         "  " G_STRINGIFY (LOCATION_TABLE) ", m_now (), m_now ());",
+         permission,
+         role_id);
 }
 
 /**
@@ -17504,10 +17514,13 @@ check_db_report_formats_trash ()
  * @brief Add permissions for all global resources.
  *
  * @param[in]  role_uuid  UUID of role.
+ * @param[in]  force_add  Whether to always try to add permissions.
  */
 static void
-add_permissions_on_globals (const gchar *role_uuid)
+add_permissions_on_globals (const gchar *role_uuid, gboolean force_add)
 {
+  gboolean must_add = force_add;
+
   if (sql_int ("SELECT count(*) FROM permissions"
                " WHERE owner is NULL"
                " AND subject_type = 'role'"
@@ -17518,8 +17531,6 @@ add_permissions_on_globals (const gchar *role_uuid)
                role_uuid)
       == 0)
     {
-      iterator_t scanners;
-
       /* Clean-up any remaining permissions. */
       sql ("DELETE FROM permissions"
            " WHERE owner IS NULL"
@@ -17529,6 +17540,13 @@ add_permissions_on_globals (const gchar *role_uuid)
            " AND subject = (SELECT id FROM roles"
            "                WHERE uuid = '%s');",
            role_uuid);
+
+      must_add = TRUE;
+    }
+
+  if (must_add)
+    {
+      iterator_t scanners;
 
       /* Global configs. */
       add_role_permission_resource (role_uuid, "GET_CONFIGS", "config",
@@ -17607,10 +17625,14 @@ add_permissions_on_globals (const gchar *role_uuid)
 
 /**
  * @brief Ensure the predefined permissions exists.
+ *
+ * @param[in]  force_add   Whether to always try to create permissions.
  */
 static void
-check_db_permissions ()
+check_db_permissions (gboolean force_add)
 {
+  gboolean must_add;
+
   if (sql_int ("SELECT count(*) FROM permissions"
                " WHERE uuid = '" PERMISSION_UUID_ADMIN_EVERYTHING "';")
       == 0)
@@ -17648,6 +17670,7 @@ check_db_permissions ()
            "  " G_STRINGIFY (LOCATION_TABLE) ", m_now (), m_now ());");
     }
 
+  must_add = force_add;
   if (sql_int ("SELECT count(*) FROM permissions"
                " WHERE subject_type = 'role'"
                " AND subject = (SELECT id FROM roles"
@@ -17659,6 +17682,10 @@ check_db_permissions ()
       sql ("DELETE FROM permissions WHERE subject_type = 'role'"
            " AND subject = (SELECT id FROM roles"
            "                WHERE uuid = '" ROLE_UUID_GUEST "');");
+      must_add = TRUE;
+    }
+  if (must_add)
+    {
       add_role_permission (ROLE_UUID_GUEST, "AUTHENTICATE");
       add_role_permission (ROLE_UUID_GUEST, "COMMANDS");
       add_role_permission (ROLE_UUID_GUEST, "HELP");
@@ -17669,6 +17696,7 @@ check_db_permissions ()
       add_role_permission (ROLE_UUID_GUEST, "GET_SETTINGS");
     }
 
+  must_add = force_add;
   if (sql_int ("SELECT count(*) FROM permissions"
                " WHERE subject_type = 'role'"
                " AND subject = (SELECT id FROM roles"
@@ -17680,6 +17708,10 @@ check_db_permissions ()
       sql ("DELETE FROM permissions WHERE subject_type = 'role'"
            " AND subject = (SELECT id FROM roles"
            "                WHERE uuid = '" ROLE_UUID_INFO "');");
+      must_add = TRUE;
+    }
+  if (must_add)
+    {
       add_role_permission (ROLE_UUID_INFO, "AUTHENTICATE");
       add_role_permission (ROLE_UUID_INFO, "COMMANDS");
       add_role_permission (ROLE_UUID_INFO, "HELP");
@@ -17690,6 +17722,7 @@ check_db_permissions ()
       add_role_permission (ROLE_UUID_INFO, "MODIFY_SETTING");
     }
 
+  must_add = force_add;
   if (sql_int ("SELECT count(*) FROM permissions"
                " WHERE subject_type = 'role'"
                " AND subject = (SELECT id FROM roles"
@@ -17701,6 +17734,10 @@ check_db_permissions ()
       sql ("DELETE FROM permissions WHERE subject_type = 'role'"
            " AND subject = (SELECT id FROM roles"
            "                WHERE uuid = '" ROLE_UUID_MONITOR "');");
+      must_add = TRUE;
+    }
+  if (must_add)
+    {
       add_role_permission (ROLE_UUID_MONITOR, "AUTHENTICATE");
       add_role_permission (ROLE_UUID_MONITOR, "COMMANDS");
       add_role_permission (ROLE_UUID_MONITOR, "GET_SETTINGS");
@@ -17708,6 +17745,7 @@ check_db_permissions ()
       add_role_permission (ROLE_UUID_MONITOR, "HELP");
     }
 
+  must_add = force_add;
   if (sql_int ("SELECT count(*) FROM permissions"
                " WHERE subject_type = 'role'"
                " AND subject = (SELECT id FROM roles"
@@ -17715,13 +17753,16 @@ check_db_permissions ()
                " AND resource = 0;")
       <= 1)
     {
-      command_t *command;
-      command = gmp_commands;
-
       /* Clean-up any remaining permissions. */
       sql ("DELETE FROM permissions WHERE subject_type = 'role'"
            " AND subject = (SELECT id FROM roles"
            "                WHERE uuid = '" ROLE_UUID_USER "');");
+      must_add = TRUE;
+    }
+  if (must_add)
+    {
+      command_t *command;
+      command = gmp_commands;
       while (command[0].name)
         {
           if (strstr (command[0].name, "DESCRIBE_AUTH") == NULL
@@ -17735,6 +17776,7 @@ check_db_permissions ()
         }
     }
 
+  must_add = force_add;
   if (sql_int ("SELECT count(*) FROM permissions"
                " WHERE subject_type = 'role'"
                " AND subject = (SELECT id FROM roles"
@@ -17742,12 +17784,16 @@ check_db_permissions ()
                " AND resource = 0;")
       <= 1)
     {
-      command_t *command;
-      command = gmp_commands;
       /* Clean-up any remaining permissions. */
       sql ("DELETE FROM permissions WHERE subject_type = 'role'"
            " AND subject = (SELECT id FROM roles"
            "                WHERE uuid = '" ROLE_UUID_OBSERVER "');");
+      must_add = TRUE;
+    }
+  if (must_add)
+    {
+      command_t *command;
+      command = gmp_commands;
       while (command[0].name)
         {
           if ((strstr (command[0].name, "GET") == command[0].name)
@@ -17763,10 +17809,10 @@ check_db_permissions ()
       add_role_permission (ROLE_UUID_OBSERVER, "MODIFY_SETTING");
     }
 
-  add_permissions_on_globals (ROLE_UUID_ADMIN);
-  add_permissions_on_globals (ROLE_UUID_GUEST);
-  add_permissions_on_globals (ROLE_UUID_OBSERVER);
-  add_permissions_on_globals (ROLE_UUID_USER);
+  add_permissions_on_globals (ROLE_UUID_ADMIN, force_add);
+  add_permissions_on_globals (ROLE_UUID_GUEST, force_add);
+  add_permissions_on_globals (ROLE_UUID_OBSERVER, force_add);
+  add_permissions_on_globals (ROLE_UUID_USER, force_add);
 
   /* Once only, ensure that all existing users have permission to see
    * themselves.  From Manager 9.0 this will be done in a migrator. */
@@ -17904,7 +17950,7 @@ check_db (int check_encryption_key)
     goto fail;
   if (check_db_report_formats_trash ())
     goto fail;
-  check_db_permissions ();
+  check_db_permissions (TRUE);
   check_db_settings ();
   cleanup_schedule_times ();
   if (check_encryption_key && check_db_encryption_key ())


### PR DESCRIPTION
The gvmd startup will now check and create the permissions for the
built-in roles and resources individually instead of just looking for
any permissions for each role.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
