### PR TITLE
Fix notes XML for lean reports (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix preference ID in "Host Discovery" config [#828](https://github.com/greenbone/gvmd/pull/828)
 - Fix order of fingerprints in get_tls_certificates [#833](https://github.com/greenbone/gvmd/pull/833)
 - Update config preferences after updating NVTs [#832](https://github.com/greenbone/gvmd/pull/832)
+- Fix notes XML for lean reports [#836](https://github.com/greenbone/gvmd/pull/836)
 
 ### Removed
 

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -9928,6 +9928,8 @@ buffer_result_notes_xml (GString *buffer, result_t result, task_t task,
     {
       get_data_t get;
       iterator_t notes;
+      GString *temp_buffer;
+
       memset (&get, '\0', sizeof (get));
       /* Most recent first. */
       get.filter = "sort-reverse=created owner=any permission=any";
@@ -9941,15 +9943,20 @@ buffer_result_notes_xml (GString *buffer, result_t result, task_t task,
                           result,
                           task);
 
-      if (lean == 0 || next (&notes))
-        g_string_append (buffer, "<notes>");
-      buffer_notes_xml (buffer,
+      temp_buffer = g_string_new ("");
+      buffer_notes_xml (temp_buffer,
                         &notes,
                         include_notes_details,
                         0,
                         NULL);
-      if (lean == 0 || next (&notes))
-        g_string_append (buffer, "</notes>");
+
+      if (lean == 0 || strlen (temp_buffer->str))
+        {
+          g_string_append (buffer, "<notes>");
+          g_string_append (buffer, temp_buffer->str);
+          g_string_append (buffer, "</notes>");
+        }
+      g_string_free (temp_buffer, TRUE);
 
       cleanup_iterator (&notes);
     }


### PR DESCRIPTION
The conditions for showing the notes in lean reports did not work as
intended, so use the same technique as in buffer_result_overrides_xml.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
