### PR TITLE
Resolve tags: solution and solution_type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 215)
+set (GVMD_DATABASE_VERSION 216)
 
 set (GVMD_SCAP_DATABASE_VERSION 15)
 

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -10170,9 +10170,29 @@ results_xml_append_nvt (iterator_t *results, GString *buffer, int cert_loaded)
       else
         {
           const char *cvss_base = result_iterator_nvt_cvss_base (results);
+          GString *tags = g_string_new (result_iterator_nvt_tag (results));
 
           if (!cvss_base && !strcmp (oid, "0"))
             cvss_base = "0.0";
+
+          /* Add the elements that are expected as part of the pipe-separated tag list
+           * via API although internally already explicitely stored. Once the API is
+           * extended to have these elements explicitely, they do not need to be
+           * added to this string anymore. */
+          if (result_iterator_nvt_solution (results))
+            {
+              if (tags->str)
+                g_string_append_printf (tags, "|solution=%s", result_iterator_nvt_solution (results));
+              else
+                g_string_append_printf (tags, "solution=%s", result_iterator_nvt_solution (results));
+            }
+          if (result_iterator_nvt_solution_type (results))
+            {
+              if (tags->str)
+                g_string_append_printf (tags, "|solution_type=%s", result_iterator_nvt_solution_type (results));
+              else
+                g_string_append_printf (tags, "solution_type=%s", result_iterator_nvt_solution_type (results));
+            }
 
           buffer_xml_append_printf (buffer,
                                     "<nvt oid=\"%s\">"
@@ -10185,7 +10205,7 @@ results_xml_append_nvt (iterator_t *results, GString *buffer, int cert_loaded)
                                     result_iterator_nvt_name (results) ?: oid,
                                     result_iterator_nvt_family (results) ?: "",
                                     cvss_base ?: "",
-                                    result_iterator_nvt_tag (results) ?: "");
+                                    tags->str ?: "");
 
           buffer_xml_append_printf (buffer, "<refs>");
           result_iterator_nvt_refs_append (buffer, results);
@@ -10193,6 +10213,8 @@ results_xml_append_nvt (iterator_t *results, GString *buffer, int cert_loaded)
                                    result_iterator_has_cert_bunds (results),
                                    result_iterator_has_dfn_certs (results));
           buffer_xml_append_printf (buffer, "</refs>");
+
+          g_string_free (tags, TRUE);
         }
 
     }

--- a/src/manage.c
+++ b/src/manage.c
@@ -7374,7 +7374,7 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count,
   if (details)
     {
       int tag_count;
-      GString *refs_str, *tags_str, *buffer;
+      GString *refs_str, *tags_str, *buffer, *nvt_tags;
       iterator_t cert_refs_iterator, tags;
       gchar *tag_name_esc, *tag_value_esc, *tag_comment_esc;
       char *default_timeout = nvt_default_timeout (oid);
@@ -7383,6 +7383,28 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count,
       DEF (tag);
 
 #undef DEF
+
+      nvt_tags = g_string_new (tag_text);
+      g_free (tag_text);
+
+      /* Add the elements that are expected as part of the pipe-separated tag list
+       * via API although internally already explicitely stored. Once the API is
+       * extended to have these elements explicitely, they do not need to be
+       * added to this string anymore. */
+      if (nvt_iterator_solution (nvts))
+        {
+          if (nvt_tags->str)
+            g_string_append_printf (nvt_tags, "|solution=%s", nvt_iterator_solution (nvts));
+          else
+            g_string_append_printf (nvt_tags, "solution=%s", result_iterator_nvt_solution (nvts));
+        }
+      if (nvt_iterator_solution_type (nvts))
+        {
+          if (nvt_tags->str)
+            g_string_append_printf (nvt_tags, "|solution_type=%s", nvt_iterator_solution_type (nvts));
+          else
+            g_string_append_printf (nvt_tags, "solution_type=%s", nvt_iterator_solution_type (nvts));
+        }
 
       refs_str = g_string_new ("");
 
@@ -7495,12 +7517,12 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count,
                               nvt_iterator_qod (nvts),
                               nvt_iterator_qod_type (nvts),
                               refs_str->str,
-                              tag_text,
+                              nvt_tags->str,
                               pref_count,
                               timeout ? timeout : "",
                               default_timeout ? default_timeout : "");
       g_free (family_text);
-      g_free (tag_text);
+      g_string_free(nvt_tags, 1);
       g_string_free(refs_str, 1);
       g_string_free(tags_str, 1);
 

