### PR TITLE
Add report_id filter keyword for TLS certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
-- Added TLS certificates as a new resource type [#585](https://github.com/greenbone/gvmd/pull/585) [#663](https://github.com/greenbone/gvmd/pull/663) [#673](https://github.com/greenbone/gvmd/pull/673) [#695](https://github.com/greenbone/gvmd/pull/695) [#703](https://github.com/greenbone/gvmd/pull/703)
+- Added TLS certificates as a new resource type [#585](https://github.com/greenbone/gvmd/pull/585) [#663](https://github.com/greenbone/gvmd/pull/663) [#673](https://github.com/greenbone/gvmd/pull/673) [#695](https://github.com/greenbone/gvmd/pull/695) [#703](https://github.com/greenbone/gvmd/pull/703) [#728](https://github.com/greenbone/gvmd/pull/728)
 - Update NVTs via OSP [#392](https://github.com/greenbone/gvmd/pull/392) [#609](https://github.com/greenbone/gvmd/pull/609) [#626](https://github.com/greenbone/gvmd/pull/626)
 - Handle addition of ID to NVT preferences. [#413](https://github.com/greenbone/gvmd/pull/413)
 - Add setting 'OMP Slave Check Period' [#491](https://github.com/greenbone/gvmd/pull/491)

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -3214,6 +3214,13 @@ create_tables ()
        "   UNION SELECT 1 AS autofp_selection"
        "   UNION SELECT 2 AS autofp_selection) AS autofp_opts;");
 
+  sql ("CREATE OR REPLACE VIEW tls_certificate_source_origins AS"
+       " SELECT sources.id AS source_id, tls_certificate,"
+       "        origin_id, origin_type, origin_data"
+       "  FROM tls_certificate_sources AS sources"
+       "  JOIN tls_certificate_origins AS origins"
+       "    ON sources.origin = origins.id;");
+
   sql ("DROP VIEW IF EXISTS vulns;");
   if (sql_int ("SELECT EXISTS (SELECT * FROM information_schema.tables"
                "               WHERE table_catalog = '%s'"

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -63900,6 +63900,10 @@ type_extra_where (const char *type, int trash, const char *filter,
       else
         extra_where = g_strdup (" AND hidden = 0");
     }
+  else if (strcasecmp (type, "TLS_CERTIFICATE") == 0)
+    {
+      extra_where = tls_certificate_extra_where (filter);
+    }
   else if (strcasecmp (type, "REPORT") == 0)
     {
       if (trash)

--- a/src/manage_sql_tls_certificates.c
+++ b/src/manage_sql_tls_certificates.c
@@ -197,19 +197,18 @@ tls_certificate_extra_where (const char *filter)
 
   report_id = filter_term_value (filter, "report_id");
 
-  g_message ("report_id=\"%s\"", report_id);
-
   if (report_id)
     {
       gchar *quoted_id;
       quoted_id = sql_quote (report_id);
       g_string_append_printf (ret,
                               " AND"
-                              " (EXISTS (SELECT * FROM"
-                              "  tls_certificate_source_origins AS src_orig"
-                              "  WHERE tls_certificate = tls_certificates.id"
-                              "    AND origin_type = 'Report'"
-                              "    AND origin_id = '%s'))",
+                              " (EXISTS"
+                              "   (SELECT * FROM"
+                              "    tls_certificate_source_origins AS src_orig"
+                              "    WHERE tls_certificate = tls_certificates.id"
+                              "      AND origin_type = 'Report'"
+                              "      AND origin_id = '%s'))",
                               quoted_id);
       g_free (quoted_id);
     }

--- a/src/manage_sql_tls_certificates.h
+++ b/src/manage_sql_tls_certificates.h
@@ -33,6 +33,9 @@ tls_certificate_filter_columns ();
 column_t*
 tls_certificate_select_columns ();
 
+gchar *
+tls_certificate_extra_where (const char *);
+
 int
 delete_tls_certificate (const char *, int);
 

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -22951,6 +22951,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <type>iso_time</type>
             <summary>Time the certificate was last collected</summary>
           </column>
+          <option>
+            <name>report_id</name>
+            <type>uuid</type>
+            <summary>UUID of the report the cerificate must appear in</summary>
+          </option>
         </filter_keywords>
       </attrib>
       <attrib>


### PR DESCRIPTION
This allows using the filter to select the TLS certificates that were found in a particular report.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
