### PR TITLE
Use status text in ticket iterator columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update result diff generation at delta reports [#650](https://github.com/greenbone/gvmd/pull/650)
 - Check and create default permissions individually [#671](https://github.com/greenbone/gvmd/pull/671)
 - Add -f arg to sendmail call in email alert [#676](https://github.com/greenbone/gvmd/pull/676) [#678](https://github.com/greenbone/gvmd/pull/678)
+- Change get_tickets to use the status text for filtering. [#697](https://github.com/greenbone/gvmd/pull/697)
 
 ### Fixed
 - A PostgreSQL statement order issue [#611](https://github.com/greenbone/gvmd/issues/611) has been addressed [#642](https://github.com/greenbone/gvmd/pull/642)

--- a/src/manage_sql_tickets.c
+++ b/src/manage_sql_tickets.c
@@ -80,31 +80,6 @@ ticket_status_integer (const char *status)
 }
 
 /**
- * @brief Get ticket status name from DB identifier.
- *
- * @param[in]   status  Status integer.
- *
- * @return Status name.
- */
-static const gchar *
-ticket_status_name (ticket_status_t status)
-{
-  switch (status)
-    {
-      case TICKET_STATUS_OPEN:
-        return "Open";
-      case TICKET_STATUS_FIXED:
-        return "Fixed";
-      case TICKET_STATUS_FIX_VERIFIED:
-        return "Fix Verified";
-      case TICKET_STATUS_CLOSED:
-        return "Closed";
-      default:
-        return "Error";
-    }
-}
-
-/**
  * @brief Filter columns for ticket iterator.
  */
 #define TICKET_ITERATOR_FILTER_COLUMNS                                        \
@@ -157,7 +132,14 @@ ticket_status_name (ticket_status_t status)
    { "host", NULL, KEYWORD_TYPE_STRING },                                     \
    { "location", NULL, KEYWORD_TYPE_STRING },                                 \
    { "solution_type", NULL, KEYWORD_TYPE_STRING },                            \
-   { "status", NULL, KEYWORD_TYPE_STRING },                                   \
+   { "(CASE status"                                                           \
+     " WHEN 0 THEN 'Open'"                                                    \
+     " WHEN 1 THEN 'Fixed'"                                                   \
+     " WHEN 2 THEN 'Fix Verified'"                                            \
+     " WHEN 3 THEN 'Closed'"                                                  \
+     " ELSE 'Error' END)",                                                    \
+     "status",                                                                \
+     KEYWORD_TYPE_STRING },                                                   \
    { "iso_time (open_time)", NULL, KEYWORD_TYPE_STRING },                     \
    { "open_time", "opened", KEYWORD_TYPE_INTEGER },                           \
    { "iso_time (fixed_time)", NULL, KEYWORD_TYPE_STRING },                    \
@@ -226,7 +208,14 @@ ticket_status_name (ticket_status_t status)
    { "host", NULL, KEYWORD_TYPE_STRING },                                     \
    { "location", NULL, KEYWORD_TYPE_STRING },                                 \
    { "solution_type", NULL, KEYWORD_TYPE_STRING },                            \
-   { "status", NULL, KEYWORD_TYPE_STRING },                                   \
+   { "(CASE status"                                                           \
+     " WHEN 0 THEN 'Open'"                                                    \
+     " WHEN 1 THEN 'Fixed'"                                                   \
+     " WHEN 2 THEN 'Fix Verified'"                                            \
+     " WHEN 3 THEN 'Closed'"                                                  \
+     " ELSE 'Error' END)",                                                    \
+     "status",                                                                \
+     KEYWORD_TYPE_STRING },                                                   \
    { "iso_time (open_time)", NULL, KEYWORD_TYPE_STRING },                     \
    { "open_time", "opened", KEYWORD_TYPE_INTEGER },                           \
    { "iso_time (fixed_time)", NULL, KEYWORD_TYPE_STRING },                    \
@@ -391,14 +380,7 @@ DEF_ACCESS (ticket_iterator_solution_type, GET_ITERATOR_COLUMN_COUNT + 6);
  *
  * @return Status of the ticket or NULL if iteration is complete.
  */
-const char*
-ticket_iterator_status (iterator_t* iterator)
-{
-  int status;
-  if (iterator->done) return NULL;
-  status = iterator_int (iterator, GET_ITERATOR_COLUMN_COUNT + 7);
-  return ticket_status_name (status);
-}
+DEF_ACCESS (ticket_iterator_status, GET_ITERATOR_COLUMN_COUNT + 7);
 
 /**
  * @brief Get column value from a ticket iterator.


### PR DESCRIPTION
This allows using the status text in filters instead of the internal
numbers that are not visible in GMP.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