--- a/src/manage.h
+++ b/src/manage.h
@@ -2015,6 +2015,9 @@ const char*
 nvt_iterator_qod_type ( iterator_t *iterator );
 
 const char*
+nvt_iterator_solution (iterator_t*);
+
+const char*
 nvt_iterator_solution_type (iterator_t*);
 
 char*

--- a/src/manage.h
+++ b/src/manage.h
@@ -1445,6 +1445,12 @@ const char*
 result_iterator_nvt_name (iterator_t *);
 
 const char*
+result_iterator_nvt_solution (iterator_t *);
+
+const char*
+result_iterator_nvt_solution_type (iterator_t *);
+
+const char*
 result_iterator_nvt_family (iterator_t *);
 
 const char*

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2013-2018 Greenbone Networks GmbH
+/* Copyright (C) 2013-2019 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *
@@ -1156,6 +1156,38 @@ migrate_213_to_214 ()
   /* Set the database version to 214 */
 
   set_db_version (214);
+
+  sql_commit ();
+
+  return 0;
+}
+
+/**
+ * @brief Migrate the database from version 215 to version 216.
+ *
+ * @return 0 success, -1 error.
+ */
+int
+migrate_215_to_216 ()
+{
+  sql_begin_immediate ();
+
+  /* Ensure that the database is currently version 215. */
+
+  if (manage_db_version () != 215)
+    {
+      sql_rollback ();
+      return -1;
+    }
+
+  /* Update the database. */
+
+  /* Extend table "nvts" with additional column "solution" */
+  sql ("ALTER TABLE IF EXISTS nvts ADD COLUMN solution text;");
+
+  /* Set the database version to 216. */
+
+  set_db_version (216);
 
   sql_commit ();
 

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -1163,6 +1163,38 @@ migrate_213_to_214 ()
 }
 
 /**
+ * @brief Migrate the database from version 214 to version 215.
+ *
+ * @return 0 success, -1 error.
+ */
+int
+migrate_214_to_215 ()
+{
+  sql_begin_immediate ();
+
+  /* Ensure that the database is currently version 214. */
+
+  if (manage_db_version () != 214)
+    {
+      sql_rollback ();
+      return -1;
+    }
+
+  /* Update the database. */
+
+  /* The column nbefile was removed from reports. */
+  sql ("ALTER TABLE reports DROP COLUMN nbefile;");
+
+  /* Set the database version to 215 */
+
+  set_db_version (215);
+
+  sql_commit ();
+
+  return 0;
+}
+
+/**
  * @brief Migrate the database from version 215 to version 216.
  *
  * @return 0 success, -1 error.
@@ -1197,38 +1229,6 @@ migrate_215_to_216 ()
 #undef UPDATE_DASHBOARD_SETTINGS
 
 /**
- * @brief Migrate the database from version 214 to version 215.
- *
- * @return 0 success, -1 error.
- */
-int
-migrate_214_to_215 ()
-{
-  sql_begin_immediate ();
-
-  /* Ensure that the database is currently version 214. */
-
-  if (manage_db_version () != 214)
-    {
-      sql_rollback ();
-      return -1;
-    }
-
-  /* Update the database. */
-
-  /* The column nbefile was removed from reports. */
-  sql ("ALTER TABLE reports DROP COLUMN nbefile;");
-
-  /* Set the database version to 215 */
-
-  set_db_version (215);
-
-  sql_commit ();
-
-  return 0;
-}
-
-/**
  * @brief The oldest version for which migration is supported
  */
 #define MIGRATE_MIN_OLD_VERSION 205
