### PR TITLE
Re-add removed install line. Added additional gpgsm prerequisite.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -30,6 +30,13 @@ Prerequisites for building tests:
 Please see the section "Prerequisites for Optional Features" below additional
 optional prerequisites.
 
+Install prerequisites on Debian GNU/Linux 'Stretch' 9:
+
+    apt-get install gcc cmake libglib2.0-dev libgnutls28-dev libpq-dev postgresql-server-dev-9.6 pkg-config libical-dev
+
+Optional prerequisites on Debian GNU/Linux 'Stretch' 9:
+
+    apt-get install gnutls-bin gpgsm
 
 ## Compiling Greenbone Vulnerability Manager
 


### PR DESCRIPTION
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

According to @timopollmeier ``gpgsm`` is required for S/MIME support. This might be related to the issue seen in e.g. #540.

I have also re-added the build dependency which seems to got dropped completely in #610 and added a few from the prerequisites mentioned / used in https://github.com/greenbone/openvas/blob/master/INSTALL.md#prerequisites-for-openvas

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
