### PR TITLE
Remove 1.3.6.1.4.1.25623.1.0.90011 from Discovery config (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - MODIFY_USER saves comment when COMMENT is empty [#842](https://github.com/greenbone/gvmd/pull/842)
 
 ### Removed
+- Remove 1.3.6.1.4.1.25623.1.0.90011 from Discovery config (9.0) [#847](https://github.com/greenbone/gvmd/pull/847)
 
 [9.0.1]: https://github.com/greenbone/gvmd/compare/v9.0.0...gvmd-9.0
 

--- a/src/manage_config_discovery.c
+++ b/src/manage_config_discovery.c
@@ -985,5 +985,12 @@ check_config_discovery (const char *uuid)
                             "yes",
                             TRUE);
 
+  sql ("DELETE FROM nvt_selectors"
+       " WHERE family_or_nvt = '1.3.6.1.4.1.25623.1.0.90011'"
+       " AND type = %d"
+       " AND name = (SELECT nvt_selector FROM configs WHERE uuid = '%s')",
+       NVT_SELECTOR_TYPE_NVT,
+       uuid);
+
   return 0;
 }

--- a/src/manage_config_discovery.c
+++ b/src/manage_config_discovery.c
@@ -797,7 +797,6 @@ make_config_discovery (char *const uuid, char *const selector_name)
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.80039", "Windows");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10394", "Windows");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10006", "Windows");
-  NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.90011", "Windows");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.900012", "Windows");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.100062", "Windows");
   NVT_SELECTOR (selector_name, "1.3.6.1.4.1.25623.1.0.10674", "Windows");


### PR DESCRIPTION
The NVT is removed from the built-in "Discovery" config because it is
not available in every feed and only adds info already covered by other
NVTs.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
