### PR TITLE
Allow "0" or empty credential_id in create_scanner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Command cleanup-report-formats for --optimize option [#652](https://github.com/greenbone/gvmd/pull/652)
 - Document container tasks in GMP doc [#688](https://github.com/greenbone/gvmd/pull/688)
 - Add lean option to GET_REPORTS [#745](https://github.com/greenbone/gvmd/pull/745)
-- Add scanner relays and OSP sensor scanner type [#756](https://github.com/greenbone/gvmd/pull/756)
+- Add scanner relays and OSP sensor scanner type [#756](https://github.com/greenbone/gvmd/pull/756) [#759](https://github.com/greenbone/gvmd/pull/759)
 
 ### Changed
 - Check if NVT preferences exist before inserting. [#406](https://github.com/greenbone/gvmd/pull/406)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -42639,7 +42639,11 @@ create_scanner (const char* name, const char *comment, const char *host,
       return 1;
     }
 
-  if (!unix_socket && itype == SCANNER_TYPE_GMP && credential_id == NULL)
+  if (!unix_socket
+      && itype == SCANNER_TYPE_GMP
+      && (credential_id == NULL
+          || strcmp (credential_id, "") == 0
+          || strcmp (credential_id, "0") == 0))
     {
       sql_rollback ();
       return 6;
@@ -42649,7 +42653,9 @@ create_scanner (const char* name, const char *comment, const char *host,
   else
     {
       credential = 0;
-      if (credential_id)
+      if (credential_id
+          && strcmp (credential_id, "")
+          && strcmp (credential_id, "0"))
         {
           if (find_credential_with_permission
               (credential_id, &credential, "get_credentials"))

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -2538,6 +2538,8 @@ create_task_check_config_scanner (config_t config, scanner_t scanner)
     return 1;
   if (ctype == 0 && stype == SCANNER_TYPE_GMP)
     return 1;
+  if (ctype == 0 && stype == SCANNER_TYPE_OSP_SENSOR)
+    return 1;
   if (ctype == 1 && stype == SCANNER_TYPE_OSP)
     return 1;
 
@@ -2613,6 +2615,10 @@ modify_task_check_config_scanner (task_t task, const char *config_id,
 
   /* GMP Scanner with OpenVAS config. */
   if (stype == SCANNER_TYPE_GMP && ctype == 0)
+    return 0;
+
+  /* OSP Sensor with OpenVAS config. */
+  if (stype == SCANNER_TYPE_OSP_SENSOR && ctype == 0)
     return 0;
 
   /* Default Scanner with OpenVAS Config. */


### PR DESCRIPTION
Previously the `create_scanner` command only accepted the `credential_id` missing completely
to set no credential. Now it also accepts "" and "0".
Also, the task config checks did not recognize the new scanner type.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
