### PR TITLE
Make bulk tagging work if resources already tagged (8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix assignment of orphaned tickets to the current user [#686](https://github.com/greenbone/gvmd/pull/686)
 - Fix ORPHAN calculations in GET_TICKETS [#687](https://github.com/greenbone/gvmd/pull/687) [#700](https://github.com/greenbone/gvmd/pull/700)
 - Fix response from GET_VULNS when given vuln_id does not exists [#699](https://github.com/greenbone/gvmd/pull/699)
+- Make bulk tagging with a filter work if the resources are already tagged [#712](https://github.com/greenbone/gvmd/pull/712)
 
 ### Removed
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -67808,13 +67808,12 @@ manage_slave_check_period ()
  * @param[in]  uuid        The resource UUID.
  * @param[in]  resource    The resource row id.
  * @param[in]  location    Whether the resource is in the trashcan.
- * @param[in]  duplicates_check  Whether to check if resource already has tag.
- * 
+ *
  * @return  0 success, -1 error
  */
 static int
 tag_add_resource (tag_t tag, const char *type, const char *uuid,
-                  resource_t resource, int location, int duplicates_check)
+                  resource_t resource, int location)
 {
   int already_added, ret;
   gchar *quoted_resource_uuid;
@@ -67823,9 +67822,7 @@ tag_add_resource (tag_t tag, const char *type, const char *uuid,
 
   quoted_resource_uuid = uuid ? sql_insert (uuid) : g_strdup ("''");
 
-  if (duplicates_check == 0)
-    already_added = 0;
-  else if (type_is_info_subtype (type))
+  if (type_is_info_subtype (type))
     already_added = sql_int ("SELECT count(*) FROM tag_resources"
                              " WHERE resource_type = '%s'"
                              " AND resource_uuid = %s"
@@ -67899,7 +67896,7 @@ tag_add_resource_uuid (tag_t tag, const char *type, const char *uuid,
   if (resource == 0)
     return 1;
 
-  return tag_add_resource (tag, type, uuid, resource, resource_location, 1);
+  return tag_add_resource (tag, type, uuid, resource, resource_location);
 }
 
 /**
@@ -67997,30 +67994,9 @@ tag_add_resources_filter (tag_t tag, const char *type, const char *filter)
             return 2;
           }
 
-        if (type_is_info_subtype (type))
-          init_iterator (&resources,
-                         "SELECT id, uuid FROM (%s) AS filter_selection"
-                         " WHERE NOT EXISTS"
-                         "  (SELECT * FROM tag_resources"
-                         "    WHERE resource_type = '%s'"
-                         "      AND resource_uuid = filter_selection.uuid"
-                         "      AND tag = %llu)",
-                         filtered_select,
-                         type,
-                         tag);
-        else
-          init_iterator (&resources,
-                         "SELECT id, uuid FROM (%s) AS filter_selection"
-                         " WHERE NOT EXISTS"
-                         "  (SELECT * FROM tag_resources"
-                         "    WHERE resource_type = '%s'"
-                         "      AND resource = filter_selection.id"
-                         "      AND resource_location = %d"
-                         "      AND tag = %llu)",
-                         filtered_select,
-                         type,
-                         LOCATION_TABLE,
-                         tag);
+        init_iterator (&resources,
+                       "%s",
+                       filtered_select);
 
         break;
       default:
@@ -68047,7 +68023,7 @@ tag_add_resources_filter (tag_t tag, const char *type, const char *filter)
       current_uuid = iterator_string (&resources, 1);
 
       add_ret = tag_add_resource (tag, type, current_uuid, resource,
-                                  LOCATION_TABLE, 0);
+                                  LOCATION_TABLE);
       if (add_ret)
         {
           ret = add_ret;


### PR DESCRIPTION
If the the resource filter for modifying a tag includes only already
tagged resources, no longer consider it as the filter returning no
resources.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
