### PR TITLE
Add checks if SSLDetails text is NULL

### DIFF
--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -1031,11 +1031,16 @@ migrate_213_to_214 ()
                           " LIMIT 1;",
                           quoted_scanner_fpr);
 
-          parse_ssldetails (ssldetails,
-                            &activation_time,
-                            &expiration_time,
-                            &issuer,
-                            &serial);
+          if (ssldetails)
+            parse_ssldetails (ssldetails,
+                              &activation_time,
+                              &expiration_time,
+                              &issuer,
+                              &serial);
+          else
+            g_warning ("%s: No SSLDetails found for fingerprint %s",
+                       __FUNCTION__,
+                       scanner_fpr);
 
           free (ssldetails);
         }

--- a/src/manage_sql_tls_certificates.c
+++ b/src/manage_sql_tls_certificates.c
@@ -1459,11 +1459,16 @@ add_tls_certificates_from_report_host (report_host_t report_host,
                       report_host,
                       quoted_scanner_fpr);
 
-      parse_ssldetails (ssldetails,
-                        &activation_time,
-                        &expiration_time,
-                        &issuer,
-                        &serial);
+      if (ssldetails)
+        parse_ssldetails (ssldetails,
+                          &activation_time,
+                          &expiration_time,
+                          &issuer,
+                          &serial);
+      else
+        g_warning ("%s: No SSLDetails found for fingerprint %s",
+                   __FUNCTION__,
+                   scanner_fpr);
 
       free (ssldetails);
 

--- a/src/manage_tls_certificates.c
+++ b/src/manage_tls_certificates.c
@@ -56,6 +56,12 @@ parse_ssldetails (const char *ssldetails,
 {
   gchar **ssldetails_split, **ssldetails_point;
 
+  if (ssldetails == NULL)
+    {
+      g_warning ("%s: ssldetails is NULL", __FUNCTION__);
+      return;
+    }
+
   ssldetails_split = g_strsplit (ssldetails, "|", -1);
   ssldetails_point = ssldetails_split;
   while (*ssldetails_point)


### PR DESCRIPTION
Passing NULL to parse_ssldetails would cause a segfault so check for
this and log a warning about it as scans should return the host detail
together with the Cert:[...] host detail.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
