### PR TITLE
Add option --optimize migrate-relay-sensors (9.0)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -419,6 +419,13 @@ supported values for `<name>` are:
   older versions, so this function can be used to correct missing severity
   scores in older reports.
 
+- `migrate-relay-sensors`
+
+  If relays are active, this can be used to make sure all sensor type
+  scanners have a matching relay, i.e. OSP sensors have an OSP relay
+  and GMP scanners have an GMP relay.
+  GMP scanners are migrated to OSP sensors if an OSP relay is available.
+
 - `rebuild-report-cache`
 
   This clears the cache containing the unfiltered result counts of all reports

--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -110,7 +110,7 @@ Modify user's password and exit.
 Modify user's password and exit.
 .TP
 \fB--optimize=\fINAME\fB\f1
-Run an optimization: vacuum, analyze, cleanup-config-prefs, cleanup-port-names, cleanup-report-formats, cleanup-result-severities, cleanup-schedule-times, rebuild-report-cache or update-report-cache.
+Run an optimization: vacuum, analyze, cleanup-config-prefs, cleanup-port-names, cleanup-report-formats, cleanup-result-severities, cleanup-schedule-times, migrate-relay-sensors, rebuild-report-cache or update-report-cache.
 .TP
 \fB--osp-vt-update=\fISCANNER-SOCKET\fB\f1
 Unix socket for OSP NVT update. Defaults to the path of the 'OpenVAS Default' scanner if it is an absolute path.

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -253,7 +253,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         <p>Run an optimization: vacuum, analyze, cleanup-config-prefs,
            cleanup-port-names, cleanup-report-formats,
            cleanup-result-severities, cleanup-schedule-times,
-           rebuild-report-cache or update-report-cache.</p>
+           migrate-relay-sensors, rebuild-report-cache
+           or update-report-cache.</p>
       </optdesc>
     </option>
     <option>

--- a/doc/gvmd.html
+++ b/doc/gvmd.html
@@ -236,7 +236,8 @@
         <p>Run an optimization: vacuum, analyze, cleanup-config-prefs,
            cleanup-port-names, cleanup-report-formats,
            cleanup-result-severities, cleanup-schedule-times,
-           rebuild-report-cache or update-report-cache.</p>
+           migrate-relay-sensors, rebuild-report-cache
+           or update-report-cache.</p>
       
     
     

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1779,7 +1779,8 @@ gvmd (int argc, char** argv)
           "Run an optimization: vacuum, analyze, cleanup-config-prefs,"
           " cleanup-port-names, cleanup-report-formats,"
           " cleanup-result-severities, cleanup-schedule-times,"
