### PR TITLE
Fix a possible migration issue from GVM-9 to GVM-10 in migrate_188_to…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Make bulk tagging with a filter work if the resources are already tagged [#712](https://github.com/greenbone/gvmd/pull/712)
 - Fix columnless search phrase filter keywords with quotes [#716](https://github.com/greenbone/gvmd/pull/716)
 - Fix issues importing results or getting them from slaves if they contain "%s" [#724](https://github.com/greenbone/gvmd/pull/724)
+- A possible database migration issue from GVMd-7 to GVMd-8 has been addressed [#742](https://github.com/greenbone/gvmd/pull/742)
 
 ### Removed
 

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -14136,6 +14136,12 @@ migrate_188_to_189 ()
 
   /* Update the database. */
 
+  /* The views result_overrides and results_autofp changed. */
+
+  sql ("DROP VIEW IF EXISTS result_overrides;");
+
+  sql ("DROP VIEW IF EXISTS results_autofp;");
+
   /* Table result_nvts was added, with links in results and overrides. */
 
   sql ("CREATE TABLE result_nvts (id SERIAL PRIMARY KEY,"


### PR DESCRIPTION
…_189.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

While upgrading the following two GVM-9 instances to GVM-10:

1. GVM-9 with GVMd 7.0.3 on Debian stable/stretch
2. GVM-9 with GVMd 7.0.3 on Debian testing/bullseye

i've noticed that instance 2. was failing with the following error:

```
md   main:MESSAGE:2019-08-13 07h52.53 utc:16607:    Greenbone Vulnerability Manager version 8.0.1 (DB revision 205)
md   main:   INFO:2019-08-13 07h52.53 utc:16607:    Migrating database.
md   main:   INFO:2019-08-13 07h52.53 utc:16607:    Migrating to 189
md manage:WARNING:2019-08-13 07h52.53 utc:16607: sql_exec_internal: sqlite3_step failed: error in view result_overrides: no such table: main.results
md manage:WARNING:2019-08-13 07h52.53 utc:16607: sqlv: sql_exec_internal failed
md manage:WARNING:2019-08-13 08h00.59 utc:17249: sql_exec_internal: sqlite3_step failed: error in view results_autofp: no such table: main.results
md manage:WARNING:2019-08-13 08h00.59 utc:17249: sqlv: sql_exec_internal failed
```

It is currently unclear why only one out of the two instances had failed. There are two differences i'm seeing:

1. They had basically the same upgrading history for previous releases but one might be still older then another one
2. The difference in the base OS (different SQLite versions?)

Dropping the view manually like described in https://community.greenbone.net/t/hints-for-migration-to-gvm-10/1971/4 allowed me to continue the migration so it might help for other users to do this directly in the affected migrator to avoid sending the user to the shell / sqlite3 command line.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
