### PR TITLE
Speed up the HELP 'brief' case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add setting "BPM Dashboard Configuration" [#764](https://github.com/greenbone/gvmd/pull/764)
 - Faster SecInfo REF retrieval for GET_REPORTS [#793](https://github.com/greenbone/gvmd/pull/793)
 - Improve performance of GET_REPORTS [#801](https://github.com/greenbone/gvmd/pull/801)
+- Speed up the HELP 'brief' case [#807](https://github.com/greenbone/gvmd/pull/807)
 
 ### Changed
 

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -20668,6 +20668,8 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
         else if (help_data->type && (strcmp (help_data->type, "brief") == 0))
           {
             command_t *commands;
+            int index;
+
             SEND_TO_CLIENT_OR_FAIL ("<help_response"
                                     " status=\"" STATUS_OK "\""
                                     " status_text=\"" STATUS_OK_TEXT "\">\n"
@@ -20675,20 +20677,15 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                                     " format=\"XML\""
                                     " extension=\"xml\""
                                     " content_type=\"text/xml\">");
-            commands = gmp_commands;
-            while ((*commands).name)
-              {
-                if ((command_disabled (gmp_parser, (*commands).name) == 0)
-                    && ((current_credentials.uuid == NULL)
-                        || acl_user_may ((*commands).name)))
-                  SENDF_TO_CLIENT_OR_FAIL ("<command>"
-                                           "<name>%s</name>"
-                                           "<summary>%s</summary>"
-                                           "</command>",
-                                           (*commands).name,
-                                           (*commands).summary);
-                commands++;
-              }
+            commands = acl_commands (gmp_parser->disabled_commands);
+            for (index = 0; commands[index].name; index++)
+              SENDF_TO_CLIENT_OR_FAIL ("<command>"
+                                       "<name>%s</name>"
+                                       "<summary>%s</summary>"
+                                       "</command>",
+                                       commands[index].name,
+                                       commands[index].summary);
+            g_free (commands);
             SEND_TO_CLIENT_OR_FAIL ("</schema>"
                                     "</help_response>");
           }

--- a/src/manage_acl.c
+++ b/src/manage_acl.c
@@ -41,6 +41,53 @@
 #define G_LOG_DOMAIN "md manage"
 
 /**
+ * @brief Get commands that the current user may run.
+ *
+ * @param[in]  disabled_commands  All disabled commands.
+ *
+ * @return Freshly allocated list of commands.  Free with g_free.
+ */
+command_t *
+acl_commands (gchar **disabled_commands)
+{
+  command_t *all, *commands;
+  int index, length;
+
+  /* Count maximum number of commands. */
+
+  length = 1;
+  all = gmp_commands;
+  while ((*all).name)
+    {
+      length++;
+      all++;
+    }
+
+  /* Fill return array with allowed commands. */
+
+  commands = g_malloc0 (length * sizeof (*commands));
+  all = gmp_commands;
+  index = 0;
+  while ((*all).name)
+    {
+      if ((disabled_commands == NULL
+           || g_strv_contains ((const char * const *) disabled_commands,
+                               (*all).name)
+              == 0)
+          && ((current_credentials.uuid == NULL)
+              || acl_user_may ((*all).name)))
+        {
+          commands[index].name = (*all).name;
+          commands[index].summary = (*all).summary;
+          index++;
+        }
+      all++;
+    }
+
+  return commands;
+}
+
+/**
  * @brief Test whether a user may perform an operation.
  *
  * @param[in]  operation  Name of operation.

--- a/src/manage_acl.c
+++ b/src/manage_acl.c
@@ -51,7 +51,7 @@ command_t *
 acl_commands (gchar **disabled_commands)
 {
   command_t *all, *commands;
-  int index, length;
+  int index, length, special_user;
 
   /* Count maximum number of commands. */
 
@@ -65,6 +65,8 @@ acl_commands (gchar **disabled_commands)
 
   /* Fill return array with allowed commands. */
 
+  special_user = (current_credentials.uuid == NULL);
+
   commands = g_malloc0 (length * sizeof (*commands));
   all = gmp_commands;
   index = 0;
@@ -74,7 +76,7 @@ acl_commands (gchar **disabled_commands)
            || g_strv_contains ((const char * const *) disabled_commands,
                                (*all).name)
               == 0)
-          && ((current_credentials.uuid == NULL)
+          && (special_user
               || acl_user_may ((*all).name)))
         {
           commands[index].name = (*all).name;

--- a/src/manage_acl.c
+++ b/src/manage_acl.c
@@ -65,7 +65,12 @@ acl_commands (gchar **disabled_commands)
 
   /* Fill return array with allowed commands. */
 
-  special_user = (current_credentials.uuid == NULL);
+  special_user = ((current_credentials.uuid == NULL)
+                  || (strlen (current_credentials.uuid) == 0));
+
+  if (special_user == 0)
+    special_user = sql_int ("SELECT user_can_everything ('%s');",
+                            current_credentials.uuid);
 
   commands = g_malloc0 (length * sizeof (*commands));
   all = gmp_commands;

--- a/src/manage_acl.h
+++ b/src/manage_acl.h
@@ -98,6 +98,9 @@
   "  OR (owner = (SELECT users.id FROM users"                  \
   "               WHERE users.uuid = '%s')))"
 
+command_t *
+acl_commands (gchar **);
+
 int
 acl_user_may (const char *);
 


### PR DESCRIPTION
Make the HELP 'brief' case faster by calling the user_can_everything SQL
function once, instead of for every command.

Because GSA runs this on every command, this speeds up the report page.
On my basic report of 5000 results this saved about 57ms of the total SQL
time of 466ms, or 12%. 

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
