### PR TITLE
Add get_aggregates support and time_status to TLS certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
-- Added TLS certificates as a new resource type [#585](https://github.com/greenbone/gvmd/pull/585) [#663](https://github.com/greenbone/gvmd/pull/663)
+- Added TLS certificates as a new resource type [#585](https://github.com/greenbone/gvmd/pull/585) [#663](https://github.com/greenbone/gvmd/pull/663) [#673](https://github.com/greenbone/gvmd/pull/673)
 - Update NVTs via OSP [#392](https://github.com/greenbone/gvmd/pull/392) [#609](https://github.com/greenbone/gvmd/pull/609) [#626](https://github.com/greenbone/gvmd/pull/626)
 - Handle addition of ID to NVT preferences. [#413](https://github.com/greenbone/gvmd/pull/413)
 - Add setting 'OMP Slave Check Period' [#491](https://github.com/greenbone/gvmd/pull/491)

--- a/src/gmp_tls_certificates.c
+++ b/src/gmp_tls_certificates.c
@@ -197,6 +197,7 @@ get_tls_certificates_run (gmp_parser_t *gmp_parser, GError **error)
          "<md5_fingerprint>%s</md5_fingerprint>"
          "<trust>%d</trust>"
          "<valid>%d</valid>"
+         "<time_status>%s</time_status>"
          "<activation_time>%s</activation_time>"
          "<expiration_time>%s</expiration_time>"
          "<subject_dn>%s</subject_dn>"
@@ -213,6 +214,7 @@ get_tls_certificates_run (gmp_parser_t *gmp_parser, GError **error)
          tls_certificate_iterator_sha256_fingerprint (&tls_certificates),
          tls_certificate_iterator_trust (&tls_certificates),
          tls_certificate_iterator_valid (&tls_certificates),
+         tls_certificate_iterator_time_status (&tls_certificates),
          tls_certificate_iterator_activation_time (&tls_certificates),
          tls_certificate_iterator_expiration_time (&tls_certificates),
          tls_certificate_iterator_subject_dn (&tls_certificates),

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -63464,6 +63464,8 @@ type_select_columns (const char *type)
     return task_columns;
   /* Tickets don't use this. */
   assert (strcasecmp (type, "ticket"));
+  if (strcasecmp (type, "TLS_CERTIFICATE") == 0)
+    return tls_certificate_select_columns ();
   if (strcasecmp (type, "USER") == 0)
     return user_columns;
   if (strcasecmp (type, "VULN") == 0)
@@ -63653,6 +63655,8 @@ type_filter_columns (const char *type)
     }
   /* Tickets don't use this. */
   assert (strcasecmp (type, "ticket"));
+  if (strcasecmp (type, "TLS_CERTIFICATE") == 0)
+    return tls_certificate_filter_columns ();
   if (strcasecmp (type, "USER") == 0)
     {
       static const char *ret[] = USER_ITERATOR_FILTER_COLUMNS;

--- a/src/manage_sql_tls_certificates.c
+++ b/src/manage_sql_tls_certificates.c
@@ -55,7 +55,7 @@ user_tls_certificate_match_internal (tls_certificate_t,
 #define TLS_CERTIFICATE_ITERATOR_FILTER_COLUMNS                               \
  { GET_ITERATOR_FILTER_COLUMNS, "subject_dn", "issuer_dn", "md5_fingerprint", \
    "activates", "expires", "valid", "certificate_format", "last_collected",   \
-   "sha256_fingerprint", "serial", NULL }
+   "sha256_fingerprint", "serial", "time_status", NULL }
 
 /**
  * @brief TLS Certificate iterator columns.
@@ -125,6 +125,17 @@ user_tls_certificate_match_internal (tls_certificate_t,
      " WHERE tls_certificate = tls_certificates.id)",                         \
      NULL,                                                                    \
      KEYWORD_TYPE_STRING                                                      \
+   },                                                                         \
+   {                                                                          \
+     "(CASE WHEN (activation_time = -1) OR (expiration_time = 1)"             \
+     "      THEN 'unknown'"                                                   \
+     "      WHEN (expiration_time < m_now() AND expiration_time != 0)"        \
+     "      THEN 'expired'"                                                   \
+     "      WHEN (activation_time > m_now())"                                 \
+     "      THEN 'inactive'"                                                  \
+     "      ELSE 'valid' END)",                                               \
+     "time_status",                                                           \
+     KEYWORD_TYPE_INTEGER                                                     \
    },                                                                         \
    {                                                                          \
      "activation_time",                                                       \
@@ -343,6 +354,16 @@ DEF_ACCESS (tls_certificate_iterator_serial,
  */
 DEF_ACCESS (tls_certificate_iterator_last_collected,
             GET_ITERATOR_COLUMN_COUNT + 11);
+
+/**
+ * @brief Get a column value from a tls_certificate iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return Value of the column or NULL if iteration is complete.
+ */
+DEF_ACCESS (tls_certificate_iterator_time_status,
+            GET_ITERATOR_COLUMN_COUNT + 12);
 
 
 /**

--- a/src/manage_sql_tls_certificates.c
+++ b/src/manage_sql_tls_certificates.c
@@ -146,6 +146,30 @@ user_tls_certificate_match_internal (tls_certificate_t,
  }
 
 /**
+ * @brief Gets the filter columns for TLS certificates.
+ *
+ * @return Constant array of filter columns.
+ */
+const char**
+tls_certificate_filter_columns ()
+{
+  static const char *columns[] = TLS_CERTIFICATE_ITERATOR_FILTER_COLUMNS;
+  return columns;
+}
+
+/**
+ * @brief Gets the select columns for TLS certificates.
+ *
+ * @return Constant array of select columns.
+ */
+column_t*
+tls_certificate_select_columns ()
+{
+  static column_t columns[] = TLS_CERTIFICATE_ITERATOR_COLUMNS;
+  return columns;
+}
+
+/**
  * @brief Count number of tls_certificates.
  *
  * @param[in]  get  GET params.
@@ -155,10 +179,10 @@ user_tls_certificate_match_internal (tls_certificate_t,
 int
 tls_certificate_count (const get_data_t *get)
 {
-  static const char *extra_columns[] = TLS_CERTIFICATE_ITERATOR_FILTER_COLUMNS;
+  static const char *filter_columns[] = TLS_CERTIFICATE_ITERATOR_FILTER_COLUMNS;
   static column_t columns[] = TLS_CERTIFICATE_ITERATOR_COLUMNS;
 
-  return count ("tls_certificate", get, columns, NULL, extra_columns,
+  return count ("tls_certificate", get, columns, NULL, filter_columns,
                 0, 0, 0, TRUE);
 }
 

--- a/src/manage_sql_tls_certificates.h
+++ b/src/manage_sql_tls_certificates.h
@@ -27,6 +27,12 @@
 #ifndef _GVMD_MANAGE_SQL_TLS_CERTIFICATES_H
 #define _GVMD_MANAGE_SQL_TLS_CERTIFICATES_H
 
+const char**
+tls_certificate_filter_columns ();
+
+column_t*
+tls_certificate_select_columns ();
+
 int
 delete_tls_certificate (const char *, int);
 

--- a/src/manage_tls_certificates.h
+++ b/src/manage_tls_certificates.h
@@ -72,6 +72,9 @@ tls_certificate_iterator_serial (iterator_t*);
 const char*
 tls_certificate_iterator_last_collected (iterator_t*);
 
+const char*
+tls_certificate_iterator_time_status (iterator_t*);
+
 int
 tls_certificate_in_use (tls_certificate_t);
 

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -22772,6 +22772,22 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             </summary>
           </column>
           <column>
+            <name>time_status</name>
+            <summary>
+              Whether the certificate is valid, expired or not active yet
+            </summary>
+            <pattern>
+              <t>
+                <alts>
+                  <alt>expired</alt>
+                  <alt>inactive</alt>
+                  <alt>unknown</alt>
+                  <alt>valid</alt>
+                </alts>
+              </t>
+            </pattern>
+          </column>
+          <column>
             <name>activates</name>
             <type>iso_time</type>
             <summary>Time before which the certificate is not valid</summary>
@@ -22845,6 +22861,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <e>sha256_fingerprint</e>
           <e>md5_fingerprint</e>
           <e>trust</e>
+          <e>time_status</e>
           <e>activation_time</e>
           <e>expiration_time</e>
           <e>subject_dn</e>
@@ -22952,6 +22969,22 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <name>valid</name>
           <summary>Whether the certificate is currently valid</summary>
           <pattern><t>boolean</t></pattern>
+        </ele>
+        <ele>
+          <name>time_status</name>
+          <summary>
+            Whether the certificate is valid, expired or not active yet
+          </summary>
+          <pattern>
+            <t>
+              <alts>
+                <alt>expired</alt>
+                <alt>inactive</alt>
+                <alt>unknown</alt>
+                <alt>valid</alt>
+              </alts>
+            </t>
+          </pattern>
         </ele>
         <ele>
           <name>activation_time</name>


### PR DESCRIPTION
This adds the option to use TLS certificates in the `get_aggregates` GMP command and the time_status field which indicates whether a certificate is valid, expired or not valid yet.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
