### PR TITLE
Fix asset host details insertion SQL (8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix array index error when modifying roles and groups [#763](https://github.com/greenbone/gvmd/pull/763)
 - Fix percent sign escaping in report_port_count [#781](https://github.com/greenbone/gvmd/pull/781)
 - Consider results_trash when deleting users [#804](https://github.com/greenbone/gvmd/pull/804)
+- Fix asset host details insertion SQL [#840](https://github.com/greenbone/gvmd/pull/840)
 
 ### Removed
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -62241,6 +62241,7 @@ hosts_set_details (report_t report)
        report,
        report,
        report,
+       report,
        report);
 }
 


### PR DESCRIPTION
The one of the host ids to be inserted into the format string was
undefined, making one of the conditions false almost every time.

**Checklist**:

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
