### PR TITLE
Get scanner preferences from OSP-OpenVAS scanner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Added TLS certificates as a new resource type [#585](https://github.com/greenbone/gvmd/pull/585) [#663](https://github.com/greenbone/gvmd/pull/663) [#673](https://github.com/greenbone/gvmd/pull/673) [#674](https://github.com/greenbone/gvmd/pull/674) [#689](https://github.com/greenbone/gvmd/pull/689) [#695](https://github.com/greenbone/gvmd/pull/695) [#703](https://github.com/greenbone/gvmd/pull/703) [#728](https://github.com/greenbone/gvmd/pull/728) [#732](https://github.com/greenbone/gvmd/pull/732) [#750](https://github.com/greenbone/gvmd/pull/750) [#752](https://github.com/greenbone/gvmd/pull/752)
-- Update NVTs via OSP [#392](https://github.com/greenbone/gvmd/pull/392) [#609](https://github.com/greenbone/gvmd/pull/609) [#626](https://github.com/greenbone/gvmd/pull/626) [#753](https://github.com/greenbone/gvmd/pull/753)
+- Update NVTs via OSP [#392](https://github.com/greenbone/gvmd/pull/392) [#609](https://github.com/greenbone/gvmd/pull/609) [#626](https://github.com/greenbone/gvmd/pull/626) [#753](https://github.com/greenbone/gvmd/pull/753) [#766](https://github.com/greenbone/gvmd/pull/766)
 - Handle addition of ID to NVT preferences. [#413](https://github.com/greenbone/gvmd/pull/413) [#744](https://github.com/greenbone/gvmd/pull/744)
 - Add setting 'OMP Slave Check Period' [#491](https://github.com/greenbone/gvmd/pull/491)
 - Document switching between releases when using Postgres. [#563](https://github.com/greenbone/gvmd/pull/563)

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1477,27 +1477,6 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
       update_nvts_from_vts (&vts, scanner_feed_version);
       free_entity (vts);
 
-      /* Tell the main process to update its NVTi cache. */
-      sql ("UPDATE %s.meta SET value = 1 WHERE name = 'update_nvti_cache';",
-           sql_schema ());
-
-      g_info ("Updating VTs in database ... done (%i VTs).",
-              sql_int ("SELECT count (*) FROM nvts;"));
-
-      if (sql_int ("SELECT coalesce ((SELECT CAST (value AS INTEGER)"
-                   "                  FROM meta"
-                   "                  WHERE name = 'checked_preferences'),"
-                   "                 0);")
-          == 0)
-        {
-          check_preference_names ("config_preferences");
-          check_preference_names ("config_preferences_trash");
-
-          sql ("INSERT INTO meta (name, value)"
-               " VALUES ('checked_preferences', 1)"
-               " ON CONFLICT (name) DO UPDATE SET value = EXCLUDED.value;");
-        }
-
       /* Update scanner preferences */
       connection = osp_connection_new (update_socket, 0, NULL, NULL, NULL);
       if (!connection)
@@ -1555,6 +1534,27 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
             }
 
           g_string_free (prefs_sql, TRUE);
+        }
+
+      /* Tell the main process to update its NVTi cache. */
+      sql ("UPDATE %s.meta SET value = 1 WHERE name = 'update_nvti_cache';",
+           sql_schema ());
+
+      g_info ("Updating VTs in database ... done (%i VTs).",
+              sql_int ("SELECT count (*) FROM nvts;"));
+
+      if (sql_int ("SELECT coalesce ((SELECT CAST (value AS INTEGER)"
+                   "                  FROM meta"
+                   "                  WHERE name = 'checked_preferences'),"
+                   "                 0);")
+          == 0)
+        {
+          check_preference_names ("config_preferences");
+          check_preference_names ("config_preferences_trash");
+
+          sql ("INSERT INTO meta (name, value)"
+               " VALUES ('checked_preferences', 1)"
+               " ON CONFLICT (name) DO UPDATE SET value = EXCLUDED.value;");
         }
     }
 

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1511,7 +1511,7 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
               gchar *quoted_name, *quoted_value;
 
               param = point->data;
-              quoted_name = sql_quote (osp_param_name (param));
+              quoted_name = sql_quote (osp_param_id (param));
               quoted_value = sql_quote (osp_param_default (param));
 
               g_string_append_printf (prefs_sql,

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1415,6 +1415,7 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
 {
   osp_connection_t *connection;
   gchar *db_feed_version, *scanner_feed_version;
+  GSList *scanner_prefs;
 
   /* Re-open DB after fork. */
 
@@ -1495,6 +1496,65 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
           sql ("INSERT INTO meta (name, value)"
                " VALUES ('checked_preferences', 1)"
                " ON CONFLICT (name) DO UPDATE SET value = EXCLUDED.value;");
+        }
+
+      /* Update scanner preferences */
+      connection = osp_connection_new (update_socket, 0, NULL, NULL, NULL);
+      if (!connection)
+        {
+          g_warning ("%s: failed to connect to %s (3)",
+                    __FUNCTION__, update_socket);
+          return -1;
+        }
+
+      scanner_prefs = NULL;
+      if (osp_get_scanner_details (connection, NULL, &scanner_prefs))
+        {
+          g_warning ("%s: failed to get scanner preferences", __FUNCTION__);
+          osp_connection_close (connection);
+          return -1;
+        }
+      else
+        {
+          GString *prefs_sql;
+          GSList *point;
+          int first;
+
+          point = scanner_prefs;
+          first = 1;
+
+          osp_connection_close (connection);
+          prefs_sql = g_string_new ("INSERT INTO nvt_preferences (name, value)"
+                                    " VALUES");
+          while (point)
+            {
+              osp_param_t *param;
+              gchar *quoted_name, *quoted_value;
+
+              param = point->data;
+              quoted_name = sql_quote (osp_param_name (param));
+              quoted_value = sql_quote (osp_param_default (param));
+
+              g_string_append_printf (prefs_sql,
+                                      "%s ('%s', '%s')",
+                                      first ? "" : ",",
+                                      quoted_name,
+                                      quoted_value);
+              first = 0;
+              point = g_slist_next (point);
+              g_free (quoted_name);
+              g_free (quoted_value);
+            }
+          g_string_append (prefs_sql,
+                           " ON CONFLICT (name)"
+                           " DO UPDATE SET value = EXCLUDED.value;");
+
+          if (first == 0)
+            {
+              sql ("%s", prefs_sql->str);
+            }
+
+          g_string_free (prefs_sql, TRUE);
         }
     }
 

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1415,7 +1415,6 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
 {
   osp_connection_t *connection;
   gchar *db_feed_version, *scanner_feed_version;
-  GSList *scanner_prefs;
 
   /* Re-open DB after fork. */
 
@@ -1446,6 +1445,7 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
   if ((db_feed_version == NULL)
       || strcmp (scanner_feed_version, db_feed_version))
     {
+      GSList *scanner_prefs;
       entity_t vts;
       osp_get_vts_opts_t get_vts_opts;
 


### PR DESCRIPTION
The preferences of the OpenVAS scanner are expected to be in the
nvt_preferences table, so they have to be added there.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
