### PR TITLE
Try authentication when verifying GMP scanners (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Extend command line options for managing scanners [#815](https://github.com/greenbone/gvmd/pull/815)
 - Update SCAP and CERT feed info in sync scripts [#809](https://github.com/greenbone/gvmd/pull/809)
+- Try authentication when verifying GMP scanners [#837](https://github.com/greenbone/gvmd/pull/837)
 
 ### Fixed
 - Consider results_trash when deleting users [#799](https://github.com/greenbone/gvmd/pull/799)

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -28193,8 +28193,13 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                                            "Service unavailable"));
                   break;
                 case 3:
-                  SEND_TO_CLIENT_OR_FAIL
-                   (XML_ERROR_SYNTAX ("verify_scanner", "No CA certificate"));
+                  SENDF_TO_CLIENT_OR_FAIL
+                   ("<verify_scanner_response status=\"%s\""
+                    " status_text=\"Failed to authenticate\">"
+                    "<version>%s</version>"
+                    "</verify_scanner_response>",
+                    STATUS_SERVICE_UNAVAILABLE,
+                    version);
                   break;
                 case 99:
                   SEND_TO_CLIENT_OR_FAIL


### PR DESCRIPTION
The verify_scanner command will now try to authenticate using the
credential given for the scanner.

**Checklist**:

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
