### PR TITLE
Fix preference ID in "Host Discovery" config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Consider results_trash when deleting users [#799](https://github.com/greenbone/gvmd/pull/799)
 - Try to get NVT preferences by id in create_config [#821](https://github.com/greenbone/gvmd/pull/821)
+- Fix preference ID in "Host Discovery" config [#828](https://github.com/greenbone/gvmd/pull/828)
 
 ### Removed
 

--- a/src/manage_config_host_discovery.c
+++ b/src/manage_config_host_discovery.c
@@ -91,7 +91,7 @@ make_config_host_discovery (char *const uuid, char *const selector_name)
   sql ("INSERT INTO config_preferences (config, type, name, value)"
        " VALUES (%llu,"
        "         'PLUGINS_PREFS',"
-       "         '" OID_PING_HOST ":6:checkbox:Report about reachable Hosts',"
+       "         '" OID_PING_HOST ":9:checkbox:Report about reachable Hosts',"
        "         'yes');",
        config);
 


### PR DESCRIPTION
The ID of the "Report about reachable Hosts" preference of the
"Ping Host" NVT must be 9, not 6.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