-          " rebuild-report-cache or update-report-cache.",
+          " migrate-relay-sensors, rebuild-report-cache or"
+          " update-report-cache.",
           "<name>" },
         { "osp-vt-update", '\0', 0, G_OPTION_ARG_STRING,
           &osp_vt_update,

--- a/src/manage.c
+++ b/src/manage.c
@@ -170,6 +170,11 @@ extern volatile int termination_signal;
 static gchar *relay_mapper_path = NULL;
 
 /**
+ * @brief Whether to migrate sensors if relays do not match.
+ */
+static int relay_migrate_sensors = 0;
+
+/**
  * @brief Number of minutes before overdue tasks timeout.
  */
 static int schedule_timeout = SCHEDULE_TIMEOUT_DEFAULT;
@@ -4908,6 +4913,142 @@ set_relay_mapper_path (const char *new_path)
 }
 
 /**
+ * @brief Gets whether to migrate sensors if relays do not match.
+ *
+ * @return Whether to migrate sensors if relays do not match.
+ */
+int
+get_relay_migrate_sensors ()
+{
+  return relay_migrate_sensors;
+}
+
+/**
+ * @brief Sets whether to migrate sensors if relays do not match.
+ *
+ * @param[in]  new_value  The new value.
+ */
+void
+set_relay_migrate_sensors (int new_value)
+{
+  relay_migrate_sensors = new_value;
+}
+
+
+static int
+get_relay_info_entity (const char *original_host, int original_port,
+                       const char *protocol, entity_t *ret_entity)
+{
+  gchar **cmd, *stdout_str, *stderr_str;
+  int ret, exit_code;
+  GError *err;
+  entity_t relay_entity;
+
+  if (ret_entity == NULL)
+    return -1;
+  else
+    *ret_entity = NULL;
+
+  stdout_str = NULL;
+  stderr_str = NULL;
+  ret = -1;
+  exit_code = -1;
+  err = NULL;
+
+  cmd = (gchar **) g_malloc (8 * sizeof (gchar *));
+  cmd[0] = g_strdup (relay_mapper_path);
+  cmd[1] = g_strdup ("--host");
+  cmd[2] = g_strdup (original_host);
+  cmd[3] = g_strdup ("--port");
+  cmd[4] = g_strdup_printf ("%d", original_port);
+  cmd[5] = g_strdup ("--protocol");
+  cmd[6] = g_strdup (protocol);
+  cmd[7] = NULL;
+
+  if (g_spawn_sync (NULL,
+                    cmd,
+                    NULL,
+                    G_SPAWN_SEARCH_PATH,
+                    NULL,
+                    NULL,
+                    &stdout_str,
+                    &stderr_str,
+                    &exit_code,
+                    &err) == FALSE)
+    {
+      g_warning ("%s: g_spawn_sync failed: %s",
+                  __FUNCTION__, err ? err->message : "");
+      g_strfreev (cmd);
+      g_free (stdout_str);
+      g_free (stderr_str);
+      return -1;
+    }
+  else if (exit_code)
+    {
+      g_warning ("%s: mapper exited with code %d",
+                  __FUNCTION__, exit_code);
+      g_message ("%s: mapper stderr:\n%s", __FUNCTION__, stderr_str);
+      g_debug ("%s: mapper stdout:\n%s", __FUNCTION__, stdout_str);
+      g_strfreev (cmd);
+      g_free (stdout_str);
+      g_free (stderr_str);
+      return -1;
+    }
+
+  relay_entity = NULL;
+  if (parse_entity (stdout_str, &relay_entity))
+    {
+      g_warning ("%s: failed to parse mapper output",
+                  __FUNCTION__);
+      g_message ("%s: mapper stdout:\n%s", __FUNCTION__, stdout_str);
+      g_message ("%s: mapper stderr:\n%s", __FUNCTION__, stderr_str);
+    }
+  else
+    {
+      ret = 0;
+      *ret_entity = relay_entity;
+    }
+
+  g_strfreev (cmd);
+  g_free (stdout_str);
+  g_free (stderr_str);
+
+  return ret;
+}
+
+gboolean
+relay_supports_scanner_type (const char *original_host, int original_port,
+                             scanner_type_t type)
+{
+  entity_t relay_entity = NULL;
+  const char *protocol;
+  gboolean ret = FALSE;
+
+  if (type == SCANNER_TYPE_GMP)
+    protocol = "GMP";
+  else if (type == SCANNER_TYPE_OSP_SENSOR)
+    protocol = "OSP";
+  else
+    return FALSE;
+
+  if (get_relay_info_entity (original_host, original_port,
+                             protocol, &relay_entity) == 0)
+    {
+      entity_t host_entity;
+      host_entity = entity_child (relay_entity, "host");
+
+      if (host_entity
+          && entity_text (host_entity)
+          && strcmp (entity_text (host_entity), ""))
+        {
+          ret = TRUE;
+        }
+    }
+  free_entity (relay_entity);
+  return ret;
+}
+
+/**
  * @brief Gets a relay hostname and port for a sensor scanner.
  *
  * If no mapper is available, a copy of the original host, port and
@@ -4948,65 +5089,10 @@ slave_get_relay (const char *original_host,
     }
   else
     {
-      gchar **cmd, *stdout_str, *stderr_str;
-      int exit_code;
-      GError *err;
-      entity_t relay_entity;
+      entity_t relay_entity = NULL;
 
-      stdout_str = NULL;
-      stderr_str = NULL;
-      exit_code = -1;
-      err = NULL;
-
-      cmd = (gchar **) g_malloc (8 * sizeof (gchar *));
-      cmd[0] = g_strdup (relay_mapper_path);
-      cmd[1] = g_strdup ("--host");
-      cmd[2] = g_strdup (original_host);
-      cmd[3] = g_strdup ("--port");
-      cmd[4] = g_strdup_printf ("%d", original_port);
-      cmd[5] = g_strdup ("--protocol");
-      cmd[6] = g_strdup (protocol);
-      cmd[7] = NULL;
-
-      if (g_spawn_sync (NULL,
-                        cmd,
-                        NULL,
-                        G_SPAWN_SEARCH_PATH,
-                        NULL,
-                        NULL,
-                        &stdout_str,
-                        &stderr_str,
-                        &exit_code,
-                        &err) == FALSE)
-        {
-          g_warning ("%s: g_spawn_sync failed: %s",
-                     __FUNCTION__, err ? err->message : "");
-          g_strfreev (cmd);
-          g_free (stdout_str);
-          g_free (stderr_str);
-          return -1;
-        }
-      else if (exit_code)
-        {
-          g_warning ("%s: mapper exited with code %d",
-                     __FUNCTION__, exit_code);
-          g_message ("%s: mapper stderr:\n%s", __FUNCTION__, stderr_str);
-          g_debug ("%s: mapper stdout:\n%s", __FUNCTION__, stdout_str);
-          g_strfreev (cmd);
-          g_free (stdout_str);
-          g_free (stderr_str);
-          return -1;
-        }
-
-      relay_entity = NULL;
-      if (parse_entity (stdout_str, &relay_entity))
-        {
-          g_warning ("%s: failed to parse mapper output",
-                     __FUNCTION__);
-          g_message ("%s: mapper stdout:\n%s", __FUNCTION__, stdout_str);
-          g_message ("%s: mapper stderr:\n%s", __FUNCTION__, stderr_str);
-        }
-      else
+      if (get_relay_info_entity (original_host, original_port,
+                                 protocol, &relay_entity) == 0)
         {
           entity_t host_entity, port_entity, ca_cert_entity;
 
@@ -5049,9 +5135,6 @@ slave_get_relay (const char *original_host,
             }
           free_entity (relay_entity);
         }
-      g_strfreev (cmd);
-      g_free (stdout_str);
-      g_free (stderr_str);
     }
 
   return ret;

--- a/src/manage.h
+++ b/src/manage.h
@@ -2856,6 +2856,15 @@ void
 set_relay_mapper_path (const char *);
 
 int
+get_relay_migrate_sensors ();
+
+void
+set_relay_migrate_sensors (int);
+
+gboolean
+relay_supports_scanner_type (const char *, int, scanner_type_t);
+
+int
 slave_get_relay (const char *,
                  int,
                  const char *,


### PR DESCRIPTION
If relays are active, this can be used to make sure all sensor type
scanners have a matching relay, i.e. OSP sensors have an OSP relay
and GMP scanners have an GMP relay.
GMP scanners are migrated to OSP sensors if an OSP relay is available.

**Checklist**:

- Tests N/A
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