@@ -1247,6 +1247,7 @@ static migrator_t database_migrators[] = {
   {213, migrate_212_to_213},
   {214, migrate_213_to_214},
   {215, migrate_214_to_215},
+  {216, migrate_215_to_216},
   /* End marker. */
   {-1, NULL}};
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -15550,7 +15550,7 @@ update_nvti_cache ()
   nvti_cache = nvtis_new ();
 
   init_iterator (&nvts,
-                 "SELECT oid, name, family, cvss_base, tag FROM nvts;");
+                 "SELECT oid, name, family, cvss_base, tag, solution, solution_type FROM nvts;");
   while (next (&nvts))
     {
       iterator_t refs;
@@ -15561,6 +15561,8 @@ update_nvti_cache ()
       nvti_set_family (nvti, iterator_string (&nvts, 2));
       nvti_set_cvss_base (nvti, iterator_string (&nvts, 3));
       nvti_set_tag (nvti, iterator_string (&nvts, 4));
+      nvti_set_solution (nvti, iterator_string (&nvts, 5));
+      nvti_set_solution_type (nvti, iterator_string (&nvts, 6));
 
       init_iterator (&refs,
                      "SELECT type, ref_id, ref_text"
@@ -24297,6 +24299,43 @@ result_iterator_nvt_name (iterator_t *iterator)
   nvti = lookup_nvti (result_iterator_nvt_oid (iterator));
   if (nvti)
     return nvti_name (nvti);
+  return NULL;
+}
+
+/**
+ * @brief Get the NVT solution from a result iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The solution of the NVT that produced the result, or NULL on error.
+ */
+const char*
+result_iterator_nvt_solution (iterator_t *iterator)
+{
+  nvti_t *nvti;
+  if (iterator->done) return NULL;
+  nvti = lookup_nvti (result_iterator_nvt_oid (iterator));
+  if (nvti)
+    return nvti_solution (nvti);
+  return NULL;
+}
+
+/**
+ * @brief Get the NVT solution_type from a result iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The solution_type of the NVT that produced the result,
+ *         or NULL on error.
+ */
+const char*
+result_iterator_nvt_solution_type (iterator_t *iterator)
+{
+  nvti_t *nvti;
+  if (iterator->done) return NULL;
+  nvti = lookup_nvti (result_iterator_nvt_oid (iterator));
+  if (nvti)
+    return nvti_solution_type (nvti);
   return NULL;
 }
 

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -871,6 +871,26 @@ DEF_ACCESS (nvt_iterator_qod, GET_ITERATOR_COLUMN_COUNT + 10);
 DEF_ACCESS (nvt_iterator_qod_type, GET_ITERATOR_COLUMN_COUNT + 11);
 
 /**
+ * @brief Get the solution_type from an NVT iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return Solution Type, or NULL if iteration is complete.  Freed by
+ *         cleanup_iterator.
+ */
+DEF_ACCESS (nvt_iterator_solution_type, GET_ITERATOR_COLUMN_COUNT + 12);
+
+/**
+ * @brief Get the solution from an NVT iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return Solution, or NULL if iteration is complete.  Freed by
+ *         cleanup_iterator.
+ */
+DEF_ACCESS (nvt_iterator_solution, GET_ITERATOR_COLUMN_COUNT + 14);
+
+/**
  * @brief Get the default timeout of an NVT.
  *
  * @param[in]  oid  The OID of the NVT to get the timeout of.

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -248,25 +248,6 @@ insert_nvt (const nvti_t *nvti)
         }
       g_strfreev (split);
 
-      /* Add the elements that are expected as part of the pipe-separated tag list
-       * via API although internally already explicitely stored. Once the API is
-       * extended to have these elements explicitely, they do not need to be
-       * added to this string anymore. */
-      if (nvti_solution (nvti))
-        {
-          if (tag->str)
-            g_string_append_printf (tag, "|solution=%s", nvti_solution (nvti));
-          else
-            g_string_append_printf (tag, "solution=%s", nvti_solution (nvti));
-        }
-      if (nvti_solution_type (nvti))
-        {
-          if (tag->str)
-            g_string_append_printf (tag, "|solution_type=%s", nvti_solution_type (nvti));
-          else
-            g_string_append_printf (tag, "solution_type=%s", nvti_solution_type (nvti));
-        }
-
       quoted_tag = sql_quote (tag->str);
       g_string_free (tag, TRUE);
     }

--- a/src/manage_sql_nvts.h
+++ b/src/manage_sql_nvts.h
@@ -55,6 +55,7 @@
    { "qod_type", NULL, KEYWORD_TYPE_STRING },                               \
    { "solution_type", NULL, KEYWORD_TYPE_STRING },                          \
    { "tag", "script_tags", KEYWORD_TYPE_STRING},                            \
+   { "solution", NULL, KEYWORD_TYPE_STRING},                                \
    { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                                     \
  }
 


### PR DESCRIPTION
Internally stores solution explicitely in the nvts table like solution_type already was.

Remove solution and solution_type from the tag element of the nvts table by
actually not adding them anymore.

However, stay compatible with the API which means to append solution
and solution_type to the tag when creating a XML for the VT (get_nvts, get_results,
get_info).

In summary this is a plain internal change with no API change.
However, the API change for VT XML is prepared with one more step.

https://github.com/greenbone/gvm-libs/pull/255 is required for this change.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
