### PR TITLE
Eliminate get_tag() and parse_tags().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove --backup command line option [#615](https://github.com/greenbone/gvmd/pull/615)
 - Remove GET_REPORTS type "assets" [#617](https://github.com/greenbone/gvmd/pull/617) [#620](https://github.com/greenbone/gvmd/pull/620)
 - Remove errors for unknown elements [#619](https://github.com/greenbone/gvmd/pull/619)
+- Eliminate get_tag() and parse_tags() [#743](https://github.com/greenbone/gvmd/pull/743)
 
 
 [Unreleased]: https://github.com/greenbone/openvas/compare/gvmd-8.0...master

--- a/src/manage.c
+++ b/src/manage.c
@@ -76,7 +76,6 @@
 #include <time.h>
 #include <unistd.h>
 
-#include <gvm/base/cvss.h>
 #include <gvm/base/hosts.h>
 #include <gvm/base/proctitle.h>
 #include <gvm/osp/osp.h>
@@ -6876,72 +6875,6 @@ file_iterator_content_64 (file_iterator_t* iterator)
     }
 
   return content;
-}
-
-
-/* Scanner Tags. */
-
-/**
- * @brief Split up the tags received from the scanner.
- *
- * @param[in]  scanner_tags  The tags sent by the scanner.
- * @param[out] tags          Tags.
- * @param[out] cvss_base     CVSS base.
- */
-void
-parse_tags (const char *scanner_tags, gchar **tags, gchar **cvss_base)
-{
-  gchar **split, **point;
-  GString *tags_buffer;
-  gboolean first;
-
-  tags_buffer = g_string_new ("");
-  split = g_strsplit (scanner_tags, "|", 0);
-  point = split;
-  *cvss_base = NULL;
-  first = TRUE;
-
-  while (*point)
-    {
-      if (strncmp (*point, "cvss_base=", strlen ("cvss_base=")) == 0)
-        {
-          /* Skip this tag. */
-        }
-      else if (strncmp (*point,
-                        "cvss_base_vector=",
-                        strlen ("cvss_base_vector="))
-               == 0)
-        {
-          if (*cvss_base == NULL)
-            *cvss_base = g_strdup_printf ("%.1f",
-                                          get_cvss_score_from_base_metrics
-                                           (*point
-                                            + strlen ("cvss_base_vector=")));
-          if (first)
-            first = FALSE;
-          else
-            g_string_append_c (tags_buffer, '|');
-          g_string_append (tags_buffer, *point);
-        }
-      else
-        {
-          if (first)
-            first = FALSE;
-          else
-            g_string_append_c (tags_buffer, '|');
-          g_string_append (tags_buffer, *point);
-        }
-      point++;
-    }
-
-  if (tags_buffer->len == 0)
-    {
-      g_string_free (tags_buffer, TRUE);
-      *tags = g_strdup ("NOTAG");
-    }
-  else
-    *tags = g_string_free (tags_buffer, FALSE);
-  g_strfreev (split);
 }
 
 

--- a/src/manage.h
+++ b/src/manage.h
@@ -3633,12 +3633,6 @@ int
 manage_empty_trashcan ();
 
 
-/* Scanner tags. */
-
-void
-parse_tags (const char *, gchar **, gchar **);
-
-
 /* SecInfo */
 
 int

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1298,7 +1298,7 @@ nvti_from_vt (entity_t vt)
           cvss_base = g_strdup_printf ("%.1f", get_cvss_score_from_base_metrics
                                            (entity_text (severity)));
           nvti_set_cvss_base (nvti, cvss_base);
-	  g_free (cvss_base);
+          g_free (cvss_base);
         }
       else
         g_warning ("%s: no severity", __FUNCTION__);

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -36,6 +36,8 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <gvm/base/cvss.h> // for get_cvss_score_from_base_metrics
+
 #include "manage_sql.h"
 #include "manage_sql_nvts.h"
 #include "sql.h"
@@ -1289,7 +1291,14 @@ nvti_from_vt (entity_t vt)
                       "cvss_base_v2")
               == 0))
         {
+          gchar * cvss_base;
+
           nvti_add_tag (nvti, "cvss_base_vector", entity_text (severity));
+
+          cvss_base = g_strdup_printf ("%.1f", get_cvss_score_from_base_metrics
+                                           (entity_text (severity)));
+          nvti_set_cvss_base (nvti, cvss_base);
+	  g_free (cvss_base);
         }
       else
         g_warning ("%s: no severity", __FUNCTION__);

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1018,49 +1018,6 @@ set_nvts_check_time ()
 }
 
 /**
- * @brief Get tag field from VT.
- *
- * @param[in]  vt  VT.
- *
- * @return Freshly allocated string for tag field.
- */
-static gchar *
-get_tag (entity_t vt)
-{
-  entity_t child;
-  GString *tag;
-  int first;
-
-  first = 1;
-  tag = g_string_new ("");
-
-  child = entity_child (vt, "severities");
-  if (child)
-    {
-      entity_t severity;
-
-      severity = entity_child (child, "severity");
-      if (severity
-          && entity_attribute (severity, "type")
-          && (strcmp (entity_attribute (severity, "type"),
-                      "cvss_base_v2")
-              == 0))
-        {
-          g_string_append_printf (tag,
-                                  "%scvss_base_vector=%s",
-                                  first ? "" : "|",
-                                  entity_text (severity));
-        }
-      else
-        g_warning ("%s: no severity", __FUNCTION__);
-    }
-  else
-    g_warning ("%s: no severities", __FUNCTION__);
-
-  return g_string_free (tag, FALSE);
-}
-
-/**
  * @brief Update NVT from VT XML.
  *
  * @param[in]  vt           OSP GET_VTS VT element.
@@ -1161,8 +1118,9 @@ nvti_from_vt (entity_t vt)
   entity_t name, summary, insight, affected, impact, detection, solution;
   entity_t creation_time, modification_time;
   entity_t refs, ref, custom, family, category;
+  entity_t severities;
+
   entities_t children;
-  gchar *tag, *cvss_base, *parsed_tags;
 
   id = entity_attribute (vt, "id");
   if (id == NULL)
@@ -1319,15 +1277,31 @@ nvti_from_vt (entity_t vt)
       children = next_entities (children);
     }
 
-  tag = get_tag (vt);
-  nvti_set_tag (nvti, tag);
+  severities = entity_child (vt, "severities");
+  if (severities)
+    {
+      entity_t severity;
+
+      severity = entity_child (severities, "severity");
+      if (severity
+          && entity_attribute (severity, "type")
+          && (strcmp (entity_attribute (severity, "type"),
+                      "cvss_base_v2")
+              == 0))
+        {
+          nvti_add_tag (nvti, "cvss_base_vector", entity_text (severity));
+        }
+      else
+        g_warning ("%s: no severity", __FUNCTION__);
+    }
+  else
+    g_warning ("%s: no severities", __FUNCTION__);
 
   custom = entity_child (vt, "custom");
   if (custom == NULL)
     {
       g_warning ("%s: VT missing CUSTOM", __FUNCTION__);
       nvti_free (nvti);
-      g_free (tag);
       return NULL;
     }
 
@@ -1336,7 +1310,6 @@ nvti_from_vt (entity_t vt)
     {
       g_warning ("%s: VT/CUSTOM missing FAMILY", __FUNCTION__);
       nvti_free (nvti);
-      g_free (tag);
       return NULL;
     }
   nvti_set_family (nvti, entity_text (family));
@@ -1346,18 +1319,9 @@ nvti_from_vt (entity_t vt)
     {
       g_warning ("%s: VT/CUSTOM missing CATEGORY", __FUNCTION__);
       nvti_free (nvti);
-      g_free (tag);
       return NULL;
     }
   nvti_set_category (nvti, atoi (entity_text (category)));
-
-  parse_tags (tag, &parsed_tags, &cvss_base);
-
-  nvti_set_cvss_base (nvti, cvss_base);
-
-  g_free (parsed_tags);
-  g_free (cvss_base);
-  g_free (tag);
 
   return nvti;
 }

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -36,7 +36,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <gvm/base/cvss.h> // for get_cvss_score_from_base_metrics
+#include <gvm/base/cvss.h>
 
 #include "manage_sql.h"
 #include "manage_sql_nvts.h"
@@ -1295,8 +1295,8 @@ nvti_from_vt (entity_t vt)
 
           nvti_add_tag (nvti, "cvss_base_vector", entity_text (severity));
 
-          cvss_base = g_strdup_printf ("%.1f", get_cvss_score_from_base_metrics
-                                           (entity_text (severity)));
+          cvss_base = g_strdup_printf ("%.1f",
+            get_cvss_score_from_base_metrics (entity_text (severity)));
           nvti_set_cvss_base (nvti, cvss_base);
           g_free (cvss_base);
         }


### PR DESCRIPTION
The function get_tag() only parses the cvss_base_vector
from the incoming OSP XML for a VT and adds it to the nvti tags
string.

Using the new function nvt_add_tag() makes avoids the knowledge
about the internal syntax (pipe-separated list).

This last tag that is parsed is now located in function nvti_from_vt().

Also this removes the parsing for "cvss_base" inside the tags
string which happened in nvti_from_vt(). Actually it is not being
parsed anyway but rather computed from the vector.

This is done now directly after parsing the cvss_base_vector from
XML inside nvt_from_vt().

An in turn this make it possible to remove parse_tags() function,
another place where the internal knowledge about the pipe-separated
syntax for tags was present.

This requires https://github.com/greenbone/gvm-libs/pull/263

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
