### PR TITLE
Return only one setting when setting_id is given (master)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix issues importing results or getting them from slaves if they contain "%s" [#723](https://github.com/greenbone/gvmd/pull/723)
 - Fix sorting by numeric filter columns [#751](https://github.com/greenbone/gvmd/pull/751)
 - Fix array index error when modifying roles and groups [#762](https://github.com/greenbone/gvmd/pull/762)
+- Make get_settings return only one setting when setting_id is given [#780](https://github.com/greenbone/gvmd/pull/780)
 
 ### Removed
 - The handling of NVT updates via OTP has been removed. [#575](https://github.com/greenbone/gvmd/pull/575)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -58624,11 +58624,15 @@ init_setting_iterator (iterator_t *iterator, const char *uuid,
                    "SELECT %s"
                    " FROM settings"
                    " WHERE uuid = '%s'"
-                   " AND " ACL_GLOBAL_OR_USER_OWNS ()
-                   /* Force the user's setting to come before the default. */
-                   " ORDER BY coalesce (owner, 0) DESC;",
+                   " AND (owner = (SELECT id FROM users WHERE uuid = '%s')"
+                   "      OR (owner IS NULL"
+                   "          AND uuid"
+                   "          NOT IN (SELECT uuid FROM settings"
+                   "                  WHERE owner = (SELECT id FROM users"
+                   "                                 WHERE uuid = '%s'))))",
                    columns,
                    quoted_uuid,
+                   current_credentials.uuid,
                    current_credentials.uuid);
   else
     init_iterator (iterator,


### PR DESCRIPTION
The get_settings GMP command will now only return the setting value that
applies instead of both the user's and the global one.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
