### PR TITLE
Break when searching for user in modify_role and modify_group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix columnless search phrase filter keywords with quotes [#715](https://github.com/greenbone/gvmd/pull/715)
 - Fix issues importing results or getting them from slaves if they contain "%s" [#723](https://github.com/greenbone/gvmd/pull/723)
 - Fix sorting by numeric filter columns [#751](https://github.com/greenbone/gvmd/pull/751)
+- Fix array index error when modifying role [#762](https://github.com/greenbone/gvmd/pull/762)
 
 ### Removed
 - The handling of NVT updates via OTP has been removed. [#575](https://github.com/greenbone/gvmd/pull/575)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix columnless search phrase filter keywords with quotes [#715](https://github.com/greenbone/gvmd/pull/715)
 - Fix issues importing results or getting them from slaves if they contain "%s" [#723](https://github.com/greenbone/gvmd/pull/723)
 - Fix sorting by numeric filter columns [#751](https://github.com/greenbone/gvmd/pull/751)
-- Fix array index error when modifying role [#762](https://github.com/greenbone/gvmd/pull/762)
+- Fix array index error when modifying roles and groups [#762](https://github.com/greenbone/gvmd/pull/762)
 
 ### Removed
 - The handling of NVT updates via OTP has been removed. [#575](https://github.com/greenbone/gvmd/pull/575)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -49912,7 +49912,10 @@ modify_group (const char *group_id, const char *name, const char *comment,
       for (index = 0; index < affected_users->len && found_user == 0; index++)
         {
           if (g_array_index (affected_users, user_t, index) == user)
-            found_user = 1;
+            {
+              found_user = 1;
+              break;
+            }
         }
 
       if (found_user)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -53671,7 +53671,10 @@ modify_role (const char *role_id, const char *name, const char *comment,
       for (index = 0; index < affected_users->len && found_user == 0; index++)
         {
           if (g_array_index (affected_users, user_t, index) == user)
-            found_user = 1;
+            {
+              found_user = 1;
+              break;
+            }
         }
 
       if (found_user)


### PR DESCRIPTION
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Without the break the wrong index is used for g_array_remove_index_fast.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
