### PR TITLE
Get refs in the NVT SQL when updating nvti_cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Faster SecInfo REF retrieval for GET_REPORTS [#793](https://github.com/greenbone/gvmd/pull/793)
 - Improve performance of GET_REPORTS [#801](https://github.com/greenbone/gvmd/pull/801) [#811](https://github.com/greenbone/gvmd/pull/811)
 - Speed up the HELP 'brief' case [#807](https://github.com/greenbone/gvmd/pull/807)
+- Faster startup [#826](https://github.com/greenbone/gvmd/pull/826)
 
 ### Changed
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -15489,10 +15489,17 @@ update_nvti_cache ()
 
   nvti_cache = nvtis_new ();
 
+  /* Because there are many NVTs and many refs it's slow to query the refs
+   * for each NVT.  So this query gets the NVTs and their refs at the same
+   * time.
+   *
+   * The NVT data is duplicated in the result of the query when there are
+   * multiple refs for an NVT, but the loop below uses nvtis_lookup to
+   * check if we've already seen the NVT.  This also means we don't have
+   * to sort the data by NVT, which would make the query too slow. */
   init_iterator (&nvts,
                  "SELECT nvts.oid, nvts.name, nvts.family, nvts.cvss_base,"
                  "       nvts.tag, nvts.solution, nvts.solution_type,"
-                 /*      7 */
                  "       vt_refs.type, vt_refs.ref_id, vt_refs.ref_text"
                  " FROM nvts"
                  " LEFT OUTER JOIN vt_refs ON nvts.oid = vt_refs.vt_oid;");


### PR DESCRIPTION
This improves the gvmd startup time by about 10s.  Previously we ran a separate SQL statement for each NVT, to retrieve the refs.

Slow gvmd startup time really frustrates me during development.

I printed and diffed nvti_cache to confirm that it was the same before and after the patch.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
