### PR TITLE
Allow use of public key auth in SCP alert (8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Command cleanup-report-formats for --optimize option [#651](https://github.com/greenbone/gvmd/pull/651)
 - Document container tasks in GMP doc [#690](https://github.com/greenbone/gvmd/pull/690)
 - New columns Ports, Apps, Distance, and Auth in the CSV Hosts report format [#734](https://github.com/greenbone/gvmd/pull/734)
+- Allow use of public key auth in SCP alert [#846](https://github.com/greenbone/gvmd/pull/846)
 
 ### Changes
 - Check and create default permissions individually [#672](https://github.com/greenbone/gvmd/pull/672)

--- a/src/alert_methods/SCP/alert
+++ b/src/alert_methods/SCP/alert
@@ -23,8 +23,9 @@ USERNAME=$1
 HOST=$2
 DEST=$3
 KNOWN_HOSTS=$4
-PASSWORD_FILE=$5
-REPORT_FILE=$6
+PRIVATE_KEY_FILE=$5
+PASSWORD_FILE=$6
+REPORT_FILE=$7
 
 KNOWN_HOSTS_FILE=`mktemp` || exit 1
 echo $KNOWN_HOSTS > $KNOWN_HOSTS_FILE
@@ -35,7 +36,12 @@ log_error() {
 }
 
 # Escape destination twice because it is also expanded on the remote end.
-sshpass -f ${PASSWORD_FILE} scp -o HashKnownHosts=no -o UserKnownHostsFile="${KNOWN_HOSTS_FILE} ~/.ssh/known_hosts ~/.ssh/known_hosts2 /etc/ssh/ssh_known_hosts" "${REPORT_FILE}" "${USERNAME}@${HOST}:'${DEST}'" 2>/dev/null
+if [ -z "$PRIVATE_KEY_FILE" ]
+then
+  sshpass -f ${PASSWORD_FILE} scp -o BatchMode=yes -o HashKnownHosts=no -o UserKnownHostsFile="${KNOWN_HOSTS_FILE} ~/.ssh/known_hosts ~/.ssh/known_hosts2 /etc/ssh/ssh_known_hosts" "${REPORT_FILE}" "${USERNAME}@${HOST}:'${DEST}'" 2>$ERROR_FILE
+else
+  sshpass -f ${PASSWORD_FILE} scp -i "$PRIVATE_KEY_FILE" -o PasswordAuthentication=no -o BatchMode=yes -o HashKnownHosts=no -o UserKnownHostsFile="${KNOWN_HOSTS_FILE} ~/.ssh/known_hosts ~/.ssh/known_hosts2 /etc/ssh/ssh_known_hosts" "${REPORT_FILE}" "${USERNAME}@${HOST}:'${DEST}'" 2>$ERROR_FILE
+fi
 
 EXIT_CODE=$?
 if [ $EXIT_CODE -eq 1 ]

--- a/src/alert_methods/SCP/alert
+++ b/src/alert_methods/SCP/alert
@@ -30,6 +30,8 @@ REPORT_FILE=$7
 KNOWN_HOSTS_FILE=`mktemp` || exit 1
 echo $KNOWN_HOSTS > $KNOWN_HOSTS_FILE
 
+ERROR_FILE=`mktemp` || exit 1
+
 log_error() {
   logger "SCP alert: $1"
   echo "$1" >&2
@@ -44,33 +46,37 @@ else
 fi
 
 EXIT_CODE=$?
+
+ERROR_SHORT=`head -n 3 $ERROR_FILE`
+
 if [ $EXIT_CODE -eq 1 ]
 then
-  log_error "sshpass failed with exit code ${EXIT_CODE}: Invalid command line argument"
+  log_error "sshpass failed with exit code ${EXIT_CODE}: Invalid command line argument: $ERROR_SHORT"
 elif [ $EXIT_CODE -eq 2 ]
 then
-  log_error "sshpass failed with exit code ${EXIT_CODE}: Conflicting arguments given"
+  log_error "sshpass failed with exit code ${EXIT_CODE}: Conflicting arguments given: $ERROR_SHORT"
 elif [ $EXIT_CODE -eq 3 ]
 then
-  log_error "sshpass failed with exit code ${EXIT_CODE}: General runtime error"
+  log_error "sshpass failed with exit code ${EXIT_CODE}: General runtime error: $ERROR_SHORT"
 elif [ $EXIT_CODE -eq 4 ]
 then
-  log_error "sshpass failed with exit code ${EXIT_CODE}: Unrecognized response from ssh (parse error)"
+  log_error "sshpass failed with exit code ${EXIT_CODE}: Unrecognized response from ssh (parse error): $ERROR_SHORT"
 elif [ $EXIT_CODE -eq 5 ]
 then
-  log_error "sshpass failed with exit code ${EXIT_CODE}: Invalid/incorrect password"
+  log_error "sshpass failed with exit code ${EXIT_CODE}: Invalid/incorrect password: $ERROR_SHORT"
 elif [ $EXIT_CODE -eq 6 ]
 then
-  log_error "sshpass failed with exit code ${EXIT_CODE}: Host public key is unknown."
+  log_error "sshpass failed with exit code ${EXIT_CODE}: Host public key is unknown: $ERROR_SHORT"
 elif [ $EXIT_CODE -eq 127 ]
 then
-  log_error "sshpass failed with exit code ${EXIT_CODE}: Command not found."
+  log_error "sshpass failed with exit code ${EXIT_CODE}: Command not found: $ERROR_SHORT"
 elif [ $EXIT_CODE -ne 0 ]
 then
-  log_error "sshpass failed with exit code ${EXIT_CODE}"
+  log_error "sshpass failed with exit code ${EXIT_CODE}: $ERROR_SHORT"
 fi
 
 rm $KNOWN_HOSTS_FILE
 rm $PASSWORD_FILE
+rm $ERROR_FILE
 
 exit $EXIT_CODE

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -10422,6 +10422,8 @@ scp_to_host (const char *username, const char *password,
                            password, strlen (password),
                            report_dir,
                            &report_path, &error_path, &extra_path);
+  if (ret)
+    return -1;
 
   if (private_key)
     {

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -10166,6 +10166,66 @@ alert_script_exec (const char *alert_id, const char *command_args,
 }
 
 /**
+ * @brief Write data to a file for use by an alert script.
+ *
+ * @param[in]  directory      Base directory to create the file in
+ * @param[in]  filename       Filename without directory
+ * @param[in]  content        The file content
+ * @param[in]  content_size   Size of the file content
+ * @param[in]  description    Short file description for error messages
+ * @param[out] file_path      Return location of combined file path
+ *
+ * @return 0 success, -1 error
+ */
+static int
+alert_write_data_file (const char *directory, const char *filename,
+                       const char *content, gsize content_size,
+                       const char *description, gchar **file_path)
+{
+  gchar *path;
+  GError *error;
+
+  if (file_path)
+    *file_path = NULL;
+
+  /* Setup certificate file */
+  path = g_build_filename (directory, filename, NULL);
+  error = NULL;
+  if (g_file_set_contents (path, content, content_size, &error) == FALSE)
+    {
+      g_warning ("%s: Failed to write %s to file: %s",
+                 __FUNCTION__,
+                 description ? description : "extra data",
+                 error->message);
+      g_free (path);
+      return -1;
+    }
+
+  if (geteuid () == 0)
+    {
+      struct passwd *nobody;
+
+      /* Run the command with lower privileges in a fork. */
+
+      nobody = getpwnam ("nobody");
+      if ((nobody == NULL)
+          || chown (path, nobody->pw_uid, nobody->pw_gid))
+        {
+          g_warning ("%s: Failed to set permissions for user nobody: %s",
+                      __FUNCTION__,
+                      strerror (errno));
+          g_free (path);
+          return -1;
+        }
+    }
+
+  if (file_path)
+    *file_path = path;
+
+  return 0;
+}
+
+/**
  * @brief Clean up common files and variables for running alert script.
  *
  * @param[in]  report_dir   The temporary directory.
@@ -10324,8 +10384,9 @@ send_to_host (const char *host, const char *port,
 /**
  * @brief Send a report to a host via TCP.
  *
- * @param[in]  password     Password.
  * @param[in]  username     Username.
+ * @param[in]  password     Password or passphrase of private key.
+ * @param[in]  private_key  Private key or NULL for password-only auth.
  * @param[in]  host         Address of host.
  * @param[in]  path         Destination filename with path.
  * @param[in]  known_hosts  Content for known_hosts file.
@@ -10336,11 +10397,15 @@ send_to_host (const char *host, const char *port,
  * @return 0 success, -1 error, -5 alert script failed.
  */
 static int
-scp_to_host (const char *password, const char *username, const char *host,
-             const char *path, const char *known_hosts, const char *report,
-             int report_size, gchar **script_message)
+scp_to_host (const char *username, const char *password,
+             const char *private_key,
+             const char *host, const char *path, const char *known_hosts,
+             const char *report, int report_size, gchar **script_message)
 {
-  gchar *clean_username, *clean_host, *clean_path;
+  const char *alert_id = "2db07698-ec49-11e5-bcff-28d24461215b";
+  char report_dir[] = "/tmp/gvmd_alert_XXXXXX";
+  gchar *report_path, *error_path, *extra_path, *private_key_path;
+  gchar *clean_username, *clean_host, *clean_path, *clean_private_key_path;
   gchar *clean_known_hosts, *command_args;
   int ret;
 
@@ -10352,22 +10417,59 @@ scp_to_host (const char *password, const char *username, const char *host,
   if (known_hosts == NULL)
     known_hosts = "";
 
+  /* Setup files. */
+  ret = alert_script_init ("report", report, report_size,
+                           password, strlen (password),
+                           report_dir,
+                           &report_path, &error_path, &extra_path);
+
+  if (private_key)
+    {
+      if (alert_write_data_file (report_dir, "private_key",
+                                 private_key, strlen (private_key),
+                                 "private key", &private_key_path))
+        {
+          alert_script_cleanup (report_dir, report_path, error_path,
+                                extra_path);
+          g_free (private_key_path);
+          return -1;
+        }
+    }
+  else
+    private_key_path = g_strdup ("");
+
+  /* Create arguments */
   clean_username = g_shell_quote (username);
   clean_host = g_shell_quote (host);
   clean_path = g_shell_quote (path);
   clean_known_hosts = g_shell_quote (known_hosts);
-  command_args = g_strdup_printf ("%s %s %s %s", clean_username,
-                                  clean_host, clean_path, clean_known_hosts);
+  clean_private_key_path = g_shell_quote (private_key_path);
+  command_args = g_strdup_printf ("%s %s %s %s %s",
+                                  clean_username,
+                                  clean_host,
+                                  clean_path,
+                                  clean_known_hosts,
+                                  clean_private_key_path);
   g_free (clean_username);
   g_free (clean_host);
   g_free (clean_path);
   g_free (clean_known_hosts);
+  g_free (clean_private_key_path);
 
-  ret = run_alert_script ("2db07698-ec49-11e5-bcff-28d24461215b",
-                          command_args, "report", report, report_size,
-                          password, strlen (password), script_message);
-
+  /* Run script */
+  ret = alert_script_exec (alert_id, command_args, report_path, report_dir,
+                           error_path, extra_path, script_message);
   g_free (command_args);
+  if (ret)
+    {
+      alert_script_cleanup (report_dir, report_path, error_path, extra_path);
+      g_free (private_key_path);
+      return ret;
+    }
+
+  /* Remove the directory and free path strings. */
+  ret = alert_script_cleanup (report_dir, report_path, error_path, extra_path);
+  g_free (private_key_path);
   return ret;
 }
 
@@ -13240,7 +13342,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
         {
           credential_t credential;
           char *credential_id;
-          char *password, *username, *host, *path, *known_hosts;
+          char *private_key, *password, *username, *host, *path, *known_hosts;
           gchar *report_content, *alert_path;
           gsize content_length;
           report_format_t report_format;
@@ -13275,9 +13377,11 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
                 {
                   message = new_secinfo_message (event, event_data, alert);
 
+                  username = credential_value (credential, "username");
                   password = credential_encrypted_value (credential,
                                                          "password");
-                  username = credential_value (credential, "username");
+                  private_key = credential_encrypted_value (credential,
+                                                            "private_key");
 
                   host = alert_data (alert, "method", "scp_host");
                   path = alert_data (alert, "method", "scp_path");
@@ -13286,11 +13390,13 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
                   alert_path = scp_alert_path_print (path, task);
                   free (path);
 
-                  ret = scp_to_host (password, username, host, alert_path,
-                                     known_hosts, message, strlen (message),
+                  ret = scp_to_host (username, password, private_key,
+                                     host, alert_path, known_hosts,
+                                     message, strlen (message),
                                      script_message);
 
                   g_free (message);
+                  free (private_key);
                   free (password);
                   free (username);
                   free (host);
@@ -13331,8 +13437,11 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
             }
           else
             {
-              password = credential_encrypted_value (credential, "password");
               username = credential_value (credential, "username");
+              password = credential_encrypted_value (credential, "password");
+              private_key = credential_encrypted_value (credential,
+                                                        "private_key");
+
 
               host = alert_data (alert, "method", "scp_host");
               path = alert_data (alert, "method", "scp_path");
@@ -13341,10 +13450,12 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
               alert_path = scp_alert_path_print (path, task);
               free (path);
 
-              ret = scp_to_host (password, username, host, alert_path,
-                                 known_hosts, report_content, content_length,
+              ret = scp_to_host (username, password, private_key,
+                                 host, alert_path, known_hosts,
+                                 report_content, content_length,
                                  script_message);
 
+              free (private_key);
               free (password);
               free (username);
               free (host);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -10188,7 +10188,7 @@ alert_write_data_file (const char *directory, const char *filename,
   if (file_path)
     *file_path = NULL;
 
-  /* Setup certificate file */
+  /* Setup extra data file */
   path = g_build_filename (directory, filename, NULL);
   error = NULL;
   if (g_file_set_contents (path, content, content_size, &error) == FALSE)
@@ -10205,7 +10205,9 @@ alert_write_data_file (const char *directory, const char *filename,
     {
       struct passwd *nobody;
 
-      /* Run the command with lower privileges in a fork. */
+      /* Set the owner for the extra data file like the other
+       * files handled by alert_script_exec, to be able to
+       * run the command with lower privileges in a fork. */
 
       nobody = getpwnam ("nobody");
       if ((nobody == NULL)
@@ -10404,7 +10406,7 @@ scp_to_host (const char *username, const char *password,
 {
   const char *alert_id = "2db07698-ec49-11e5-bcff-28d24461215b";
   char report_dir[] = "/tmp/gvmd_alert_XXXXXX";
-  gchar *report_path, *error_path, *extra_path, *private_key_path;
+  gchar *report_path, *error_path, *password_path, *private_key_path;
   gchar *clean_username, *clean_host, *clean_path, *clean_private_key_path;
   gchar *clean_known_hosts, *command_args;
   int ret;
@@ -10417,22 +10419,24 @@ scp_to_host (const char *username, const char *password,
   if (known_hosts == NULL)
     known_hosts = "";
 
-  /* Setup files. */
+  /* Setup files, including password but not private key */
   ret = alert_script_init ("report", report, report_size,
                            password, strlen (password),
                            report_dir,
-                           &report_path, &error_path, &extra_path);
+                           &report_path, &error_path, &password_path);
   if (ret)
     return -1;
 
   if (private_key)
     {
+      /* Setup private key here because alert_script_init and alert_script_exec
+       *  only handle one extra file. */
       if (alert_write_data_file (report_dir, "private_key",
                                  private_key, strlen (private_key),
                                  "private key", &private_key_path))
         {
           alert_script_cleanup (report_dir, report_path, error_path,
-                                extra_path);
+                                password_path);
           g_free (private_key_path);
           return -1;
         }
@@ -10460,17 +10464,19 @@ scp_to_host (const char *username, const char *password,
 
   /* Run script */
   ret = alert_script_exec (alert_id, command_args, report_path, report_dir,
-                           error_path, extra_path, script_message);
+                           error_path, password_path, script_message);
   g_free (command_args);
   if (ret)
     {
-      alert_script_cleanup (report_dir, report_path, error_path, extra_path);
+      alert_script_cleanup (report_dir, report_path, error_path,
+                            password_path);
       g_free (private_key_path);
       return ret;
     }
 
   /* Remove the directory and free path strings. */
-  ret = alert_script_cleanup (report_dir, report_path, error_path, extra_path);
+  ret = alert_script_cleanup (report_dir, report_path, error_path,
+                              password_path);
   g_free (private_key_path);
   return ret;
 }


### PR DESCRIPTION
The alert now not only works with password but also SSH key credentials.
Also, the error messages now also include the first lines of the sshpass / scp stderr output.

(Backport of #845)

**Checklist**:

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
