### PR TITLE
Fix columnless filter keywords with quotes (8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix assignment of orphaned tickets to the current user [#686](https://github.com/greenbone/gvmd/pull/686)
 - Fix ORPHAN calculations in GET_TICKETS [#687](https://github.com/greenbone/gvmd/pull/687) [#700](https://github.com/greenbone/gvmd/pull/700)
 - Fix response from GET_VULNS when given vuln_id does not exists [#699](https://github.com/greenbone/gvmd/pull/699)
+- Fix columnless search phrase filter keywords with quotes [#716](https://github.com/greenbone/gvmd/pull/716)
 
 ### Removed
 

--- a/src/gmp_get.c
+++ b/src/gmp_get.c
@@ -510,21 +510,28 @@ buffer_get_filter_xml (GString *msg,
     {
       keyword_t *keyword;
       keyword = *point;
-      buffer_xml_append_printf (
-        msg,
-        "<keyword>"
-        "<column>%s</column>"
-        "<relation>%s</relation>"
-        "<value>%s%s%s</value>"
-        "</keyword>",
-        keyword->column ? keyword->column : "",
-        keyword->equal ? "="
-                       : (keyword_special (keyword)
-                            ? ""
-                            : keyword_relation_symbol (keyword->relation)),
-        keyword->quoted ? "\"" : "",
-        keyword->string ? keyword->string : "",
-        keyword->quoted ? "\"" : "");
+      const char *relation_symbol;
+
+      if (keyword->equal)
+        relation_symbol = "=";
+      else if (keyword->approx)
+        relation_symbol = "~";
+      else if (keyword_special (keyword))
+        relation_symbol = "";
+      else
+        relation_symbol = keyword_relation_symbol (keyword->relation);
+
+      buffer_xml_append_printf (msg,
+                                "<keyword>"
+                                "<column>%s</column>"
+                                "<relation>%s</relation>"
+                                "<value>%s%s%s</value>"
+                                "</keyword>",
+                                keyword->column ? keyword->column : "",
+                                relation_symbol,
+                                keyword->quoted ? "\"" : "",
+                                keyword->string ? keyword->string : "",
+                                keyword->quoted ? "\"" : "");
       point++;
     }
   filter_free (split);

--- a/src/manage.h
+++ b/src/manage.h
@@ -3581,6 +3581,7 @@ typedef enum
 struct keyword
 {
   gchar *column;               ///< The column prefix, or NULL.
+  int approx;                    ///< Whether the keyword is like "~example".
   int equal;                   ///< Whether the keyword is like "=example".
   int integer_value;           ///< Integer value of the keyword.
   double double_value;         ///< Floating point value of the keyword.

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -2076,6 +2076,8 @@ split_filter (const gchar* given_filter)
                 keyword = g_malloc0 (sizeof (keyword_t));
                 if (*filter == '=')
                   keyword->equal = 1;
+                else
+                  keyword->approx = 1;
                 current_part = filter + 1;
                 between = 0;
                 break;
@@ -2168,9 +2170,11 @@ split_filter (const gchar* given_filter)
                 in_quote = 1;
                 current_part++;
               }
-            else if (keyword->equal && filter == current_part)
+            else if ((keyword->equal || keyword->approx)
+                     && filter == current_part)
               {
-                /* A quoted exact term, like ="abc". */
+                /* A quoted exact term, like ="abc"
+                 * or a prefixed approximate term, like ~"abc". */
                 in_quote = 1;
                 current_part++;
               }
@@ -2735,14 +2739,24 @@ manage_clean_filter_remove (const gchar *filter, const gchar *column)
               break;
           }
       else
-        if (keyword->quoted)
-          g_string_append_printf (clean, " %s\"%s\"",
-                                  keyword->equal ? "=" : "",
-                                  keyword->string);
-        else
-          g_string_append_printf (clean, " %s%s",
-                                  keyword->equal ? "=" : "",
-                                  keyword->string);
+        {
+          const char *relation_symbol;
+          if (keyword->equal)
+            relation_symbol = "=";
+          else if (keyword->approx)
+            relation_symbol = "~";
+          else
+            relation_symbol = "";
+
+          if (keyword->quoted)
+            g_string_append_printf (clean, " %s\"%s\"",
+                                    relation_symbol,
+                                    keyword->string);
+          else
+            g_string_append_printf (clean, " %s%s",
+                                    relation_symbol,
+                                    keyword->string);
+        }
       point++;
     }
   filter_free (split);


### PR DESCRIPTION
The quote marks in general search phrase keywords starting with "~",
(like `~"abc"`) were not detected correctly.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
