### PR TITLE
If the nvt preference is "file" type, encode it into Base64 format. (gvmd-9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix array index error when modifying roles and groups [#762](https://github.com/greenbone/gvmd/pull/762)
 - Add NULL check in nvts_feed_version_epoch [#773](https://github.com/greenbone/gvmd/pull/773)
 - Fix percent sign escaping in report_port_count [#782](https://github.com/greenbone/gvmd/pull/782)
+- If the nvt preference is "file" type, encode it into Base64 format [#785](https://github.com/greenbone/gvmd/pull/785)
 
 ### Removed
 - The handling of NVT updates via OTP has been removed. [#575](https://github.com/greenbone/gvmd/pull/575)

--- a/src/manage.c
+++ b/src/manage.c
@@ -3785,10 +3785,12 @@ target_osp_ssh_credential (target_t target)
       if (strcmp (type, "usk") == 0)
         {
           const char *private_key = credential_iterator_private_key (&iter);
+          gchar *base64 = g_base64_encode ((guchar *) private_key,
+                                           strlen (private_key));
           osp_credential_set_auth_data (osp_credential,
-                                        "private",
-                                        g_base64_encode ((guchar *) private_key,
-                                                         strlen(private_key)));
+                                        "private", base64);
+          g_free (base64);
+
         }
       cleanup_iterator (&iter);
       return osp_credential;
@@ -4093,7 +4095,7 @@ launch_osp_openvas_task (task_t task, target_t target, const char *scan_id,
               g_strfreev (split_value);
             }
           else if (strcmp (type, "file") == 0)
-            osp_value = g_base64_encode ((guchar*) value, strlen(value));
+            osp_value = g_base64_encode ((guchar*) value, strlen (value));
 
           osp_vt = g_hash_table_lookup (vts_hash_table, oid);
           if (osp_vt)

--- a/src/manage.c
+++ b/src/manage.c
@@ -3787,7 +3787,8 @@ target_osp_ssh_credential (target_t target)
           const char *private_key = credential_iterator_private_key (&iter);
           osp_credential_set_auth_data (osp_credential,
                                         "private",
-                                        private_key);
+                                        g_base64_encode ((guchar *) private_key,
+                                                         strlen(private_key)));
         }
       cleanup_iterator (&iter);
       return osp_credential;
@@ -4091,6 +4092,8 @@ launch_osp_openvas_task (task_t task, target_t target, const char *scan_id,
               osp_value = g_strdup (split_value[0]);
               g_strfreev (split_value);
             }
+          else if (strcmp (type, "file") == 0)
+            osp_value = g_base64_encode ((guchar*) value, strlen(value));
 
           osp_vt = g_hash_table_lookup (vts_hash_table, oid);
           if (osp_vt)


### PR DESCRIPTION
Backport pr #784 