### PR TITLE
Send delete command to ospd after stopping the task.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add -f arg to sendmail call in email alert [#676](https://github.com/greenbone/gvmd/pull/676) [#678](https://github.com/greenbone/gvmd/pull/678)
 - Change get_tickets to use the status text for filtering. [#697](https://github.com/greenbone/gvmd/pull/697)
 - Made checks to prevent duplicate user names stricter. [#708](https://github.com/greenbone/gvmd/pull/708)
+- Send delete command to ospd after stopping the task. [#710](https://github.com/greenbone/gvmd/pull/710)
 
 ### Fixed
 - A PostgreSQL statement order issue [#611](https://github.com/greenbone/gvmd/issues/611) has been addressed [#642](https://github.com/greenbone/gvmd/pull/642)

--- a/src/manage.c
+++ b/src/manage.c
@@ -5028,6 +5028,17 @@ stop_osp_task (task_t task)
   set_task_run_status (task, TASK_STATUS_STOP_REQUESTED);
   ret = osp_stop_scan (connection, scan_id, NULL);
   osp_connection_close (connection);
+  if (ret)
+    {
+      g_free (scan_id);
+      goto end_stop_osp;
+    }
+
+  connection = osp_scanner_connect (task_scanner (task));
+  if (!connection)
+    goto end_stop_osp;
+  ret = osp_delete_scan (connection, scan_id);
+  osp_connection_close (connection);
   g_free (scan_id);
 
 end_stop_osp:


### PR DESCRIPTION
Otherwise, the task/scan will be kept in the ospd memory, since it
does not delete the task automatically if it was stopped.