### PR TITLE
 Make --osp-vt-update optional, use default scanner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Check if NVT preferences exist before inserting. [#406](https://github.com/greenbone/gvmd/pull/406)
 - Raise minimum version for SQL functions. [#420](https://github.com/greenbone/gvmd/pull/420)
-- Run OpenVAS scans via OSP instead of OTP. [#422](https://github.com/greenbone/gvmd/pull/422) [#584](https://github.com/greenbone/gvmd/pull/584) [#623](https://github.com/greenbone/gvmd/pull/623) [#636](https://github.com/greenbone/gvmd/pull/636) [#704](https://github.com/greenbone/gvmd/pull/704)
+- Run OpenVAS scans via OSP instead of OTP. [#422](https://github.com/greenbone/gvmd/pull/422) [#584](https://github.com/greenbone/gvmd/pull/584) [#623](https://github.com/greenbone/gvmd/pull/623) [#636](https://github.com/greenbone/gvmd/pull/636) [#704](https://github.com/greenbone/gvmd/pull/704) [#729](https://github.com/greenbone/gvmd/pull/729)
 - Request nvti_cache update only at very end of NVT update. [#426](https://github.com/greenbone/gvmd/pull/426)
 - Consolidate NVT references into unified "refs" element. [#427](https://github.com/greenbone/gvmd/pull/427)
 - Update gvm-libs version requirements to v11.0. [#480](https://github.com/greenbone/gvmd/pull/480)

--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -113,7 +113,7 @@ Modify user's password and exit.
 Run an optimization: vacuum, analyze, cleanup-config-prefs, cleanup-port-names, cleanup-report-formats, cleanup-result-severities, cleanup-schedule-times, rebuild-report-cache or update-report-cache.
 .TP
 \fB--osp-vt-update=\fISCANNER-SOCKET\fB\f1
-Unix socket for OSP NVT update. Default is to do an OTP update.
+Unix socket for OSP NVT update. Defaults to the path of the 'OpenVAS Default' scanner if it is an absolute path.
 .TP
 \fB--password=\fIPASSWORD\fB\f1
 Password, for --create-user.

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -259,7 +259,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <option>
       <p><opt>--osp-vt-update=<arg>SCANNER-SOCKET</arg></opt></p>
       <optdesc>
-        <p>Unix socket for OSP NVT update.  Default is to do an OTP update.</p>
+        <p>Unix socket for OSP NVT update.  Defaults to the path of the 'OpenVAS Default' scanner if it is an absolute path.</p>
       </optdesc>
     </option>
     <option>

--- a/doc/gvmd.html
+++ b/doc/gvmd.html
@@ -242,7 +242,7 @@
     
       <p><b>--osp-vt-update=<em>SCANNER-SOCKET</em></b></p>
       
-        <p>Unix socket for OSP NVT update.  Default is to do an OTP update.</p>
+        <p>Unix socket for OSP NVT update.  Defaults to the path of the 'OpenVAS Default' scanner if it is an absolute path.</p>
       
     
     

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1795,7 +1795,8 @@ gvmd (int argc, char** argv)
           "<name>" },
         { "osp-vt-update", '\0', 0, G_OPTION_ARG_STRING,
           &osp_vt_update,
-          "Unix socket for OSP NVT update.  Default is to do an OTP update.",
+          "Unix socket for OSP NVT update.  Defaults to the path of the"
+          "'OpenVAS Default' scanner if it is an absolute path.",
           "<scanner-socket>" },
         { "password", '\0', 0, G_OPTION_ARG_STRING,
           &password,

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1136,7 +1136,7 @@ update_nvt_cache_retry ()
           else
             {
               g_warning ("%s: No OSP VT update socket set", __FUNCTION__);
-              exit (-1);
+              exit (EXIT_FAILURE);
             }
         }
     }

--- a/src/manage.h
+++ b/src/manage.h
@@ -2781,6 +2781,9 @@ scanner_password (scanner_t);
 int
 scanner_count (const get_data_t *);
 
+char *
+openvas_default_scanner_host ();
+
 int
 init_scanner_iterator (iterator_t*, const get_data_t *);
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -43640,6 +43640,18 @@ scanner_count (const get_data_t *get)
 }
 
 /**
+ * @brief Get the default scanner path or host.
+ *
+ * @return Newly allocated scanner path or host.
+ */
+char *
+openvas_default_scanner_host ()
+{
+  return sql_string ("SELECT host FROM scanners WHERE uuid = '%s'",
+                     SCANNER_UUID_DEFAULT);
+}
+
+/**
  * @brief Create a new connection to an OSP scanner.
  *
  * @param[in]   scanner     Scanner.

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -62,6 +62,40 @@ blank_control_chars (char *string)
 }
 
 
+/* NVT related global options */
+
+/**
+ * @brief File socket for OSP NVT update.  NULL to update via OTP.
+ */
+static gchar *osp_vt_update_socket = NULL;
+
+/**
+ * @brief Get the current file socket for OSP NVT update.
+ *
+ * @return The path of the file socket for OSP NVT update.
+ */
+const gchar *
+get_osp_vt_update_socket ()
+{
+  return osp_vt_update_socket;
+}
+
+/**
+ * @brief Set the file socket for OSP NVT update.
+ *
+ * @param new_socket The new path of the file socket for OSP NVT update.
+ */
+void
+set_osp_vt_update_socket (const char *new_socket)
+{
+  if (new_socket)
+    {
+      g_free (osp_vt_update_socket);
+      osp_vt_update_socket = g_strdup (new_socket);
+    }
+}
+
+
 /* NVT's. */
 
 /**

--- a/src/manage_sql_nvts.h
+++ b/src/manage_sql_nvts.h
@@ -95,6 +95,12 @@
    { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                                     \
  }
 
+const char *
+get_osp_vt_update_socket ();
+
+void
+set_osp_vt_update_socket (const char *new_socket);
+
 void
 check_db_nvts ();
 


### PR DESCRIPTION
The OSP VT update socket no longer has to be given with the command line
if the socket path of the "OpenVAS Default" scanner can be used instead.
Also, update_nvt_cache_retry will no longer fork endlessly if the socket
path is still NULL for some reason and the documentation is updated.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
