### PR TITLE
Do not pass in SQL string vars as format strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix response from GET_VULNS when given vuln_id does not exists [#696](https://github.com/greenbone/gvmd/pull/696)
 - Make bulk tagging with a filter work if the resources are already tagged [#711](https://github.com/greenbone/gvmd/pull/711)
 - Fix columnless search phrase filter keywords with quotes [#715](https://github.com/greenbone/gvmd/pull/715)
+- Fix issues importing results or getting them from slaves if they contain "%s" [#723](https://github.com/greenbone/gvmd/pull/723)
 
 ### Removed
 - The handling of NVT updates via OTP has been removed. [#575](https://github.com/greenbone/gvmd/pull/575)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -22289,7 +22289,7 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
       /* Limit the number of results inserted at a time. */
       if (insert_count == CREATE_REPORT_INSERT_SIZE)
         {
-          sql (insert->str);
+          sql ("%s", insert->str);
           g_string_truncate (insert, 0);
           count++;
           insert_count = 0;
@@ -22319,7 +22319,7 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
 
   if (first == 0)
     {
-      sql (insert->str);
+      sql ("%s", insert->str);
       report_cache_counts (report, 1, 1, NULL);
       sql_commit ();
       gvm_usleep (CREATE_REPORT_CHUNK_SLEEP);
@@ -22414,7 +22414,7 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
         /* Limit the number of details inserted at a time. */
         if (insert_count == CREATE_REPORT_INSERT_SIZE)
           {
-            sql (insert->str);
+            sql ("%s", insert->str);
             g_string_truncate (insert, 0);
             count++;
             insert_count = 0;
@@ -22446,7 +22446,7 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
       }
 
   if (first == 0)
-    sql (insert->str);
+    sql ("%s", insert->str);
 
   sql_commit ();
   g_string_free (insert, TRUE);
@@ -32562,7 +32562,7 @@ init_task_file_iterator (iterator_t* iterator, task_t task, const char* file)
                            " FROM task_files"
                            " WHERE task = %llu;",
                            task);
-  init_iterator (iterator, sql);
+  init_iterator (iterator, "%s", sql);
   g_free (sql);
 }
 
@@ -48701,7 +48701,7 @@ update_from_slave_insert (GString *buffer, report_t report)
 
           g_string_append (buffer, " RETURNING id;");
 
-          init_iterator (&ids, buffer->str);
+          init_iterator (&ids, "%s", buffer->str);
           while (next (&ids))
             report_add_result_for_buffer (report, iterator_int64 (&ids, 0));
           cleanup_iterator (&ids);
@@ -48716,7 +48716,7 @@ update_from_slave_insert (GString *buffer, report_t report)
                report, report);
         }
       else
-        sql (buffer->str);
+        sql ("%s", buffer->str);
 
       g_string_truncate (buffer, 0);
     }

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -341,7 +341,7 @@ init_nvt_selector_iterator (iterator_t* iterator, const char* selector,
                            " FROM nvt_selectors"
                            " WHERE type = %i;",
                            type);
-  init_iterator (iterator, sql);
+  init_iterator (iterator, "%s", sql);
   g_free (sql);
 }
 
@@ -3082,7 +3082,7 @@ init_user_config_iterator (iterator_t* iterator, config_t config, int trash,
                            sort_field ? sort_field : "id",
                            ascending ? "ASC" : "DESC");
   g_free (columns);
-  init_iterator (iterator, sql);
+  init_iterator (iterator, "%s", sql);
   g_free (sql);
 }
 
@@ -3360,7 +3360,7 @@ init_preference_iterator (iterator_t* iterator, config_t config)
                          " FROM config_preferences"
                          " WHERE config = %llu;",
                          config);
-  init_iterator (iterator, sql);
+  init_iterator (iterator, "%s", sql);
   g_free (sql);
 }
 

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -703,7 +703,7 @@ init_nvt_iterator (iterator_t* iterator, nvt_t nvt, config_t config,
                              " FROM nvts WHERE id = %llu;",
                              nvt_iterator_columns (),
                              nvt);
-      init_iterator (iterator, sql);
+      init_iterator (iterator, "%s", sql);
       g_free (sql);
     }
   else if (config)
@@ -713,7 +713,7 @@ init_nvt_iterator (iterator_t* iterator, nvt_t nvt, config_t config,
       sql = select_config_nvts (config, family, ascending, sort_field);
       if (sql)
         {
-          init_iterator (iterator, sql);
+          init_iterator (iterator, "%s", sql);
           g_free (sql);
         }
       else


### PR DESCRIPTION
Some sql and init_iterator calls were passing in variables with complete
SQL strings in place of the format strings. If the SQL in the variable
contained substrings that resembled placeholders like '%s' they would
be replaced with garbage data.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
