### PR TITLE
Get coverage when running unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - checkout
       - run:
           name: Configure and run unit tests
-          command: mkdir build && cd build/ && cmake -DBACKEND=POSTGRESQL -DCMAKE_BUILD_TYPE=Release -DCOVERAGE=1 .. && make && make tests && CTEST_OUTPUT_ON_FAILURE=1 make test && lcov --directory . --capture --output-file coverage.info && genhtml -o coverage coverage.info
+          command: mkdir build && cd build/ && cmake -DBACKEND=POSTGRESQL -DCMAKE_BUILD_TYPE=Release -DENABLE_COVERAGE=1 .. && make && make tests && CTEST_OUTPUT_ON_FAILURE=1 make test && lcov --directory . --capture --output-file coverage.info && genhtml -o coverage coverage.info
   build_postgresql_debug:
     docker:
       - image: greenbone/build-env-gvm-master-debian-stretch-gcc-postgresql

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - checkout
       - run:
           name: Configure and run unit tests
-          command: mkdir build && cd build/ && cmake -DBACKEND=POSTGRESQL -DCMAKE_BUILD_TYPE=Release .. && make tests && CTEST_OUTPUT_ON_FAILURE=1 make test
+          command: mkdir build && cd build/ && cmake -DBACKEND=POSTGRESQL -DCMAKE_BUILD_TYPE=Release -DCOVERAGE=1 .. && make && make tests && CTEST_OUTPUT_ON_FAILURE=1 make test && lcov --directory . --capture --output-file coverage.info && genhtml -o coverage coverage.info
   build_postgresql_debug:
     docker:
       - image: greenbone/build-env-gvm-master-debian-stretch-gcc-postgresql

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,7 +268,7 @@ set (LINKER_HARDENING_FLAGS     "-Wl,-z,relro -Wl,-z,now")
 set (CMAKE_C_FLAGS              "${CMAKE_C_FLAGS} -Wall -D_BSD_SOURCE -D_ISOC99_SOURCE -D_SVID_SOURCE -D_DEFAULT_SOURCE -D_FILE_OFFSET_BITS=64")
 
 set (CMAKE_C_FLAGS_DEBUG        "${CMAKE_C_FLAGS_DEBUG} -Werror -Wshadow ${COVERAGE_FLAGS} ${DEBUG_FUNCTION_NAMES_FLAGS}")
-set (CMAKE_C_FLAGS_RELEASE      "${CMAKE_C_FLAGS_RELEASE} ${HARDENING_FLAGS}")
+set (CMAKE_C_FLAGS_RELEASE      "${CMAKE_C_FLAGS_RELEASE} ${HARDENING_FLAGS} ${COVERAGE_FLAGS}")
 
 # Flags used only for the gvmd binary, and not for the Postgres module.
 set (C_FLAGS_DEBUG_GVMD         "-Wredundant-decls")


### PR DESCRIPTION
This gets the coverage summary printed at the end of the unit test CI, like this:

```
Overall coverage rate:
  lines......: 0.4% (174 of 44615 lines)
  functions..: 1.8% (39 of 2142 functions)
```

A bit hidden away, but it's a start.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
