### PR TITLE
Remove tag_value()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 - Remove support for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)
+- Removed tag_value() by using nvti_get_tag() [#825](https://github.com/greenbone/gvmd/pull/825)
 
 [20.4]: https://github.com/greenbone/gvmd/compare/v9.0.0...master
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -21074,8 +21074,8 @@ make_result (task_t task, const char* host, const char *hostname,
       if (nvti)
         {
           gchar *qod_str, *qod_type;
-          qod_str = tag_value (nvti_tag (nvti), "qod");
-          qod_type = tag_value (nvti_tag (nvti), "qod_type");
+          qod_str = nvti_get_tag (nvti, "qod");
+          qod_type = nvti_get_tag (nvti, "qod_type");
 
           if (qod_str == NULL || sscanf (qod_str, "%d", &qod) != 1)
             qod = qod_from_type (qod_type);
@@ -48909,8 +48909,8 @@ buffer_insert (GString *buffer, task_t task, const char* host,
       if (nvti)
         {
           gchar *qod_str, *qod_type;
-          qod_str = tag_value (nvti_tag (nvti), "qod");
-          qod_type = tag_value (nvti_tag (nvti), "qod_type");
+          qod_str = nvti_get_tag (nvti, "qod");
+          qod_type = nvti_get_tag (nvti, "qod_type");
 
           if (qod_str == NULL || sscanf (qod_str, "%d", &qod) != 1)
             qod = qod_from_type (qod_type);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -1152,44 +1152,6 @@ vector_find_filter (const gchar **vector, const gchar *string)
 }
 
 /**
- * @brief Extract a tag from a pipe separated tag list.
- *
- * @param[in]   tags  Tag list.
- * @param[out]  tag   Tag name.
- *
- * @return Newly allocated tag value.
- */
-gchar *
-tag_value (const gchar *tags, const gchar *tag)
-{
-  gchar **split, **point;
-
-  /* creation_date=2009-04-09 14:18:58 +0200 (Thu, 09 Apr 2009)|... */
-
-  if (tags == NULL)
-    return g_strdup ("");
-
-  split = g_strsplit (tags, "|", 0);
-  point = split;
-
-  while (*point)
-    {
-      if ((strlen (*point) > strlen (tag))
-          && (strncmp (*point, tag, strlen (tag)) == 0)
-          && ((*point)[strlen (tag)] == '='))
-        {
-          gchar *ret;
-          ret = g_strdup (*point + strlen (tag) + 1);
-          g_strfreev (split);
-          return ret;
-        }
-      point++;
-    }
-  g_strfreev (split);
-  return g_strdup ("");
-}
-
-/**
  * @brief Get last time NVT alerts were checked.
  *
  * @return Last check time.

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -368,8 +368,6 @@ host_nthlast_report_host (const char *, report_host_t *, int);
 char*
 report_host_ip (const char *);
 
-gchar *tag_value (const gchar *, const gchar *);
-
 void trim_report (report_t);
 
 int delete_report_internal (report_t);

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -279,7 +279,7 @@ insert_nvt (const nvti_t *nvti)
 
   quoted_cvss_base = sql_quote (nvti_cvss_base (nvti) ? nvti_cvss_base (nvti) : "");
 
-  qod_str = tag_value (nvti_tag (nvti), "qod");
+  qod_str = nvti_get_tag (nvti, "qod");
   qod_type = nvti_qod_type (nvti);
 
   if (qod_str == NULL || sscanf (qod_str, "%d", &qod) != 1)


### PR DESCRIPTION
The function tag_value() is a function that has knowledge about the internal
pipe-syntax for tags. This patch removes the function by using the alternative nvti_get_tag()
of the nvti API. That function is introduced with
https://github.com/greenbone/gvm-libs/pull/285

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
