### PR TITLE
Fix asset host details insertion SQL (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix preference ID in "Host Discovery" config [#828](https://github.com/greenbone/gvmd/pull/828)
 - Fix order of fingerprints in get_tls_certificates [#833](https://github.com/greenbone/gvmd/pull/833)
 - Update config preferences after updating NVTs [#832](https://github.com/greenbone/gvmd/pull/832)
+- Fix asset host details insertion SQL [#839](https://github.com/greenbone/gvmd/pull/839)
 
 ### Removed
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -57056,6 +57056,7 @@ hosts_set_details (report_t report)
        report,
        report,
        report,
+       report,
        report);
 }
 


### PR DESCRIPTION
The one of the host ids to be inserted into the format string was
undefined, making one of the conditions false almost every time.

**Checklist**:

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
