### PR TITLE
Create host and OS assets for OSP-OpenVAS scans (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Change get_tickets to use the status text for filtering. [#697](https://github.com/greenbone/gvmd/pull/697)
 - Made checks to prevent duplicate user names stricter. [#708](https://github.com/greenbone/gvmd/pull/708) [#722](https://github.com/greenbone/gvmd/pull/722)
 - Send delete command to ospd after stopping the task. [#710](https://github.com/greenbone/gvmd/pull/710)
-- Check whether hosts are alive and have results when adding them in slave scans. [#717](https://github.com/greenbone/gvmd/pull/717) [#726](https://github.com/greenbone/gvmd/pull/726) [#736](https://github.com/greenbone/gvmd/pull/736)
+- Check whether hosts are alive and have results when adding them in slave scans. [#717](https://github.com/greenbone/gvmd/pull/717) [#726](https://github.com/greenbone/gvmd/pull/726) [#736](https://github.com/greenbone/gvmd/pull/736) [#771](https://github.com/greenbone/gvmd/pull/771)
 - Use explicit nvti timestamps [#725](https://github.com/greenbone/gvmd/pull/725)
 - New columns Ports, Apps, Distance, and Auth in the CSV Hosts report format [#733](https://github.com/greenbone/gvmd/pull/733)
 - The details attribute of GET_REPORTS now defaults to 0 [#747](https://github.com/greenbone/gvmd/pull/747)

--- a/src/manage.c
+++ b/src/manage.c
@@ -4238,6 +4238,9 @@ fork_osp_scan_handler (task_t task, target_t target, char **report_id_return)
   g_free (report_id);
   if (rc == 0)
     {
+      hosts_set_identifiers (global_current_report);
+      hosts_set_max_severity (global_current_report, NULL, NULL);
+      hosts_set_details (global_current_report);
       set_task_run_status (task, TASK_STATUS_DONE);
       set_report_scan_run_status (global_current_report, TASK_STATUS_DONE);
     }

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -58425,6 +58425,11 @@ add_assets_from_host_in_report (report_t report, const char *host_ip)
     }
 
   /* Create assets */
+  if (report_host_noticeable (report, host_ip))
+    {
+      host_notice (host_ip, "ip", host_ip, "Report Host", report_id, 1, 1);
+    }
+
   ret = add_tls_certificates_from_report_host (report_host,
                                                report_id,
                                                host_ip);


### PR DESCRIPTION
For OSP-OpenVAS scans host or OS asset were not created even if the task had the "add to assets" preference enabled.

Backport of #731

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- N/A Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
