### PR TITLE
Add include_certificate_data to TLS certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
-- Added TLS certificates as a new resource type [#585](https://github.com/greenbone/gvmd/pull/585) [#663](https://github.com/greenbone/gvmd/pull/663) [#673](https://github.com/greenbone/gvmd/pull/673) [#695](https://github.com/greenbone/gvmd/pull/695) [#703](https://github.com/greenbone/gvmd/pull/703)
+- Added TLS certificates as a new resource type [#585](https://github.com/greenbone/gvmd/pull/585) [#663](https://github.com/greenbone/gvmd/pull/663) [#673](https://github.com/greenbone/gvmd/pull/673) [#695](https://github.com/greenbone/gvmd/pull/695) [#703](https://github.com/greenbone/gvmd/pull/703) [#732](https://github.com/greenbone/gvmd/pull/732)
 - Update NVTs via OSP [#392](https://github.com/greenbone/gvmd/pull/392) [#609](https://github.com/greenbone/gvmd/pull/609) [#626](https://github.com/greenbone/gvmd/pull/626)
 - Handle addition of ID to NVT preferences. [#413](https://github.com/greenbone/gvmd/pull/413)
 - Add setting 'OMP Slave Check Period' [#491](https://github.com/greenbone/gvmd/pull/491)

--- a/src/gmp_tls_certificates.c
+++ b/src/gmp_tls_certificates.c
@@ -79,11 +79,21 @@ get_tls_certificates_reset ()
  */
 void
 get_tls_certificates_start (const gchar **attribute_names,
-                   const gchar **attribute_values)
+                            const gchar **attribute_values)
 {
+  const gchar *include_certificate_data;
+
   get_data_parse_attributes (&get_tls_certificates_data.get, "tls_certificate",
                              attribute_names,
                              attribute_values);
+
+  if (find_attribute (attribute_names, attribute_values,
+                      "include_certificate_data", &include_certificate_data))
+    {
+       get_data_set_extra (&get_tls_certificates_data.get,
+                           "include_certificate_data",
+                           include_certificate_data);
+    }
 }
 
 /**
@@ -96,9 +106,20 @@ void
 get_tls_certificates_run (gmp_parser_t *gmp_parser, GError **error)
 {
   iterator_t tls_certificates;
-  int count, filtered, ret, first;
+  int count, filtered, ret, first, include_certificate_data;
+  const char *include_certificate_data_str;
 
   count = 0;
+
+  include_certificate_data_str
+    = get_data_get_extra (&get_tls_certificates_data.get,
+                          "include_certificate_data");
+  if (include_certificate_data_str
+      && strcmp (include_certificate_data_str, "")
+      && strcmp (include_certificate_data_str, "0"))
+    include_certificate_data = 1;
+  else
+    include_certificate_data = 0;
 
   ret = init_get ("get_tls_certificates",
                   &get_tls_certificates_data.get,
@@ -207,7 +228,7 @@ get_tls_certificates_run (gmp_parser_t *gmp_parser, GError **error)
          tls_certificate_iterator_certificate_format (&tls_certificates)
             ? tls_certificate_iterator_certificate_format (&tls_certificates)
             : "unknown",
-         get_tls_certificates_data.get.details
+         (get_tls_certificates_data.get.details || include_certificate_data)
             ? tls_certificate_iterator_certificate (&tls_certificates)
             : "",
          tls_certificate_iterator_md5_fingerprint (&tls_certificates),

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -22958,6 +22958,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         <summary>ID of filter to use to filter query</summary>
         <type>uuid</type>
       </attrib>
+      <attrib>
+        <name>include_certificate_data</name>
+        <summary>Whether to include certificate_data even if details are not requested</summary>
+        <type>boolean</type>
+      </attrib>
     </pattern>
     <response>
       <pattern>


### PR DESCRIPTION
The get_tls_certificates GMP command now has an option to include the
certificate_data element even if details are not requested.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
