### PR TITLE
src/manage_pg.c : fix for gvmd error  'sql: (null)' when initialize the db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Faster counting in GET_REPORTS when ignoring pagination [#795](https://github.com/greenbone/gvmd/pull/795)
 - Improve performance of GET_REPORTS [#797](https://github.com/greenbone/gvmd/pull/797)
 - Consider results_trash when deleting users [#800](https://github.com/greenbone/gvmd/pull/800)
+- Escaping correctly the percent sign in sql statements  [#818](https://github.com/greenbone/gvmd/pull/818)
 
 ### Removed
 - Remove suport for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -674,7 +674,7 @@ manage_create_sql_functions ()
            " BEGIN"
            "   CASE"
            "   WHEN NOT valid_db_resource_type ($1)"
-           "   THEN RAISE EXCEPTION 'Invalid resource type argument: %', $1;"
+           "   THEN RAISE EXCEPTION 'Invalid resource type argument: %%', $1;"
            "   WHEN $1 = 'note'"
            "        AND $3 = "  G_STRINGIFY (LOCATION_TABLE)
            "   THEN RETURN (SELECT 'Note for: '"
@@ -937,7 +937,7 @@ manage_create_sql_functions ()
        "   ELSIF $1 > 0.0 AND $1 <= 10.0 THEN"
        "     RETURN 'Alarm';"
        "   ELSE"
-       "     RAISE EXCEPTION 'Invalid severity score given: %', $1;"
+       "     RAISE EXCEPTION 'Invalid severity score given: %%', $1;"
        "   END IF;"
        " END;"
        "$$ LANGUAGE plpgsql"


### PR DESCRIPTION
For Alpine, this patch allows gvmd to initialize the db without errors by escaping correctly the percent sign.

This patch address the issue described in:  https://github.com/greenbone/gvmd/issues/805

.: Francesco Colista