### PR TITLE
Make several NVTI tags internally explicit.  

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 218)
+set (GVMD_DATABASE_VERSION 219)
 
 set (GVMD_SCAP_DATABASE_VERSION 15)
 

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -10170,23 +10170,72 @@ results_xml_append_nvt (iterator_t *results, GString *buffer, int cert_loaded)
           if (!cvss_base && !strcmp (oid, "0"))
             cvss_base = "0.0";
 
-          /* Add the elements that are expected as part of the pipe-separated tag list
-           * via API although internally already explicitely stored. Once the API is
-           * extended to have these elements explicitely, they do not need to be
-           * added to this string anymore. */
+          /* Add the elements that are expected as part of the pipe-separated
+           * tag list via API although internally already explicitely stored.
+           * Once the API is extended to have these elements explicitely, they
+           * do not need to be added to this tag string anymore. */
+          if (result_iterator_nvt_summary (results))
+            {
+              if (tags->str)
+                g_string_append_printf (tags, "|summary=%s",
+                                        result_iterator_nvt_summary (results));
+              else
+                g_string_append_printf (tags, "summary=%s",
+                                        result_iterator_nvt_summary (results));
+            }
+          if (result_iterator_nvt_insight (results))
+            {
+              if (tags->str)
+                g_string_append_printf (tags, "|insight=%s",
+                                        result_iterator_nvt_insight (results));
+              else
+                g_string_append_printf (tags, "insight=%s",
+                                        result_iterator_nvt_insight (results));
+            }
+          if (result_iterator_nvt_affected (results))
+            {
+              if (tags->str)
+                g_string_append_printf (tags, "|affected=%s",
+                                        result_iterator_nvt_affected (results));
+              else
+                g_string_append_printf (tags, "affected=%s",
+                                        result_iterator_nvt_affected (results));
+            }
+          if (result_iterator_nvt_impact (results))
+            {
+              if (tags->str)
+                g_string_append_printf (tags, "|impact=%s",
+                                        result_iterator_nvt_impact (results));
+              else
+                g_string_append_printf (tags, "impact=%s",
+                                        result_iterator_nvt_impact (results));
+            }
           if (result_iterator_nvt_solution (results))
             {
               if (tags->str)
-                g_string_append_printf (tags, "|solution=%s", result_iterator_nvt_solution (results));
+                g_string_append_printf (tags, "|solution=%s",
+                                        result_iterator_nvt_solution (results));
               else
-                g_string_append_printf (tags, "solution=%s", result_iterator_nvt_solution (results));
+                g_string_append_printf (tags, "solution=%s",
+                                        result_iterator_nvt_solution (results));
+            }
+          if (result_iterator_nvt_detection (results))
+            {
+              if (tags->str)
+                g_string_append_printf (tags, "|vuldetect=%s",
+                                        result_iterator_nvt_detection (results));
+              else
+                g_string_append_printf (tags, "vuldetect=%s",
+                                        result_iterator_nvt_detection (results));
             }
           if (result_iterator_nvt_solution_type (results))
             {
               if (tags->str)
-                g_string_append_printf (tags, "|solution_type=%s", result_iterator_nvt_solution_type (results));
+                g_string_append_printf (tags, "|solution_type=%s",
+                                        result_iterator_nvt_solution_type (results));
               else
-                g_string_append_printf (tags, "solution_type=%s", result_iterator_nvt_solution_type (results));
+                g_string_append_printf (tags, "solution_type=%s",
+                                        result_iterator_nvt_solution_type (results));
             }
 
           buffer_xml_append_printf (buffer,

--- a/src/manage.c
+++ b/src/manage.c
@@ -7257,20 +7257,70 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count,
       /* Add the elements that are expected as part of the pipe-separated tag list
        * via API although internally already explicitely stored. Once the API is
        * extended to have these elements explicitely, they do not need to be
-       * added to this string anymore. */
-      if (nvt_iterator_solution (nvts))
+       * added to this tag string anymore. */
+      if (nvt_iterator_summary (nvts) && nvt_iterator_summary (nvts)[0])
         {
           if (nvt_tags->str)
-            g_string_append_printf (nvt_tags, "|solution=%s", nvt_iterator_solution (nvts));
+            g_string_append_printf (nvt_tags, "|summary=%s",
+                                    nvt_iterator_summary (nvts));
           else
-            g_string_append_printf (nvt_tags, "solution=%s", result_iterator_nvt_solution (nvts));
+            g_string_append_printf (nvt_tags, "summary=%s",
+                                    nvt_iterator_summary (nvts));
         }
-      if (nvt_iterator_solution_type (nvts))
+      if (nvt_iterator_insight (nvts) && nvt_iterator_insight (nvts)[0])
         {
           if (nvt_tags->str)
-            g_string_append_printf (nvt_tags, "|solution_type=%s", nvt_iterator_solution_type (nvts));
+            g_string_append_printf (nvt_tags, "|insight=%s",
+                                    nvt_iterator_insight (nvts));
           else
-            g_string_append_printf (nvt_tags, "solution_type=%s", nvt_iterator_solution_type (nvts));
+            g_string_append_printf (nvt_tags, "insight=%s",
+                                    nvt_iterator_insight (nvts));
+        }
+      if (nvt_iterator_affected (nvts) && nvt_iterator_affected (nvts)[0])
+        {
+          if (nvt_tags->str)
+            g_string_append_printf (nvt_tags, "|affected=%s",
+                                    nvt_iterator_affected (nvts));
+          else
+            g_string_append_printf (nvt_tags, "affected=%s",
+                                    nvt_iterator_affected (nvts));
+        }
+      if (nvt_iterator_impact (nvts) && nvt_iterator_impact (nvts)[0])
+        {
+          if (nvt_tags->str)
+            g_string_append_printf (nvt_tags, "|impact=%s",
+                                    nvt_iterator_impact (nvts));
+          else
+            g_string_append_printf (nvt_tags, "impact=%s",
+                                    nvt_iterator_impact (nvts));
+        }
+      if (nvt_iterator_solution (nvts) && nvt_iterator_solution (nvts)[0])
+        {
+          if (nvt_tags->str)
+            g_string_append_printf (nvt_tags, "|solution=%s",
+                                    nvt_iterator_solution (nvts));
+          else
+            g_string_append_printf (nvt_tags, "solution=%s",
+                                    nvt_iterator_solution (nvts));
+        }
+      if (nvt_iterator_solution_type (nvts)
+          && nvt_iterator_solution_type (nvts)[0])
+        {
+          if (nvt_tags->str)
+            g_string_append_printf (nvt_tags, "|solution_type=%s",
+                                    nvt_iterator_solution_type (nvts));
+          else
+            g_string_append_printf (nvt_tags, "solution_type=%s",
+                                    nvt_iterator_solution_type (nvts));
+        }
+      if (nvt_iterator_detection (nvts) && nvt_iterator_detection (nvts)[0])
+        {
+          if (nvt_tags->str)
+            g_string_append_printf (nvt_tags, "|vuldetect=%s",
+                                    nvt_iterator_detection (nvts));
+          else
+            g_string_append_printf (nvt_tags, "vuldetect=%s",
+                                    nvt_iterator_detection (nvts));
         }
 
       refs_str = g_string_new ("");

--- a/src/manage.h
+++ b/src/manage.h
@@ -1445,10 +1445,25 @@ const char*
 result_iterator_nvt_name (iterator_t *);
 
 const char*
+result_iterator_nvt_summary (iterator_t *);
+
+const char*
+result_iterator_nvt_insight (iterator_t *);
+
+const char*
+result_iterator_nvt_affected (iterator_t *);
+
+const char*
+result_iterator_nvt_impact (iterator_t *);
+
+const char*
 result_iterator_nvt_solution (iterator_t *);
 
 const char*
 result_iterator_nvt_solution_type (iterator_t *);
+
+const char*
+result_iterator_nvt_detection (iterator_t *);
 
 const char*
 result_iterator_nvt_family (iterator_t *);
@@ -1991,6 +2006,18 @@ const char*
 nvt_iterator_name (iterator_t*);
 
 const char*
+nvt_iterator_summary (iterator_t*);
+
+const char*
+nvt_iterator_insight (iterator_t*);
+
+const char*
+nvt_iterator_affected (iterator_t*);
+
+const char*
+nvt_iterator_impact (iterator_t*);
+
+const char*
 nvt_iterator_description (iterator_t*);
 
 const char*
@@ -2004,6 +2031,9 @@ nvt_iterator_family (iterator_t*);
 
 const char*
 nvt_iterator_cvss_base (iterator_t*);
+
+const char*
+nvt_iterator_detection (iterator_t*);
 
 const char*
 nvt_iterator_qod (iterator_t*);

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -1324,6 +1324,43 @@ migrate_217_to_218 ()
   return 0;
 }
 
