### PR TITLE
Remove nbefile column from SQL in make_report

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -21936,11 +21936,11 @@ report_clear_count_cache (report_t report,
 report_t
 make_report (task_t task, const char* uuid, task_status_t status)
 {
-  sql ("INSERT into reports (uuid, owner, task, date, nbefile, comment,"
+  sql ("INSERT into reports (uuid, owner, task, date, comment,"
        " scan_run_status, slave_progress, slave_task_uuid)"
        " VALUES ('%s',"
        " (SELECT owner FROM tasks WHERE tasks.id = %llu),"
-       " %llu, %i, '', '', %u, 0, '');",
+       " %llu, %i, '', %u, 0, '');",
        uuid, task, task, time (NULL), status);
   return sql_last_insert_id ();
 }


### PR DESCRIPTION
This column was removed from the reports table in DB version 215.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
