### PR TITLE
Use UTC in iCalendar strings (9.0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 220)
+set (GVMD_DATABASE_VERSION 221)
 
 set (GVMD_SCAP_DATABASE_VERSION 15)
 

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -1481,6 +1481,88 @@ migrate_219_to_220 ()
   return 0;
 }
 
+/**
+ * @brief Convert iCalendar strings of schedules to new format for version 221.
+ *
+ * @param[in]  trash  Whether to convert the trash table.
+ */
+static void convert_schedules_221 (gboolean trash)
+{
+  iterator_t schedules;
+
+  init_iterator (&schedules,
+                 "SELECT id, icalendar, uuid FROM %s;",
+                 trash ? "schedules_trash" : "schedules");
+
+  while (next (&schedules))
+    {
+      schedule_t schedule;
+      const char *ical_string, *schedule_id;
+      icalcomponent *ical_component;
+      gchar *error_out;
+
+      error_out = NULL;
+      schedule = iterator_int64 (&schedules, 0);
+      ical_string = iterator_string (&schedules, 1);
+      schedule_id = iterator_string (&schedules, 2);
+
+      ical_component = icalendar_from_string (ical_string, &error_out);
+      if (ical_component == NULL)
+        g_warning ("Error converting schedule %s: %s", schedule_id, error_out);
+      else
+        {
+          gchar *quoted_ical;
+
+          quoted_ical
+            = sql_quote (icalcomponent_as_ical_string (ical_component));
+
+          sql ("UPDATE %s SET icalendar = '%s' WHERE id = %llu",
+               trash ? "schedules_trash" : "schedules",
+               quoted_ical,
+               schedule);
+
+          g_free (quoted_ical);
+        }
+
+      g_free (error_out);
+    }
+
+  cleanup_iterator (&schedules);
+}
+
+/**
+ * @brief Migrate the database from version 220 to version 221.
+ *
+ * @return 0 success, -1 error.
+ */
+int
+migrate_220_to_221 ()
+{
+  sql_begin_immediate ();
+
+  /* Ensure that the database is currently version 220. */
+
+  if (manage_db_version () != 220)
+    {
+      sql_rollback ();
+      return -1;
+    }
+
+  /* Update the database. */
+
+  /* Convert iCalendar strings of all schedules */
+  convert_schedules_221 (FALSE);
+  convert_schedules_221 (TRUE);
+
+  /* Set the database version to 221. */
+
+  set_db_version (221);
+
+  sql_commit ();
+
+  return 0;
+}
+
 #undef UPDATE_DASHBOARD_SETTINGS
 
 /**
@@ -1507,6 +1589,7 @@ static migrator_t database_migrators[] = {
   {218, migrate_217_to_218},
   {219, migrate_218_to_219},
   {220, migrate_219_to_220},
+  {221, migrate_220_to_221},
   /* End marker. */
   {-1, NULL}};
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -44392,7 +44392,7 @@ create_schedule (const char* name, const char *comment,
     {
       ical_component = icalendar_from_old_schedule_data
                           (first_time, period, period_months, duration,
-                           byday_mask, zone);
+                           byday_mask);
       quoted_ical = sql_quote (icalcomponent_as_ical_string (ical_component));
     }
 
@@ -45427,7 +45427,7 @@ modify_schedule (const char *schedule_id, const char *name, const char *comment,
 
   /* Update basic data */
   quoted_comment = comment ? sql_quote (comment) : NULL;
-  quoted_timezone = timezone ? sql_quote (zone) : NULL;
+  quoted_timezone = zone ? sql_quote (zone) : NULL;
 
   sql ("UPDATE schedules SET"
        " name = %s%s%s,"
@@ -45596,8 +45596,7 @@ modify_schedule (const char *schedule_id, const char *name, const char *comment,
       ical_component = icalendar_from_old_schedule_data
                           (real_first_time,
                            real_period, real_period_months,
-                           real_duration, real_byday,
-                           real_timezone);
+                           real_duration, real_byday);
       quoted_icalendar
         = sql_quote (icalcomponent_as_ical_string (ical_component));
 

--- a/src/manage_utils.h
+++ b/src/manage_utils.h
@@ -74,8 +74,7 @@ int
 hosts_str_contains (const char *, const char *, int);
 
 icalcomponent *
-icalendar_from_old_schedule_data (time_t, time_t, time_t, time_t, int,
-                                  const char *);
+icalendar_from_old_schedule_data (time_t, time_t, time_t, time_t, int);
 
 icalcomponent *
 icalendar_from_string (const char *, gchar **);


### PR DESCRIPTION
To simplify the timezone handling, times like DTSTART are now
always converted to UTC and old schedules are migrated to this
new format.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
