### PR TITLE
Add NULL check in nvts_feed_version_epoch (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix issues importing results or getting them from slaves if they contain "%s" [#723](https://github.com/greenbone/gvmd/pull/723)
 - Fix sorting by numeric filter columns [#751](https://github.com/greenbone/gvmd/pull/751)
 - Fix array index error when modifying roles and groups [#762](https://github.com/greenbone/gvmd/pull/762)
+- Add NULL check in nvts_feed_version_epoch [#773](https://github.com/greenbone/gvmd/pull/773)
 
 ### Removed
 - The handling of NVT updates via OTP has been removed. [#575](https://github.com/greenbone/gvmd/pull/575)

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -169,10 +169,19 @@ nvts_feed_version ()
 time_t
 nvts_feed_version_epoch ()
 {
+  gchar *feed_version;
   struct tm tm;
 
+  feed_version = nvts_feed_version ();
+
+  if (feed_version == NULL)
+    return 0;
+
   memset (&tm, 0, sizeof (struct tm));
-  strptime (nvts_feed_version (), "%Y%m%d%H%M%S", &tm);
+  strptime (feed_version, "%Y%m%d%H%M%S", &tm);
+
+  g_free (feed_version);
+
   return mktime (&tm);
 }
 


### PR DESCRIPTION
Also adds freeing of feed_version.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
