### PR TITLE
Store session info in db variables instead of in temp table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Add setting "BPM Dashboard Configuration" [#764](https://github.com/greenbone/gvmd/pull/764)
 - Faster SecInfo REF retrieval for GET_REPORTS [#793](https://github.com/greenbone/gvmd/pull/793)
-- Improve performance of GET_REPORTS [#801](https://github.com/greenbone/gvmd/pull/801)
+- Improve performance of GET_REPORTS [#801](https://github.com/greenbone/gvmd/pull/801) [#811](https://github.com/greenbone/gvmd/pull/811)
 - Speed up the HELP 'brief' case [#807](https://github.com/greenbone/gvmd/pull/807)
 
 ### Changed

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -52,14 +52,6 @@ manage_session_init (const char *uuid)
 {
   sql ("SET SESSION \"gvmd.user.uuid\" = '%s';", uuid);
   sql ("SET SESSION \"gvmd.tz_override\" = '';");
-
-  sql ("CREATE TEMPORARY TABLE IF NOT EXISTS current_credentials"
-       " (id SERIAL PRIMARY KEY,"
-       "  uuid text UNIQUE NOT NULL,"
-       "  tz_override text);");
-  sql ("DELETE FROM current_credentials;");
-  if (uuid)
-    sql ("INSERT INTO current_credentials (uuid) VALUES ('%s');", uuid);
 }
 
 /**
@@ -2052,12 +2044,6 @@ void
 create_tables ()
 {
   gchar *owned_clause;
-
-  sql ("DROP TABLE IF EXISTS current_credentials");
-  sql ("CREATE TEMPORARY TABLE IF NOT EXISTS current_credentials"
-       " (id SERIAL PRIMARY KEY,"
-       "  uuid text UNIQUE NOT NULL,"
-       "  tz_override text);");
 
   sql ("CREATE TABLE IF NOT EXISTS meta"
        " (id SERIAL PRIMARY KEY,"

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -51,6 +51,7 @@ void
 manage_session_init (const char *uuid)
 {
   sql ("SET SESSION \"gvmd.user.uuid\" = '%s';", uuid);
+  sql ("SET SESSION \"gvmd.tz_override\" = '';");
 
   sql ("CREATE TEMPORARY TABLE IF NOT EXISTS current_credentials"
        " (id SERIAL PRIMARY KEY,"
@@ -959,7 +960,7 @@ manage_create_sql_functions ()
        "   user_offset interval;"
        " BEGIN"
        "   user_zone :="
-       "     coalesce ((SELECT tz_override FROM current_credentials),"
+       "     coalesce ((SELECT current_setting ('gvmd.tz_override')),"
        "               (SELECT timezone FROM users"
        "                WHERE uuid"
        "                      = (SELECT current_setting ('gvmd.user.uuid'))));"

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -23641,10 +23641,11 @@ result_iterator_opts_table (int autofp, int override, int dynamic)
 {
   return g_strdup_printf
           (", (SELECT"
-           "   (SELECT current_setting ('gvmd.user.uuid')) AS user_uuid,"
+           "   '%s'::text AS user_uuid,"
            "   %d AS autofp,"
            "   %d AS override,"
            "   %d AS dynamic) AS opts",
+           current_credentials.uuid ? current_credentials.uuid : "",
            autofp,
            override,
            dynamic);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -23331,8 +23331,12 @@ where_qod (int min_qod)
       "name",                                                                 \
       KEYWORD_TYPE_STRING },                                                  \
     { "''", "comment", KEYWORD_TYPE_STRING },                                 \
-    { " iso_time ( date )", "creation_time", KEYWORD_TYPE_STRING },           \
-    { " iso_time ( date )", "modification_time", KEYWORD_TYPE_STRING },       \
+    { " iso_time (date, opts.user_zone)",                                     \
+      "creation_time",                                                        \
+      KEYWORD_TYPE_STRING },                                                  \
+    { " iso_time (date, opts.user_zone)",                                     \
+      "modification_time",                                                    \
+      KEYWORD_TYPE_STRING },                                                  \
     { "date", "created", KEYWORD_TYPE_INTEGER },                              \
     { "date", "modified", KEYWORD_TYPE_INTEGER },                             \
     { "(SELECT name FROM users WHERE users.id = results.owner)",              \
@@ -23935,13 +23939,10 @@ init_result_get_iterator_severity (iterator_t* iterator, const get_data_t *get,
   autofp = filter_term_autofp (filter ? filter : get->filter);
 
   if (autofp == 0)
-    {
-      columns[0].select = "0";
-      extra_tables = NULL;
-    }
-  else
-    extra_tables = result_iterator_opts_table (autofp, apply_overrides,
-                                               dynamic_severity);
+    columns[0].select = "0";
+
+  extra_tables = result_iterator_opts_table (autofp, apply_overrides,
+                                             dynamic_severity);
 
   extra_where = results_extra_where (get->trash, report, host,
                                      autofp, apply_overrides, dynamic_severity,

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -23136,10 +23136,9 @@ where_levels_auto (const char *levels, const char *new_severity_sql,
                       " AND ((owner IS NULL)"
                       "      OR (owner"
                       "          = (SELECT id FROM users"
-                      "             WHERE users.uuid"
-                      "                   = (SELECT current_setting"
-                      "                              ('gvmd.user.uuid')))))"
-                      " ORDER BY coalesce (owner, 0) DESC LIMIT 1;");
+                      "             WHERE users.uuid = '%s')))"
+                      " ORDER BY coalesce (owner, 0) DESC LIMIT 1;",
+                      current_credentials.uuid ? current_credentials.uuid : "");
 
   /* High. */
   if (strchr (levels, 'h'))

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -23490,9 +23490,7 @@ where_qod (int min_qod)
       "                  AND result_new_severities.user"                      \
       "                      = (SELECT users.id"                              \
       "                         FROM users"                                   \
-      "                         WHERE users.uuid"                             \
-      "                               = (SELECT current_setting"              \
-      "                                          ('gvmd.user.uuid')))"        \
+      "                         WHERE users.uuid = opts.user_uuid)"           \
       "                  AND result_new_severities.override = opts.override"  \
       "                  AND result_new_severities.dynamic = opts.dynamic"    \
       "                  LIMIT 1))",                                          \
@@ -23515,8 +23513,7 @@ where_qod (int min_qod)
       " AND result_new_severities.user"                                       \
       "     = (SELECT users.id"                                               \
       "        FROM users"                                                    \
-      "        WHERE users.uuid"                                              \
-      "              = (SELECT current_setting ('gvmd.user.uuid')))"          \
+      "        WHERE users.uuid = opts.user_uuid)"                            \
       " AND result_new_severities.override = opts.override"                   \
       " AND result_new_severities.dynamic = opts.dynamic"                     \
       " LIMIT 1)",                                                            \
@@ -23642,13 +23639,15 @@ where_qod (int min_qod)
 static gchar*
 result_iterator_opts_table (int autofp, int override, int dynamic)
 {
-  return g_strdup_printf (", (SELECT"
-                          "   %d AS autofp,"
-                          "   %d AS override,"
-                          "   %d AS dynamic) AS opts",
-                          autofp,
-                          override,
-                          dynamic);
+  return g_strdup_printf
+          (", (SELECT"
+           "   (SELECT current_setting ('gvmd.user.uuid')) AS user_uuid,"
+           "   %d AS autofp,"
+           "   %d AS override,"
+           "   %d AS dynamic) AS opts",
+           autofp,
+           override,
+           dynamic);
 }
 
 /**
@@ -23818,9 +23817,7 @@ init_result_get_iterator_severity (iterator_t* iterator, const get_data_t *get,
                      "   AND result_new_severities.user"
                      "       = (SELECT users.id"
                      "          FROM users"
-                     "          WHERE users.uuid"
-                     "                = (SELECT current_setting"
-                     "                           ('gvmd.user.uuid')))"
+                     "          WHERE users.uuid = opts.user_uuid)"
                      "   AND result_new_severities.override = %i"
                      "   AND result_new_severities.dynamic = %i"
                      "   LIMIT 1))",

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -15343,8 +15343,9 @@ init_manage_process (const gchar *database)
       abort ();
     }
 
-  /* Ensure the user session variable always exists. */
+  /* Ensure the user session variables always exists. */
   sql ("SET SESSION \"gvmd.user.uuid\" = '';");
+  sql ("SET SESSION \"gvmd.tz_override\" = '';");
 
   /* Attach the SCAP and CERT databases. */
   manage_attach_databases ();
@@ -28306,7 +28307,7 @@ tz_revert (gchar *zone, char *tz, char *old_tz_override)
         unsetenv ("TZ");
 
       quoted_old_tz_override = sql_insert (old_tz_override);
-      sql ("UPDATE current_credentials SET tz_override = %s",
+      sql ("SET SESSION \"gvmd.tz_override\" = %s;",
            quoted_old_tz_override);
       g_free (quoted_old_tz_override);
 
@@ -29413,11 +29414,11 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
           return -1;
         }
 
-      old_tz_override = sql_string ("SELECT tz_override"
-                                    " FROM current_credentials;");
+      old_tz_override = sql_string ("SELECT current_setting"
+                                    "        ('gvmd.tz_override');");
 
       quoted_zone = sql_insert (zone);
-      sql ("UPDATE current_credentials SET tz_override = %s", quoted_zone);
+      sql ("SET SESSION \"gvmd.tz_override\" = %s;", quoted_zone);
       g_free (quoted_zone);
 
       tzset ();

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -23472,8 +23472,12 @@ where_qod (int min_qod)
       "name",                                                                 \
       KEYWORD_TYPE_STRING },                                                  \
     { "''", "comment", KEYWORD_TYPE_STRING },                                 \
-    { " iso_time ( date )", "creation_time", KEYWORD_TYPE_STRING },           \
-    { " iso_time ( date )", "modification_time", KEYWORD_TYPE_STRING },       \
+    { " iso_time (date, opts.user_zone)",                                     \
+      "creation_time",                                                        \
+      KEYWORD_TYPE_STRING },                                                  \
+    { " iso_time (date, opts.user_zone)",                                     \
+      "modification_time",                                                    \
+      KEYWORD_TYPE_STRING },                                                  \
     { "date", "created", KEYWORD_TYPE_INTEGER },                              \
     { "date", "modified", KEYWORD_TYPE_INTEGER },                             \
     { "(SELECT name FROM users WHERE users.id = results.owner)",              \
@@ -23635,16 +23639,24 @@ result_iterator_opts_table (int autofp, int override, int dynamic)
   if (current_credentials.uuid)
     return g_strdup_printf
             (", (SELECT"
+             "   coalesce ((SELECT current_setting ('gvmd.tz_override')),"
+             "             (SELECT timezone FROM users"
+             "              WHERE uuid = '%s'))"
+             "   AS user_zone,"
              "   (SELECT id FROM users WHERE uuid = '%s') AS user_id,"
              "   %d AS autofp,"
              "   %d AS override,"
              "   %d AS dynamic) AS opts",
+             current_credentials.uuid,
              current_credentials.uuid,
              autofp,
              override,
              dynamic);
   return g_strdup_printf
           (", (SELECT"
+           "   coalesce ((SELECT current_setting ('gvmd.tz_override')),"
+           "             'UTC')"
+           "   AS user_zone,"
            "   '':text AS user_id,"
            "   %d AS autofp,"
            "   %d AS override,"

--- a/src/manage_sql_tickets.c
+++ b/src/manage_sql_tickets.c
@@ -119,8 +119,9 @@ ticket_status_integer (const char *status)
      "                LIMIT 1)"                                               \
      "       AND result_new_severities.user"                                  \
      "           = (SELECT users.id"                                          \
-     "              FROM current_credentials, users"                          \
-     "              WHERE current_credentials.uuid = users.uuid)"             \
+     "              FROM users"                                               \
+     "              WHERE users.uuid"                                         \
+     "                    = SELECT current_setting ('gvmd.user.uuid'))"       \
      "       AND result_new_severities.override = 1"                          \
      "       AND result_new_severities.dynamic = 0"                           \
      "       LIMIT 1)"                                                        \


### PR DESCRIPTION
This avoids the CREATE TEMP TABLE that is run at the beginning of every GMP
session, by instead storing the info in Postgres session variables.

These CREATE TEMP TABLEs were about 10% of the total SQL time on my example
report.  With this PR these statements no longer appear in the pg_stats summary,
but it is hard to see if the total time improved.  Sometimes it is a low as 390ms
but sometimes it is 450ms as before.

I thought perhaps the total time was not consistently lower because of accessing
the session vars in the result iterator columns and SQL functions.  So I've
added commits which move these accesses out into the opts "table".  This
does not seem to improve the situation, but I'm leaving them in here
because they're a start towards not needing the session variables at all.  That's
good because: 1 It will save us a percent or two not having to set them up, 2 the
SQL functions will be simpler (and maaaybe some will be faster).

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
