### PR TITLE
Only pass filter to osp_get_vts_ext if there's a version

### DIFF
--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1457,7 +1457,10 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
           return -1;
         }
 
-      get_vts_opts.filter = g_strdup_printf ("modification_time>%s", db_feed_version); 
+      if (db_feed_version)
+        get_vts_opts.filter = g_strdup_printf ("modification_time>%s", db_feed_version);
+      else
+        get_vts_opts.filter = NULL;
       if (osp_get_vts_ext (connection, get_vts_opts, &vts))
         {
           g_warning ("%s: failed to get VTs", __FUNCTION__);


### PR DESCRIPTION
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
