### PR TITLE
Fixes for unique user names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Check and create default permissions individually [#671](https://github.com/greenbone/gvmd/pull/671)
 - Add -f arg to sendmail call in email alert [#676](https://github.com/greenbone/gvmd/pull/676) [#678](https://github.com/greenbone/gvmd/pull/678)
 - Change get_tickets to use the status text for filtering. [#697](https://github.com/greenbone/gvmd/pull/697)
-- Made checks to prevent duplicate user names stricter. [#708](https://github.com/greenbone/gvmd/pull/708)
+- Made checks to prevent duplicate user names stricter. [#708](https://github.com/greenbone/gvmd/pull/708) [#722](https://github.com/greenbone/gvmd/pull/722)
 - Send delete command to ospd after stopping the task. [#710](https://github.com/greenbone/gvmd/pull/710)
 - Check whether hosts are alive and have results when adding them in slave scans. [#717](https://github.com/greenbone/gvmd/pull/717)
 

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -1304,6 +1304,13 @@ migrate_217_to_218 ()
 
   /* Update the database. */
 
+  /* Ensure all user names are unique */
+
+  sql ("UPDATE users"
+       " SET name = uniquify('user', name, NULL, '')"
+       " WHERE id != (SELECT min(id) FROM users AS inner_users"
+       "              WHERE users.name = inner_users.name);");
+
   /* Add an UNIQUE constraint to the name column of users */
 
   sql ("ALTER TABLE users ADD UNIQUE (name);");

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -1039,7 +1039,7 @@ manage_create_sql_functions ()
        "   LOOP"
        "     EXECUTE 'SELECT count (*) = 0 FROM ' || type || 's"
        "              WHERE name = $1"
-       "              AND ((owner IS NULL) OR (owner = $2))'"
+       "              AND (($2 IS NULL) OR (owner IS NULL) OR (owner = $2))'"
        "       INTO unique_candidate"
        "       USING candidate, owner;"
        "     EXIT WHEN unique_candidate;"


### PR DESCRIPTION
This fixes the migrator in case there are already duplicate user names, prevents some
errors if the constraint is violated and modifies the `uniquify` function so it can check if a name is globally unique.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
