### PR TITLE
Try importing private keys with libssh if GnuTLS fails (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Extend command line options for managing scanners [#815](https://github.com/greenbone/gvmd/pull/815)
 - Update SCAP and CERT feed info in sync scripts [#809](https://github.com/greenbone/gvmd/pull/809)
+- Try importing private keys with libssh if GnuTLS fails [#841](https://github.com/greenbone/gvmd/pull/841)
 
 ### Fixed
 - Consider results_trash when deleting users [#799](https://github.com/greenbone/gvmd/pull/799)

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -468,11 +468,18 @@ check_private_key (const char *key_str, const char *key_phrase)
                                      key_phrase, 0);
   if (ret)
     {
-      g_message ("%s: import failed: %s",
-                 __FUNCTION__, gnutls_strerror (ret));
-      gnutls_x509_privkey_deinit (key);
-      g_free (data.data);
-      return 1;
+      gchar *public_key;
+      public_key = gvm_ssh_public_from_private (key_str, key_phrase);
+
+      if (public_key == NULL)
+        {
+          gnutls_x509_privkey_deinit (key);
+          g_free (data.data);
+          g_message ("%s: import failed: %s",
+                    __FUNCTION__, gnutls_strerror (ret));
+          return 1;
+        }
+      g_free (public_key);
     }
   g_free (data.data);
   gnutls_x509_privkey_deinit (key);


### PR DESCRIPTION
If check_private_key cannot import a key with GnuTLS, try importing it
with gvm_ssh_public_from_private as some key types may only be supported
by libssh.

**Checklist**:

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
