### PR TITLE
Ensure tls_certificates table exists in migrator

### DIFF
--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -687,6 +687,24 @@ migrate_212_to_213 ()
 
   /* Update the database. */
 
+  /* Ensure the table tls_certificates exists */
+  sql ("CREATE TABLE IF NOT EXISTS tls_certificates"
+       " (id SERIAL PRIMARY KEY,"
+       "  uuid text UNIQUE NOT NULL,"
+       "  owner integer REFERENCES users (id) ON DELETE RESTRICT,"
+       "  name text,"
+       "  comment text,"
+       "  creation_time integer,"
+       "  modification_time integer,"
+       "  certificate text,"
+       "  subject_dn text,"
+       "  issuer_dn text,"
+       "  activation_time integer,"
+       "  expiration_time integer,"
+       "  md5_fingerprint text,"
+       "  trust integer,"
+       "  certificate_format text);");
+
   /* Add columns to tls_certificates */
   sql ("ALTER TABLE tls_certificates"
        " ADD COLUMN sha256_fingerprint text;");


### PR DESCRIPTION
The migrator function migrate_212_to_213 now creates the table in case
the migration is run from a version that does not have it yet.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [X] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
