### PR TITLE
Try to get NVT preferences by id in create_config (9.0)

### DIFF
--- a/src/gmp_configs.c
+++ b/src/gmp_configs.c
@@ -90,7 +90,7 @@ nvt_selector_new (char *name, char *type, int include, char *family_or_nvt)
  *
  * @return Newly allocated preference.
  */
-static gpointer
+gpointer
 preference_new (char *id, char *name, char *type, char *value, char *nvt_name,
                 char *nvt_oid, array_t *alts, char* default_value,
                 char *hr_name)
@@ -109,6 +109,31 @@ preference_new (char *id, char *name, char *type, char *value, char *nvt_name,
   preference->hr_name = hr_name;
 
   return preference;
+}
+
+/**
+ * @brief Frees a preference including its assigned values.
+ *
+ * @param[in]  preference  The preference to free.
+ */
+void
+preference_free (preference_t *preference)
+{
+  if (preference == NULL)
+    return;
+
+  free (preference->id);
+  free (preference->name);
+  free (preference->type);
+  free (preference->value);
+  free (preference->nvt_name);
+  free (preference->nvt_oid);
+  if (preference->alts)
+    g_ptr_array_free (preference->alts, TRUE);
+  free (preference->default_value);
+  free (preference->hr_name);
+
+  g_free (preference);
 }
 
 

--- a/src/manage_configs.h
+++ b/src/manage_configs.h
@@ -28,5 +28,12 @@
 
 #include "manage.h"
 
+gpointer
+preference_new (char *, char *, char *, char *, char *,
+                char *, array_t *, char*,
+                char *);
+
+void
+preference_free (preference_t *);
 
 #endif /* not _GVMD_MANAGE_CONFIGS_H */


### PR DESCRIPTION
When importing a config try to get the preferences by their id from the
nvt_preferences table in case their name has changed since the config
was exported.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- N/A Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
