### PR TITLE
Do not pass in SQL string vars as format strings (8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix assignment of orphaned tickets to the current user [#686](https://github.com/greenbone/gvmd/pull/686)
 - Fix ORPHAN calculations in GET_TICKETS [#687](https://github.com/greenbone/gvmd/pull/687) [#700](https://github.com/greenbone/gvmd/pull/700)
 - Fix response from GET_VULNS when given vuln_id does not exists [#699](https://github.com/greenbone/gvmd/pull/699)
+- Fix issues importing results or getting them from slaves if they contain "%s" [#724](https://github.com/greenbone/gvmd/pull/724)
 
 ### Removed
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -22627,7 +22627,7 @@ create_report (array_t *results, const char *task_id, const char *task_name,
       /* Limit the number of results inserted at a time. */
       if (insert_count == CREATE_REPORT_INSERT_SIZE)
         {
-          sql (insert->str);
+          sql ("%s", insert->str);
           g_string_truncate (insert, 0);
           count++;
           insert_count = 0;
@@ -22657,7 +22657,7 @@ create_report (array_t *results, const char *task_id, const char *task_name,
 
   if (first == 0)
     {
-      sql (insert->str);
+      sql ("%s", insert->str);
       report_cache_counts (report, 1, 1, NULL);
       sql_commit ();
       gvm_usleep (CREATE_REPORT_CHUNK_SLEEP);
@@ -22752,7 +22752,7 @@ create_report (array_t *results, const char *task_id, const char *task_name,
         /* Limit the number of details inserted at a time. */
         if (insert_count == CREATE_REPORT_INSERT_SIZE)
           {
-            sql (insert->str);
+            sql ("%s", insert->str);
             g_string_truncate (insert, 0);
             count++;
             insert_count = 0;
@@ -22770,7 +22770,7 @@ create_report (array_t *results, const char *task_id, const char *task_name,
       }
 
   if (first == 0)
-    sql (insert->str);
+    sql ("%s", insert->str);
 
   sql_commit ();
   g_string_free (insert, TRUE);
@@ -33896,7 +33896,7 @@ init_task_file_iterator (iterator_t* iterator, task_t task, const char* file)
                            " FROM task_files"
                            " WHERE task = %llu;",
                            task);
-  init_iterator (iterator, sql);
+  init_iterator (iterator, "%s", sql);
   g_free (sql);
 }
 
@@ -37673,7 +37673,7 @@ init_user_config_iterator (iterator_t* iterator, config_t config, int trash,
                            sort_field ? sort_field : "id",
                            ascending ? "ASC" : "DESC");
   g_free (columns);
-  init_iterator (iterator, sql);
+  init_iterator (iterator, "%s", sql);
   g_free (sql);
 }
 
@@ -37936,7 +37936,7 @@ init_preference_iterator (iterator_t* iterator, config_t config)
                          " FROM config_preferences"
                          " WHERE config = %llu;",
                          config);
-  init_iterator (iterator, sql);
+  init_iterator (iterator, "%s", sql);
   g_free (sql);
 }
 
@@ -40017,7 +40017,7 @@ init_nvt_selector_iterator (iterator_t* iterator, const char* selector,
                            " FROM nvt_selectors"
                            " WHERE type = %i;",
                            type);
-  init_iterator (iterator, sql);
+  init_iterator (iterator, "%s", sql);
   g_free (sql);
 }
 
@@ -54359,7 +54359,7 @@ update_from_slave_insert (GString *buffer, report_t report)
 
           g_string_append (buffer, " RETURNING id;");
 
-          init_iterator (&ids, buffer->str);
+          init_iterator (&ids, "%s", buffer->str);
           while (next (&ids))
             report_add_result_for_buffer (report, iterator_int64 (&ids, 0));
           cleanup_iterator (&ids);
@@ -54374,7 +54374,7 @@ update_from_slave_insert (GString *buffer, report_t report)
                report, report);
         }
       else
-        sql (buffer->str);
+        sql ("%s", buffer->str);
 
       g_string_truncate (buffer, 0);
     }

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -718,7 +718,7 @@ init_nvt_iterator (iterator_t *iterator,
                              " FROM nvts WHERE id = %llu;",
                              nvt_iterator_columns (),
                              nvt);
-      init_iterator (iterator, sql);
+      init_iterator (iterator, "%s", sql);
       g_free (sql);
     }
   else if (config)
@@ -729,7 +729,7 @@ init_nvt_iterator (iterator_t *iterator,
       sql = select_config_nvts (config, family, ascending, sort_field);
       if (sql)
         {
-          init_iterator (iterator, sql);
+          init_iterator (iterator, "%s", sql);
           g_free (sql);
         }
       else


### PR DESCRIPTION
Some sql and init_iterator calls were passing in variables with complete
SQL strings in place of the format strings. If the SQL in the variable
contained substrings that resembled placeholders like '%s' they would
be replaced with garbage data.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
