### PR TITLE
Add -f arg to sendmail call in email alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Change NVT references like CVEs and BID to general vt_refs. [#570](https://github.com/greenbone/gvmd/pull/570) [#574](https://github.com/greenbone/gvmd/pull/574) [#582](https://github.com/greenbone/gvmd/pull/582)
 - Update Postgres to SQLite migration. [#581](https://github.com/greenbone/gvmd/pull/581) [#601](https://github.com/greenbone/gvmd/pull/601) [#604](https://github.com/greenbone/gvmd/pull/604) [#605](https://github.com/greenbone/gvmd/pull/605)
 - Update result diff generation at delta reports [#650](https://github.com/greenbone/gvmd/pull/650)
+- Add -f arg to sendmail call in email alert [#676](https://github.com/greenbone/gvmd/pull/676)
 
 ### Fixed
 - Fix iCalendar recurrence and timezone handling [#654](https://github.com/greenbone/gvmd/pull/654)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -9351,11 +9351,12 @@ email (const char *to_address, const char *from_address, const char *subject,
        const char *attachment_name, const char *attachment_extension,
        credential_t recipient_credential)
 {
-  int ret, content_fd, to_fd;
+  int ret, content_fd, args_fd;
   gchar *command;
   GError *error = NULL;
   char content_file_name[] = "/tmp/gvmd-content-XXXXXX";
-  char to_file_name[] = "/tmp/gvmd-to-XXXXXX";
+  char args_file_name[] = "/tmp/gvmd-args-XXXXXX";
+  gchar *sendmail_args;
   FILE *content_file;
 
   content_fd = mkstemp (content_file_name);
@@ -9497,28 +9498,36 @@ email (const char *to_address, const char *from_address, const char *subject,
         }
     }
 
-  to_fd = mkstemp (to_file_name);
-  if (to_fd == -1)
+  args_fd = mkstemp (args_file_name);
+  if (args_fd == -1)
     {
       g_warning ("%s: mkstemp: %s", __FUNCTION__, strerror (errno));
       fclose (content_file);
       return -1;
     }
 
-  g_file_set_contents (to_file_name, to_address, strlen (to_address), &error);
+  sendmail_args = g_strdup_printf ("-f %s %s",
+                                   from_address,
+                                   to_address);
+  g_file_set_contents (args_file_name,
+                       sendmail_args,
+                       strlen (sendmail_args),
+                       &error);
+  g_free (sendmail_args);
+
   if (error)
     {
       g_warning ("%s", error->message);
       g_error_free (error);
       fclose (content_file);
-      close (to_fd);
+      close (args_fd);
       return -1;
     }
 
   command = g_strdup_printf ("xargs -a %s -I XXX"
                              " /usr/sbin/sendmail XXX < %s"
                              " > /dev/null 2>&1",
-                             to_file_name,
+                             args_file_name,
                              content_file_name);
 
   g_debug ("   command: %s", command);
@@ -9533,16 +9542,16 @@ email (const char *to_address, const char *from_address, const char *subject,
                  command);
       g_free (command);
       fclose (content_file);
-      close (to_fd);
+      close (args_fd);
       unlink (content_file_name);
-      unlink (to_file_name);
+      unlink (args_file_name);
       return -1;
     }
   g_free (command);
   fclose (content_file);
-  close (to_fd);
+  close (args_fd);
   unlink (content_file_name);
-  unlink (to_file_name);
+  unlink (args_file_name);
   return 0;
 }
 


### PR DESCRIPTION
This sets the sender more explicitly, so sendmail can use it for the
"Return-Path" header for example.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
