### PR TITLE
Always convert iCalendar strings to use UTC (master)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add scanner relays and OSP sensor scanner type [#756](https://github.com/greenbone/gvmd/pull/756) [#759](https://github.com/greenbone/gvmd/pull/759)
 
 ### Changed
+- Always convert iCalendar strings to use UTC. [#777](https://github.com/greenbone/gvmd/pull/777)
 - Check if NVT preferences exist before inserting. [#406](https://github.com/greenbone/gvmd/pull/406)
 - Raise minimum version for SQL functions. [#420](https://github.com/greenbone/gvmd/pull/420)
 - Run OpenVAS scans via OSP instead of OTP. [#422](https://github.com/greenbone/gvmd/pull/422) [#584](https://github.com/greenbone/gvmd/pull/584) [#623](https://github.com/greenbone/gvmd/pull/623) [#636](https://github.com/greenbone/gvmd/pull/636) [#704](https://github.com/greenbone/gvmd/pull/704) [#729](https://github.com/greenbone/gvmd/pull/729)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add scanner relays and OSP sensor scanner type [#756](https://github.com/greenbone/gvmd/pull/756) [#759](https://github.com/greenbone/gvmd/pull/759)
 
 ### Changed
-- Always convert iCalendar strings to use UTC. [#777](https://github.com/greenbone/gvmd/pull/777)
+- Always convert iCalendar strings to use UTC. [#778](https://github.com/greenbone/gvmd/pull/778)
 - Check if NVT preferences exist before inserting. [#406](https://github.com/greenbone/gvmd/pull/406)
 - Raise minimum version for SQL functions. [#420](https://github.com/greenbone/gvmd/pull/420)
 - Run OpenVAS scans via OSP instead of OTP. [#422](https://github.com/greenbone/gvmd/pull/422) [#584](https://github.com/greenbone/gvmd/pull/584) [#623](https://github.com/greenbone/gvmd/pull/623) [#636](https://github.com/greenbone/gvmd/pull/636) [#704](https://github.com/greenbone/gvmd/pull/704) [#729](https://github.com/greenbone/gvmd/pull/729)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 220)
+set (GVMD_DATABASE_VERSION 221)
 
 set (GVMD_SCAP_DATABASE_VERSION 15)
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -44392,7 +44392,7 @@ create_schedule (const char* name, const char *comment,
     {
       ical_component = icalendar_from_old_schedule_data
                           (first_time, period, period_months, duration,
-                           byday_mask, zone);
+                           byday_mask);
       quoted_ical = sql_quote (icalcomponent_as_ical_string (ical_component));
     }
 
@@ -45427,7 +45427,7 @@ modify_schedule (const char *schedule_id, const char *name, const char *comment,
 
   /* Update basic data */
   quoted_comment = comment ? sql_quote (comment) : NULL;
-  quoted_timezone = timezone ? sql_quote (zone) : NULL;
+  quoted_timezone = zone ? sql_quote (zone) : NULL;
 
   sql ("UPDATE schedules SET"
        " name = %s%s%s,"
@@ -45596,8 +45596,7 @@ modify_schedule (const char *schedule_id, const char *name, const char *comment,
       ical_component = icalendar_from_old_schedule_data
                           (real_first_time,
                            real_period, real_period_months,
-                           real_duration, real_byday,
-                           real_timezone);
+                           real_duration, real_byday);
       quoted_icalendar
         = sql_quote (icalcomponent_as_ical_string (ical_component));
 

--- a/src/manage_utils.h
+++ b/src/manage_utils.h
@@ -74,8 +74,7 @@ int
 hosts_str_contains (const char *, const char *, int);
 
 icalcomponent *
-icalendar_from_old_schedule_data (time_t, time_t, time_t, time_t, int,
-                                  const char *);
+icalendar_from_old_schedule_data (time_t, time_t, time_t, time_t, int);
 
 icalcomponent *
 icalendar_from_string (const char *, gchar **);


### PR DESCRIPTION
To simplify the timezone handling, times like DTSTART are now
always converted to UTC and old schedules are migrated to this
new format.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
