### PR TITLE
Consider results_trash when deleting users (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 ### Fixed
+- Consider results_trash when deleting users [#799](https://github.com/greenbone/gvmd/pull/799)
 
 ### Removed
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -60738,6 +60738,8 @@ delete_user (const char *user_id_arg, const char *name_arg, int ultimate,
            inheritor, user);
       sql ("UPDATE results SET owner = %llu WHERE owner = %llu;",
            inheritor, user);
+      sql ("UPDATE results_trash SET owner = %llu WHERE owner = %llu;",
+           inheritor, user);
 
       sql ("UPDATE overrides SET owner = %llu WHERE owner = %llu;",
            inheritor, user);
@@ -60874,6 +60876,9 @@ delete_user (const char *user_id_arg, const char *name_arg, int ultimate,
 
   /* Results. */
   sql ("DELETE FROM results"
+       " WHERE report IN (SELECT id FROM reports WHERE owner = %llu);",
+       user);
+  sql ("DELETE FROM results_trash"
        " WHERE report IN (SELECT id FROM reports WHERE owner = %llu);",
        user);
 


### PR DESCRIPTION
Results from trash tasks are now also deleted or inherited, fixing SQL
constraint errors.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
