### PR TITLE
Fix columnless filter keywords with quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix assignment of orphaned tickets to the current user [#685](https://github.com/greenbone/gvmd/pull/685)
 - Fix response from GET_VULNS when given vuln_id does not exists [#696](https://github.com/greenbone/gvmd/pull/696)
 - Make bulk tagging with a filter work if the resources are already tagged [#711](https://github.com/greenbone/gvmd/pull/711)
+- Fix columnless search phrase filter keywords with quotes [#715](https://github.com/greenbone/gvmd/pull/715)
 
 ### Removed
 - The handling of NVT updates via OTP has been removed. [#575](https://github.com/greenbone/gvmd/pull/575)

--- a/src/gmp_get.c
+++ b/src/gmp_get.c
@@ -518,6 +518,17 @@ buffer_get_filter_xml (GString *msg, const char* type,
     {
       keyword_t *keyword;
       keyword = *point;
+      const char *relation_symbol;
+
+      if (keyword->equal)
+        relation_symbol = "=";
+      else if (keyword->approx)
+        relation_symbol = "~";
+      else if (keyword_special (keyword))
+        relation_symbol = "";
+      else
+        relation_symbol = keyword_relation_symbol (keyword->relation);
+
       buffer_xml_append_printf (msg,
                                 "<keyword>"
                                 "<column>%s</column>"
@@ -525,11 +536,7 @@ buffer_get_filter_xml (GString *msg, const char* type,
                                 "<value>%s%s%s</value>"
                                 "</keyword>",
                                 keyword->column ? keyword->column : "",
-                                keyword->equal
-                                  ? "="
-                                  : (keyword_special (keyword)
-                                       ? ""
-                                       : keyword_relation_symbol (keyword->relation)),
+                                relation_symbol,
                                 keyword->quoted ? "\"" : "",
                                 keyword->string ? keyword->string : "",
                                 keyword->quoted ? "\"" : "");

--- a/src/manage.h
+++ b/src/manage.h
@@ -3482,6 +3482,7 @@ typedef enum
 struct keyword
 {
   gchar *column;                 ///< The column prefix, or NULL.
+  int approx;                    ///< Whether the keyword is like "~example".
   int equal;                     ///< Whether the keyword is like "=example".
   int integer_value;             ///< Integer value of the keyword.
   double double_value;           ///< Floating point value of the keyword.


### PR DESCRIPTION
The quote marks in general search phrase keywords starting with "~",
(like `~"abc"`) were not detected correctly.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
