### PR TITLE
Drop "modify_report" GMP command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 - Remove support for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)
 - Removed tag_value() by using nvti_get_tag() [#825](https://github.com/greenbone/gvmd/pull/825)
+- Remove support for "MODIFY_REPORT" GMP command [#823](https://github.com/greenbone/gvmd/pull/823)
 
 [20.4]: https://github.com/greenbone/gvmd/compare/v9.0.0...master
 

--- a/src/manage.h
+++ b/src/manage.h
@@ -1369,9 +1369,6 @@ int
 report_timestamp (const char*, gchar**);
 
 int
-modify_report (const char*, const char*);
-
-int
 delete_report (const char *, int);
 
 int

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -1564,6 +1564,38 @@ migrate_220_to_221 ()
   return 0;
 }
 
+/**
+ * @brief Migrate the database from version 221 to version 222.
+ *
+ * @return 0 success, -1 error.
+ */
+int
+migrate_221_to_222 ()
+{
+  sql_begin_immediate ();
+
+  /* Ensure that the database is currently version 221. */
+
+  if (manage_db_version () != 221)
+    {
+      sql_rollback ();
+      return -1;
+    }
+
+  /* Update the database. */
+
+  /* Remove permissions on the remove command MODIFY_REPORT */
+  sql ("DELETE FROM permissions WHERE name = 'modify_report';");
+
+  /* Set the database version to 222. */
+
+  set_db_version (222);
+
+  sql_commit ();
+
+  return 0;
+}
+
 #undef UPDATE_DASHBOARD_SETTINGS
 
 /**
@@ -1591,6 +1623,7 @@ static migrator_t database_migrators[] = {
   {219, migrate_218_to_219},
   {220, migrate_219_to_220},
   {221, migrate_220_to_221},
+  {222, migrate_221_to_222},
   /* End marker. */
   {-1, NULL}};
 

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -1586,6 +1586,7 @@ migrate_221_to_222 ()
 
   /* Remove permissions on the remove command MODIFY_REPORT */
   sql ("DELETE FROM permissions WHERE name = 'modify_report';");
+  sql ("DELETE FROM permissions_trash WHERE name = 'modify_report';");
 
   /* Set the database version to 222. */
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -630,7 +630,6 @@ command_t gmp_commands[]
     {"MODIFY_OVERRIDE", "Modify an existing override."},
     {"MODIFY_PERMISSION", "Modify an existing permission."},
     {"MODIFY_PORT_LIST", "Modify an existing port list."},
-    {"MODIFY_REPORT", "Modify an existing report."},
     {"MODIFY_REPORT_FORMAT", "Modify an existing report format."},
     {"MODIFY_ROLE", "Modify an existing role."},
     {"MODIFY_SCANNER", "Modify an existing scanner."},
@@ -26254,65 +26253,6 @@ delete_report_internal (report_t report)
         return -1;
         break;
     }
-
-  return 0;
-}
-
-/**
- * @brief Modify a report.
- *
- * @param[in]   report_id       UUID of report.
- * @param[in]   comment         Comment on report.
- *
- * @return 0 success, 1 failed to find report, 2 report_id required, 3 comment
- * required, 99 permission denied, -1 internal error.
- */
-int
-modify_report (const char *report_id, const char *comment)
-{
-  gchar *quoted_comment;
-  report_t report;
-
-  if (report_id == NULL)
-    return 2;
-
-  if (comment == NULL)
-    return 3;
-
-  sql_begin_immediate ();
-
-  assert (current_credentials.uuid);
-
-  if (acl_user_may ("modify_report") == 0)
-    {
-      sql_rollback ();
-      return 99;
-    }
-
-  report = 0;
-  if (find_report_with_permission (report_id, &report, "modify_report"))
-    {
-      sql_rollback ();
-      return -1;
-    }
-
-  if (report == 0)
-    {
-      sql_rollback ();
-      return 1;
-    }
-
-  quoted_comment = sql_quote (comment ? comment : "");
-
-  sql ("UPDATE reports SET"
-       " comment = '%s'"
-       " WHERE id = %llu;",
-       quoted_comment,
-       report);
-
-  g_free (quoted_comment);
-
-  sql_commit ();
 
   return 0;
 }

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -3146,7 +3146,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <c>modify_override</c>
           <c>modify_permission</c>
           <c>modify_port_list</c>
-          <c>modify_report</c>
           <c>modify_report_format</c>
           <c>modify_role</c>
           <c>modify_scanner</c>
@@ -3277,7 +3276,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <r>modify_override</r>
             <r>modify_permission</r>
             <r>modify_port_list</r>
-            <r>modify_report</r>
             <r>modify_report_format</r>
             <r>modify_role</r>
             <r>modify_scanner</r>
@@ -25408,58 +25406,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </example>
   </command>
   <command>
-    <name>modify_report</name>
-    <summary>Modify an existing report</summary>
-    <description>
-      <p>
-        The client uses the modify_report command to change an existing
-        report.
-      </p>
-    </description>
-    <pattern>
-      <attrib>
-        <name>report_id</name>
-        <summary>ID of report to modify</summary>
-        <type>uuid</type>
-        <required>1</required>
-      </attrib>
-      <e>comment</e>
-    </pattern>
-    <ele>
-      <name>comment</name>
-      <summary>The comment on the report</summary>
-      <pattern>
-        text
-      </pattern>
-    </ele>
-    <response>
-      <pattern>
-        <attrib>
-          <name>status</name>
-          <type>status</type>
-          <required>1</required>
-        </attrib>
-        <attrib>
-          <name>status_text</name>
-          <type>text</type>
-          <required>1</required>
-        </attrib>
-      </pattern>
-    </response>
-    <example>
-      <summary>Modify a report comment</summary>
-      <request>
-        <modify_report report_id="254cd3ef-bbe1-4d58-859d-21b8d0c046c6">
-          <comment>Monthly scan of the webserver.</comment>
-        </modify_report>
-      </request>
-      <response>
-        <modify_report_response status="200" status_text="OK">
-        </modify_report_response>
-      </response>
-    </example>
-  </command>
-  <command>
     <name>modify_report_format</name>
     <summary>Update an existing report format</summary>
     <description>
@@ -27214,6 +27160,17 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <description>
       <p>
         The type "ALLINFO" is not supported aymore.
+      </p>
+    </description>
+    <version>20.04</version>
+  </change>
+
+  <change>
+    <command>MODIFY_REPORT</command>
+    <summary>The command MODIFY_REPORT is removed</summary>
+    <description>
+      <p>
+        The command "MODIFY_REPORT" is not supported aymore.
       </p>
     </description>
     <version>20.04</version>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -27159,18 +27159,17 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <summary>Attribute "type" can not be "ALLINFO" anymore</summary>
     <description>
       <p>
-        The type "ALLINFO" is not supported aymore.
+        The type "ALLINFO" is not supported anymore.
       </p>
     </description>
     <version>20.04</version>
   </change>
-
   <change>
     <command>MODIFY_REPORT</command>
     <summary>The command MODIFY_REPORT is removed</summary>
     <description>
       <p>
-        The command "MODIFY_REPORT" is not supported aymore.
+        The command "MODIFY_REPORT" is not supported anymore.
       </p>
     </description>
     <version>20.04</version>


### PR DESCRIPTION
This command only offered to set a comment for a report. It was actually never
used by GSA.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
