### PR TITLE
Round 5 of OTP cleanout

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -13025,19 +13025,19 @@ handle_get_configs (gmp_parser_t *gmp_parser, GError **error)
           g_free (s_name);
           SEND_TO_CLIENT_OR_FAIL ("<preferences>");
 
-          init_preference_iterator (&prefs, config);
+          init_config_preference_iterator (&prefs, config);
           while (next (&prefs))
             {
               const char *name, *hr_name, *value, *type, *def;
               char *ovaldi_files = NULL;
 
-              hr_name = preference_iterator_hr_name (&prefs);
-              name = preference_iterator_name (&prefs);
-              value = preference_iterator_value (&prefs);
-              def = preference_iterator_default (&prefs);
+              hr_name = config_preference_iterator_hr_name (&prefs);
+              name = config_preference_iterator_name (&prefs);
+              value = config_preference_iterator_value (&prefs);
+              def = config_preference_iterator_default (&prefs);
               if (!strcmp (name, "definitions_file"))
                 ovaldi_files = get_ovaldi_files ();
-              type = preference_iterator_type (&prefs);
+              type = config_preference_iterator_type (&prefs);
               SENDF_TO_CLIENT_OR_FAIL
                ("<preference>"
                 "<nvt oid=\"\"><name/></nvt>"

--- a/src/gmpd.c
+++ b/src/gmpd.c
@@ -536,16 +536,7 @@ serve_gmp (gvm_connection_t *client_connection, const gchar *database,
         }
 
       if (!ret)
-        {
-          /* Timeout periodically.  This was needed in the past so that OTP
-           * scan handling processes could check if the client had stopped
-           * the task. */
-          struct timeval timeout;
-
-          timeout.tv_usec = 0;
-          timeout.tv_sec = 1;
-          ret = select (nfds, &readfds, &writefds, NULL, &timeout);
-        }
+        ret = select (nfds, &readfds, &writefds, NULL, NULL);
       if ((ret < 0 && errno == EINTR) || ret == 0)
         continue;
       if (ret < 0)

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -171,14 +171,14 @@
 /**
  * @brief Scanner port.
  *
- * Used if /etc/services "otp" and --port missing.
+ * Used if --scanner-port is missing.
  */
 #define OPENVASSD_PORT 9391
 
 /**
  * @brief Manager port.
  *
- * Used if /etc/services "gmp" and --sport are missing.
+ * Used if /etc/services "otp" and --port are missing.
  */
 #define GVMD_PORT 9390
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -3346,23 +3346,23 @@ task_scanner_options (task_t task, target_t target)
   iterator_t prefs;
 
   config = task_config (task);
-  init_preference_iterator (&prefs, config);
+  init_config_preference_iterator (&prefs, config);
   table = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
   while (next (&prefs))
     {
       char *name, *value = NULL;
       const char *type;
 
-      name = g_strdup (preference_iterator_name (&prefs));
-      type = preference_iterator_type (&prefs);
+      name = g_strdup (config_preference_iterator_name (&prefs));
+      type = config_preference_iterator_type (&prefs);
 
       if (g_str_has_prefix (type, "credential_"))
         {
           credential_t credential = 0;
           iterator_t iter;
-          const char *uuid = preference_iterator_value (&prefs);
+          const char *uuid = config_preference_iterator_value (&prefs);
 
-          if (!strcmp (preference_iterator_value (&prefs), "0"))
+          if (!strcmp (config_preference_iterator_value (&prefs), "0"))
             credential = target_ssh_credential (target);
           else if (find_resource ("credential", uuid, &credential))
             {
@@ -3409,16 +3409,16 @@ task_scanner_options (task_t task, target_t target)
         {
           char *fname;
 
-          if (!preference_iterator_value (&prefs))
+          if (!config_preference_iterator_value (&prefs))
             continue;
           fname = g_strdup_printf ("%s/%s", GVM_SCAP_DATA_DIR "/",
-                                   preference_iterator_value (&prefs));
+                                   config_preference_iterator_value (&prefs));
           value = gvm_file_as_base64 (fname);
           if (!value)
             continue;
         }
       else
-        value = g_strdup (preference_iterator_value (&prefs));
+        value = g_strdup (config_preference_iterator_value (&prefs));
       g_hash_table_insert (table, name, value);
     }
   cleanup_iterator (&prefs);

--- a/src/manage.c
+++ b/src/manage.c
@@ -4003,12 +4003,12 @@ launch_osp_openvas_task (task_t task, target_t target, const char *scan_id,
   /* Setup general scanner preferences */
   scanner_options
     = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
-  init_otp_pref_iterator (&scanner_prefs_iter, config, "SERVER_PREFS");
+  init_preference_iterator (&scanner_prefs_iter, config, "SERVER_PREFS");
   while (next (&scanner_prefs_iter))
     {
       const char *name, *value;
-      name = otp_pref_iterator_name (&scanner_prefs_iter);
-      value = otp_pref_iterator_value (&scanner_prefs_iter);
+      name = preference_iterator_name (&scanner_prefs_iter);
+      value = preference_iterator_value (&scanner_prefs_iter);
       if (name && value)
         {
           const char *osp_value;
@@ -4056,15 +4056,15 @@ launch_osp_openvas_task (task_t task, target_t target, const char *scan_id,
   cleanup_iterator (&families);
 
   /* Setup VT preferences */
-  init_otp_pref_iterator (&prefs, config, "PLUGINS_PREFS");
+  init_preference_iterator (&prefs, config, "PLUGINS_PREFS");
   while (next (&prefs))
     {
       const char *full_name, *value;
       osp_vt_single_t *osp_vt;
       gchar **split_name;
 
-      full_name = otp_pref_iterator_name (&prefs);
-      value = otp_pref_iterator_value (&prefs);
+      full_name = preference_iterator_name (&prefs);
+      value = preference_iterator_value (&prefs);
       split_name = g_strsplit (full_name, ":", 4);
 
       osp_vt = NULL;

--- a/src/manage.c
+++ b/src/manage.c
@@ -4712,7 +4712,7 @@ run_task_prepare_report (task_t task, char **report_id, int from,
 }
 
 /**
- * @brief Start a slave/GMP task.
+ * @brief Start a slave GMP task.
  *
  * A process is forked to run the task, but the forked process never returns.
  *
@@ -4730,10 +4730,10 @@ run_task_prepare_report (task_t task, char **report_id, int from,
  *         -9 failed to fork.
  */
 static int
-run_slave_or_gmp_task (task_t task, int from, char **report_id,
-                       gvm_connection_t *connection,
-                       const gchar *slave_id,
-                       const gchar *slave_name)
+run_gmp_slave_task (task_t task, int from, char **report_id,
+                    gvm_connection_t *connection,
+                    const gchar *slave_id,
+                    const gchar *slave_name)
 {
   int ret, pid;
   task_status_t run_status;
@@ -4838,7 +4838,7 @@ run_slave_or_gmp_task (task_t task, int from, char **report_id,
 
   uuid = report_uuid (global_current_report);
   snprintf (title, sizeof (title),
-            "gvmd: OTP: Handling slave scan %s",
+            "gvmd: GMP: Handling slave scan %s",
             uuid);
   free (uuid);
   proctitle_set (title);
@@ -4941,8 +4941,8 @@ run_gmp_task (task_t task, scanner_t scanner, int from, char **report_id)
 
   connection.tls = 1;
 
-  ret = run_slave_or_gmp_task (task, from, report_id, &connection, scanner_id,
-                               name);
+  ret = run_gmp_slave_task (task, from, report_id, &connection, scanner_id,
+                            name);
 
   free (connection.host_string);
   free (connection.username);

--- a/src/manage.h
+++ b/src/manage.h
@@ -994,10 +994,6 @@ request_delete_task (task_t*);
 int
 delete_task (task_t, int);
 
-/* For otp.c. */
-int
-delete_task_lock (task_t, int);
-
 void
 append_to_task_comment (task_t, const char*, int);
 

--- a/src/manage.h
+++ b/src/manage.h
@@ -1922,22 +1922,22 @@ manage_set_config_preference (const gchar *, const char*, const char*,
                               const char*);
 
 void
-init_preference_iterator (iterator_t *, config_t);
+init_config_preference_iterator (iterator_t *, config_t);
 
 const char*
-preference_iterator_name (iterator_t *);
+config_preference_iterator_name (iterator_t *);
 
 const char*
-preference_iterator_value (iterator_t *);
+config_preference_iterator_value (iterator_t *);
 
 const char*
-preference_iterator_type (iterator_t *);
+config_preference_iterator_type (iterator_t *);
 
 const char*
-preference_iterator_default (iterator_t *);
+config_preference_iterator_default (iterator_t *);
 
 const char*
-preference_iterator_hr_name (iterator_t *);
+config_preference_iterator_hr_name (iterator_t *);
 
 int
 manage_set_config (const gchar *, const char*, const char *, const char *);

--- a/src/manage.h
+++ b/src/manage.h
@@ -1393,7 +1393,7 @@ void
 set_scan_host_end_time (report_t, const char*, const char*);
 
 void
-set_scan_host_end_time_otp (report_t, const char*, const char*);
+set_scan_host_end_time_ctime (report_t, const char*, const char*);
 
 int
 report_timestamp (const char*, gchar**);

--- a/src/manage.h
+++ b/src/manage.h
@@ -1378,7 +1378,7 @@ void
 set_scan_end_time (report_t, const char*);
 
 void
-set_scan_end_time_otp (report_t, const char*);
+set_scan_end_time_ctime (report_t, const char*);
 
 void
 set_scan_end_time_epoch (report_t, time_t);

--- a/src/manage.h
+++ b/src/manage.h
@@ -240,33 +240,6 @@ manage_transaction_stop (gboolean);
 
 /* Task structures. */
 
-extern short scanner_active;
-
-/** @todo Should be in otp.c/h. */
-/**
- * @brief A port.
- */
-typedef struct
-{
-  unsigned int number;       ///< Port number.
-  port_protocol_t protocol;  ///< Port protocol (TCP, UDP, ...).
-  char* string;              ///< Original string describing port.
-} port_t;
-
-/** @todo Should be in otp.c/h. */
-/**
- * @brief The record of a message.
- */
-typedef struct
-{
-  char* host;           ///< Host message describes.
-  char* hostname;       ///< Hostname message describes.
-  port_t port;          ///< The port.
-  char* description;    ///< Description of the message.
-  char* oid;            ///< NVT identifier.
-} message_t;
-
-
 /**
  * @brief Task statuses, also used as scan/report statuses.
  *

--- a/src/manage.h
+++ b/src/manage.h
@@ -1369,7 +1369,7 @@ char*
 scan_end_time_uuid (const char *);
 
 void
-set_scan_start_time_otp (report_t, const char*);
+set_scan_start_time_ctime (report_t, const char*);
 
 void
 set_scan_start_time_epoch (report_t, time_t);
@@ -1384,7 +1384,7 @@ void
 set_scan_end_time_epoch (report_t, time_t);
 
 void
-set_scan_host_start_time_otp (report_t, const char*, const char*);
+set_scan_host_start_time_ctime (report_t, const char*, const char*);
 
 int
 scan_host_end_time (report_t, const char*);

--- a/src/manage.h
+++ b/src/manage.h
@@ -907,7 +907,7 @@ void
 set_task_start_time_epoch (task_t, int);
 
 void
-set_task_start_time_otp (task_t, char*);
+set_task_start_time_ctime (task_t, char*);
 
 void
 set_task_end_time (task_t task, char* time);

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -1311,13 +1311,6 @@ manage_create_sql_functions ()
        "  SELECT uuid_generate_v4 ()::text AS result;"
        "$$ LANGUAGE SQL;");
 
-  sql ("CREATE OR REPLACE FUNCTION tag (text, text) RETURNS text AS $$"
-       /* Extract a tag from an OTP tag list. */
-       "  SELECT split_part (unnest, '=', 2)"
-       "  FROM unnest (string_to_array ($1, '|'))"
-       "  WHERE split_part (unnest, '=', 1) = $2;"
-       "$$ LANGUAGE SQL;");
-
   if (sql_int ("SELECT EXISTS (SELECT * FROM information_schema.tables"
                "               WHERE table_catalog = '%s'"
                "               AND table_schema = 'public'"

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -14230,7 +14230,7 @@ manage_test_alert (const char *alert_id, gchar **script_message)
   set_scan_host_start_time_ctime (report, "127.0.0.1", clean);
   if (result)
     report_add_result (report, result);
-  set_scan_host_end_time_otp (report, "127.0.0.1", clean);
+  set_scan_host_end_time_ctime (report, "127.0.0.1", clean);
   set_scan_end_time_otp (report, clean);
   g_free (clean);
   ret = manage_alert (alert_id,
@@ -25501,7 +25501,7 @@ set_scan_host_end_time (report_t report, const char* host,
  * @param[in]  timestamp  End time.  OTP format (ctime).
  */
 void
-set_scan_host_end_time_otp (report_t report, const char* host,
+set_scan_host_end_time_ctime (report_t report, const char* host,
                             const char* timestamp)
 {
   gchar *quoted_host;
@@ -31537,7 +31537,7 @@ parse_osp_report (task_t task, report_t report, const char *report_xml)
         }
       else if (host && nvt_id && desc && (strcmp (nvt_id, "HOST_END") == 0))
         {
-          set_scan_host_end_time_otp (report, host, desc);
+          set_scan_host_end_time_ctime (report, host, desc);
           add_assets_from_host_in_report (report, host);
         }
       else

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -14225,7 +14225,7 @@ manage_test_alert (const char *alert_id, gchar **script_message)
   clean = g_strdup (now_string);
   if (clean[strlen (clean) - 1] == '\n')
     clean[strlen (clean) - 1] = '\0';
-  set_task_start_time_otp (task, g_strdup (clean));
+  set_task_start_time_ctime (task, g_strdup (clean));
   set_scan_start_time_otp (report, g_strdup (clean));
   set_scan_host_start_time_otp (report, "127.0.0.1", clean);
   if (result)
@@ -19698,7 +19698,7 @@ set_task_start_time_epoch (task_t task, int time)
  * @param[in]  time  New time.  UTC ctime format.  Freed before return.
  */
 void
-set_task_start_time_otp (task_t task, char* time)
+set_task_start_time_ctime (task_t task, char* time)
 {
   sql ("UPDATE tasks SET start_time = %i, modification_time = m_now ()"
        " WHERE id = %llu;",

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -14231,7 +14231,7 @@ manage_test_alert (const char *alert_id, gchar **script_message)
   if (result)
     report_add_result (report, result);
   set_scan_host_end_time_ctime (report, "127.0.0.1", clean);
-  set_scan_end_time_otp (report, clean);
+  set_scan_end_time_ctime (report, clean);
   g_free (clean);
   ret = manage_alert (alert_id,
                       task_id,
@@ -25437,7 +25437,7 @@ set_scan_end_time (report_t report, const char* timestamp)
  *                        time.
  */
 void
-set_scan_end_time_otp (report_t report, const char* timestamp)
+set_scan_end_time_ctime (report_t report, const char* timestamp)
 {
   if (timestamp)
     sql ("UPDATE reports SET end_time = %i WHERE id = %llu;",

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -42517,8 +42517,7 @@ create_scanner (const char* name, const char *comment, const char *host,
     return 2;
   if (itype <= SCANNER_TYPE_NONE || itype >= SCANNER_TYPE_MAX)
     return 2;
-  /* XXX: Workaround for unix socket case. Should add a host type flag, or
-   * remove otp over tcp case entirely. */
+  /* XXX: Workaround for unix socket case. */
   if (gvm_get_host_type (host) == -1 && !unix_socket)
     return 2;
   if (resource_with_name_exists (name, "scanner", 0))

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -14226,8 +14226,8 @@ manage_test_alert (const char *alert_id, gchar **script_message)
   if (clean[strlen (clean) - 1] == '\n')
     clean[strlen (clean) - 1] = '\0';
   set_task_start_time_ctime (task, g_strdup (clean));
-  set_scan_start_time_otp (report, g_strdup (clean));
-  set_scan_host_start_time_otp (report, "127.0.0.1", clean);
+  set_scan_start_time_ctime (report, g_strdup (clean));
+  set_scan_host_start_time_ctime (report, "127.0.0.1", clean);
   if (result)
     report_add_result (report, result);
   set_scan_host_end_time_otp (report, "127.0.0.1", clean);
@@ -25357,7 +25357,7 @@ set_scan_start_time_epoch (report_t report, time_t timestamp)
  * @param[in]  timestamp  Start time.  In OTP format (ctime).
  */
 void
-set_scan_start_time_otp (report_t report, const char* timestamp)
+set_scan_start_time_ctime (report_t report, const char* timestamp)
 {
   sql ("UPDATE reports SET start_time = %i WHERE id = %llu;",
        parse_utc_ctime (timestamp),
@@ -25549,7 +25549,7 @@ set_scan_host_start_time (report_t report, const char* host,
  * @param[in]  timestamp  Start time.  OTP format (ctime).
  */
 void
-set_scan_host_start_time_otp (report_t report, const char* host,
+set_scan_host_start_time_ctime (report_t report, const char* host,
                               const char* timestamp)
 {
   gchar *quoted_host;
@@ -31533,7 +31533,7 @@ parse_osp_report (task_t task, report_t report, const char *report_xml)
         }
       else if (host && nvt_id && desc && (strcmp (nvt_id, "HOST_START") == 0))
         {
-          set_scan_host_start_time_otp (report, host, desc);
+          set_scan_host_start_time_ctime (report, host, desc);
         }
       else if (host && nvt_id && desc && (strcmp (nvt_id, "HOST_END") == 0))
         {

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -1152,7 +1152,7 @@ vector_find_filter (const gchar **vector, const gchar *string)
 }
 
 /**
- * @brief Extract a tag from an OTP tag list.
+ * @brief Extract a tag from a pipe separated tag list.
  *
  * @param[in]   tags  Tag list.
  * @param[out]  tag   Tag name.
@@ -34913,7 +34913,7 @@ target_port_list (target_t target)
 }
 
 /**
- * @brief Return the port range of a target, in OTP format.
+ * @brief Return the port range of a target, in GMP port range list format.
  *
  * For "OpenVAS Default", return the explicit port ranges instead of "default".
  *
@@ -51631,7 +51631,7 @@ create_port_list_lock (const char *quoted_id, const char *quoted_name,
  *
  * @param[in]   name            Name of port list.
  * @param[in]   comment         Comment on port list.
- * @param[in]   port_range      Traditional OTP style port range.  NULL for "default".
+ * @param[in]   port_range      GMP style port range list.  NULL for "default".
  * @param[out]  port_list       Created port list.
  *
  * @return 0 success, 4 error in port range.

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -19474,7 +19474,7 @@ set_task_run_status (task_t task, task_status_t status)
 /**
  * @brief Atomically set the run state of a task to requested.
  *
- * Only used by run_slave_or_gmp_task and run_otp_task.
+ * Only used by run_gmp_slave_task.
  *
  * @param[in]  task    Task.
  * @param[out] status  Old run status of task.

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -19695,14 +19695,14 @@ set_task_start_time_epoch (task_t task, int time)
  * @brief Set the start time of a task.
  *
  * @param[in]  task  Task.
- * @param[in]  time  New time.  OTP format (ctime).  Freed before return.
+ * @param[in]  time  New time.  UTC ctime format.  Freed before return.
  */
 void
 set_task_start_time_otp (task_t task, char* time)
 {
   sql ("UPDATE tasks SET start_time = %i, modification_time = m_now ()"
        " WHERE id = %llu;",
-       parse_otp_time (time),
+       parse_utc_ctime (time),
        task);
   free (time);
 }
@@ -25360,7 +25360,7 @@ void
 set_scan_start_time_otp (report_t report, const char* timestamp)
 {
   sql ("UPDATE reports SET start_time = %i WHERE id = %llu;",
-       parse_otp_time (timestamp),
+       parse_utc_ctime (timestamp),
        report);
 }
 
@@ -25441,7 +25441,7 @@ set_scan_end_time_otp (report_t report, const char* timestamp)
 {
   if (timestamp)
     sql ("UPDATE reports SET end_time = %i WHERE id = %llu;",
-         parse_otp_time (timestamp), report);
+         parse_utc_ctime (timestamp), report);
   else
     sql ("UPDATE reports SET end_time = NULL WHERE id = %llu;",
          report);
@@ -25511,9 +25511,9 @@ set_scan_host_end_time_otp (report_t report, const char* host,
                report, quoted_host))
     sql ("UPDATE report_hosts SET end_time = %i"
          " WHERE report = %llu AND host = '%s';",
-         parse_otp_time (timestamp), report, quoted_host);
+         parse_utc_ctime (timestamp), report, quoted_host);
   else
-    manage_report_host_add (report, host, 0, parse_otp_time (timestamp));
+    manage_report_host_add (report, host, 0, parse_utc_ctime (timestamp));
   g_free (quoted_host);
 }
 
@@ -25559,9 +25559,9 @@ set_scan_host_start_time_otp (report_t report, const char* host,
                report, quoted_host))
     sql ("UPDATE report_hosts SET start_time = %i"
          " WHERE report = %llu AND host = '%s';",
-         parse_otp_time (timestamp), report, quoted_host);
+         parse_utc_ctime (timestamp), report, quoted_host);
   else
-    manage_report_host_add (report, host, parse_otp_time (timestamp), 0);
+    manage_report_host_add (report, host, parse_utc_ctime (timestamp), 0);
   g_free (quoted_host);
 }
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -25354,7 +25354,7 @@ set_scan_start_time_epoch (report_t report, time_t timestamp)
  * @brief Set the start time of a scan.
  *
  * @param[in]  report     The report associated with the scan.
- * @param[in]  timestamp  Start time.  In OTP format (ctime).
+ * @param[in]  timestamp  Start time.  In UTC ctime format.
  */
 void
 set_scan_start_time_ctime (report_t report, const char* timestamp)
@@ -25433,7 +25433,7 @@ set_scan_end_time (report_t report, const char* timestamp)
  * @brief Set the end time of a scan.
  *
  * @param[in]  report     The report associated with the scan.
- * @param[in]  timestamp  End time.  OTP format (ctime).  If NULL, clear end
+ * @param[in]  timestamp  End time.  In UTC ctime format.  If NULL, clear end
  *                        time.
  */
 void
@@ -25498,7 +25498,7 @@ set_scan_host_end_time (report_t report, const char* host,
  *
  * @param[in]  report     Report associated with the scan.
  * @param[in]  host       Host.
- * @param[in]  timestamp  End time.  OTP format (ctime).
+ * @param[in]  timestamp  End time.  In UTC ctime format.
  */
 void
 set_scan_host_end_time_ctime (report_t report, const char* host,
@@ -25546,7 +25546,7 @@ set_scan_host_start_time (report_t report, const char* host,
  *
  * @param[in]  report     Report associated with the scan.
  * @param[in]  host       Host.
- * @param[in]  timestamp  Start time.  OTP format (ctime).
+ * @param[in]  timestamp  Start time.  In UTC ctime format.
  */
 void
 set_scan_host_start_time_ctime (report_t report, const char* host,

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -56278,8 +56278,8 @@ hosts_set_identifiers (report_t report)
 
               host_new = host = sql_last_insert_id ();
 
-              /* Make sure the Report Host identifiers added for OTP HOST_START in
-               * otp.c refer to the new host. */
+              /* Make sure the Report Host identifiers added when the host was
+               * first noticed now refer to the new host. */
 
               sql ("UPDATE host_identifiers SET host = %llu"
                    " WHERE source_id = (SELECT uuid FROM reports"

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -392,9 +392,9 @@ void set_task_schedule_next_time (task_t, time_t);
 
 void set_task_schedule_next_time_uuid (const gchar *, time_t);
 
-void init_otp_pref_iterator (iterator_t *, config_t, const char *);
-const char *otp_pref_iterator_name (iterator_t *);
-const char *otp_pref_iterator_value (iterator_t *);
+void init_preference_iterator (iterator_t *, config_t, const char *);
+const char *preference_iterator_name (iterator_t *);
+const char *preference_iterator_value (iterator_t *);
 
 port_list_t target_port_list (target_t);
 credential_t target_ssh_credential (target_t);

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -3420,11 +3420,11 @@ DEF_ACCESS (config_preference_iterator_default, 3);
 DEF_ACCESS (config_preference_iterator_hr_name, 4);
 
 /**
- * @brief Initialise an "OTP" preference iterator.
+ * @brief Initialise a config preference iterator, with defaults.
  *
  * Assume the caller has permission to access the config.
  *
- * This version substitutes the scanner preference when the NVT preference
+ * This version substitutes the NVT preference when the config preference
  * is missing.
  *
  * @param[in]  iterator  Iterator.
@@ -3432,9 +3432,9 @@ DEF_ACCESS (config_preference_iterator_hr_name, 4);
  * @param[in]  section   Preference section.
  */
 void
-init_otp_pref_iterator (iterator_t* iterator,
-                        config_t config,
-                        const char* section)
+init_preference_iterator (iterator_t* iterator,
+                          config_t config,
+                          const char* section)
 {
   gchar *quoted_section;
 
@@ -3470,24 +3470,24 @@ init_otp_pref_iterator (iterator_t* iterator,
 }
 
 /**
- * @brief Get the NAME from a host iterator.
+ * @brief Get the NAME from a preference iterator.
  *
  * @param[in]  iterator  Iterator.
  *
  * @return NAME, or NULL if iteration is complete.  Freed by
  *         cleanup_iterator.
  */
-DEF_ACCESS (otp_pref_iterator_name, 0);
+DEF_ACCESS (preference_iterator_name, 0);
 
 /**
- * @brief Get the value from a otp_pref iterator.
+ * @brief Get the value from a preference iterator.
  *
  * @param[in]  iterator  Iterator.
  *
  * @return Value, or NULL if iteration is complete.  Freed by
  *         cleanup_iterator.
  */
-DEF_ACCESS (otp_pref_iterator_value, 1);
+DEF_ACCESS (preference_iterator_value, 1);
 
 /**
  * @brief Return the NVT selector associated with a config.

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -3352,7 +3352,7 @@ trash_config_readable_uuid (const gchar *config_id)
  * @param[in]  config    Config.
  */
 void
-init_preference_iterator (iterator_t* iterator, config_t config)
+init_config_preference_iterator (iterator_t* iterator, config_t config)
 {
   gchar* sql;
 
@@ -3374,7 +3374,7 @@ init_preference_iterator (iterator_t* iterator, config_t config)
  * @return The name of the preference iterator, or NULL if iteration is
  *         complete.  Freed by cleanup_iterator.
  */
-DEF_ACCESS (preference_iterator_name, 0);
+DEF_ACCESS (config_preference_iterator_name, 0);
 
 /**
  * @brief Get the value from a preference iterator.
@@ -3384,7 +3384,7 @@ DEF_ACCESS (preference_iterator_name, 0);
  * @return The value of the preference iterator, or NULL if iteration is
  *         complete.  Freed by cleanup_iterator.
  */
-DEF_ACCESS (preference_iterator_value, 1);
+DEF_ACCESS (config_preference_iterator_value, 1);
 
 /**
  * @brief Get the type from a preference iterator.
@@ -3394,7 +3394,7 @@ DEF_ACCESS (preference_iterator_value, 1);
  * @return The value of the preference iterator, or NULL if iteration is
  *         complete.  Freed by cleanup_iterator.
  */
-DEF_ACCESS (preference_iterator_type, 2);
+DEF_ACCESS (config_preference_iterator_type, 2);
 
 /**
  * @brief Get the default from a preference iterator.
@@ -3404,7 +3404,7 @@ DEF_ACCESS (preference_iterator_type, 2);
  * @return The default of the preference iterator, or NULL if iteration is
  *         complete.  Freed by cleanup_iterator.
  */
-DEF_ACCESS (preference_iterator_default, 3);
+DEF_ACCESS (config_preference_iterator_default, 3);
 
 /**
  * @brief Get the hr_name from a preference iterator.
@@ -3417,7 +3417,7 @@ DEF_ACCESS (preference_iterator_default, 3);
  * @return The hr_name of the preference iterator, or NULL if iteration is
  *         complete.  Freed by cleanup_iterator.
  */
-DEF_ACCESS (preference_iterator_hr_name, 4);
+DEF_ACCESS (config_preference_iterator_hr_name, 4);
 
 /**
  * @brief Initialise an "OTP" preference iterator.

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -65,7 +65,7 @@ blank_control_chars (char *string)
 /* NVT related global options */
 
 /**
- * @brief File socket for OSP NVT update.  NULL to update via OTP.
+ * @brief File socket for OSP NVT update.
  */
 static gchar *osp_vt_update_socket = NULL;
 

--- a/src/manage_utils.c
+++ b/src/manage_utils.c
@@ -496,7 +496,7 @@ next_time (time_t first, int period, int period_months, int byday,
 }
 
 /**
- * @brief Try convert an OTP NVT tag time string into epoch time.
+ * @brief Try convert an NVT time string into epoch time.
  *
  * @param[in]   string   String.
  * @param[out]  seconds  Time as seconds since the epoch.

--- a/src/utils.c
+++ b/src/utils.c
@@ -171,16 +171,14 @@ parse_utc_time (const char *format, const char *text_time)
 }
 
 /**
- * @brief Convert an OTP time into seconds since epoch.
- *
- * Use UTC as timezone.
+ * @brief Convert a UTC ctime string into seconds since the epoch.
  *
  * @param[in]  text_time  Time as text in ctime format.
  *
  * @return Time since epoch.  0 on error.
  */
 int
-parse_otp_time (const char *text_time)
+parse_utc_ctime (const char *text_time)
 {
   return parse_utc_time ("%a %b %d %H:%M:%S %Y", text_time);
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -35,7 +35,7 @@ int
 gvm_sleep (unsigned int);
 
 int
-parse_otp_time (const char *);
+parse_utc_ctime (const char *);
 
 int
 parse_feed_timestamp (const char *);


### PR DESCRIPTION
This should be the final round of cleanup.  There's only one reference to
OTP left in the code: the name used by /etc/services for port 9390.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
