### PR TITLE
Return only one setting when setting_id is given (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Accelerate NVT feed update [#757](https://github.com/greenbone/gvmd/pull/757)
 
 ### Fixed
+- Make get_settings return only one setting when setting_id is given [#779](https://github.com/greenbone/gvmd/pull/779)
 - A PostgreSQL statement order issue [#611](https://github.com/greenbone/gvmd/issues/611) has been addressed [#642](https://github.com/greenbone/gvmd/pull/642)
 - Fix iCalendar recurrence and timezone handling [#654](https://github.com/greenbone/gvmd/pull/654)
 - Fix issues with some scheduled tasks by using iCalendar more instead of old period fields [#656](https://github.com/greenbone/gvmd/pull/655)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -58623,11 +58623,15 @@ init_setting_iterator (iterator_t *iterator, const char *uuid,
                    "SELECT %s"
                    " FROM settings"
                    " WHERE uuid = '%s'"
-                   " AND " ACL_GLOBAL_OR_USER_OWNS ()
-                   /* Force the user's setting to come before the default. */
-                   " ORDER BY coalesce (owner, 0) DESC;",
+                   " AND (owner = (SELECT id FROM users WHERE uuid = '%s')"
+                   "      OR (owner IS NULL"
+                   "          AND uuid"
+                   "          NOT IN (SELECT uuid FROM settings"
+                   "                  WHERE owner = (SELECT id FROM users"
+                   "                                 WHERE uuid = '%s'))))",
                    columns,
                    quoted_uuid,
+                   current_credentials.uuid,
                    current_credentials.uuid);
   else
     init_iterator (iterator,


### PR DESCRIPTION
The get_settings GMP command will now only return the setting value that
applies instead of both the user's and the global one.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