+/**
+ * @brief Migrate the database from version 216 to version 217.
+ *
+ * @return 0 success, -1 error.
+ */
+int
+migrate_218_to_219 ()
+{
+  sql_begin_immediate ();
+
+  /* Ensure that the database is currently version 218. */
+
+  if (manage_db_version () != 218)
+    {
+      sql_rollback ();
+      return -1;
+    }
+
+  /* Update the database. */
+
+  /* Extend table "nvts" with additional columns "summary",
+   * "insight", "affected", "detection" and "impact" */
+  sql ("ALTER TABLE IF EXISTS nvts ADD COLUMN summary text;");
+  sql ("ALTER TABLE IF EXISTS nvts ADD COLUMN insight text;");
+  sql ("ALTER TABLE IF EXISTS nvts ADD COLUMN affected text;");
+  sql ("ALTER TABLE IF EXISTS nvts ADD COLUMN detection text;");
+  sql ("ALTER TABLE IF EXISTS nvts ADD COLUMN impact text;");
+
+  /* Set the database version to 219. */
+
+  set_db_version (219);
+
+  sql_commit ();
+
+  return 0;
+}
+
 #undef UPDATE_DASHBOARD_SETTINGS
 
 /**
@@ -1348,6 +1385,7 @@ static migrator_t database_migrators[] = {
   {216, migrate_215_to_216},
   {217, migrate_216_to_217},
   {218, migrate_217_to_218},
+  {219, migrate_218_to_219},
   /* End marker. */
   {-1, NULL}};
 

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -2920,6 +2920,10 @@ create_tables ()
        "  oid text UNIQUE NOT NULL,"
        "  name text,"
        "  comment text,"
