### PR TITLE
Fix issue #611 (8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add -f arg to sendmail call in email alert [#677](https://github.com/greenbone/gvmd/pull/677) [#679](https://github.com/greenbone/gvmd/pull/679)
 
 ### Fixed
+- A PostgreSQL statement order issue [#611](https://github.com/greenbone/gvmd/issues/611) has been addressed [#691](https://github.com/greenbone/gvmd/pull/691)
 - Fix iCalendar recurrence and timezone handling [#653](https://github.com/greenbone/gvmd/pull/653)
 - Fix issues with some scheduled tasks by using iCalendar more instead of old period fields [#655](https://github.com/greenbone/gvmd/pull/655)
 - Fix an issue in getting the reports from GMP scanners [#658](https://github.com/greenbone/gvmd/pull/658) [#666](https://github.com/greenbone/gvmd/pull/666)

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -3282,12 +3282,11 @@ check_db_sequences ()
 {
   iterator_t sequence_tables;
   init_iterator (&sequence_tables,
-                 "SELECT table_name, column_name,"
-                 "       pg_get_serial_sequence (table_name, column_name)"
-                 "  FROM information_schema.columns"
-                 "  WHERE table_schema = 'public'"
-                 "    AND pg_get_serial_sequence (table_name, column_name)"
-                 "        IS NOT NULL;");
+                 "WITH table_columns AS ("
+                 " SELECT table_name, column_name FROM information_schema.columns"
+                 "  WHERE table_schema = 'public')"
+                 " SELECT *, pg_get_serial_sequence (table_name, column_name) FROM table_columns"
+                 "  WHERE pg_get_serial_sequence (table_name, column_name) IS NOT NULL;");
 
   while (next (&sequence_tables))
     {


### PR DESCRIPTION
Backport of #642.

```
STATEMENT:  SELECT table_name, column_name,       pg_get_serial_sequence (table_name, column_name)  FROM information_schema.columns  WHERE table_schema = public    AND pg_get_serial_sequence (table_name, column_name)        IS NOT NULL;
ERROR:  relation "information_schema_catalog_name" does not exist
```

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
