### PR TITLE
fixed start task failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix columnless search phrase filter keywords with quotes [#716](https://github.com/greenbone/gvmd/pull/716)
 - Fix issues importing results or getting them from slaves if they contain "%s" [#724](https://github.com/greenbone/gvmd/pull/724)
 - A possible database migration issue from GVMd-7 to GVMd-8 has been addressed [#742](https://github.com/greenbone/gvmd/pull/742)
+- Fix escaping that was preventing start_task from running [#758](https://github.com/greenbone/gvmd/pull/758)
 
 ### Removed
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -38041,7 +38041,7 @@ init_otp_pref_iterator (iterator_t* iterator,
                  " WHERE config_preferences.config = %llu"
                  " AND config_preferences.type = '%s'"
                  " AND (config_preferences.name = nvt_preferences.name"
-                 "      OR config_preferences.name LIKE 'timeout.%')"
+                 "      OR config_preferences.name LIKE 'timeout.%%')"
                  " AND config_preferences.name != 'max_checks'"
                  " AND config_preferences.name != 'max_hosts'"
                  " UNION"


### PR DESCRIPTION
- [ ] [issue](https://github.com/greenbone/gvmd/issues/473#issuecomment-535839734) 
fixed start a task failed.
cannot start a task in alpine linux .
python code:
```python
  # -*- coding:utf-8 -*-

from gvm.connections import UnixSocketConnection
from gvm.errors import GvmError
from gvm.protocols.latest import Gmp
from gvm.transforms import EtreeCheckCommandTransform
from gvm.xml import pretty_print
import sys
import uuid

path = '/var/run/gvmd.sock'
connection = UnixSocketConnection(path=path)
transform = EtreeCheckCommandTransform()
gmp = Gmp(connection=connection, transform=transform)

username = 'admin'
password = 'admin'

try:
    tasks = []

    with gmp:
        gmp.authenticate(username, password)
        if not gmp.is_authenticated():
            print('not authenticate')

        tasks = gmp.get_tasks()
        for task in tasks.xpath('task'):
            task_id, = task.xpath("@id")
            print(task_id, task.find('name').text)
            pretty_print(gmp.start_task(task_id=task_id))

except GvmError as e:
    print('An error occurred', e, file=sys.stderr)
```
- [ ] Tests
Verify the problem.
```c
#include <glib.h>
#include <stdio.h>

// use centos or other linux
/*
void
test_glib(const char *format, ...)
{
    gchar *formatted = NULL;
    va_list args;
    va_start (args, format);

    formatted = g_strdup_vprintf(format, args);
    printf("format: %d %s\n", len, formatted);
    va_end(args);
}
*/
// use vasprintf 
void
test_vasprintf(const char *format, ...)
{
    gint len;
    gchar *formatted = NULL;
    va_list args;
    va_start (args, format);
    len = vasprintf (&formatted, format, args);
    if (len < 0)
        formatted = NULL;
    printf("format: %d %s\n", len, formatted);
    va_end(args);
}

void 
main(void)
{
    long long int config = 5;
    gchar *t1 = "SERVER_PREFS";
    gchar *t2 = "NOT LIKE '%[%]%'";
    
    /**
        simale test
    **/
    //test_glib("%llu, %s, %s, %llu\n", config, t1, t2, config);
    test_vasprintf("%llu, %s, %s, %llu\n", config, t1, t2, config);
    
    /*
        origin sql code
        results are different on alpine linux and centos
    */
    const char *format = "SELECT config_preferences.name, config_preferences.value"
         " FROM config_preferences, nvt_preferences"
         " WHERE config_preferences.config = %llu"
         " AND config_preferences.type = '%s'"
         " AND (config_preferences.name = nvt_preferences.name"
         "      OR config_preferences.name LIKE 'timeout.%')"
         " AND config_preferences.name != 'max_checks'"
         " AND config_preferences.name != 'max_hosts'"            
         " UNION"                                                       
         " SELECT nvt_preferences.name, nvt_preferences.value"
         " FROM nvt_preferences"
         " WHERE nvt_preferences.name %s"
         " AND (SELECT COUNT(*) FROM config_preferences"
         "      WHERE config = %llu"
         "      AND config_preferences.name = nvt_preferences.name) = 0;\n\n";
    
    //test_glib(format, config, t1, t2, config);
    
    test_vasprintf(format, config, t1, t2, config); // It' ok on centos result, But it turns out to be null on alpine linux
    
    /*
        change 'timeout.%' to 'timeout.%%'
    */
    
    const char *format1 = "SELECT config_preferences.name, config_preferences.value"
         " FROM config_preferences, nvt_preferences"
         " WHERE config_preferences.config = %llu"
         " AND config_preferences.type = '%s'"
         " AND (config_preferences.name = nvt_preferences.name"
         "      OR config_preferences.name LIKE 'timeout.%%')"
         " AND config_preferences.name != 'max_checks'"
         " AND config_preferences.name != 'max_hosts'"            
         " UNION"                                                       
         " SELECT nvt_preferences.name, nvt_preferences.value"
         " FROM nvt_preferences"
         " WHERE nvt_preferences.name %s"
         " AND (SELECT COUNT(*) FROM config_preferences"
         "      WHERE config = %llu"
         "      AND config_preferences.name = nvt_preferences.name) = 0;\n\n";
    //test_glib(format1, config, t1, t2, config);
    
    test_vasprintf(format1, config, t1, t2, config);// same result, on centos and alpine linux
    
}
```