+       "  summary text,"
+       "  insight text,"
+       "  affected text,"
+       "  impact text,"
        "  cve text,"
        "  tag text,"
        "  category text,"
@@ -2929,6 +2933,7 @@ create_tables ()
        "  modification_time integer,"
        "  solution text,"
        "  solution_type text,"
+       "  detection text,"
        "  qod integer,"
        "  qod_type text);");
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -24273,6 +24273,78 @@ result_iterator_nvt_name (iterator_t *iterator)
 }
 
 /**
+ * @brief Get the NVT summary from a result iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The summary of the NVT that produced the result, or NULL on error.
+ */
+const char*
+result_iterator_nvt_summary (iterator_t *iterator)
+{
+  nvti_t *nvti;
+  if (iterator->done) return NULL;
+  nvti = lookup_nvti (result_iterator_nvt_oid (iterator));
+  if (nvti)
+    return nvti_summary (nvti);
+  return NULL;
+}
+
+/**
+ * @brief Get the NVT insight from a result iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The insight of the NVT that produced the result, or NULL on error.
+ */
+const char*
+result_iterator_nvt_insight (iterator_t *iterator)
+{
+  nvti_t *nvti;
+  if (iterator->done) return NULL;
+  nvti = lookup_nvti (result_iterator_nvt_oid (iterator));
+  if (nvti)
+    return nvti_insight (nvti);
+  return NULL;
+}
+
+/**
+ * @brief Get the NVT affected from a result iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The affected of the NVT that produced the result, or NULL on error.
+ */
+const char*
+result_iterator_nvt_affected (iterator_t *iterator)
+{
+  nvti_t *nvti;
+  if (iterator->done) return NULL;
+  nvti = lookup_nvti (result_iterator_nvt_oid (iterator));
+  if (nvti)
+    return nvti_affected (nvti);
+  return NULL;
+}
+
+/**
+ * @brief Get the NVT affected from a result iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return Impact text of the NVT that produced the result, or NULL on error.
+ */
+const char*
+result_iterator_nvt_impact (iterator_t *iterator)
+{
+  nvti_t *nvti;
+  if (iterator->done) return NULL;
+  nvti = lookup_nvti (result_iterator_nvt_oid (iterator));
+  if (nvti)
+    return nvti_impact (nvti);
+  return NULL;
+}
+
+/**
  * @brief Get the NVT solution from a result iterator.
  *
  * @param[in]  iterator  Iterator.
@@ -24306,6 +24378,24 @@ result_iterator_nvt_solution_type (iterator_t *iterator)
   nvti = lookup_nvti (result_iterator_nvt_oid (iterator));
   if (nvti)
     return nvti_solution_type (nvti);
+  return NULL;
+}
+
+/**
+ * @brief Get the NVT detection from a result iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The detection of the NVT that produced the result, or NULL on error.
+ */
+const char*
+result_iterator_nvt_detection (iterator_t *iterator)
+{
+  nvti_t *nvti;
+  if (iterator->done) return NULL;
+  nvti = lookup_nvti (result_iterator_nvt_oid (iterator));
+  if (nvti)
+    return nvti_detection (nvti);
   return NULL;
 }
 

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1128,7 +1128,6 @@ get_tag (entity_t vt)
                                   "%scvss_base_vector=%s",
                                   first ? "" : "|",
                                   entity_text (severity));
