### PR TITLE
Update gvm-portnames-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Consider results_trash when deleting users [#800](https://github.com/greenbone/gvmd/pull/800)
+- Update to gvm-portnames-update to use new nomenclature [#802](https://github.com/greenbone/gvmd/pull/802)
 
 ### Removed
 - Remove suport for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)

--- a/tools/gvm-portnames-update.in
+++ b/tools/gvm-portnames-update.in
@@ -49,12 +49,12 @@ fi
 
 # Configure DB_DIR where our DB is located.
 if [ -z "$DB_DIR" ]; then
-  OPENVASSD=`which openvassd`
-  if [ -z "$OPENVASSD" ] ; then
-    echo "[e] Error: openvassd is not in the path, could not determine the Manager directory."
+  OPENVAS=`which openvas`
+  if [ -z "$OPENVAS" ] ; then
+    echo "[e] Error: openvas is not in the path, could not determine the Manager directory."
     exit 1
   else
-    OV_DIR=`openvassd -s | awk -F" = " '/^plugins_folder/ { print $2 }' | sed -s 's/\(^.*\)\/plugins/\1/'`
+    OV_DIR=`openvas -s | awk -F" = " '/^plugins_folder/ { print $2 }' | sed -s 's/\(^.*\)\/plugins/\1/'`
   fi
   DB_DIR="$OV_DIR/gvmd"
 fi


### PR DESCRIPTION
 When issueing the command 
`gvm-portnames-update service-names-port-numbers.xml` 
to update iana service names we get:

> [e] Error: openvassd is not in the path, could not determine the Manager directory.

Simple name change (openvassd -> openvas). Openvassd was the scanner's name in previous versions of gvm.


**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

* N/A Tests
* [x]  [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry

