### PR TITLE
Consider results_trash when deleting users (8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix escaping that was preventing start_task from running [#758](https://github.com/greenbone/gvmd/pull/758)
 - Fix array index error when modifying roles and groups [#763](https://github.com/greenbone/gvmd/pull/763)
 - Fix percent sign escaping in report_port_count [#781](https://github.com/greenbone/gvmd/pull/781)
+- Consider results_trash when deleting users [#804](https://github.com/greenbone/gvmd/pull/804)
 
 ### Removed
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -66034,6 +66034,8 @@ delete_user (const char *user_id_arg, const char *name_arg, int ultimate,
            inheritor, user);
       sql ("UPDATE results SET owner = %llu WHERE owner = %llu;",
            inheritor, user);
+      sql ("UPDATE results_trash SET owner = %llu WHERE owner = %llu;",
+           inheritor, user);
 
       sql ("UPDATE overrides SET owner = %llu WHERE owner = %llu;",
            inheritor, user);
@@ -66168,6 +66170,9 @@ delete_user (const char *user_id_arg, const char *name_arg, int ultimate,
 
   /* Results. */
   sql ("DELETE FROM results"
+       " WHERE report IN (SELECT id FROM reports WHERE owner = %llu);",
+       user);
+  sql ("DELETE FROM results_trash"
        " WHERE report IN (SELECT id FROM reports WHERE owner = %llu);",
        user);
 


### PR DESCRIPTION
Results from trash tasks are now also deleted or inherited, fixing SQL
constraint errors.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