-          first = 0;
         }
       else
         g_warning ("%s: no severity", __FUNCTION__);

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -190,7 +190,8 @@ static void
 insert_nvt (const nvti_t *nvti)
 {
   gchar *qod_str, *qod_type, *cve;
-  gchar *quoted_name, *quoted_cve, *quoted_tag;
+  gchar *quoted_name, *quoted_summary, *quoted_insight, *quoted_affected,
+	*quoted_impact, *quoted_detection, *quoted_cve, *quoted_tag;
   gchar *quoted_cvss_base, *quoted_qod_type, *quoted_family, *value;
   gchar *quoted_solution, *quoted_solution_type;
   int creation_time, modification_time, qod, i;
@@ -198,14 +199,21 @@ insert_nvt (const nvti_t *nvti)
   cve = nvti_refs (nvti, "cve", "", 0);
 
   quoted_name = sql_quote (nvti_name (nvti) ? nvti_name (nvti) : "");
-  quoted_cve = sql_quote (cve ? cve : "");
+  quoted_summary = sql_quote (nvti_summary (nvti) ? nvti_summary (nvti) : "");
+  quoted_insight = sql_quote (nvti_insight (nvti) ? nvti_insight (nvti) : "");
+  quoted_affected = sql_quote (nvti_affected (nvti) ?
+                               nvti_affected (nvti) : "");
+  quoted_impact = sql_quote (nvti_impact (nvti) ? nvti_impact (nvti) : "");
 
+  quoted_cve = sql_quote (cve ? cve : "");
   g_free (cve);
 
   quoted_solution = sql_quote (nvti_solution (nvti) ?
                                nvti_solution (nvti) : "");
   quoted_solution_type = sql_quote (nvti_solution_type (nvti) ?
                                     nvti_solution_type (nvti) : "");
+  quoted_detection = sql_quote (nvti_detection (nvti) ?
+                                nvti_detection (nvti) : "");
 
   if (nvti_tag (nvti))
     {
@@ -320,16 +328,17 @@ insert_nvt (const nvti_t *nvti)
                nvti_oid (nvti)))
     sql ("DELETE FROM nvts WHERE oid = '%s';", nvti_oid (nvti));
 
-  sql ("INSERT into nvts (oid, name,"
-       " cve, tag, category, family, cvss_base,"
+  sql ("INSERT into nvts (oid, name, summary, insight, affected,"
+       " impact, cve, tag, category, family, cvss_base,"
        " creation_time, modification_time, uuid, solution_type,"
-       " solution, qod, qod_type)"
-       " VALUES ('%s', '%s', '%s',"
-       " '%s', %i, '%s', '%s', %i, %i, '%s', '%s', '%s', %d, '%s');",
-       nvti_oid (nvti), quoted_name, quoted_cve, quoted_tag,
+       " solution, detection, qod, qod_type)"
+       " VALUES ('%s', '%s', '%s', '%s', '%s', '%s', '%s',"
+       " '%s', %i, '%s', '%s', %i, %i, '%s', '%s', '%s', '%s', %d, '%s');",
+       nvti_oid (nvti), quoted_name, quoted_summary, quoted_insight,
+       quoted_affected, quoted_impact, quoted_cve, quoted_tag,
        nvti_category (nvti), quoted_family, quoted_cvss_base, creation_time,
-       modification_time, nvti_oid (nvti), quoted_solution_type, quoted_solution,
-       qod, quoted_qod_type);
+       modification_time, nvti_oid (nvti), quoted_solution_type,
+       quoted_solution, quoted_detection, qod, quoted_qod_type);
 
   sql ("DELETE FROM vt_refs where vt_oid = '%s';", nvti_oid (nvti));
 
@@ -351,12 +360,17 @@ insert_nvt (const nvti_t *nvti)
     }
 
   g_free (quoted_name);
+  g_free (quoted_summary);
+  g_free (quoted_insight);
+  g_free (quoted_affected);
+  g_free (quoted_impact);
   g_free (quoted_cve);
   g_free (quoted_tag);
   g_free (quoted_cvss_base);
   g_free (quoted_family);
   g_free (quoted_solution);
   g_free (quoted_solution_type);
+  g_free (quoted_detection);
   g_free (quoted_qod_type);
 }
 
@@ -878,6 +892,56 @@ DEF_ACCESS (nvt_iterator_solution_type, GET_ITERATOR_COLUMN_COUNT + 12);
 DEF_ACCESS (nvt_iterator_solution, GET_ITERATOR_COLUMN_COUNT + 14);
 
 /**
+ * @brief Get the summary from an NVT iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return Summary, or NULL if iteration is complete.  Freed by
+ *         cleanup_iterator.
+ */
+DEF_ACCESS (nvt_iterator_summary, GET_ITERATOR_COLUMN_COUNT + 15);
+
+/**
+ * @brief Get the insight from an NVT iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return Insight, or NULL if iteration is complete.  Freed by
+ *         cleanup_iterator.
+ */
+DEF_ACCESS (nvt_iterator_insight, GET_ITERATOR_COLUMN_COUNT + 16);
+
+/**
+ * @brief Get the affected from an NVT iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return Affected, or NULL if iteration is complete.  Freed by
+ *         cleanup_iterator.
+ */
+DEF_ACCESS (nvt_iterator_affected, GET_ITERATOR_COLUMN_COUNT + 17);
+
+/**
+ * @brief Get the impact from an NVT iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return Impact, or NULL if iteration is complete.  Freed by
+ *         cleanup_iterator.
+ */
+DEF_ACCESS (nvt_iterator_impact, GET_ITERATOR_COLUMN_COUNT + 18);
+
+/**
+ * @brief Get the detection from an NVT iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return Detection, or NULL if iteration is complete.  Freed by
+ *         cleanup_iterator.
+ */
+DEF_ACCESS (nvt_iterator_detection, GET_ITERATOR_COLUMN_COUNT + 19);
+
+/**
  * @brief Get the default timeout of an NVT.
  *
  * @param[in]  oid  The OID of the NVT to get the timeout of.
@@ -1072,46 +1136,6 @@ get_tag (entity_t vt)
   else
     g_warning ("%s: no severities", __FUNCTION__);
 
-  child = entity_child (vt, "detection");
-  if (child)
-    {
-      if (strlen (entity_text (child)))
-        {
-          g_string_append_printf (tag,
-                                  "%svuldetect=%s",
-                                  first ? "" : "|",
-                                  entity_text (child));
-          first = 0;
-        }
-    }
-
-  child = entity_child (vt, "summary");
-  if (child)
-    {
-      g_string_append_printf (tag,
-                              "%ssummary=%s",
-                              first ? "" : "|",
-                              entity_text (child));
-      first = 0;
-    }
-
-  child = entity_child (vt, "insight");
-  if (child)
-    {
-      g_string_append_printf (tag,
-                              "%sinsight=%s",
-                              first ? "" : "|",
-                              entity_text (child));
-      first = 0;
-    }
-
-  child = entity_child (vt, "affected");
-  if (child)
-    g_string_append_printf (tag,
-                            "%saffected=%s",
-                            first ? "" : "|",
-                            entity_text (child));
-
   return g_string_free (tag, FALSE);
 }
 
@@ -1213,7 +1237,8 @@ nvti_from_vt (entity_t vt)
 {
   nvti_t *nvti = nvti_new ();
   const char *id;
-  entity_t name, detection, solution, refs, ref, custom, family, category;
+  entity_t name, summary, insight, affected, impact, detection, solution,
+           refs, ref, custom, family, category;
   entities_t children;
   gchar *tag, *cvss_base, *parsed_tags;
 
@@ -1235,9 +1260,26 @@ nvti_from_vt (entity_t vt)
     }
   nvti_set_name (nvti, entity_text (name));
 
+  summary = entity_child (vt, "summary");
+  if (summary)
+    nvti_set_summary (nvti, entity_text (summary));
+
+  insight = entity_child (vt, "insight");
+  if (insight)
+    nvti_set_insight (nvti, entity_text (insight));
+
+  affected = entity_child (vt, "affected");
+  if (affected)
+    nvti_set_affected (nvti, entity_text (affected));
+
+  impact = entity_child (vt, "impact");
+  if (impact)
+    nvti_set_impact (nvti, entity_text (impact));
+
   detection = entity_child (vt, "detection");
   if (detection)
     {
+      nvti_set_detection (nvti, entity_text (detection));
       nvti_set_qod_type (nvti, entity_attribute (detection, "qod_type"));
     }
 

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -190,8 +190,8 @@ static void
 insert_nvt (const nvti_t *nvti)
 {
   gchar *qod_str, *qod_type, *cve;
-  gchar *quoted_name, *quoted_summary, *quoted_insight, *quoted_affected,
-	*quoted_impact, *quoted_detection, *quoted_cve, *quoted_tag;
+  gchar *quoted_name, *quoted_summary, *quoted_insight, *quoted_affected;
+  gchar *quoted_impact, *quoted_detection, *quoted_cve, *quoted_tag;
   gchar *quoted_cvss_base, *quoted_qod_type, *quoted_family, *value;
   gchar *quoted_solution, *quoted_solution_type;
   int creation_time, modification_time, qod, i;
@@ -1236,8 +1236,8 @@ nvti_from_vt (entity_t vt)
 {
   nvti_t *nvti = nvti_new ();
   const char *id;
-  entity_t name, summary, insight, affected, impact, detection, solution,
-           refs, ref, custom, family, category;
+  entity_t name, summary, insight, affected, impact, detection, solution;
+  entity_t refs, ref, custom, family, category;
   entities_t children;
   gchar *tag, *cvss_base, *parsed_tags;
 

--- a/src/manage_sql_nvts.h
+++ b/src/manage_sql_nvts.h
@@ -56,6 +56,11 @@
    { "solution_type", NULL, KEYWORD_TYPE_STRING },                          \
    { "tag", "script_tags", KEYWORD_TYPE_STRING},                            \
    { "solution", NULL, KEYWORD_TYPE_STRING},                                \
+   { "summary", NULL, KEYWORD_TYPE_STRING },                                \
+   { "insight", NULL, KEYWORD_TYPE_STRING },                                \
+   { "affected", NULL, KEYWORD_TYPE_STRING },                               \
+   { "impact", NULL, KEYWORD_TYPE_STRING },                                 \
+   { "detection", NULL, KEYWORD_TYPE_STRING },                              \
    { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                                     \
  }
 
@@ -81,7 +86,12 @@
    { "qod_type", NULL, KEYWORD_TYPE_STRING },                               \
    { "solution_type", NULL, KEYWORD_TYPE_STRING },                          \
    { "tag", "script_tags", KEYWORD_TYPE_STRING },                           \
-   { "solution", NULL, KEYWORD_TYPE_STRING},                                \
+   { "solution", NULL, KEYWORD_TYPE_STRING },                               \
+   { "summary", NULL, KEYWORD_TYPE_STRING },                                \
+   { "insight", NULL, KEYWORD_TYPE_STRING },                                \
+   { "affected", NULL, KEYWORD_TYPE_STRING },                               \
+   { "impact", NULL, KEYWORD_TYPE_STRING },                                 \
+   { "detection", NULL, KEYWORD_TYPE_STRING },                              \
    { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                                     \
  }
 


### PR DESCRIPTION
This change makes the elements "summary", "insight", "detection", "impact" and "affected" explicit columns of the table "nvts".

These elements are already explicit in the vt object incoming via OSP.

For keeping GMP API compatibility, the 5 elements are serialized into the "tag" string.

The API is not modified, the changes are only internally.

This PR requires https://github.com/greenbone/gvm-libs/pull/258

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
