### PR TITLE
Fix order of fingerprints in get_tls_certificates (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Consider results_trash when deleting users [#799](https://github.com/greenbone/gvmd/pull/799)
 - Try to get NVT preferences by id in create_config [#821](https://github.com/greenbone/gvmd/pull/821)
 - Fix preference ID in "Host Discovery" config [#828](https://github.com/greenbone/gvmd/pull/828)
+- Fix order of fingerprints in get_tls_certificates [#833](https://github.com/greenbone/gvmd/pull/833)
 
 ### Removed
 

--- a/src/gmp_tls_certificates.c
+++ b/src/gmp_tls_certificates.c
@@ -231,8 +231,8 @@ get_tls_certificates_run (gmp_parser_t *gmp_parser, GError **error)
          (get_tls_certificates_data.get.details || include_certificate_data)
             ? tls_certificate_iterator_certificate (&tls_certificates)
             : "",
-         tls_certificate_iterator_md5_fingerprint (&tls_certificates),
          tls_certificate_iterator_sha256_fingerprint (&tls_certificates),
+         tls_certificate_iterator_md5_fingerprint (&tls_certificates),
          tls_certificate_iterator_trust (&tls_certificates),
          tls_certificate_iterator_valid (&tls_certificates),
          tls_certificate_iterator_time_status (&tls_certificates),


### PR DESCRIPTION
The MD5 and SHA256 fingerprints were swapped in the response.

**Checklist**:
- N/A Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
