### PR TITLE
Replace __FUNCTION__ with __func__

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -387,7 +387,7 @@ try_gpgme_import (const char *key_str, GArray *key_types,
 
   if (mkdtemp (gpg_temp_dir) == NULL)
     {
-      g_warning ("%s: mkdtemp failed", __FUNCTION__);
+      g_warning ("%s: mkdtemp failed", __func__);
       return -1;
     }
 
@@ -469,7 +469,7 @@ check_private_key (const char *key_str, const char *key_phrase)
   if (ret)
     {
       g_message ("%s: import failed: %s",
-                 __FUNCTION__, gnutls_strerror (ret));
+                 __func__, gnutls_strerror (ret));
       gnutls_x509_privkey_deinit (key);
       g_free (data.data);
       return 1;
@@ -9832,14 +9832,14 @@ strdiff (const gchar *one, const gchar *two)
   old_lc_all = getenv ("LC_ALL") ? g_strdup (getenv ("LC_ALL")) : NULL;
   if (setenv ("LC_ALL", "C", 1) == -1)
     {
-      g_warning ("%s: failed to set LC_ALL", __FUNCTION__);
+      g_warning ("%s: failed to set LC_ALL", __func__);
       return NULL;
     }
 
   old_language = getenv ("LANGUAGE") ? g_strdup (getenv ("LANGUAGE")) : NULL;
   if (setenv ("LANGUAGE", "C", 1) == -1)
     {
-      g_warning ("%s: failed to set LANGUAGE", __FUNCTION__);
+      g_warning ("%s: failed to set LANGUAGE", __func__);
       return NULL;
     }
 
@@ -9853,7 +9853,7 @@ strdiff (const gchar *one, const gchar *two)
   cmd[5] = g_strdup ("Report 2");
   cmd[6] = NULL;
   g_debug ("%s: Spawning in %s: %s \"%s\" \"%s\"",
-           __FUNCTION__, dir,
+           __func__, dir,
            cmd[0], cmd[1], cmd[2]);
   if ((g_spawn_sync (dir,
                      cmd,
@@ -9873,12 +9873,12 @@ strdiff (const gchar *one, const gchar *two)
       else
         {
           g_debug ("%s: failed to run diff: %d (WIF %i, WEX %i)",
-                   __FUNCTION__,
+                   __func__,
                    exit_status,
                    WIFEXITED (exit_status),
                    WEXITSTATUS (exit_status));
-          g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
-          g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);
+          g_debug ("%s: stdout: %s", __func__, standard_out);
+          g_debug ("%s: stderr: %s", __func__, standard_err);
           ret = NULL;
           g_free (standard_out);
         }
@@ -9888,12 +9888,12 @@ strdiff (const gchar *one, const gchar *two)
 
   if (old_lc_all && (setenv ("LC_ALL", old_lc_all, 1) == -1))
     {
-      g_warning ("%s: failed to reset LC_ALL", __FUNCTION__);
+      g_warning ("%s: failed to reset LC_ALL", __func__);
       ret = NULL;
     }
   else if (old_language && (setenv ("LANGUAGE", old_language, 1) == -1))
     {
-      g_warning ("%s: failed to reset LANGUAGE", __FUNCTION__);
+      g_warning ("%s: failed to reset LANGUAGE", __func__);
       ret = NULL;
     }
 
@@ -13476,7 +13476,7 @@ handle_get_credentials (gmp_parser_t *gmp_parser, GError **error)
           case CREDENTIAL_FORMAT_NONE:
             break;
           default:
-            g_warning ("%s: Unexpected credential format.", __FUNCTION__);
+            g_warning ("%s: Unexpected credential format.", __func__);
         }
 
       if (get_credentials_data->scanners)
@@ -13651,7 +13651,7 @@ get_feed_info_parse (entity_t entity, const gchar *config_path,
   child = entity_child (entity, "name");
   if (child == NULL)
     {
-      g_warning ("%s: Missing name in '%s'", __FUNCTION__, config_path);
+      g_warning ("%s: Missing name in '%s'", __func__, config_path);
       return -1;
     }
   *name = entity_text (child);
@@ -13660,7 +13660,7 @@ get_feed_info_parse (entity_t entity, const gchar *config_path,
   if (child == NULL)
     {
       g_warning ("%s: Missing description in '%s'",
-                 __FUNCTION__, config_path);
+                 __func__, config_path);
       return -1;
     }
   *description = entity_text (child);
@@ -13668,7 +13668,7 @@ get_feed_info_parse (entity_t entity, const gchar *config_path,
   child = entity_child (entity, "version");
   if (child == NULL)
     {
-      g_warning ("%s: Missing version in '%s'", __FUNCTION__, config_path);
+      g_warning ("%s: Missing version in '%s'", __func__, config_path);
       return -1;
     }
   *version = entity_text (child);
@@ -13702,7 +13702,7 @@ get_feed_info (int feed_type, gchar **feed_name, gchar **feed_version,
                                    : GVM_CERT_DATA_DIR,
                                   "feed.xml",
                                   NULL);
-  g_debug ("%s: config_path: %s", __FUNCTION__, config_path);
+  g_debug ("%s: config_path: %s", __func__, config_path);
 
   /* Read the file in. */
 
@@ -13711,7 +13711,7 @@ get_feed_info (int feed_type, gchar **feed_name, gchar **feed_version,
   if (error)
     {
       g_warning ("%s: Failed to read '%s': %s",
-                  __FUNCTION__,
+                  __func__,
                  config_path,
                  error->message);
       g_error_free (error);
@@ -13723,7 +13723,7 @@ get_feed_info (int feed_type, gchar **feed_name, gchar **feed_version,
 
   if (parse_entity (xml, &entity))
     {
-      g_warning ("%s: Failed to parse '%s'", __FUNCTION__, config_path);
+      g_warning ("%s: Failed to parse '%s'", __func__, config_path);
       g_free (config_path);
       return -1;
     }
@@ -13794,7 +13794,7 @@ get_feed (gmp_parser_t *gmp_parser, GError **error, int feed_type)
                    /* "-rw-r--r--" */
                    S_IWUSR | S_IRUSR | S_IROTH | S_IRGRP);
   if (lockfile == -1)
-    g_warning ("%s: failed to open lock file '%s': %s", __FUNCTION__,
+    g_warning ("%s: failed to open lock file '%s': %s", __func__,
                lockfile_name, strerror (errno));
   else
     {
@@ -13819,7 +13819,7 @@ get_feed (gmp_parser_t *gmp_parser, GError **error, int feed_type)
                     }
                   else
                     {
-                      g_warning ("%s: %s", __FUNCTION__, file_error->message);
+                      g_warning ("%s: %s", __func__, file_error->message);
                       g_error_free (file_error);
                     }
                 }
@@ -13838,7 +13838,7 @@ get_feed (gmp_parser_t *gmp_parser, GError **error, int feed_type)
                 }
             }
           else
-            g_warning ("%s: flock: %s", __FUNCTION__, strerror (errno));
+            g_warning ("%s: flock: %s", __func__, strerror (errno));
         }
       else
         /* Got the lock, so no sync is in progress. */
@@ -13846,7 +13846,7 @@ get_feed (gmp_parser_t *gmp_parser, GError **error, int feed_type)
     }
 
   if (close (lockfile))
-    g_warning ("%s: failed to close lock file '%s': %s", __FUNCTION__,
+    g_warning ("%s: failed to close lock file '%s': %s", __func__,
                lockfile_name, strerror (errno));
 
   g_free (lockfile_name);
@@ -18263,7 +18263,7 @@ get_task_schedule_xml (task_t task)
                                             "get_schedules"))
             g_error ("%s: GET_TASKS: error finding"
                       " task schedule, aborting",
-                      __FUNCTION__);
+                      __func__);
           schedule_available = (found > 0);
         }
     }
@@ -18537,7 +18537,7 @@ handle_get_tasks (gmp_parser_t *gmp_parser, GError **error)
               if (report_timestamp (current_report_id, &timestamp))
                 g_error ("%s: GET_TASKS: error getting timestamp"
                          " of report, aborting",
-                         __FUNCTION__);
+                         __func__);
 
               scan_start = scan_start_time_uuid (current_report_id),
               scan_end = scan_end_time_uuid (current_report_id),
@@ -18578,7 +18578,7 @@ handle_get_tasks (gmp_parser_t *gmp_parser, GError **error)
                                  0, min_qod))
                 g_error ("%s: GET_TASKS: error getting counts for"
                          " first report, aborting",
-                         __FUNCTION__);
+                         __func__);
             }
 
           second_last_report_id = task_second_last_report_id (index);
@@ -18596,7 +18596,7 @@ handle_get_tasks (gmp_parser_t *gmp_parser, GError **error)
                                     0, min_qod))
                 g_error ("%s: GET_TASKS: error getting counts for"
                          " second report, aborting",
-                         __FUNCTION__);
+                         __func__);
             }
 
           last_report_id = task_iterator_last_report (&tasks);
@@ -18608,7 +18608,7 @@ handle_get_tasks (gmp_parser_t *gmp_parser, GError **error)
               if (report_timestamp (last_report_id, &timestamp))
                 g_error ("%s: GET_TASKS: error getting timestamp for"
                          " last report, aborting",
-                         __FUNCTION__);
+                         __func__);
 
               scan_start = scan_start_time_uuid (last_report_id);
               scan_end = scan_end_time_uuid (last_report_id);
@@ -18650,7 +18650,7 @@ handle_get_tasks (gmp_parser_t *gmp_parser, GError **error)
                         0, min_qod))
                     g_error ("%s: GET_TASKS: error getting counts for"
                              " last report, aborting",
-                             __FUNCTION__);
+                             __func__);
                 }
               else
                 {
@@ -18663,7 +18663,7 @@ handle_get_tasks (gmp_parser_t *gmp_parser, GError **error)
               if (report_timestamp (last_report_id, &timestamp))
                 g_error ("%s: GET_TASKS: error getting timestamp for"
                          " last report, aborting",
-                         __FUNCTION__);
+                         __func__);
 
               scan_start = scan_start_time_uuid (last_report_id);
               scan_end = scan_end_time_uuid (last_report_id);
@@ -18761,7 +18761,7 @@ handle_get_tasks (gmp_parser_t *gmp_parser, GError **error)
                                                 "get_targets"))
                 g_error ("%s: GET_TASKS: error finding task target,"
                          " aborting",
-                         __FUNCTION__);
+                         __func__);
               target_available = (found > 0);
             }
           else
@@ -18780,7 +18780,7 @@ handle_get_tasks (gmp_parser_t *gmp_parser, GError **error)
                                               "get_configs"))
                 g_error ("%s: GET_TASKS: error finding task config,"
                          " aborting",
-                         __FUNCTION__);
+                         __func__);
               config_available = (found > 0);
             }
           scanner_available = 1;
@@ -18802,7 +18802,7 @@ handle_get_tasks (gmp_parser_t *gmp_parser, GError **error)
                       (task_scanner_uuid, &found, "get_scanners"))
                     g_error ("%s: GET_TASKS: error finding"
                              " task scanner, aborting",
-                             __FUNCTION__);
+                             __func__);
                   scanner_available = (found > 0);
                 }
             }

--- a/src/gmp_tickets.c
+++ b/src/gmp_tickets.c
@@ -228,7 +228,7 @@ get_tickets_run (gmp_parser_t *gmp_parser, GError **error)
           if (report_timestamp (ticket_iterator_report_id (&tickets),
                                 &timestamp))
             g_error ("%s: error getting timestamp of report, aborting",
-                     __FUNCTION__);
+                     __func__);
 
           SENDF_TO_CLIENT_OR_FAIL ("<report id=\"%s\">"
                                    "<timestamp>%s</timestamp>"
@@ -271,7 +271,7 @@ get_tickets_run (gmp_parser_t *gmp_parser, GError **error)
                                     &timestamp))
                 g_error ("%s: error getting timestamp of verified report,"
                          " aborting",
-                         __FUNCTION__);
+                         __func__);
 
               SENDF_TO_CLIENT_OR_FAIL ("<fix_verified_report>"
                                        "<report id=\"%s\">"

--- a/src/gmp_tls_certificates.c
+++ b/src/gmp_tls_certificates.c
@@ -883,7 +883,7 @@ tls_certificate_origin_extra_xml (const char *origin_type,
       report = 0;
       if (find_report_with_permission (origin_id, &report, "get_reports"))
         {
-          g_warning ("%s : error getting report", __FUNCTION__);
+          g_warning ("%s : error getting report", __func__);
         }
 
       if (report)
@@ -899,7 +899,7 @@ tls_certificate_origin_extra_xml (const char *origin_type,
           task = 0;
           if (report_task (report, &task))
             {
-              g_warning ("%s : error getting report task", __FUNCTION__);
+              g_warning ("%s : error getting report task", __func__);
             }
 
           if (task)

--- a/src/gmpd.c
+++ b/src/gmpd.c
@@ -146,7 +146,7 @@ read_from_client_unix (int client_socket)
             /* Interrupted, try read again. */
             continue;
           g_warning ("%s: failed to read from client: %s",
-                     __FUNCTION__, strerror (errno));
+                     __func__, strerror (errno));
           return -1;
         }
       if (count == 0)
@@ -208,10 +208,10 @@ read_from_client_tls (gnutls_session_t* client_session)
               int alert = gnutls_alert_get (*client_session);
               const char* alert_name = gnutls_alert_get_name (alert);
               g_warning ("%s: TLS Alert %d: %s",
-                         __FUNCTION__, alert, alert_name);
+                         __func__, alert, alert_name);
             }
           g_warning ("%s: failed to read from client: %s",
-                     __FUNCTION__, gnutls_strerror ((int) count));
+                     __func__, gnutls_strerror ((int) count));
           return -1;
         }
       if (count == 0)
@@ -280,7 +280,7 @@ write_to_client_tls (gnutls_session_t* client_session)
             /** @todo Rehandshake. */
             continue;
           g_warning ("%s: failed to write to client: %s",
-                     __FUNCTION__,
+                     __func__,
                      gnutls_strerror ((int) count));
           return -1;
         }
@@ -319,7 +319,7 @@ write_to_client_unix (int client_socket)
             /* Interrupted, try write again. */
             continue;
           g_warning ("%s: failed to write to client: %s",
-                     __FUNCTION__,
+                     __func__,
                      strerror (errno));
           return -1;
         }
@@ -377,7 +377,7 @@ gmpd_send_to_client (const char* msg, void* write_to_client_data)
             break;
           case -1:      /* Error. */
             g_debug ("   %s full (%i < %zu); client write failed",
-                    __FUNCTION__,
+                    __func__,
                     ((buffer_size_t) TO_CLIENT_BUFFER_SIZE) - to_client_end,
                     strlen (msg));
             return TRUE;
@@ -500,7 +500,7 @@ serve_gmp (gvm_connection_t *client_connection, const gchar *database,
       if (termination_signal)
         {
           g_debug ("%s: Received %s signal.",
-                   __FUNCTION__,
+                   __func__,
                    sys_siglist[get_termination_signal()]);
 
           goto client_free;
@@ -546,7 +546,7 @@ serve_gmp (gvm_connection_t *client_connection, const gchar *database,
         continue;
       if (ret < 0)
         {
-          g_warning ("%s: child select failed: %s", __FUNCTION__,
+          g_warning ("%s: child select failed: %s", __func__,
                      strerror (errno));
           rc = -1;
           goto client_free;

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -313,13 +313,13 @@ option_lock (lockfile_t *lockfile_checking)
 
   if (lockfile_lock_shared_nb (&lockfile_helping, "gvm-helping"))
     {
-      g_critical ("%s: Error getting helping lock", __FUNCTION__);
+      g_critical ("%s: Error getting helping lock", __func__);
       return -1;
     }
 
   if (lockfile_unlock (lockfile_checking))
     {
-      g_critical ("%s: Error releasing checking lock", __FUNCTION__);
+      g_critical ("%s: Error releasing checking lock", __func__);
       return -1;
     }
 
@@ -405,7 +405,7 @@ watch_client_connection (void* data)
         {
           if (watcher_data->connection_closed == 0)
             {
-              g_debug ("%s: Client connection closed", __FUNCTION__);
+              g_debug ("%s: Client connection closed", __func__);
               sql_cancel ();
               active = 0;
               watcher_data->connection_closed = 1;
@@ -444,7 +444,7 @@ serve_client (int server_socket, gvm_connection_t *client_connection)
                       &optval, sizeof (int)))
         {
           g_critical ("%s: failed to set SO_KEEPALIVE on scanner socket: %s",
-                      __FUNCTION__,
+                      __func__,
                       strerror (errno));
           exit (EXIT_FAILURE);
         }
@@ -465,7 +465,7 @@ serve_client (int server_socket, gvm_connection_t *client_connection)
       && gvm_server_attach (client_connection->socket, &client_session))
     {
       g_debug ("%s: failed to attach client session to socket %i",
-               __FUNCTION__,
+               __func__,
               client_connection->socket);
       goto fail;
     }
@@ -475,7 +475,7 @@ serve_client (int server_socket, gvm_connection_t *client_connection)
   if (fcntl (client_connection->socket, F_SETFL, O_NONBLOCK) == -1)
     {
       g_warning ("%s: failed to set real client socket flag: %s",
-                 __FUNCTION__,
+                 __func__,
                  strerror (errno));
       goto fail;
     }
@@ -550,7 +550,7 @@ accept_and_maybe_fork (int server_socket, sigset_t *sigmask_current)
         /* The connection is gone, return to select. */
         return;
       g_critical ("%s: failed to accept client connection: %s",
-                  __FUNCTION__,
+                  __func__,
                   strerror (errno));
       exit (EXIT_FAILURE);
     }
@@ -580,7 +580,7 @@ accept_and_maybe_fork (int server_socket, sigset_t *sigmask_current)
           if (sigaction (SIGCHLD, &action, NULL) == -1)
             {
               g_critical ("%s: failed to set client SIGCHLD handler: %s",
-                          __FUNCTION__,
+                          __func__,
                           strerror (errno));
               shutdown (client_socket, SHUT_RDWR);
               close (client_socket);
@@ -593,7 +593,7 @@ accept_and_maybe_fork (int server_socket, sigset_t *sigmask_current)
           if (fcntl (client_socket, F_SETFL, O_NONBLOCK) == -1)
             {
               g_critical ("%s: failed to set client socket flag: %s",
-                          __FUNCTION__,
+                          __func__,
                           strerror (errno));
               shutdown (client_socket, SHUT_RDWR);
               close (client_socket);
@@ -612,7 +612,7 @@ accept_and_maybe_fork (int server_socket, sigset_t *sigmask_current)
       case -1:
         /* Parent when error, return to select. */
         g_warning ("%s: failed to fork child: %s",
-                   __FUNCTION__,
+                   __func__,
                    strerror (errno));
         close (client_socket);
         break;
@@ -656,13 +656,13 @@ fork_connection_internal (gvm_connection_t *client_connection,
 
       case -1:
         /* Parent when error. */
-        g_warning ("%s: fork: %s", __FUNCTION__, strerror (errno));
+        g_warning ("%s: fork: %s", __func__, strerror (errno));
         return -1;
         break;
 
       default:
         /* Parent.  Return to caller. */
-        g_debug ("%s: %i forked %i", __FUNCTION__, getpid (), pid);
+        g_debug ("%s: %i forked %i", __func__, getpid (), pid);
         return pid;
         break;
     }
@@ -679,7 +679,7 @@ fork_connection_internal (gvm_connection_t *client_connection,
   /* Create a connected pair of sockets. */
   if (socketpair (AF_UNIX, SOCK_STREAM, 0, sockets))
     {
-      g_warning ("%s: socketpair: %s", __FUNCTION__, strerror (errno));
+      g_warning ("%s: socketpair: %s", __func__, strerror (errno));
       exit (EXIT_FAILURE);
     }
 
@@ -704,7 +704,7 @@ fork_connection_internal (gvm_connection_t *client_connection,
         if (sigaction (SIGCHLD, &action, NULL) == -1)
           {
             g_critical ("%s: failed to set client SIGCHLD handler: %s",
-                        __FUNCTION__,
+                        __func__,
                         strerror (errno));
             shutdown (parent_client_socket, SHUT_RDWR);
             close (parent_client_socket);
@@ -717,7 +717,7 @@ fork_connection_internal (gvm_connection_t *client_connection,
         if (fcntl (parent_client_socket, F_SETFL, O_NONBLOCK) == -1)
           {
             g_critical ("%s: failed to set client socket flag: %s",
-                        __FUNCTION__,
+                        __func__,
                         strerror (errno));
             shutdown (parent_client_socket, SHUT_RDWR);
             close (parent_client_socket);
@@ -751,7 +751,7 @@ fork_connection_internal (gvm_connection_t *client_connection,
                                 &client_credentials))
               {
                 g_critical ("%s: client server initialisation failed",
-                            __FUNCTION__);
+                            __func__);
                 exit (EXIT_FAILURE);
               }
             set_gnutls_priority (&client_session, priorities_option);
@@ -763,7 +763,7 @@ fork_connection_internal (gvm_connection_t *client_connection,
         /* Serve client. */
 
         g_debug ("%s: serving GMP to client on socket %i",
-                 __FUNCTION__, parent_client_socket);
+                 __func__, parent_client_socket);
 
         memset (client_connection, 0, sizeof (*client_connection));
         client_connection->tls = use_tls;
@@ -778,14 +778,14 @@ fork_connection_internal (gvm_connection_t *client_connection,
       case -1:
         /* Parent when error. */
 
-        g_warning ("%s: fork: %s", __FUNCTION__, strerror (errno));
+        g_warning ("%s: fork: %s", __func__, strerror (errno));
         exit (EXIT_FAILURE);
         break;
 
       default:
         /* Parent.  */
 
-        g_debug ("%s: %i forked %i", __FUNCTION__, getpid (), pid);
+        g_debug ("%s: %i forked %i", __func__, getpid (), pid);
 
         proctitle_set ("gvmd: Requesting GMP internally");
 
@@ -816,7 +816,7 @@ fork_connection_internal (gvm_connection_t *client_connection,
           }
 
         g_debug ("%s: all set to request GMP on socket %i",
-                 __FUNCTION__, client_connection->socket);
+                 __func__, client_connection->socket);
 
         return 0;
         break;
@@ -888,7 +888,7 @@ cleanup ()
     {
       if (fclose (log_stream))
         g_critical ("%s: failed to close log stream: %s",
-                    __FUNCTION__,
+                    __func__,
                     strerror (errno));
     }
 #endif /* LOG */
@@ -922,7 +922,7 @@ setup_signal_handler (int signal, void (*handler) (int), int block)
   if (sigaction (signal, &action, NULL) == -1)
     {
       g_critical ("%s: failed to register %s handler",
-                  __FUNCTION__, sys_siglist[signal]);
+                  __func__, sys_siglist[signal]);
       exit (EXIT_FAILURE);
     }
 }
@@ -953,7 +953,7 @@ setup_signal_handler_info (int signal,
   if (sigaction (signal, &action, NULL) == -1)
     {
       g_critical ("%s: failed to register %s handler",
-                  __FUNCTION__, sys_siglist[signal]);
+                  __func__, sys_siglist[signal]);
       exit (EXIT_FAILURE);
     }
 }
@@ -1121,7 +1121,7 @@ update_nvt_cache_retry ()
             exit (update_nvt_cache_osp (osp_update_socket));
           else
             {
-              g_warning ("%s: No OSP VT update socket set", __FUNCTION__);
+              g_warning ("%s: No OSP VT update socket set", __func__);
               exit (EXIT_FAILURE);
             }
         }
@@ -1144,7 +1144,7 @@ fork_update_nvt_cache ()
   if (update_in_progress)
     {
       g_debug ("%s: Update skipped because an update is in progress",
-              __FUNCTION__);
+              __func__);
       return 1;
     }
 
@@ -1153,12 +1153,12 @@ fork_update_nvt_cache ()
   /* Block SIGCHLD until parent records the value of the child PID. */
   if (sigemptyset (&sigmask_all))
     {
-      g_critical ("%s: Error emptying signal set", __FUNCTION__);
+      g_critical ("%s: Error emptying signal set", __func__);
       return -1;
     }
   if (pthread_sigmask (SIG_BLOCK, &sigmask_all, &sigmask_current))
     {
-      g_critical ("%s: Error setting signal mask", __FUNCTION__);
+      g_critical ("%s: Error setting signal mask", __func__);
       return -1;
     }
 
@@ -1191,18 +1191,18 @@ fork_update_nvt_cache ()
 
       case -1:
         /* Parent when error. */
-        g_warning ("%s: fork: %s", __FUNCTION__, strerror (errno));
+        g_warning ("%s: fork: %s", __func__, strerror (errno));
         update_in_progress = 0;
         if (pthread_sigmask (SIG_SETMASK, &sigmask_current, NULL))
-          g_warning ("%s: Error resetting signal mask", __FUNCTION__);
+          g_warning ("%s: Error resetting signal mask", __func__);
         return -1;
 
       default:
         /* Parent.  Unblock signals and continue. */
-        g_debug ("%s: %i forked %i", __FUNCTION__, getpid (), pid);
+        g_debug ("%s: %i forked %i", __func__, getpid (), pid);
         update_in_progress = pid;
         if (pthread_sigmask (SIG_SETMASK, &sigmask_current, NULL))
-          g_warning ("%s: Error resetting signal mask", __FUNCTION__);
+          g_warning ("%s: Error resetting signal mask", __func__);
         return 0;
     }
 }
@@ -1227,12 +1227,12 @@ serve_and_schedule ()
 
   if (sigfillset (&sigmask_all))
     {
-      g_critical ("%s: Error filling signal set", __FUNCTION__);
+      g_critical ("%s: Error filling signal set", __func__);
       exit (EXIT_FAILURE);
     }
   if (pthread_sigmask (SIG_BLOCK, &sigmask_all, &sigmask_current))
     {
-      g_critical ("%s: Error setting signal mask", __FUNCTION__);
+      g_critical ("%s: Error setting signal mask", __func__);
       exit (EXIT_FAILURE);
     }
   sigmask_normal = &sigmask_current;
@@ -1274,7 +1274,7 @@ serve_and_schedule ()
             case 0:
               last_schedule_time = time (NULL);
               g_debug ("%s: last_schedule_time: %li",
-                       __FUNCTION__, last_schedule_time);
+                       __func__, last_schedule_time);
               break;
             case 1:
               break;
@@ -1299,7 +1299,7 @@ serve_and_schedule ()
           if (errno == EINTR)
             continue;
           g_critical ("%s: select failed: %s",
-                      __FUNCTION__,
+                      __func__,
                       strerror (errno));
           exit (EXIT_FAILURE);
         }
@@ -1309,12 +1309,12 @@ serve_and_schedule ()
           /* Have an incoming connection. */
           if (FD_ISSET (manager_socket, &exceptfds))
             {
-              g_critical ("%s: exception in select", __FUNCTION__);
+              g_critical ("%s: exception in select", __func__);
               exit (EXIT_FAILURE);
             }
           if ((manager_socket_2 > -1) && FD_ISSET (manager_socket_2, &exceptfds))
             {
-              g_critical ("%s: exception in select (2)", __FUNCTION__);
+              g_critical ("%s: exception in select (2)", __func__);
               exit (EXIT_FAILURE);
             }
           if (FD_ISSET (manager_socket, &readfds))
@@ -1330,7 +1330,7 @@ serve_and_schedule ()
             case 0:
               last_schedule_time = time (NULL);
               g_debug ("%s: last_schedule_time 2: %li",
-                       __FUNCTION__, last_schedule_time);
+                       __func__, last_schedule_time);
               break;
             case 1:
               break;
@@ -1383,7 +1383,7 @@ manager_listen (const char *address_str_unix, const char *address_str_tls,
   memset (&address_tls, 0, sizeof (struct sockaddr_storage));
   memset (&address_unix, 0, sizeof (struct sockaddr_un));
 
-  g_debug ("%s: address_str_unix: %s", __FUNCTION__, address_str_unix);
+  g_debug ("%s: address_str_unix: %s", __func__, address_str_unix);
   if (address_str_unix)
     {
       struct stat state;
@@ -1396,7 +1396,7 @@ manager_listen (const char *address_str_unix, const char *address_str_tls,
                sizeof (address_unix.sun_path) - 1);
 
       g_debug ("%s: address_unix.sun_path: %s",
-               __FUNCTION__,
+               __func__,
                address_unix.sun_path);
 
       *soc = socket (AF_UNIX, SOCK_STREAM, 0);
@@ -1512,12 +1512,12 @@ manager_listen (const char *address_str_unix, const char *address_str_tls,
           passwd = getpwnam (socket_owner);
           if (passwd == NULL)
             {
-              g_warning ("%s: User %s not found.", __FUNCTION__, socket_owner);
+              g_warning ("%s: User %s not found.", __func__, socket_owner);
               return -1;
             }
           if (chown (address_str_unix, passwd->pw_uid, -1) == -1)
             {
-              g_warning ("%s: chown: %s", __FUNCTION__, strerror (errno));
+              g_warning ("%s: chown: %s", __func__, strerror (errno));
               return -1;
             }
         }
@@ -1529,12 +1529,12 @@ manager_listen (const char *address_str_unix, const char *address_str_tls,
           group = getgrnam (socket_group);
           if (group == NULL)
             {
-              g_warning ("%s: Group %s not found.", __FUNCTION__, socket_group);
+              g_warning ("%s: Group %s not found.", __func__, socket_group);
               return -1;
             }
           if (chown (address_str_unix, -1, group->gr_gid) == -1)
             {
-              g_warning ("%s: chown: %s", __FUNCTION__, strerror (errno));
+              g_warning ("%s: chown: %s", __func__, strerror (errno));
               return -1;
             }
         }
@@ -1544,12 +1544,12 @@ manager_listen (const char *address_str_unix, const char *address_str_tls,
       omode = strtol (socket_mode, 0, 8);
       if (omode <= 0 || omode > 4095)
         {
-          g_warning ("%s: Erroneous --listen-mode value", __FUNCTION__);
+          g_warning ("%s: Erroneous --listen-mode value", __func__);
           return -1;
         }
       if (chmod (address_str_unix, omode) == -1)
         {
-          g_warning ("%s: chmod: %s", __FUNCTION__, strerror (errno));
+          g_warning ("%s: chmod: %s", __func__, strerror (errno));
           return -1;
         }
     }
@@ -1892,7 +1892,7 @@ gvmd (int argc, char** argv)
   if (!g_option_context_parse (option_context, &argc, &argv, &error))
     {
       g_option_context_free (option_context);
-      g_critical ("%s: g_option_context_parse: %s", __FUNCTION__,
+      g_critical ("%s: g_option_context_parse: %s", __func__,
                   error->message);
       exit (EXIT_FAILURE);
     }
@@ -1951,7 +1951,7 @@ gvmd (int argc, char** argv)
       if (manager_address_string || manager_address_string_2)
         {
           g_critical ("%s: --listen or --listen2 given with --unix-socket",
-                      __FUNCTION__);
+                      __func__);
           return EXIT_FAILURE;
         }
     }
@@ -1960,7 +1960,7 @@ gvmd (int argc, char** argv)
       && (manager_port_string || manager_port_string_2))
     {
       g_critical ("%s: --port or --port2 given when listening on UNIX socket",
-                  __FUNCTION__);
+                  __func__);
       return EXIT_FAILURE;
     }
 
@@ -1977,10 +1977,10 @@ gvmd (int argc, char** argv)
 
   if (migrate_database
       && manage_migrate_needs_timezone (log_config, database))
-    g_info ("%s: leaving TZ as is, for migrator", __FUNCTION__);
+    g_info ("%s: leaving TZ as is, for migrator", __func__);
   else if (setenv ("TZ", "utc 0", 1) == -1)
     {
-      g_critical ("%s: failed to set timezone", __FUNCTION__);
+      g_critical ("%s: failed to set timezone", __func__);
       exit (EXIT_FAILURE);
     }
   tzset ();
@@ -2071,11 +2071,11 @@ gvmd (int argc, char** argv)
       case 0:
         break;
       case 1:
-        g_warning ("%s: Another process is busy starting up", __FUNCTION__);
+        g_warning ("%s: Another process is busy starting up", __func__);
         return EXIT_FAILURE;
       case -1:
       default:
-        g_critical ("%s: Error trying to get checking lock", __FUNCTION__);
+        g_critical ("%s: Error trying to get checking lock", __func__);
         return EXIT_FAILURE;
     }
 
@@ -2089,11 +2089,11 @@ gvmd (int argc, char** argv)
         {
           case 1:
             g_warning ("%s: Main process is running, refusing to migrate",
-                       __FUNCTION__);
+                       __func__);
             return EXIT_FAILURE;
           case -1:
             g_warning ("%s: Error checking serving lock",
-                       __FUNCTION__);
+                       __func__);
             return EXIT_FAILURE;
         }
 
@@ -2101,27 +2101,27 @@ gvmd (int argc, char** argv)
         {
           case 1:
             g_warning ("%s: An option process is running, refusing to migrate",
-                       __FUNCTION__);
+                       __func__);
             return EXIT_FAILURE;
           case -1:
             g_warning ("%s: Error checking helping lock",
-                       __FUNCTION__);
+                       __func__);
             return EXIT_FAILURE;
         }
 
       switch (lockfile_lock_nb (&lockfile_migrating, "gvm-migrating"))
         {
           case 1:
-            g_warning ("%s: A migrate is already running", __FUNCTION__);
+            g_warning ("%s: A migrate is already running", __func__);
             return EXIT_FAILURE;
           case -1:
-            g_critical ("%s: Error getting migrating lock", __FUNCTION__);
+            g_critical ("%s: Error getting migrating lock", __func__);
             return EXIT_FAILURE;
         }
 
       if (lockfile_unlock (&lockfile_checking))
         {
-          g_critical ("%s: Error releasing checking lock", __FUNCTION__);
+          g_critical ("%s: Error releasing checking lock", __func__);
           return EXIT_FAILURE;
         }
 
@@ -2136,36 +2136,36 @@ gvmd (int argc, char** argv)
             return EXIT_SUCCESS;
           case 1:
             g_warning ("%s: databases are already at the supported version",
-                       __FUNCTION__);
+                       __func__);
             return EXIT_SUCCESS;
           case 2:
             g_warning ("%s: database migration too hard",
-                       __FUNCTION__);
+                       __func__);
             return EXIT_FAILURE;
           case 11:
             g_warning ("%s: cannot migrate SCAP database",
-                       __FUNCTION__);
+                       __func__);
             return EXIT_FAILURE;
           case 12:
             g_warning ("%s: cannot migrate CERT database",
-                       __FUNCTION__);
+                       __func__);
             return EXIT_FAILURE;
           case -1:
             g_critical ("%s: database migration failed",
-                        __FUNCTION__);
+                        __func__);
             return EXIT_FAILURE;
           case -11:
             g_critical ("%s: SCAP database migration failed",
-                        __FUNCTION__);
+                        __func__);
             return EXIT_FAILURE;
           case -12:
             g_critical ("%s: CERT database migration failed",
-                        __FUNCTION__);
+                        __func__);
             return EXIT_FAILURE;
           default:
             assert (0);
             g_critical ("%s: strange return from manage_migrate",
-                        __FUNCTION__);
+                        __func__);
             return EXIT_FAILURE;
         }
     }
@@ -2175,7 +2175,7 @@ gvmd (int argc, char** argv)
 
   if (lockfile_locked ("gvm-migrating"))
     {
-      g_warning ("%s: A migrate is in progress", __FUNCTION__);
+      g_warning ("%s: A migrate is in progress", __func__);
       return EXIT_FAILURE;
     }
 
@@ -2197,7 +2197,7 @@ gvmd (int argc, char** argv)
                                           NULL);
       if (g_file_test (password_policy, G_FILE_TEST_EXISTS) == FALSE)
         g_warning ("%s: password policy missing: %s",
-                   __FUNCTION__,
+                   __func__,
                    password_policy);
       g_free (password_policy);
     }
@@ -2489,7 +2489,7 @@ gvmd (int argc, char** argv)
 
   if (lockfile_locked ("gvm-helping"))
     {
-      g_warning ("%s: An option process is running", __FUNCTION__);
+      g_warning ("%s: An option process is running", __func__);
       return EXIT_FAILURE;
     }
 
@@ -2498,11 +2498,11 @@ gvmd (int argc, char** argv)
       case 0:
         break;
       case 1:
-        g_warning ("%s: Main process is already running", __FUNCTION__);
+        g_warning ("%s: Main process is already running", __func__);
         return EXIT_FAILURE;
       case -1:
       default:
-        g_critical ("%s: Error trying to get serving lock", __FUNCTION__);
+        g_critical ("%s: Error trying to get serving lock", __func__);
         return EXIT_FAILURE;
     }
 
@@ -2518,7 +2518,7 @@ gvmd (int argc, char** argv)
           case -1:
             /* Parent when error. */
             g_critical ("%s: failed to fork into background: %s",
-                        __FUNCTION__,
+                        __func__,
                         strerror (errno));
             log_config_free ();
             exit (EXIT_FAILURE);
@@ -2541,14 +2541,14 @@ gvmd (int argc, char** argv)
       case 0:
         break;
       case -2:
-        g_critical ("%s: database is wrong version", __FUNCTION__);
+        g_critical ("%s: database is wrong version", __func__);
         log_config_free ();
         exit (EXIT_FAILURE);
         break;
       case -4:
         g_critical ("%s: --max-ips-per-target out of range"
                     " (min=1, max=%i, requested=%i)",
-                    __FUNCTION__,
+                    __func__,
                     MANAGE_ABSOLUTE_MAX_IPS_PER_TARGET,
                     max_ips_per_target);
         log_config_free ();
@@ -2556,7 +2556,7 @@ gvmd (int argc, char** argv)
         break;
       case -1:
       default:
-        g_critical ("%s: failed to initialise GMP daemon", __FUNCTION__);
+        g_critical ("%s: failed to initialise GMP daemon", __func__);
         log_config_free ();
         exit (EXIT_FAILURE);
     }
@@ -2565,7 +2565,7 @@ gvmd (int argc, char** argv)
 
   if (lockfile_unlock (&lockfile_checking))
     {
-      g_critical ("%s: Error releasing checking lock", __FUNCTION__);
+      g_critical ("%s: Error releasing checking lock", __func__);
       return EXIT_FAILURE;
     }
 
@@ -2574,7 +2574,7 @@ gvmd (int argc, char** argv)
   if (atexit (&cleanup))
     {
       g_critical ("%s: failed to register `atexit' cleanup function",
-                  __FUNCTION__);
+                  __func__);
       log_config_free ();
       exit (EXIT_FAILURE);
     }
@@ -2600,7 +2600,7 @@ gvmd (int argc, char** argv)
       == -1)
     {
       g_critical ("%s: failed to create log directory: %s",
-                  __FUNCTION__,
+                  __func__,
                   strerror (errno));
       exit (EXIT_FAILURE);
     }
@@ -2609,7 +2609,7 @@ gvmd (int argc, char** argv)
   if (log_stream == NULL)
     {
       g_critical ("%s: failed to open log file: %s",
-                  __FUNCTION__,
+                  __func__,
                   strerror (errno));
       exit (EXIT_FAILURE);
     }
@@ -2637,7 +2637,7 @@ gvmd (int argc, char** argv)
                           &client_credentials))
         {
           g_critical ("%s: client server initialisation failed",
-                      __FUNCTION__);
+                      __func__);
           exit (EXIT_FAILURE);
         }
       priorities_option = priorities;
@@ -2693,7 +2693,7 @@ gvmd (int argc, char** argv)
         {
           g_debug ("%s: Using OSP VT update socket from default OpenVAS"
                    " scanner: %s",
-                   __FUNCTION__,
+                   __func__,
                    default_socket);
           set_osp_vt_update_socket (default_socket);
         }
@@ -2702,7 +2702,7 @@ gvmd (int argc, char** argv)
           g_critical ("%s: No OSP VT update socket found."
                       " Use --osp-vt-update or change the 'OpenVAS Default'"
                       " scanner to use the main ospd-openvas socket.",
-                      __FUNCTION__);
+                      __func__);
           return EXIT_FAILURE;
         }
       free (default_socket);

--- a/src/lsc_user.c
+++ b/src/lsc_user.c
@@ -73,12 +73,12 @@ create_ssh_key (const char *comment, const char *passphrase,
 
   if (!comment || comment[0] == '\0')
     {
-      g_warning ("%s: comment must be set", __FUNCTION__);
+      g_warning ("%s: comment must be set", __func__);
       return -1;
     }
   if (!passphrase || strlen (passphrase) < 5)
     {
-      g_warning ("%s: password must be longer than 4 characters", __FUNCTION__);
+      g_warning ("%s: password must be longer than 4 characters", __func__);
       return -1;
     }
 
@@ -87,7 +87,7 @@ create_ssh_key (const char *comment, const char *passphrase,
   dir = g_path_get_dirname (privpath);
   if (g_mkdir_with_parents (dir, 0755 /* "rwxr-xr-x" */ ))
     {
-      g_warning ("%s: failed to access %s", __FUNCTION__, dir);
+      g_warning ("%s: failed to access %s", __func__, dir);
       g_free (dir);
       return -1;
     }
@@ -108,16 +108,16 @@ create_ssh_key (const char *comment, const char *passphrase,
       if (err)
         {
           g_warning ("%s: failed to create private key: %s",
-                     __FUNCTION__, err->message);
+                     __func__, err->message);
           g_error_free (err);
         }
       else
-        g_warning ("%s: failed to create private key", __FUNCTION__);
+        g_warning ("%s: failed to create private key", __func__);
       g_debug ("%s: key-gen failed with %d (WIF %i, WEX %i).\n",
-               __FUNCTION__, exit_status, WIFEXITED (exit_status),
+               __func__, exit_status, WIFEXITED (exit_status),
                WEXITSTATUS (exit_status));
-      g_debug ("%s: stdout: %s", __FUNCTION__, astdout);
-      g_debug ("%s: stderr: %s", __FUNCTION__, astderr);
+      g_debug ("%s: stdout: %s", __func__, astdout);
+      g_debug ("%s: stderr: %s", __func__, astderr);
       g_free (command);
       g_free (astdout);
       g_free (astderr);
@@ -201,21 +201,21 @@ lsc_user_rpm_create (const gchar *username,
 
   /* Create a temporary directory. */
 
-  g_debug ("%s: create temporary directory", __FUNCTION__);
+  g_debug ("%s: create temporary directory", __func__);
   if (mkdtemp (tmpdir) == NULL)
     return FALSE;
-  g_debug ("%s: temporary directory: %s", __FUNCTION__, tmpdir);
+  g_debug ("%s: temporary directory: %s", __func__, tmpdir);
 
   /* Copy the public key into the temporary directory. */
 
-  g_debug ("%s: copy key to temporary directory", __FUNCTION__);
+  g_debug ("%s: copy key to temporary directory", __func__);
   pubkey_basename = g_strdup_printf ("%s.pub", username);
   new_pubkey_filename = g_build_filename (tmpdir, pubkey_basename, NULL);
   if (gvm_file_copy (public_key_path, new_pubkey_filename)
       == FALSE)
     {
       g_warning ("%s: failed to copy key file %s to %s",
-                 __FUNCTION__, public_key_path, new_pubkey_filename);
+                 __func__, public_key_path, new_pubkey_filename);
       g_free (pubkey_basename);
       g_free (new_pubkey_filename);
       return FALSE;
@@ -224,7 +224,7 @@ lsc_user_rpm_create (const gchar *username,
   /* Execute create-rpm script with the temporary directory as the
    * target and the public key in the temporary directory as the key. */
 
-  g_debug ("%s: Attempting RPM build", __FUNCTION__);
+  g_debug ("%s: Attempting RPM build", __func__);
   cmd = (gchar **) g_malloc (6 * sizeof (gchar *));
   cmd[0] = g_build_filename (GVM_DATA_DIR,
                              "gvm-lsc-rpm-creator.sh",
@@ -235,7 +235,7 @@ lsc_user_rpm_create (const gchar *username,
   cmd[4] = g_strdup (to_filename);
   cmd[5] = NULL;
   g_debug ("%s: Spawning in %s: %s %s %s %s %s",
-           __FUNCTION__, tmpdir, cmd[0], cmd[1], cmd[2], cmd[3], cmd[4]);
+           __func__, tmpdir, cmd[0], cmd[1], cmd[2], cmd[3], cmd[4]);
   if ((g_spawn_sync (tmpdir,
                      cmd,
                      NULL,                  /* Environment. */
@@ -251,12 +251,12 @@ lsc_user_rpm_create (const gchar *username,
       || WEXITSTATUS (exit_status))
     {
       g_warning ("%s: failed to create the rpm: %d (WIF %i, WEX %i)",
-                 __FUNCTION__,
+                 __func__,
                  exit_status,
                  WIFEXITED (exit_status),
                  WEXITSTATUS (exit_status));
-      g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
-      g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);
+      g_debug ("%s: stdout: %s", __func__, standard_out);
+      g_debug ("%s: stderr: %s", __func__, standard_err);
       success = FALSE;
     }
 
@@ -276,7 +276,7 @@ lsc_user_rpm_create (const gchar *username,
   if (gvm_file_remove_recurse (tmpdir) != 0 && success == TRUE)
     {
       g_warning ("%s: failed to remove temporary directory %s",
-                 __FUNCTION__, tmpdir);
+                 __func__, tmpdir);
       success = FALSE;
     }
 
@@ -322,7 +322,7 @@ lsc_user_rpm_recreate (const gchar *name, const char *public_key,
   if (mkdtemp (rpm_dir) == NULL)
     goto free_exit;
   rpm_path = g_build_filename (rpm_dir, "p.rpm", NULL);
-  g_debug ("%s: rpm_path: %s", __FUNCTION__, rpm_path);
+  g_debug ("%s: rpm_path: %s", __func__, rpm_path);
   if (lsc_user_rpm_create (name, public_key_path, rpm_path) == FALSE)
     {
       g_free (rpm_path);
@@ -388,21 +388,21 @@ lsc_user_deb_create (const gchar *username,
 
   /* Create a temporary directory. */
 
-  g_debug ("%s: create temporary directory", __FUNCTION__);
+  g_debug ("%s: create temporary directory", __func__);
   if (mkdtemp (tmpdir) == NULL)
     return FALSE;
-  g_debug ("%s: temporary directory: %s", __FUNCTION__, tmpdir);
+  g_debug ("%s: temporary directory: %s", __func__, tmpdir);
 
   /* Copy the public key into the temporary directory. */
 
-  g_debug ("%s: copy key to temporary directory", __FUNCTION__);
+  g_debug ("%s: copy key to temporary directory", __func__);
   pubkey_basename = g_strdup_printf ("%s.pub", username);
   new_pubkey_filename = g_build_filename (tmpdir, pubkey_basename, NULL);
   if (gvm_file_copy (public_key_path, new_pubkey_filename)
       == FALSE)
     {
       g_warning ("%s: failed to copy key file %s to %s",
-                 __FUNCTION__, public_key_path, new_pubkey_filename);
+                 __func__, public_key_path, new_pubkey_filename);
       g_free (pubkey_basename);
       g_free (new_pubkey_filename);
       return FALSE;
@@ -411,7 +411,7 @@ lsc_user_deb_create (const gchar *username,
   /* Execute create-deb script with the temporary directory as the
    * target and the public key in the temporary directory as the key. */
 
-  g_debug ("%s: Attempting DEB build", __FUNCTION__);
+  g_debug ("%s: Attempting DEB build", __func__);
   cmd = (gchar **) g_malloc (7 * sizeof (gchar *));
   cmd[0] = g_build_filename (GVM_DATA_DIR,
                              "gvm-lsc-deb-creator.sh",
@@ -423,7 +423,7 @@ lsc_user_deb_create (const gchar *username,
   cmd[5] = g_strdup (maintainer);
   cmd[6] = NULL;
   g_debug ("%s: Spawning in %s: %s %s %s %s %s %s",
-           __FUNCTION__, tmpdir,
+           __func__, tmpdir,
            cmd[0], cmd[1], cmd[2], cmd[3], cmd[4], cmd[5]);
   if ((g_spawn_sync (tmpdir,
                      cmd,
@@ -440,12 +440,12 @@ lsc_user_deb_create (const gchar *username,
       || WEXITSTATUS (exit_status))
     {
       g_warning ("%s: failed to create the deb: %d (WIF %i, WEX %i)",
-                 __FUNCTION__,
+                 __func__,
                  exit_status,
                  WIFEXITED (exit_status),
                  WEXITSTATUS (exit_status));
-      g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
-      g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);
+      g_debug ("%s: stdout: %s", __func__, standard_out);
+      g_debug ("%s: stderr: %s", __func__, standard_err);
       success = FALSE;
     }
 
@@ -466,7 +466,7 @@ lsc_user_deb_create (const gchar *username,
   if (gvm_file_remove_recurse (tmpdir) != 0 && success == TRUE)
     {
       g_warning ("%s: failed to remove temporary directory %s",
-                 __FUNCTION__, tmpdir);
+                 __func__, tmpdir);
       success = FALSE;
     }
 
@@ -514,7 +514,7 @@ lsc_user_deb_recreate (const gchar *name, const char *public_key,
   if (mkdtemp (deb_dir) == NULL)
     goto free_exit;
   deb_path = g_build_filename (deb_dir, "p.deb", NULL);
-  g_debug ("%s: deb_path: %s", __FUNCTION__, deb_path);
+  g_debug ("%s: deb_path: %s", __func__, deb_path);
   if (lsc_user_deb_create (name, public_key_path, deb_path, maintainer)
         == FALSE)
     {
@@ -685,7 +685,7 @@ execute_makensis (const gchar *nsis_script)
   cmd[2] = NULL;
   g_debug ("--- executing makensis");
   g_debug ("%s: Spawning in %s: %s %s",
-           __FUNCTION__,
+           __func__,
            dirname, cmd[0], cmd[1]);
   if ((g_spawn_sync (dirname,
                      cmd,
@@ -701,12 +701,12 @@ execute_makensis (const gchar *nsis_script)
       || WEXITSTATUS (exit_status))
     {
       g_warning ("%s: failed to create the exe: %d (WIF %i, WEX %i)",
-                 __FUNCTION__,
+                 __func__,
                  exit_status,
                  WIFEXITED (exit_status),
                  WEXITSTATUS (exit_status));
-      g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
-      g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);
+      g_debug ("%s: stdout: %s", __func__, standard_out);
+      g_debug ("%s: stderr: %s", __func__, standard_err);
       ret = -1;
     }
 
@@ -740,14 +740,14 @@ lsc_user_exe_create (const gchar *user_name, const gchar *password,
 
   if (create_nsis_script (nsis_script, to_filename, user_name, password))
     {
-      g_warning ("%s: Failed to create NSIS script", __FUNCTION__);
+      g_warning ("%s: Failed to create NSIS script", __func__);
       g_free (nsis_script);
       return -1;
     }
 
   if (execute_makensis (nsis_script))
     {
-      g_warning ("%s: Failed to execute makensis", __FUNCTION__);
+      g_warning ("%s: Failed to execute makensis", __func__);
       g_free (nsis_script);
       return -1;
     }

--- a/src/manage.c
+++ b/src/manage.c
@@ -369,7 +369,7 @@ get_certificate_info (const gchar* certificate, gssize certificate_len,
             {
               g_warning ("%s: PEM encoded certificate expected if"
                          " certificate_length is negative",
-                         __FUNCTION__);
+                         __func__);
               return -1;
             }
 
@@ -901,7 +901,7 @@ severity_to_level (double severity, int mode)
   else
     {
       g_warning ("%s: Invalid severity score given: %f",
-                 __FUNCTION__, severity);
+                 __func__, severity);
       return (NULL);
     }
 }
@@ -929,7 +929,7 @@ severity_to_type (double severity)
   else
     {
       g_warning ("%s: Invalid severity score given: %f",
-                 __FUNCTION__, severity);
+                 __func__, severity);
       return (NULL);
     }
 }
@@ -1778,7 +1778,7 @@ slave_connect (gvm_connection_t *connection)
   if (connection->socket == -1)
     {
       g_warning ("%s: failed to open connection to %s on %i",
-                 __FUNCTION__,
+                 __func__,
                  connection->host_string,
                  connection->port);
       return -1;
@@ -1792,14 +1792,14 @@ slave_connect (gvm_connection_t *connection)
                     &optval, sizeof (int)))
       {
         g_warning ("%s: failed to set SO_KEEPALIVE on slave socket: %s",
-                   __FUNCTION__,
+                   __func__,
                    strerror (errno));
         gvm_connection_close (connection);
         return -1;
       }
   }
 
-  g_debug ("   %s: connected", __FUNCTION__);
+  g_debug ("   %s: connected", __func__);
 
   /* Authenticate using the slave login. */
 
@@ -1809,7 +1809,7 @@ slave_connect (gvm_connection_t *connection)
       return 1;
     }
 
-  g_debug ("   %s: authenticated", __FUNCTION__);
+  g_debug ("   %s: authenticated", __func__);
 
   return 0;
 }
@@ -1831,18 +1831,18 @@ slave_sleep_connect (gvm_connection_t *connection, task_t task)
           || (task_run_status (task) == TASK_STATUS_STOP_REQUESTED))
         {
           if (task_run_status (task) == TASK_STATUS_STOP_REQUESTED_GIVEUP)
-            g_debug ("   %s: task stopped for giveup", __FUNCTION__);
+            g_debug ("   %s: task stopped for giveup", __func__);
           else
-            g_debug ("   %s: task stopped", __FUNCTION__);
+            g_debug ("   %s: task stopped", __func__);
           set_task_run_status (current_scanner_task, TASK_STATUS_STOPPED);
           return 3;
         }
-      g_debug ("   %s: sleeping for %i", __FUNCTION__,
+      g_debug ("   %s: sleeping for %i", __func__,
                manage_slave_check_period ());
       gvm_sleep (manage_slave_check_period ());
     }
   while (slave_connect (connection));
-  g_debug ("   %s: connected", __FUNCTION__);
+  g_debug ("   %s: connected", __func__);
   return 0;
 }
 
@@ -2140,7 +2140,7 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
   if (atexit (&cleanup_slave))
     {
       g_critical ("%s: failed to register `atexit' slave_cleanup function",
-                  __FUNCTION__);
+                  __func__);
       goto fail;
     }
 
@@ -2204,7 +2204,7 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
                   global_slave_report_uuid = get_tasks_last_report (get_tasks);
                   if (global_slave_report_uuid == NULL)
                     {
-                      g_warning ("%s: slave report %s missing UUID", __FUNCTION__,
+                      g_warning ("%s: slave report %s missing UUID", __func__,
                                  global_slave_task_uuid);
                       goto fail;
                     }
@@ -2543,16 +2543,16 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
             }
         }
 
-      g_debug ("   %s: slave SSH credential uuid: %s", __FUNCTION__,
+      g_debug ("   %s: slave SSH credential uuid: %s", __func__,
                global_slave_ssh_credential_uuid);
 
-      g_debug ("   %s: slave SMB credential uuid: %s", __FUNCTION__,
+      g_debug ("   %s: slave SMB credential uuid: %s", __func__,
                global_slave_smb_credential_uuid);
 
-      g_debug ("   %s: slave ESXi credential uuid: %s", __FUNCTION__,
+      g_debug ("   %s: slave ESXi credential uuid: %s", __func__,
                global_slave_esxi_credential_uuid);
 
-      g_debug ("   %s: slave SNMP credential uuid: %s", __FUNCTION__,
+      g_debug ("   %s: slave SNMP credential uuid: %s", __func__,
                global_slave_snmp_credential_uuid);
 
       /* Create the target on the slave. */
@@ -2660,7 +2660,7 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
         }
 
       g_debug ("   %s: slave target uuid: %s",
-               __FUNCTION__,
+               __func__,
                global_slave_target_uuid);
 
       /* Create the config on the slave. */
@@ -2779,7 +2779,7 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
       }
 
       g_debug ("   %s: slave config uuid: %s",
-               __FUNCTION__,
+               __func__,
                global_slave_config_uuid);
 
       /* Create the task on the slave. */
@@ -2898,7 +2898,7 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
                                    TASK_STATUS_STOP_WAITING);
             break;
           case TASK_STATUS_STOP_REQUESTED_GIVEUP:
-            g_debug ("   %s: task stopped for giveup", __FUNCTION__);
+            g_debug ("   %s: task stopped for giveup", __func__);
             set_task_run_status (current_scanner_task, TASK_STATUS_STOPPED);
             goto giveup;
             break;
@@ -3061,7 +3061,7 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
 
       free_entity (get_tasks);
 
-      g_debug ("   %s: sleeping for %i\n", __FUNCTION__,
+      g_debug ("   %s: sleeping for %i\n", __func__,
                manage_slave_check_period ());
       gvm_sleep (manage_slave_check_period ());
     }
@@ -3120,7 +3120,7 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
   global_slave_ssh_credential_uuid = NULL;
   gvm_connection_close (connection);
   global_slave_connection = NULL;
-  g_debug ("   %s: succeed", __FUNCTION__);
+  g_debug ("   %s: succeed", __func__);
   return 0;
 
  fail_stop_task:
@@ -3169,13 +3169,13 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
                                    del_opts);
   free (global_slave_ssh_credential_uuid);
  fail:
-  g_debug ("   %s: fail (%i)", __FUNCTION__, ret_fail);
+  g_debug ("   %s: fail (%i)", __func__, ret_fail);
   gvm_connection_close (connection);
   global_slave_connection = NULL;
   return ret_fail;
 
  giveup:
-  g_debug ("   %s: giveup (%i)", __FUNCTION__, ret_giveup);
+  g_debug ("   %s: giveup (%i)", __func__, ret_giveup);
   gvm_connection_close (connection);
   global_slave_connection = NULL;
   return ret_giveup;
@@ -3231,7 +3231,7 @@ handle_slave_task (task_t task, target_t target,
   uuid = gvm_uuid_make ();
   if (uuid == NULL)
     {
-      g_warning ("%s: Failed to make UUID", __FUNCTION__);
+      g_warning ("%s: Failed to make UUID", __func__);
       return -1;
     }
 
@@ -3239,7 +3239,7 @@ handle_slave_task (task_t task, target_t target,
   if (name == NULL)
     {
       free (uuid);
-      g_warning ("%s: Failed to get task name", __FUNCTION__);
+      g_warning ("%s: Failed to get task name", __func__);
       return -2;
     }
   slave_task_name = g_strdup_printf ("%s for %s", uuid, name);
@@ -3280,7 +3280,7 @@ handle_slave_task (task_t task, target_t target,
             if (current_signal)
               {
                 g_debug ("%s: Received %s signal.",
-                         __FUNCTION__,
+                         __func__,
                          sys_siglist[get_termination_signal()]);
               }
             if (global_current_report)
@@ -3292,7 +3292,7 @@ handle_slave_task (task_t task, target_t target,
             g_free (slave_task_name);
             return 0;
           }
-        g_debug ("   %s: sleeping for %i\n", __FUNCTION__,
+        g_debug ("   %s: sleeping for %i\n", __func__,
                  manage_slave_check_period ());
         gvm_sleep (manage_slave_check_period ());
       }
@@ -3302,7 +3302,7 @@ handle_slave_task (task_t task, target_t target,
       if (get_termination_signal ())
         {
           g_debug ("%s: Received %s signal.",
-                   __FUNCTION__,
+                   __func__,
                    sys_siglist[get_termination_signal()]);
           if (global_current_report)
             {
@@ -3680,14 +3680,14 @@ get_osp_task_options (task_t task, target_t target)
       init_credential_iterator_one (&iter, cred);
       if (!next (&iter))
         {
-          g_warning ("%s: LSC Credential not found.", __FUNCTION__);
+          g_warning ("%s: LSC Credential not found.", __func__);
           g_hash_table_destroy (options);
           cleanup_iterator (&iter);
           return NULL;
         }
       if (credential_iterator_private_key (&iter))
         {
-          g_warning ("%s: LSC Credential not a user/pass pair.", __FUNCTION__);
+          g_warning ("%s: LSC Credential not a user/pass pair.", __func__);
           g_hash_table_destroy (options);
           cleanup_iterator (&iter);
           return NULL;
@@ -3763,7 +3763,7 @@ target_osp_ssh_credential (target_t target)
       init_credential_iterator_one (&iter, credential);
       if (!next (&iter))
         {
-          g_warning ("%s: SSH Credential not found.", __FUNCTION__);
+          g_warning ("%s: SSH Credential not found.", __func__);
           cleanup_iterator (&iter);
           return NULL;
         }
@@ -3771,7 +3771,7 @@ target_osp_ssh_credential (target_t target)
       if (strcmp (type, "up") && strcmp (type, "usk"))
         {
           g_warning ("%s: SSH Credential not a user/pass pair"
-                     " or user/ssh key.", __FUNCTION__);
+                     " or user/ssh key.", __func__);
           cleanup_iterator (&iter);
           return NULL;
         }
@@ -3821,13 +3821,13 @@ target_osp_smb_credential (target_t target)
       init_credential_iterator_one (&iter, credential);
       if (!next (&iter))
         {
-          g_warning ("%s: SMB Credential not found.", __FUNCTION__);
+          g_warning ("%s: SMB Credential not found.", __func__);
           cleanup_iterator (&iter);
           return NULL;
         }
       if (strcmp (credential_iterator_type (&iter), "up"))
         {
-          g_warning ("%s: SMB Credential not a user/pass pair.", __FUNCTION__);
+          g_warning ("%s: SMB Credential not a user/pass pair.", __func__);
           cleanup_iterator (&iter);
           return NULL;
         }
@@ -3865,14 +3865,14 @@ target_osp_esxi_credential (target_t target)
       init_credential_iterator_one (&iter, credential);
       if (!next (&iter))
         {
-          g_warning ("%s: ESXi Credential not found.", __FUNCTION__);
+          g_warning ("%s: ESXi Credential not found.", __func__);
           cleanup_iterator (&iter);
           return NULL;
         }
       if (strcmp (credential_iterator_type (&iter), "up"))
         {
           g_warning ("%s: ESXi Credential not a user/pass pair.",
-                     __FUNCTION__);
+                     __func__);
           cleanup_iterator (&iter);
           return NULL;
         }
@@ -3910,14 +3910,14 @@ target_osp_snmp_credential (target_t target)
       init_credential_iterator_one (&iter, credential);
       if (!next (&iter))
         {
-          g_warning ("%s: SNMP Credential not found.", __FUNCTION__);
+          g_warning ("%s: SNMP Credential not found.", __func__);
           cleanup_iterator (&iter);
           return NULL;
         }
       if (strcmp (credential_iterator_type (&iter), "snmp"))
         {
           g_warning ("%s: SNMP Credential not of type 'snmp'.",
-                     __FUNCTION__);
+                     __func__);
           cleanup_iterator (&iter);
           return NULL;
         }
@@ -4166,7 +4166,7 @@ fork_osp_scan_handler (task_t task, target_t target, char **report_id_return)
 
   if (create_current_report (task, &report_id, TASK_STATUS_REQUESTED))
     {
-      g_debug ("   %s: failed to create report", __FUNCTION__);
+      g_debug ("   %s: failed to create report", __func__);
       return -1;
     }
 
@@ -4180,7 +4180,7 @@ fork_osp_scan_handler (task_t task, target_t target, char **report_id_return)
         /* Parent, failed to fork. */
         global_current_report = 0;
         g_warning ("%s: Failed to fork: %s",
-                   __FUNCTION__,
+                   __func__,
                    strerror (errno));
         set_task_interrupted (task,
                               "Error forking scan handler."
@@ -4326,18 +4326,18 @@ cve_scan_host (task_t task, gvm_host_t *gvm_host)
   if (ip == NULL)
     ip = g_strdup (host);
 
-  g_debug ("%s: ip: %s", __FUNCTION__, ip);
+  g_debug ("%s: ip: %s", __func__, ip);
 
   /* Get the last report that applies to the host. */
 
   if (host_nthlast_report_host (ip, &report_host, 1))
     {
-      g_warning ("%s: Failed to get nthlast report", __FUNCTION__);
+      g_warning ("%s: Failed to get nthlast report", __func__);
       g_free (ip);
       return 1;
     }
 
-  g_debug ("%s: report_host: %llu", __FUNCTION__, report_host);
+  g_debug ("%s: report_host: %llu", __func__, report_host);
 
   if (report_host)
     {
@@ -4391,7 +4391,7 @@ cve_scan_host (task_t task, gvm_host_t *gvm_host)
                                        (&prognosis));
 
               g_debug ("%s: making result with severity %1.1f desc [%s]",
-                       __FUNCTION__, severity, desc);
+                       __func__, severity, desc);
 
               result = make_cve_result (task, ip, cve, severity, desc);
               g_free (desc);
@@ -4459,7 +4459,7 @@ fork_cve_scan_handler (task_t task, target_t target)
 
   if (create_current_report (task, &report_id, TASK_STATUS_REQUESTED))
     {
-      g_debug ("   %s: failed to create report", __FUNCTION__);
+      g_debug ("   %s: failed to create report", __func__);
       return -1;
     }
 
@@ -4473,7 +4473,7 @@ fork_cve_scan_handler (task_t task, target_t target)
       case -1:
         /* Parent, failed to fork. */
         g_warning ("%s: Failed to fork: %s",
-                   __FUNCTION__,
+                   __func__,
                    strerror (errno));
         set_task_interrupted (task,
                               "Error forking scan handler."
@@ -4484,7 +4484,7 @@ fork_cve_scan_handler (task_t task, target_t target)
         return -9;
       default:
         /* Parent, successfully forked. */
-        g_debug ("%s: %i forked %i", __FUNCTION__, getpid (), pid);
+        g_debug ("%s: %i forked %i", __func__, getpid (), pid);
         return 0;
     }
 
@@ -4829,7 +4829,7 @@ run_gmp_slave_task (task_t task, int from, char **report_id,
         break;
       default:
         g_debug ("%s: forked %i to run slave/gmp task",
-                 __FUNCTION__,
+                 __func__,
                  pid);
         /* Parent.  Return, in order to respond to client. */
         global_current_report = (report_t) 0;
@@ -4983,7 +4983,7 @@ slave_get_relay (const char *original_host,
                         &err) == FALSE)
         {
           g_warning ("%s: g_spawn_sync failed: %s",
-                     __FUNCTION__, err ? err->message : "");
+                     __func__, err ? err->message : "");
           g_strfreev (cmd);
           g_free (stdout_str);
           g_free (stderr_str);
@@ -4992,9 +4992,9 @@ slave_get_relay (const char *original_host,
       else if (exit_code)
         {
           g_warning ("%s: mapper exited with code %d",
-                     __FUNCTION__, exit_code);
-          g_message ("%s: mapper stderr:\n%s", __FUNCTION__, stderr_str);
-          g_debug ("%s: mapper stdout:\n%s", __FUNCTION__, stdout_str);
+                     __func__, exit_code);
+          g_message ("%s: mapper stderr:\n%s", __func__, stderr_str);
+          g_debug ("%s: mapper stdout:\n%s", __func__, stdout_str);
           g_strfreev (cmd);
           g_free (stdout_str);
           g_free (stderr_str);
@@ -5005,9 +5005,9 @@ slave_get_relay (const char *original_host,
       if (parse_entity (stdout_str, &relay_entity))
         {
           g_warning ("%s: failed to parse mapper output",
-                     __FUNCTION__);
-          g_message ("%s: mapper stdout:\n%s", __FUNCTION__, stdout_str);
-          g_message ("%s: mapper stderr:\n%s", __FUNCTION__, stderr_str);
+                     __func__);
+          g_message ("%s: mapper stdout:\n%s", __func__, stdout_str);
+          g_message ("%s: mapper stderr:\n%s", __func__, stderr_str);
         }
       else
         {
@@ -5048,7 +5048,7 @@ slave_get_relay (const char *original_host,
             {
               g_warning ("%s: mapper output did not contain"
                          " HOST, PORT and CA_CERT",
-                         __FUNCTION__);
+                         __func__);
             }
           free_entity (relay_entity);
         }
@@ -5129,18 +5129,18 @@ run_gmp_task (task_t task, scanner_t scanner, int from, char **report_id)
   connection.host_string = scanner_host (scanner);
   if (connection.host_string == NULL)
     {
-      g_warning ("%s: Scanner has no host", __FUNCTION__);
+      g_warning ("%s: Scanner has no host", __func__);
       return -1;
     }
 
-  g_debug ("   %s: connection.host: %s", __FUNCTION__,
+  g_debug ("   %s: connection.host: %s", __func__,
            connection.host_string);
 
   connection.port = scanner_port (scanner);
   if (connection.port == -1)
     {
       free (connection.host_string);
-      g_warning ("%s: Scanner has no port", __FUNCTION__);
+      g_warning ("%s: Scanner has no port", __func__);
       return -1;
     }
 
@@ -5148,7 +5148,7 @@ run_gmp_task (task_t task, scanner_t scanner, int from, char **report_id)
   if (connection.username == NULL)
     {
       free (connection.host_string);
-      g_warning ("%s: Scanner has no login username", __FUNCTION__);
+      g_warning ("%s: Scanner has no login username", __func__);
       return -1;
     }
 
@@ -5157,7 +5157,7 @@ run_gmp_task (task_t task, scanner_t scanner, int from, char **report_id)
     {
       free (connection.username);
       free (connection.host_string);
-      g_warning ("%s: Scanner has no login password", __FUNCTION__);
+      g_warning ("%s: Scanner has no login password", __func__);
       return -1;
     }
 
@@ -5703,7 +5703,7 @@ get_slave_system_report_types (const char *required_type, gchar ***start,
   if (original_host == NULL)
     return -1;
 
-  g_debug ("   %s: host: %s", __FUNCTION__, original_host);
+  g_debug ("   %s: host: %s", __func__, original_host);
 
   original_port = scanner_port (slave);
   if (original_port == -1)
@@ -5725,7 +5725,7 @@ get_slave_system_report_types (const char *required_type, gchar ***start,
   if (ret == 1)
     {
       g_message ("%s: no relay found for %s:%d",
-                 __FUNCTION__, original_host, original_port);
+                 __func__, original_host, original_port);
       free (original_host);
       free (original_ca_cert);
       return 4;
@@ -5754,7 +5754,7 @@ get_slave_system_report_types (const char *required_type, gchar ***start,
   if (socket == -1)
     return 4;
 
-  g_debug ("   %s: connected", __FUNCTION__);
+  g_debug ("   %s: connected", __func__);
 
   /* Authenticate using the slave login. */
 
@@ -5764,7 +5764,7 @@ get_slave_system_report_types (const char *required_type, gchar ***start,
       goto fail;
     }
 
-  g_debug ("   %s: authenticated", __FUNCTION__);
+  g_debug ("   %s: authenticated", __func__);
 
   if (gmp_get_system_reports (&session, required_type, 1, &get))
     {
@@ -5882,9 +5882,9 @@ get_system_report_types (const char *required_type, gchar ***start,
           || (WIFEXITED (exit_status) == 0)
           || WEXITSTATUS (exit_status))
         {
-          g_debug ("%s: gvmcg failed with %d", __FUNCTION__, exit_status);
-          g_debug ("%s: stdout: %s", __FUNCTION__, astdout);
-          g_debug ("%s: stderr: %s", __FUNCTION__, astderr);
+          g_debug ("%s: gvmcg failed with %d", __func__, exit_status);
+          g_debug ("%s: stdout: %s", __func__, astdout);
+          g_debug ("%s: stderr: %s", __func__, astderr);
           g_free (astdout);
           g_free (astderr);
           *start = *types = g_malloc0 (sizeof (gchar*) * 2);
@@ -6071,7 +6071,7 @@ gmp_slave_system_report (const char *name, const char *duration,
   if (original_host == NULL)
     return -1;
 
-  g_debug ("   %s: host: %s", __FUNCTION__, original_host);
+  g_debug ("   %s: host: %s", __func__, original_host);
 
   original_port = scanner_port (slave);
   if (original_port == -1)
@@ -6093,7 +6093,7 @@ gmp_slave_system_report (const char *name, const char *duration,
   if (ret == 1)
     {
       g_message ("%s: no relay found for %s:%d",
-                 __FUNCTION__, original_host, original_port);
+                 __func__, original_host, original_port);
       free (original_host);
       free (original_ca_cert);
       return 4;
@@ -6122,7 +6122,7 @@ gmp_slave_system_report (const char *name, const char *duration,
   if (socket == -1)
     return 4;
 
-  g_debug ("   %s: connected", __FUNCTION__);
+  g_debug ("   %s: connected", __func__);
 
   /* Authenticate using the slave login. */
 
@@ -6132,7 +6132,7 @@ gmp_slave_system_report (const char *name, const char *duration,
       goto fail;
     }
 
-  g_debug ("   %s: authenticated", __FUNCTION__);
+  g_debug ("   %s: authenticated", __func__);
 
   opts = gmp_get_system_reports_opts_defaults;
   opts.name = name;
@@ -6162,7 +6162,7 @@ gmp_slave_system_report (const char *name, const char *duration,
     }
 
   free_entity (get);
-  g_warning ("   %s: error getting entity", __FUNCTION__);
+  g_warning ("   %s: error getting entity", __func__);
   return 6;
 
  fail:
@@ -6387,9 +6387,9 @@ manage_system_report (const char *name, const char *duration,
       gsize output_len;
       GString *buffer;
 
-      g_debug ("%s: gvmcg failed with %d", __FUNCTION__, exit_status);
-      g_debug ("%s: stdout: %s", __FUNCTION__, astdout);
-      g_debug ("%s: stderr: %s", __FUNCTION__, astderr);
+      g_debug ("%s: gvmcg failed with %d", __func__, exit_status);
+      g_debug ("%s: stdout: %s", __func__, astdout);
+      g_debug ("%s: stderr: %s", __func__, astderr);
       g_free (astdout);
       g_free (astderr);
       g_free (command);
@@ -6586,12 +6586,12 @@ scheduled_task_start (scheduled_task_t *scheduled_task,
 
       case -1:
         /* Parent on error. */
-        g_warning ("%s: fork failed", __FUNCTION__);
+        g_warning ("%s: fork failed", __func__);
         return -1;
 
       default:
         /* Parent.  Continue to next task. */
-        g_debug ("%s: %i forked %i", __FUNCTION__, getpid (), pid);
+        g_debug ("%s: %i forked %i", __func__, getpid (), pid);
         return 0;
     }
 
@@ -6606,7 +6606,7 @@ scheduled_task_start (scheduled_task_t *scheduled_task,
 
       case -1:
         /* Parent on error. */
-        g_warning ("%s: fork_connection failed", __FUNCTION__);
+        g_warning ("%s: fork_connection failed", __func__);
         reschedule_task (scheduled_task->task_uuid);
         scheduled_task_free (scheduled_task);
         exit (EXIT_FAILURE);
@@ -6624,17 +6624,17 @@ scheduled_task_start (scheduled_task_t *scheduled_task,
           proctitle_set (title);
 
           g_debug ("%s: %i fork_connectioned %i",
-                   __FUNCTION__, getpid (), pid);
+                   __func__, getpid (), pid);
 
           if (signal (SIGCHLD, SIG_DFL) == SIG_ERR)
-            g_warning ("%s: failed to set SIGCHLD", __FUNCTION__);
+            g_warning ("%s: failed to set SIGCHLD", __func__);
           while (waitpid (pid, &status, 0) < 0)
             {
               if (errno == ECHILD)
                 {
                   g_warning ("%s: Failed to get child exit,"
                              " so task '%s' may not have been scheduled",
-                             __FUNCTION__,
+                             __func__,
                              scheduled_task->task_uuid);
                   scheduled_task_free (scheduled_task);
                   exit (EXIT_FAILURE);
@@ -6642,11 +6642,11 @@ scheduled_task_start (scheduled_task_t *scheduled_task,
               if (errno == EINTR)
                 continue;
               g_warning ("%s: waitpid: %s",
-                         __FUNCTION__,
+                         __func__,
                          strerror (errno));
               g_warning ("%s: As a result, task '%s' may not have been"
                          " scheduled",
-                         __FUNCTION__,
+                         __func__,
                          scheduled_task->task_uuid);
               scheduled_task_free (scheduled_task);
               exit (EXIT_FAILURE);
@@ -6709,7 +6709,7 @@ scheduled_task_start (scheduled_task_t *scheduled_task,
 
           /* Child failed, reset task schedule time and exit. */
 
-          g_warning ("%s: child failed", __FUNCTION__);
+          g_warning ("%s: child failed", __func__);
           reschedule_task (scheduled_task->task_uuid);
           scheduled_task_free (scheduled_task);
           exit (EXIT_FAILURE);
@@ -6727,7 +6727,7 @@ scheduled_task_start (scheduled_task_t *scheduled_task,
   auth_opts.username = scheduled_task->owner_name;
   if (gmp_authenticate_info_ext_c (&connection, auth_opts))
     {
-      g_warning ("%s: gmp_authenticate failed", __FUNCTION__);
+      g_warning ("%s: gmp_authenticate failed", __func__);
       scheduled_task_free (scheduled_task);
       gvm_connection_free (&connection);
       exit (EXIT_FAILURE);
@@ -6741,7 +6741,7 @@ scheduled_task_start (scheduled_task_t *scheduled_task,
                                    scheduled_task->task_uuid,
                                    NULL))
         {
-          g_warning ("%s: gmp_start_task and gmp_resume_task failed", __FUNCTION__);
+          g_warning ("%s: gmp_start_task and gmp_resume_task failed", __func__);
           scheduled_task_free (scheduled_task);
           gvm_connection_free (&connection);
           exit (EXIT_FAILURE);
@@ -6785,7 +6785,7 @@ scheduled_task_stop (scheduled_task_t *scheduled_task,
 
       case -1:
         /* Parent on error. */
-        g_warning ("%s: stop fork failed", __FUNCTION__);
+        g_warning ("%s: stop fork failed", __func__);
         return -1;
 
       default:
@@ -6874,7 +6874,7 @@ manage_schedule (manage_connection_forker_t fork_connection,
         {
           g_warning ("%s: manage_update_nvti_cache error"
                      " (Perhaps the db went down?)",
-                     __FUNCTION__);
+                     __func__);
           /* Just ignore, in case the db went down temporarily. */
           return 0;
         }
@@ -6895,7 +6895,7 @@ manage_schedule (manage_connection_forker_t fork_connection,
         {
           g_warning ("%s: iterator init error"
                      " (Perhaps the db went down?)",
-                     __FUNCTION__);
+                     __func__);
           /* Just ignore, in case the db went down temporarily. */
           return 0;
         }
@@ -6918,7 +6918,7 @@ manage_schedule (manage_connection_forker_t fork_connection,
         zone = task_schedule_iterator_timezone (&schedules);
 
         g_debug ("%s: start due for %llu, setting next_time",
-                 __FUNCTION__,
+                 __func__,
                  task_schedule_iterator_task (&schedules));
         set_task_schedule_next_time
          (task_schedule_iterator_task (&schedules),
@@ -6933,7 +6933,7 @@ manage_schedule (manage_connection_forker_t fork_connection,
         if (timed_out)
           {
             g_message (" %s: Task timed out: %s",
-                       __FUNCTION__,
+                       __func__,
                        task_schedule_iterator_task_uuid (&schedules));
             continue;
           }
@@ -7164,7 +7164,7 @@ get_report_format_files (const char *dir_name, GPtrArray **start)
   if (n < 0)
     {
       g_warning ("%s: failed to open dir %s: %s",
-                 __FUNCTION__,
+                 __func__,
                  dir_name,
                  strerror (errno));
       return -1;
@@ -7324,7 +7324,7 @@ file_iterator_content_64 (file_iterator_t* iterator)
       if (error)
         {
           g_debug ("%s: failed to read %s: %s",
-                   __FUNCTION__, path_name, error->message);
+                   __func__, path_name, error->message);
           g_error_free (error);
         }
       g_free (path_name);
@@ -7373,19 +7373,19 @@ delete_slave_task (const gchar *host, int port, const gchar *username,
 
   /* Connect to the slave. */
 
-  g_debug ("   %s: host: %s", __FUNCTION__, host);
+  g_debug ("   %s: host: %s", __func__, host);
 
   socket = gvm_server_open (&session, host, port);
   if (socket == -1) return -1;
 
-  g_debug ("   %s: connected", __FUNCTION__);
+  g_debug ("   %s: connected", __func__);
 
   /* Authenticate using the slave login. */
 
   if (gmp_authenticate (&session, username, password))
     return -1;
 
-  g_debug ("   %s: authenticated", __FUNCTION__);
+  g_debug ("   %s: authenticated", __func__);
 
   /* Get the UUIDs of the slave resources. */
 
@@ -7621,7 +7621,7 @@ xsl_transform (gchar *stylesheet, gchar *xmlfile, gchar **param_names,
   /* DEBUG: display the final command line. */
   cmd_full = g_strjoinv (" ", cmd);
   g_debug ("%s: Spawning in parent dir: %s",
-           __FUNCTION__, cmd_full);
+           __func__, cmd_full);
   g_free (cmd_full);
   /* --- */
 
@@ -7640,12 +7640,12 @@ xsl_transform (gchar *stylesheet, gchar *xmlfile, gchar **param_names,
       || WEXITSTATUS (exit_status))
     {
       g_debug ("%s: failed to transform the xml: %d (WIF %i, WEX %i)",
-               __FUNCTION__,
+               __func__,
                exit_status,
                WIFEXITED (exit_status),
                WEXITSTATUS (exit_status));
-      g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);
-      g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
+      g_debug ("%s: stderr: %s", __func__, standard_err);
+      g_debug ("%s: stdout: %s", __func__, standard_out);
       success = FALSE;
     }
   else if (strlen (standard_out) == 0)
@@ -7987,7 +7987,7 @@ manage_scap_update_time ()
       if (error)
         {
           g_debug ("%s: failed to read %s: %s",
-                   __FUNCTION__, SCAP_TIMESTAMP_FILENAME, error->message);
+                   __func__, SCAP_TIMESTAMP_FILENAME, error->message);
           g_error_free (error);
         }
       return "";
@@ -8476,7 +8476,7 @@ gvm_migrate_secinfo (int feed_type)
     lockfile_basename = "gvm-sync-cert";
   else
     {
-      g_warning ("%s: unsupported feed_type", __FUNCTION__);
+      g_warning ("%s: unsupported feed_type", __func__);
       return -1;
     }
 
@@ -8501,15 +8501,15 @@ gvm_migrate_secinfo (int feed_type)
         {
           if (close (lockfile))
             g_warning ("%s: failed to close lockfile: %s",
-                       __FUNCTION__,
+                       __func__,
                        strerror (errno));
           g_free (lockfile_name);
           return 1;
         }
-      g_debug ("%s: flock: %s", __FUNCTION__, strerror (errno));
+      g_debug ("%s: flock: %s", __func__, strerror (errno));
       if (close (lockfile))
         g_warning ("%s: failed to close lockfile: %s",
-                   __FUNCTION__,
+                   __func__,
                    strerror (errno));
       g_free (lockfile_name);
       return -1;
@@ -8630,7 +8630,7 @@ manage_run_wizard (const gchar *wizard_name,
   if (get_error)
     {
       g_warning ("%s: Failed to read wizard: %s",
-                 __FUNCTION__,
+                 __func__,
                  get_error->message);
       g_error_free (get_error);
       return -1;
@@ -8641,7 +8641,7 @@ manage_run_wizard (const gchar *wizard_name,
   entity = NULL;
   if (parse_entity (wizard, &entity))
     {
-      g_warning ("%s: Failed to parse wizard", __FUNCTION__);
+      g_warning ("%s: Failed to parse wizard", __func__);
       g_free (wizard);
       return -1;
     }
@@ -8712,7 +8712,7 @@ manage_run_wizard (const gchar *wizard_name,
               || (strcmp (entity_text (name_entity), "") == 0))
             {
               g_warning ("%s: Wizard PARAM missing NAME",
-                         __FUNCTION__);
+                         __func__);
               free_entity (entity);
               return -1;
             }
@@ -8724,7 +8724,7 @@ manage_run_wizard (const gchar *wizard_name,
               || (strcmp (entity_text (regex_entity), "") == 0))
             {
               g_warning ("%s: Wizard PARAM missing REGEX",
-                         __FUNCTION__);
+                         __func__);
               free_entity (entity);
               return -1;
             }
@@ -8826,7 +8826,7 @@ manage_run_wizard (const gchar *wizard_name,
           if (command == NULL)
             {
               g_warning ("%s: Wizard STEP missing COMMAND",
-                         __FUNCTION__);
+                         __func__);
               free_entity (entity);
               g_free (response);
               g_free (extra);
@@ -8840,7 +8840,7 @@ manage_run_wizard (const gchar *wizard_name,
           if (xsl_fd == -1)
             {
               g_warning ("%s: Wizard XSL file create failed",
-                         __FUNCTION__);
+                         __func__);
               free_entity (entity);
               g_free (response);
               g_free (extra);
@@ -8852,7 +8852,7 @@ manage_run_wizard (const gchar *wizard_name,
           if (xsl_file == NULL)
             {
               g_warning ("%s: Wizard XSL file open failed",
-                         __FUNCTION__);
+                         __func__);
               close (xsl_fd);
               free_entity (entity);
               g_free (response);
@@ -8870,7 +8870,7 @@ manage_run_wizard (const gchar *wizard_name,
           if (xml_fd == -1)
             {
               g_warning ("%s: Wizard XML file create failed",
-                         __FUNCTION__);
+                         __func__);
               fclose (xsl_file);
               unlink (xsl_file_name);
               free_entity (entity);
@@ -8884,7 +8884,7 @@ manage_run_wizard (const gchar *wizard_name,
           if (xml_file == NULL)
             {
               g_warning ("%s: Wizard XML file open failed",
-                         __FUNCTION__);
+                         __func__);
               fclose (xsl_file);
               unlink (xsl_file_name);
               close (xml_fd);
@@ -8914,7 +8914,7 @@ manage_run_wizard (const gchar *wizard_name,
               unlink (xml_file_name);
               free_entity (entity);
               g_warning ("%s: Wizard failed to write XML",
-                         __FUNCTION__);
+                         __func__);
               g_free (response);
               g_free (extra);
               g_string_free (params_xml, TRUE);
@@ -8934,7 +8934,7 @@ manage_run_wizard (const gchar *wizard_name,
           if (gmp == NULL)
             {
               g_warning ("%s: Wizard XSL transform failed",
-                         __FUNCTION__);
+                         __func__);
               free_entity (entity);
               g_free (response);
               g_free (extra);
@@ -8971,7 +8971,7 @@ manage_run_wizard (const gchar *wizard_name,
               if (parse_entity (response, &response_entity))
                 {
                   g_warning ("%s: Wizard failed to parse response",
-                             __FUNCTION__);
+                             __func__);
                   free_entity (entity);
                   g_free (response);
                   g_free (extra);
@@ -9018,7 +9018,7 @@ manage_run_wizard (const gchar *wizard_name,
               if (xsl_fd == -1)
                 {
                   g_warning ("%s: Wizard extra_data XSL file create failed",
-                            __FUNCTION__);
+                            __func__);
                   free_entity (entity);
                   g_free (response);
                   g_free (extra);
@@ -9030,7 +9030,7 @@ manage_run_wizard (const gchar *wizard_name,
               if (xsl_file == NULL)
                 {
                   g_warning ("%s: Wizard extra_data XSL file open failed",
-                            __FUNCTION__);
+                            __func__);
                   close (xsl_fd);
                   free_entity (entity);
                   g_free (response);
@@ -9048,7 +9048,7 @@ manage_run_wizard (const gchar *wizard_name,
               if (xml_fd == -1)
                 {
                   g_warning ("%s: Wizard XML file create failed",
-                            __FUNCTION__);
+                            __func__);
                   fclose (xsl_file);
                   unlink (xsl_file_name);
                   free_entity (entity);
@@ -9062,7 +9062,7 @@ manage_run_wizard (const gchar *wizard_name,
               if (xml_file == NULL)
                 {
                   g_warning ("%s: Wizard XML file open failed",
-                            __FUNCTION__);
+                            __func__);
                   fclose (xsl_file);
                   unlink (xsl_file_name);
                   close (xml_fd);
@@ -9094,7 +9094,7 @@ manage_run_wizard (const gchar *wizard_name,
                   unlink (extra_xml_file_name);
                   free_entity (entity);
                   g_warning ("%s: Wizard failed to write XML",
-                            __FUNCTION__);
+                            __func__);
                   g_free (response);
                   g_free (extra);
                   g_string_free (params_xml, TRUE);
@@ -9147,7 +9147,7 @@ manage_run_wizard (const gchar *wizard_name,
         }
       else
         {
-          g_warning ("%s: failed to parse extra data", __FUNCTION__);
+          g_warning ("%s: failed to parse extra data", __func__);
           free_entity (entity);
           g_string_free (params_xml, TRUE);
           return -1;

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -1058,7 +1058,7 @@ migrate_213_to_214 ()
                               &serial);
           else
             g_warning ("%s: No SSLDetails found for fingerprint %s",
-                       __FUNCTION__,
+                       __func__,
                        scanner_fpr);
 
           free (ssldetails);
@@ -1422,7 +1422,7 @@ replace_preference_names_219_to_220 (const char *table_name)
           g_free (quoted_new_name);
         }
       else
-        g_warning ("%s: No new name for '%s'", __FUNCTION__, old_name);
+        g_warning ("%s: No new name for '%s'", __func__, old_name);
     }
   cleanup_iterator (&preferences);
 }
@@ -1681,7 +1681,7 @@ manage_migrate (GSList *log_config, const gchar *database)
   if (old_version == -2)
     {
       g_warning ("%s: no task tables yet, so no need to migrate them",
-                 __FUNCTION__);
+                 __func__);
       version_current = 1;
     }
   else if (old_version == new_version)

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -549,7 +549,7 @@ manage_create_sql_functions ()
                " WHERE name = 'uuid-ossp' AND installed_version IS NOT NULL;")
       == 0)
     {
-      g_warning ("%s: PostgreSQL extension uuid-ossp required", __FUNCTION__);
+      g_warning ("%s: PostgreSQL extension uuid-ossp required", __func__);
       return -1;
     }
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -919,7 +919,7 @@ parse_iso_time (const char *text_time)
               == -1)
             {
               g_warning ("%s: Failed to switch to timezone %s",
-                         __FUNCTION__, current_credentials.timezone);
+                         __func__, current_credentials.timezone);
               if (tz != NULL)
                 setenv ("TZ", tz, 1);
               g_free (tz);
@@ -935,7 +935,7 @@ parse_iso_time (const char *text_time)
               if (strptime ((char*) text_time, "%F %T", &tm) == NULL)
                 {
                   assert (0);
-                  g_warning ("%s: Failed to parse time", __FUNCTION__);
+                  g_warning ("%s: Failed to parse time", __func__);
                   if (tz != NULL)
                     setenv ("TZ", tz, 1);
                   g_free (tz);
@@ -952,7 +952,7 @@ parse_iso_time (const char *text_time)
 
           if (setenv ("TZ", "UTC", 1) == -1)
             {
-              g_warning ("%s: Failed to switch to UTC", __FUNCTION__);
+              g_warning ("%s: Failed to switch to UTC", __func__);
               if (tz != NULL)
                 setenv ("TZ", tz, 1);
               g_free (tz);
@@ -964,7 +964,7 @@ parse_iso_time (const char *text_time)
           if (strptime ((char*) text_time, "%FT%TZ", &tm) == NULL)
             {
               assert (0);
-              g_warning ("%s: Failed to parse time", __FUNCTION__);
+              g_warning ("%s: Failed to parse time", __func__);
               if (tz != NULL)
                 setenv ("TZ", tz, 1);
               g_free (tz);
@@ -975,7 +975,7 @@ parse_iso_time (const char *text_time)
       epoch_time = mktime (&tm);
       if (epoch_time == -1)
         {
-          g_warning ("%s: Failed to make time", __FUNCTION__);
+          g_warning ("%s: Failed to make time", __func__);
           if (tz != NULL)
             setenv ("TZ", tz, 1);
           g_free (tz);
@@ -987,7 +987,7 @@ parse_iso_time (const char *text_time)
         {
           if (setenv ("TZ", tz, 1) == -1)
             {
-              g_warning ("%s: Failed to switch to original TZ", __FUNCTION__);
+              g_warning ("%s: Failed to switch to original TZ", __func__);
               g_free (tz);
               return 0;
             }
@@ -1014,7 +1014,7 @@ parse_iso_time (const char *text_time)
           epoch_time = mktime (&tm);
           if (epoch_time == -1)
             {
-              g_warning ("%s: Failed to make time", __FUNCTION__);
+              g_warning ("%s: Failed to make time", __func__);
               return 0;
             }
           return epoch_time;
@@ -1032,7 +1032,7 @@ parse_iso_time (const char *text_time)
                                 offset_minute);
       if (setenv ("TZ", new_tz, 1) == -1)
         {
-          g_warning ("%s: Failed to switch to %s", __FUNCTION__, new_tz);
+          g_warning ("%s: Failed to switch to %s", __func__, new_tz);
           g_free (new_tz);
           if (tz != NULL)
             setenv ("TZ", tz, 1);
@@ -1048,7 +1048,7 @@ parse_iso_time (const char *text_time)
       if (strptime ((char*) text_time, "%FT%T%z", &tm) == NULL)
         {
           assert (0);
-          g_warning ("%s: Failed to parse time", __FUNCTION__);
+          g_warning ("%s: Failed to parse time", __func__);
           if (tz != NULL)
             setenv ("TZ", tz, 1);
           g_free (tz);
@@ -1058,7 +1058,7 @@ parse_iso_time (const char *text_time)
       epoch_time = mktime (&tm);
       if (epoch_time == -1)
         {
-          g_warning ("%s: Failed to make time", __FUNCTION__);
+          g_warning ("%s: Failed to make time", __func__);
           if (tz != NULL)
             setenv ("TZ", tz, 1);
           g_free (tz);
@@ -1070,7 +1070,7 @@ parse_iso_time (const char *text_time)
         {
           if (setenv ("TZ", tz, 1) == -1)
             {
-              g_warning ("%s: Failed to switch to original TZ", __FUNCTION__);
+              g_warning ("%s: Failed to switch to original TZ", __func__);
               g_free (tz);
               return 0;
             }
@@ -1280,7 +1280,7 @@ column_array_copy (column_t *columns)
       count++;
     }
 
-  g_debug ("%s: %i", __FUNCTION__, count);
+  g_debug ("%s: %i", __func__, count);
   start = g_malloc0 (sizeof (column_t) * count);
   point = start;
 
@@ -5442,7 +5442,7 @@ init_aggregate_iterator (iterator_t* iterator, const char *type,
   assert (get);
 
   if (get->id)
-    g_warning ("%s: Called with an id parameter", __FUNCTION__);
+    g_warning ("%s: Called with an id parameter", __func__);
 
   if ((manage_scap_loaded () == FALSE
        && (strcmp (type, "cve") == 0
@@ -9022,7 +9022,7 @@ email_write_content (FILE *content_file,
                body)
       < 0)
     {
-      g_warning ("%s: output error", __FUNCTION__);
+      g_warning ("%s: output error", __func__);
       return -1;
     }
 
@@ -9042,7 +9042,7 @@ email_write_content (FILE *content_file,
                    attachment_extension)
           < 0)
         {
-          g_warning ("%s: output error", __FUNCTION__);
+          g_warning ("%s: output error", __func__);
           return -1;
         }
 
@@ -9056,7 +9056,7 @@ email_write_content (FILE *content_file,
                          attachment)
                 < 0)
               {
-                g_warning ("%s: output error", __FUNCTION__);
+                g_warning ("%s: output error", __func__);
                 return -1;
               }
             attachment += 72;
@@ -9069,7 +9069,7 @@ email_write_content (FILE *content_file,
                          attachment)
                 < 0)
               {
-                g_warning ("%s: output error", __FUNCTION__);
+                g_warning ("%s: output error", __func__);
                 return -1;
               }
             break;
@@ -9079,7 +9079,7 @@ email_write_content (FILE *content_file,
                    "--=-=-=-=-=--\n")
           < 0)
         {
-          g_warning ("%s: output error", __FUNCTION__);
+          g_warning ("%s: output error", __func__);
           return -1;
         }
     }
@@ -9140,7 +9140,7 @@ email_encrypt_gpg (FILE *plain_file, FILE *encrypted_file,
                             : "automated@openvas.org",
                subject) < 0)
     {
-      g_warning ("%s: output error at headers", __FUNCTION__);
+      g_warning ("%s: output error at headers", __func__);
       return -1;
     }
 
@@ -9156,7 +9156,7 @@ email_encrypt_gpg (FILE *plain_file, FILE *encrypted_file,
                "\n"
                "--=-=-=-=-=--\n") < 0)
     {
-      g_warning ("%s: output error at end of message", __FUNCTION__);
+      g_warning ("%s: output error at end of message", __func__);
       return -1;
     }
 
@@ -9205,7 +9205,7 @@ email_encrypt_smime (FILE *plain_file, FILE *encrypted_file,
                             : "automated@openvas.org",
                subject) < 0)
     {
-      g_warning ("%s: output error at headers", __FUNCTION__);
+      g_warning ("%s: output error at headers", __func__);
       return -1;
     }
 
@@ -9213,7 +9213,7 @@ email_encrypt_smime (FILE *plain_file, FILE *encrypted_file,
   if (gvm_smime_encrypt_stream (plain_file, encrypted_file, to_address,
                                 certificate, -1))
     {
-      g_warning ("%s: encryption failed", __FUNCTION__);
+      g_warning ("%s: encryption failed", __func__);
       return -1;
     }
 
@@ -9221,7 +9221,7 @@ email_encrypt_smime (FILE *plain_file, FILE *encrypted_file,
   if (fprintf (encrypted_file, 
                "\n") < 0)
     {
-      g_warning ("%s: output error at end of message", __FUNCTION__);
+      g_warning ("%s: output error at end of message", __func__);
       return -1;
     }
 
@@ -9269,7 +9269,7 @@ email (const char *to_address, const char *from_address, const char *subject,
   content_fd = mkstemp (content_file_name);
   if (content_fd == -1)
     {
-      g_warning ("%s: mkstemp: %s", __FUNCTION__, strerror (errno));
+      g_warning ("%s: mkstemp: %s", __func__, strerror (errno));
       return -1;
     }
 
@@ -9280,7 +9280,7 @@ email (const char *to_address, const char *from_address, const char *subject,
   if (content_file == NULL)
     {
       g_warning ("%s: Could not open content file: %s",
-                 __FUNCTION__, strerror (errno));
+                 __func__, strerror (errno));
       close (content_fd);
       return -1;
     }
@@ -9305,7 +9305,7 @@ email (const char *to_address, const char *from_address, const char *subject,
           if (plain_fd == -1)
             {
               g_warning ("%s: mkstemp for plain text file: %s",
-                         __FUNCTION__, strerror (errno));
+                         __func__, strerror (errno));
               fclose (content_file);
               unlink (content_file_name);
               cleanup_iterator (&iterator);
@@ -9316,7 +9316,7 @@ email (const char *to_address, const char *from_address, const char *subject,
           if (plain_file == NULL)
             {
               g_warning ("%s: Could not open plain text file: %s",
-                         __FUNCTION__, strerror (errno));
+                         __func__, strerror (errno));
               fclose (content_file);
               unlink (content_file_name);
               close (plain_fd);
@@ -9353,7 +9353,7 @@ email (const char *to_address, const char *from_address, const char *subject,
 
               if (ret)
                 {
-                  g_warning ("%s: PGP encryption failed", __FUNCTION__);
+                  g_warning ("%s: PGP encryption failed", __func__);
                   fclose (content_file);
                   unlink (content_file_name);
                   cleanup_iterator (&iterator);
@@ -9371,7 +9371,7 @@ email (const char *to_address, const char *from_address, const char *subject,
 
               if (ret)
                 {
-                  g_warning ("%s: S/MIME encryption failed", __FUNCTION__);
+                  g_warning ("%s: S/MIME encryption failed", __func__);
                   fclose (content_file);
                   unlink (content_file_name);
                   cleanup_iterator (&iterator);
@@ -9381,7 +9381,7 @@ email (const char *to_address, const char *from_address, const char *subject,
           else
             {
               g_warning ("%s: Invalid recipient credential type",
-                        __FUNCTION__);
+                        __func__);
               fclose (content_file);
               unlink (content_file_name);
               fclose (plain_file);
@@ -9408,7 +9408,7 @@ email (const char *to_address, const char *from_address, const char *subject,
   args_fd = mkstemp (args_file_name);
   if (args_fd == -1)
     {
-      g_warning ("%s: mkstemp: %s", __FUNCTION__, strerror (errno));
+      g_warning ("%s: mkstemp: %s", __func__, strerror (errno));
       fclose (content_file);
       return -1;
     }
@@ -9443,7 +9443,7 @@ email (const char *to_address, const char *from_address, const char *subject,
   if ((ret == -1) || WEXITSTATUS (ret))
     {
       g_warning ("%s: system failed with ret %i, %i, %s",
-                 __FUNCTION__,
+                 __func__,
                  ret,
                  WEXITSTATUS (ret),
                  command);
@@ -9487,7 +9487,7 @@ http_get (const char *url)
   cmd[3] = g_strdup (url);
   cmd[4] = NULL;
   g_debug ("%s: Spawning in /tmp/: %s %s %s %s",
-           __FUNCTION__, cmd[0], cmd[1], cmd[2], cmd[3]);
+           __func__, cmd[0], cmd[1], cmd[2], cmd[3]);
   if ((g_spawn_sync ("/tmp/",
                      cmd,
                      NULL,                  /* Environment. */
@@ -9503,12 +9503,12 @@ http_get (const char *url)
       || WEXITSTATUS (exit_status))
     {
       g_debug ("%s: wget failed: %d (WIF %i, WEX %i)",
-               __FUNCTION__,
+               __func__,
                exit_status,
                WIFEXITED (exit_status),
                WEXITSTATUS (exit_status));
-      g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
-      g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);
+      g_debug ("%s: stdout: %s", __func__, standard_out);
+      g_debug ("%s: stderr: %s", __func__, standard_err);
       ret = -1;
     }
   else
@@ -9562,7 +9562,7 @@ alert_script_init (const char *report_filename, const char* report,
 
   if (mkdtemp (report_dir) == NULL)
     {
-      g_warning ("%s: mkdtemp failed", __FUNCTION__);
+      g_warning ("%s: mkdtemp failed", __func__);
       return -1;
     }
 
@@ -9578,7 +9578,7 @@ alert_script_init (const char *report_filename, const char* report,
   if (error)
     {
       g_warning ("%s: could not write report: %s",
-                 __FUNCTION__, error->message);
+                 __func__, error->message);
       g_error_free (error);
       g_free (*report_path);
       gvm_file_remove_recurse (report_dir);
@@ -9591,7 +9591,7 @@ alert_script_init (const char *report_filename, const char* report,
 
   if (mkstemp (*error_path) == -1)
     {
-      g_warning ("%s: mkstemp for error output failed", __FUNCTION__);
+      g_warning ("%s: mkstemp for error output failed", __func__);
       gvm_file_remove_recurse (report_dir);
       g_free (*report_path);
       g_free (*error_path);
@@ -9605,7 +9605,7 @@ alert_script_init (const char *report_filename, const char* report,
       *extra_path = g_strdup_printf ("%s/extra_XXXXXX", report_dir);
       if (mkstemp (*extra_path) == -1)
         {
-          g_warning ("%s: mkstemp for extra data failed", __FUNCTION__);
+          g_warning ("%s: mkstemp for extra data failed", __func__);
           gvm_file_remove_recurse (report_dir);
           g_free (*report_path);
           g_free (*error_path);
@@ -9618,7 +9618,7 @@ alert_script_init (const char *report_filename, const char* report,
       if (error)
         {
           g_warning ("%s: could not write extra data: %s",
-                    __FUNCTION__, error->message);
+                    __func__, error->message);
           g_error_free (error);
           gvm_file_remove_recurse (report_dir);
           g_free (*report_path);
@@ -9665,7 +9665,7 @@ alert_script_exec (const char *alert_id, const char *command_args,
   if (!g_file_test (script, G_FILE_TEST_EXISTS))
     {
       g_warning ("%s: Failed to find alert script: %s",
-           __FUNCTION__,
+           __func__,
            script);
       g_free (script);
       g_free (script_dir);
@@ -9684,7 +9684,7 @@ alert_script_exec (const char *alert_id, const char *command_args,
     if (previous_dir == NULL)
       {
         g_warning ("%s: Failed to getcwd: %s",
-                   __FUNCTION__,
+                   __func__,
                    strerror (errno));
         g_free (previous_dir);
         g_free (script);
@@ -9695,7 +9695,7 @@ alert_script_exec (const char *alert_id, const char *command_args,
     if (chdir (script_dir))
       {
         g_warning ("%s: Failed to chdir: %s",
-                   __FUNCTION__,
+                   __func__,
                    strerror (errno));
         g_free (previous_dir);
         g_free (script);
@@ -9741,7 +9741,7 @@ alert_script_exec (const char *alert_id, const char *command_args,
                                      nobody->pw_gid)))
           {
             g_warning ("%s: Failed to set permissions for user nobody: %s",
-                       __FUNCTION__,
+                       __func__,
                        strerror (errno));
             g_free (previous_dir);
             g_free (command);
@@ -9762,20 +9762,20 @@ alert_script_exec (const char *alert_id, const char *command_args,
                 if (setgroups (0,NULL))
                   {
                     g_warning ("%s (child): setgroups: %s",
-                               __FUNCTION__, strerror (errno));
+                               __func__, strerror (errno));
                     exit (EXIT_FAILURE);
                   }
                 if (setgid (nobody->pw_gid))
                   {
                     g_warning ("%s (child): setgid: %s",
-                               __FUNCTION__,
+                               __func__,
                                strerror (errno));
                     exit (EXIT_FAILURE);
                   }
                 if (setuid (nobody->pw_uid))
                   {
                     g_warning ("%s (child): setuid: %s",
-                               __FUNCTION__,
+                               __func__,
                                strerror (errno));
                     exit (EXIT_FAILURE);
                   }
@@ -9788,7 +9788,7 @@ alert_script_exec (const char *alert_id, const char *command_args,
                   {
                     g_warning ("%s (child):"
                                " system failed with ret %i, %i, %s",
-                               __FUNCTION__,
+                               __func__,
                                ret,
                                WEXITSTATUS (ret),
                                command);
@@ -9802,7 +9802,7 @@ alert_script_exec (const char *alert_id, const char *command_args,
                                              NULL, &error) == FALSE)
                       {
                         g_warning ("%s: failed to test error message: %s",
-                                    __FUNCTION__, error->message);
+                                    __func__, error->message);
                         g_error_free (error);
                         if (message)
                           g_free (*message);
@@ -9824,7 +9824,7 @@ alert_script_exec (const char *alert_id, const char *command_args,
                           {
                             g_warning ("%s: failed to write error message:"
                                         " %s",
-                                        __FUNCTION__, error->message);
+                                        __func__, error->message);
                             g_error_free (error);
                             g_free (*message);
                             exit (EXIT_FAILURE);
@@ -9842,11 +9842,11 @@ alert_script_exec (const char *alert_id, const char *command_args,
               /* Parent when error. */
 
               g_warning ("%s: Failed to fork: %s",
-                         __FUNCTION__,
+                         __func__,
                          strerror (errno));
               if (chdir (previous_dir))
                 g_warning ("%s: and chdir failed",
-                           __FUNCTION__);
+                           __func__);
               g_free (previous_dir);
               g_free (command);
               return -1;
@@ -9863,21 +9863,21 @@ alert_script_exec (const char *alert_id, const char *command_args,
                     if (errno == ECHILD)
                       {
                         g_warning ("%s: Failed to get child exit status",
-                                   __FUNCTION__);
+                                   __func__);
                         if (chdir (previous_dir))
                           g_warning ("%s: and chdir failed",
-                                     __FUNCTION__);
+                                     __func__);
                         g_free (previous_dir);
                         return -1;
                       }
                     if (errno == EINTR)
                       continue;
                     g_warning ("%s: wait: %s",
-                               __FUNCTION__,
+                               __func__,
                                strerror (errno));
                     if (chdir (previous_dir))
                       g_warning ("%s: and chdir failed",
-                                 __FUNCTION__);
+                                 __func__);
                     g_free (previous_dir);
                     return -1;
                   }
@@ -9894,7 +9894,7 @@ alert_script_exec (const char *alert_id, const char *command_args,
                                                    NULL, &error) == FALSE)
                             {
                               g_warning ("%s: failed to get error message: %s",
-                                         __FUNCTION__, error->message);
+                                         __func__, error->message);
                               g_error_free (error);
                             }
 
@@ -9906,27 +9906,27 @@ alert_script_exec (const char *alert_id, const char *command_args,
                         }
                       if (chdir (previous_dir))
                         g_warning ("%s: chdir failed",
-                                   __FUNCTION__);
+                                   __func__);
                       return -5;
                     case EXIT_FAILURE:
                     default:
                       g_warning ("%s: child failed, %s",
-                                 __FUNCTION__,
+                                 __func__,
                                  command);
                       if (chdir (previous_dir))
                         g_warning ("%s: and chdir failed",
-                                   __FUNCTION__);
+                                   __func__);
                       g_free (previous_dir);
                       return -1;
                     }
                 else
                   {
                     g_warning ("%s: child failed, %s",
-                               __FUNCTION__,
+                               __func__,
                                command);
                     if (chdir (previous_dir))
                       g_warning ("%s: and chdir failed",
-                                 __FUNCTION__);
+                                 __func__);
                     g_free (previous_dir);
                     return -1;
                   }
@@ -9947,13 +9947,13 @@ alert_script_exec (const char *alert_id, const char *command_args,
         if (ret == -1)
           {
             g_warning ("%s: system failed with ret %i, %i, %s",
-                       __FUNCTION__,
+                       __func__,
                        ret,
                        WEXITSTATUS (ret),
                        command);
             if (chdir (previous_dir))
               g_warning ("%s: and chdir failed",
-                         __FUNCTION__);
+                         __func__);
             g_free (previous_dir);
             g_free (command);
             return -1;
@@ -9967,7 +9967,7 @@ alert_script_exec (const char *alert_id, const char *command_args,
                       == FALSE)
                   {
                     g_warning ("%s: failed to get error message: %s",
-                               __FUNCTION__, error->message);
+                               __func__, error->message);
                     g_error_free (error);
                   }
 
@@ -9997,7 +9997,7 @@ alert_script_exec (const char *alert_id, const char *command_args,
     if (chdir (previous_dir))
       {
         g_warning ("%s: Failed to chdir back: %s",
-                   __FUNCTION__,
+                   __func__,
                    strerror (errno));
         g_free (previous_dir);
         return -1;
@@ -10105,7 +10105,7 @@ snmp_to_host (const char *community, const char *agent, const char *message,
 
   if (community == NULL || agent == NULL || message == NULL)
     {
-      g_warning ("%s: parameter was NULL", __FUNCTION__);
+      g_warning ("%s: parameter was NULL", __func__);
       return -1;
     }
 
@@ -10295,7 +10295,7 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
 
   if (mkdtemp (report_dir) == NULL)
     {
-      g_warning ("%s: mkdtemp failed", __FUNCTION__);
+      g_warning ("%s: mkdtemp failed", __func__);
       return -1;
     }
 
@@ -10364,7 +10364,7 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
     if (previous_dir == NULL)
       {
         g_warning ("%s: Failed to getcwd: %s",
-                   __FUNCTION__,
+                   __func__,
                    strerror (errno));
         g_free (report_file);
         g_free (pkcs12_file);
@@ -10378,7 +10378,7 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
     if (chdir (script_dir))
       {
         g_warning ("%s: Failed to chdir: %s",
-                   __FUNCTION__,
+                   __func__,
                    strerror (errno));
         g_free (report_file);
         g_free (pkcs12_file);
@@ -10424,7 +10424,7 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
             || chown (pkcs12_file, nobody->pw_uid, nobody->pw_gid))
           {
             g_warning ("%s: Failed to set permissions for user nobody: %s",
-                       __FUNCTION__,
+                       __func__,
                        strerror (errno));
             g_free (report_file);
             g_free (pkcs12_file);
@@ -10447,20 +10447,20 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
                 if (setgroups (0,NULL))
                   {
                     g_warning ("%s (child): setgroups: %s",
-                               __FUNCTION__, strerror (errno));
+                               __func__, strerror (errno));
                     exit (EXIT_FAILURE);
                   }
                 if (setgid (nobody->pw_gid))
                   {
                     g_warning ("%s (child): setgid: %s",
-                               __FUNCTION__,
+                               __func__,
                                strerror (errno));
                     exit (EXIT_FAILURE);
                   }
                 if (setuid (nobody->pw_uid))
                   {
                     g_warning ("%s (child): setuid: %s",
-                               __FUNCTION__,
+                               __func__,
                                strerror (errno));
                     exit (EXIT_FAILURE);
                   }
@@ -10472,7 +10472,7 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
                   {
                     g_warning ("%s (child):"
                                " system failed with ret %i, %i, %s",
-                               __FUNCTION__,
+                               __func__,
                                ret,
                                WEXITSTATUS (ret),
                                command);
@@ -10486,11 +10486,11 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
             /* Parent when error. */
 
             g_warning ("%s: Failed to fork: %s",
-                       __FUNCTION__,
+                       __func__,
                        strerror (errno));
             if (chdir (previous_dir))
               g_warning ("%s: and chdir failed",
-                         __FUNCTION__);
+                         __func__);
             g_free (previous_dir);
             g_free (command);
             return -1;
@@ -10509,21 +10509,21 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
                     if (errno == ECHILD)
                       {
                         g_warning ("%s: Failed to get child exit status",
-                                   __FUNCTION__);
+                                   __func__);
                         if (chdir (previous_dir))
                           g_warning ("%s: and chdir failed",
-                                     __FUNCTION__);
+                                     __func__);
                         g_free (previous_dir);
                         return -1;
                       }
                     if (errno == EINTR)
                       continue;
                     g_warning ("%s: wait: %s",
-                               __FUNCTION__,
+                               __func__,
                                strerror (errno));
                     if (chdir (previous_dir))
                       g_warning ("%s: and chdir failed",
-                                 __FUNCTION__);
+                                 __func__);
                     g_free (previous_dir);
                     return -1;
                   }
@@ -10535,22 +10535,22 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
                     case EXIT_FAILURE:
                     default:
                       g_warning ("%s: child failed, %s",
-                                 __FUNCTION__,
+                                 __func__,
                                  command);
                       if (chdir (previous_dir))
                         g_warning ("%s: and chdir failed",
-                                   __FUNCTION__);
+                                   __func__);
                       g_free (previous_dir);
                       return -1;
                     }
                 else
                   {
                     g_warning ("%s: child failed, %s",
-                               __FUNCTION__,
+                               __func__,
                                command);
                     if (chdir (previous_dir))
                       g_warning ("%s: and chdir failed",
-                                 __FUNCTION__);
+                                 __func__);
                     g_free (previous_dir);
                     return -1;
                   }
@@ -10573,13 +10573,13 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
         if (ret == -1)
           {
             g_warning ("%s: system failed with ret %i, %i, %s",
-                       __FUNCTION__,
+                       __func__,
                        ret,
                        WEXITSTATUS (ret),
                        command);
             if (chdir (previous_dir))
               g_warning ("%s: and chdir failed",
-                         __FUNCTION__);
+                         __func__);
             g_free (previous_dir);
             g_free (command);
             return -1;
@@ -10593,7 +10593,7 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
     if (chdir (previous_dir))
       {
         g_warning ("%s: Failed to chdir back: %s",
-                   __FUNCTION__,
+                   __func__,
                    strerror (errno));
         g_free (previous_dir);
         return -1;
@@ -10639,7 +10639,7 @@ send_to_verinice (const char *url, const char *username, const char *password,
 
   if (mkdtemp (archive_dir) == NULL)
     {
-      g_warning ("%s: mkdtemp failed", __FUNCTION__);
+      g_warning ("%s: mkdtemp failed", __func__);
       return -1;
     }
 
@@ -10666,7 +10666,7 @@ send_to_verinice (const char *url, const char *username, const char *password,
   if (!g_file_test (script, G_FILE_TEST_EXISTS))
     {
       g_warning ("%s: Failed to find alert script: %s",
-           __FUNCTION__,
+           __func__,
            script);
       g_free (archive_file);
       g_free (script);
@@ -10686,7 +10686,7 @@ send_to_verinice (const char *url, const char *username, const char *password,
     if (previous_dir == NULL)
       {
         g_warning ("%s: Failed to getcwd: %s",
-                   __FUNCTION__,
+                   __func__,
                    strerror (errno));
         g_free (archive_file);
         g_free (previous_dir);
@@ -10698,7 +10698,7 @@ send_to_verinice (const char *url, const char *username, const char *password,
     if (chdir (script_dir))
       {
         g_warning ("%s: Failed to chdir: %s",
-                   __FUNCTION__,
+                   __func__,
                    strerror (errno));
         g_free (archive_file);
         g_free (previous_dir);
@@ -10747,7 +10747,7 @@ send_to_verinice (const char *url, const char *username, const char *password,
             || chown (archive_file, nobody->pw_uid, nobody->pw_gid))
           {
             g_warning ("%s: Failed to set permissions for user nobody: %s",
-                       __FUNCTION__,
+                       __func__,
                        strerror (errno));
             g_free (previous_dir);
             g_free (archive_file);
@@ -10771,20 +10771,20 @@ send_to_verinice (const char *url, const char *username, const char *password,
                 if (setgroups (0,NULL))
                   {
                     g_warning ("%s (child): setgroups: %s",
-                               __FUNCTION__, strerror (errno));
+                               __func__, strerror (errno));
                     exit (EXIT_FAILURE);
                   }
                 if (setgid (nobody->pw_gid))
                   {
                     g_warning ("%s (child): setgid: %s",
-                               __FUNCTION__,
+                               __func__,
                                strerror (errno));
                     exit (EXIT_FAILURE);
                   }
                 if (setuid (nobody->pw_uid))
                   {
                     g_warning ("%s (child): setuid: %s",
-                               __FUNCTION__,
+                               __func__,
                                strerror (errno));
                     exit (EXIT_FAILURE);
                   }
@@ -10796,7 +10796,7 @@ send_to_verinice (const char *url, const char *username, const char *password,
                   {
                     g_warning ("%s (child):"
                                " system failed with ret %i, %i, %s",
-                               __FUNCTION__,
+                               __func__,
                                ret,
                                WEXITSTATUS (ret),
                                log_command);
@@ -10810,11 +10810,11 @@ send_to_verinice (const char *url, const char *username, const char *password,
             /* Parent when error. */
 
             g_warning ("%s: Failed to fork: %s",
-                       __FUNCTION__,
+                       __func__,
                        strerror (errno));
             if (chdir (previous_dir))
               g_warning ("%s: and chdir failed",
-                         __FUNCTION__);
+                         __func__);
             g_free (previous_dir);
             g_free (command);
             g_free (log_command);
@@ -10832,21 +10832,21 @@ send_to_verinice (const char *url, const char *username, const char *password,
                     if (errno == ECHILD)
                       {
                         g_warning ("%s: Failed to get child exit status",
-                                   __FUNCTION__);
+                                   __func__);
                         if (chdir (previous_dir))
                           g_warning ("%s: and chdir failed",
-                                     __FUNCTION__);
+                                     __func__);
                         g_free (previous_dir);
                         return -1;
                       }
                     if (errno == EINTR)
                       continue;
                     g_warning ("%s: wait: %s",
-                               __FUNCTION__,
+                               __func__,
                                strerror (errno));
                     if (chdir (previous_dir))
                       g_warning ("%s: and chdir failed",
-                                 __FUNCTION__);
+                                 __func__);
                     g_free (previous_dir);
                     return -1;
                   }
@@ -10858,22 +10858,22 @@ send_to_verinice (const char *url, const char *username, const char *password,
                     case EXIT_FAILURE:
                     default:
                       g_warning ("%s: child failed, %s",
-                                 __FUNCTION__,
+                                 __func__,
                                  log_command);
                       if (chdir (previous_dir))
                         g_warning ("%s: and chdir failed",
-                                   __FUNCTION__);
+                                   __func__);
                       g_free (previous_dir);
                       return -1;
                     }
                 else
                   {
                     g_warning ("%s: child failed, %s",
-                               __FUNCTION__,
+                               __func__,
                                log_command);
                     if (chdir (previous_dir))
                       g_warning ("%s: and chdir failed",
-                                 __FUNCTION__);
+                                 __func__);
                     g_free (previous_dir);
                     return -1;
                   }
@@ -10895,13 +10895,13 @@ send_to_verinice (const char *url, const char *username, const char *password,
         if (ret == -1)
           {
             g_warning ("%s: system failed with ret %i, %i, %s",
-                       __FUNCTION__,
+                       __func__,
                        ret,
                        WEXITSTATUS (ret),
                        log_command);
             if (chdir (previous_dir))
               g_warning ("%s: and chdir failed",
-                         __FUNCTION__);
+                         __func__);
             g_free (previous_dir);
             g_free (command);
             return -1;
@@ -10917,7 +10917,7 @@ send_to_verinice (const char *url, const char *username, const char *password,
     if (chdir (previous_dir))
       {
         g_warning ("%s: Failed to chdir back: %s",
-                   __FUNCTION__,
+                   __func__,
                    strerror (errno));
         g_free (previous_dir);
         return -1;
@@ -10963,7 +10963,7 @@ buffer_vfire_call_input (gchar *key, gchar *value, GString *buffer)
   else                                                                        \
     {                                                                         \
       *message = g_strdup ("Mandatory " G_STRINGIFY(param) " missing.");      \
-      g_warning ("%s: Missing " G_STRINGIFY(param) ".", __FUNCTION__);        \
+      g_warning ("%s: Missing " G_STRINGIFY(param) ".", __func__);        \
       g_string_free (config_xml, TRUE);                                       \
       return -1;                                                              \
     }
@@ -11049,7 +11049,7 @@ send_to_vfire (const char *base_url, const char *client_id,
   if (config_xml_fd == -1)
     {
       g_warning ("%s: Could not create alert script config file: %s",
-                 __FUNCTION__, strerror (errno));
+                 __func__, strerror (errno));
       g_string_free (config_xml, TRUE);
       return -1;
     }
@@ -11058,7 +11058,7 @@ send_to_vfire (const char *base_url, const char *client_id,
   if (config_xml_file == NULL)
     {
       g_warning ("%s: Could not open alert script config file: %s",
-                 __FUNCTION__, strerror (errno));
+                 __func__, strerror (errno));
       g_string_free (config_xml, TRUE);
       close (config_xml_fd);
       return -1;
@@ -11067,7 +11067,7 @@ send_to_vfire (const char *base_url, const char *client_id,
   if (fprintf (config_xml_file, "%s", config_xml->str) <= 0)
     {
       g_warning ("%s: Could not write alert script config file: %s",
-                 __FUNCTION__, strerror (errno));
+                 __func__, strerror (errno));
       g_string_free (config_xml, TRUE);
       fclose (config_xml_file);
       return -1;
@@ -11104,16 +11104,16 @@ send_to_vfire (const char *base_url, const char *client_id,
                     &err) == FALSE)
     {
       g_warning ("%s: Failed to run alert script: %s",
-                 __FUNCTION__, err->message);
+                 __func__, err->message);
       ret = -1;
     }
 
   if (exit_status)
     {
       g_warning ("%s: Alert script exited with status %d",
-                 __FUNCTION__, exit_status);
+                 __func__, exit_status);
       g_message ("%s: stderr: %s",
-                 __FUNCTION__, *message);
+                 __func__, *message);
       ret = -5;
     }
 
@@ -11177,7 +11177,7 @@ send_to_tippingpoint (const char *report, size_t report_size,
                            &error) == FALSE)
     {
       g_warning ("%s: Failed to write TLS certificate to file: %s",
-                 __FUNCTION__, error->message);
+                 __func__, error->message);
       alert_script_cleanup (report_dir, report_path, error_path, extra_path);
       g_free (cert_path);
       return -1;
@@ -11194,7 +11194,7 @@ send_to_tippingpoint (const char *report, size_t report_size,
           || chown (cert_path, nobody->pw_uid, nobody->pw_gid))
         {
           g_warning ("%s: Failed to set permissions for user nobody: %s",
-                      __FUNCTION__,
+                      __func__,
                       strerror (errno));
           g_free (cert_path);
           alert_script_cleanup (report_dir, report_path, error_path,
@@ -11320,7 +11320,7 @@ alert_subject_print (const gchar *subject, event_t event,
                   if (tm == NULL)
                     {
                       g_warning ("%s: localtime failed, aborting",
-                                 __FUNCTION__);
+                                 __func__);
                       abort ();
                     }
                   if (strftime (time_string, 98, "%F", tm) == 0)
@@ -11491,7 +11491,7 @@ alert_message_print (const gchar *message, event_t event,
                   if (tm == NULL)
                     {
                       g_warning ("%s: localtime failed, aborting",
-                                 __FUNCTION__);
+                                 __func__);
                       abort ();
                     }
                   if (strftime (time_string, 98, "%F", tm) == 0)
@@ -11935,7 +11935,7 @@ get_delta_report (alert_t alert, task_t task, report_t report)
   if (strcmp (delta_type, "Previous") == 0)
     {
       if (task_report_previous (task, report, &delta_report))
-        g_warning ("%s: failed to get previous report", __FUNCTION__);
+        g_warning ("%s: failed to get previous report", __func__);
     }
   else if (strcmp (delta_type, "Report") == 0)
     {
@@ -11949,7 +11949,7 @@ get_delta_report (alert_t alert, task_t task, report_t report)
           && find_report_with_permission (delta_report_id,
                                           &delta_report,
                                           "get_reports"))
-        g_warning ("%s: error while finding report", __FUNCTION__);
+        g_warning ("%s: error while finding report", __func__);
     }
   free (delta_type);
 
@@ -12155,7 +12155,7 @@ report_content_for_alert (alert_t alert, report_t report, task_t task,
               || (report_format == 0))
             {
               g_warning ("%s: Could not find report format '%s' for %s",
-                         __FUNCTION__, format_uuid,
+                         __func__, format_uuid,
                          alert_method_name (alert_method (alert)));
               g_free (format_uuid);
               return -2;
@@ -12170,7 +12170,7 @@ report_content_for_alert (alert_t alert, report_t report, task_t task,
           || (report_format == 0))
         {
           g_warning ("%s: Could not find report format '%s' for %s",
-                     __FUNCTION__, report_format_lookup,
+                     __func__, report_format_lookup,
                      alert_method_name (alert_method (alert)));
           return -2;
         }
@@ -12181,7 +12181,7 @@ report_content_for_alert (alert_t alert, report_t report, task_t task,
       if (fallback_format_id == NULL)
         {
           g_warning ("%s: No fallback report format for %s",
-                     __FUNCTION__,
+                     __func__,
                      alert_method_name (alert_method (alert)));
           return -1;
         }
@@ -12193,7 +12193,7 @@ report_content_for_alert (alert_t alert, report_t report, task_t task,
           || (report_format == 0))
         {
           g_warning ("%s: Could not find fallback RFP '%s' for %s",
-                      __FUNCTION__, fallback_format_id,
+                      __func__, fallback_format_id,
                      alert_method_name (alert_method (alert)));
           return -2;
         }
@@ -12360,7 +12360,7 @@ escalate_to_vfire (alert_t alert, task_t task, report_t report, event_t event,
     {
       g_warning ("%s: Ticket events with method"
                  " \"Alemba vFire\" not support",
-                 __FUNCTION__);
+                 __func__);
       return -1;
     }
 
@@ -12392,7 +12392,7 @@ escalate_to_vfire (alert_t alert, task_t task, report_t report, event_t event,
   // Generate reports
   if (mkdtemp (reports_dir) == NULL)
     {
-      g_warning ("%s: mkdtemp failed", __FUNCTION__);
+      g_warning ("%s: mkdtemp failed", __func__);
       get_data_reset (alert_filter_get);
       g_free (alert_filter_get);
       return -1;
@@ -12447,7 +12447,7 @@ escalate_to_vfire (alert_t alert, task_t task, report_t report, event_t event,
                                             : NULL);
           if (report_content == NULL)
             {
-              g_warning ("%s: Failed to generate report", __FUNCTION__);
+              g_warning ("%s: Failed to generate report", __func__);
 
               get_data_reset (alert_filter_get);
               g_free (alert_filter_get);
@@ -12479,7 +12479,7 @@ escalate_to_vfire (alert_t alert, task_t task, report_t report, event_t event,
           if (error)
             {
               g_warning ("%s: Failed to write report to %s: %s",
-                         __FUNCTION__,
+                         __func__,
                          alert_report_item->local_filename,
                          error->message);
 
@@ -13000,7 +13000,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
             {
               g_warning ("%s: Ticket events with method"
                          " \"HTTP Get\" not support",
-                         __FUNCTION__);
+                         __func__);
               return -1;
             }
 
@@ -13008,7 +13008,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
             {
               g_warning ("%s: Event \"%s NVTs arrived\" with method"
                          " \"HTTP Get\" not support",
-                         __FUNCTION__,
+                         __func__,
                          event == EVENT_NEW_SECINFO ? "New" : "Updated");
               return -1;
             }
@@ -13092,7 +13092,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
             {
               g_warning ("%s: Ticket events with method"
                          " \"SCP\" not support",
-                         __FUNCTION__);
+                         __func__);
               return -1;
             }
 
@@ -13153,7 +13153,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
                    &report_format, NULL);
           if (ret || report_content == NULL)
             {
-              g_warning ("%s: Empty Report", __FUNCTION__);
+              g_warning ("%s: Empty Report", __func__);
               return -1;
             }
 
@@ -13209,7 +13209,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
             {
               g_warning ("%s: Ticket events with method"
                          " \"Send\" not support",
-                         __FUNCTION__);
+                         __func__);
               return -1;
             }
 
@@ -13246,7 +13246,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
                    &report_format, NULL);
           if (ret || report_content == NULL)
             {
-              g_warning ("%s: Empty Report", __FUNCTION__);
+              g_warning ("%s: Empty Report", __func__);
               return -1;
             }
 
@@ -13282,7 +13282,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
             {
               g_warning ("%s: Ticket events with method"
                          " \"SMP\" not support",
-                         __FUNCTION__);
+                         __func__);
               return -1;
             }
 
@@ -13386,7 +13386,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
               if (ret == 0)
                 {
                   g_warning ("%s: Could not find credential %s",
-                             __FUNCTION__, credential_id);
+                             __func__, credential_id);
                 }
               free (credential_id);
               free (share_path);
@@ -13424,7 +13424,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
             {
               g_warning ("%s: Ticket events with method"
                          " \"SNMP\" not support",
-                         __FUNCTION__);
+                         __func__);
               return -1;
             }
 
@@ -13491,7 +13491,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
             {
               g_warning ("%s: Ticket events with method"
                          " \"Sourcefire\" not support",
-                         __FUNCTION__);
+                         __func__);
               return -1;
             }
 
@@ -13499,7 +13499,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
             {
               g_warning ("%s: Event \"%s NVTs arrived\" with method"
                          " \"Sourcefire\" not support",
-                         __FUNCTION__,
+                         __func__,
                          event == EVENT_NEW_SECINFO ? "New" : "Updated");
               return -1;
             }
@@ -13514,7 +13514,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
                    NULL, NULL, NULL, NULL, &report_format, NULL);
           if (ret || report_content == NULL)
             {
-              g_warning ("%s: Empty Report", __FUNCTION__);
+              g_warning ("%s: Empty Report", __func__);
               return -1;
             }
 
@@ -13611,7 +13611,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
             {
               g_warning ("%s: Ticket events with method"
                          " \"TippingPoint SMS\" not support",
-                         __FUNCTION__);
+                         __func__);
               return -1;
             }
 
@@ -13706,7 +13706,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
             {
               g_warning ("%s: Ticket events with method"
                          " \"Verinice\" not support",
-                         __FUNCTION__);
+                         __func__);
               return -1;
             }
 
@@ -13714,7 +13714,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
             {
               g_warning ("%s: Event \"%s NVTs arrived\" with method"
                          " \"Verinice\" not support",
-                         __FUNCTION__,
+                         __func__,
                          event == EVENT_NEW_SECINFO ? "New" : "Updated");
               return -1;
             }
@@ -13729,7 +13729,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
                    NULL, NULL, NULL, NULL, &report_format, NULL);
           if (ret || report_content == NULL)
             {
-              g_warning ("%s: Empty Report", __FUNCTION__);
+              g_warning ("%s: Empty Report", __func__);
               return -1;
             }
 
@@ -13788,7 +13788,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
             {
               g_warning ("%s: Event \"%s NVTs arrived\" with method"
                          " \"Start Task\" not support",
-                         __FUNCTION__,
+                         __func__,
                          event == EVENT_NEW_SECINFO ? "New" : "Updated");
               return -1;
             }
@@ -13797,7 +13797,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
 
           if (manage_fork_connection == NULL)
             {
-              g_warning ("%s: no connection fork available", __FUNCTION__);
+              g_warning ("%s: no connection fork available", __func__);
               return -1;
             }
 
@@ -13812,7 +13812,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
               case -1:
                 /* Parent on error. */
                 g_free (task_id);
-                g_warning ("%s: fork failed", __FUNCTION__);
+                g_warning ("%s: fork failed", __func__);
                 return -1;
                 break;
 
@@ -14236,10 +14236,10 @@ condition_met (task_t task, report_t report, alert_t alert,
             {
               last_report = 0;
               if (task_last_report (task, &last_report))
-                g_warning ("%s: failed to get last report", __FUNCTION__);
+                g_warning ("%s: failed to get last report", __func__);
             }
 
-          g_debug ("%s: last_report: %llu", __FUNCTION__, last_report);
+          g_debug ("%s: last_report: %llu", __func__, last_report);
           if (last_report)
             {
               int db_count;
@@ -14254,7 +14254,7 @@ condition_met (task_t task, report_t report, alert_t alert,
               db_count = debugs + holes + infos + logs + warnings
                          + false_positives;
 
-              g_debug ("%s: count: %i vs %i", __FUNCTION__, db_count, count);
+              g_debug ("%s: count: %i vs %i", __func__, db_count, count);
               if (db_count >= count)
                 {
                   g_free (filter_id);
@@ -14293,7 +14293,7 @@ condition_met (task_t task, report_t report, alert_t alert,
             {
               last_report = 0;
               if (task_last_report (task, &last_report))
-                g_warning ("%s: failed to get last report", __FUNCTION__);
+                g_warning ("%s: failed to get last report", __func__);
             }
 
           if (last_report)
@@ -14312,7 +14312,7 @@ condition_met (task_t task, report_t report, alert_t alert,
 
               second_last_report = 0;
               if (task_second_last_report (task, &second_last_report))
-                g_warning ("%s: failed to get second last report", __FUNCTION__);
+                g_warning ("%s: failed to get second last report", __func__);
 
               if (second_last_report)
                 {
@@ -15301,7 +15301,7 @@ init_manage_process (const gchar *database)
   /* Open the database. */
   if (sql_open (database))
     {
-      g_warning ("%s: sql_open failed", __FUNCTION__);
+      g_warning ("%s: sql_open failed", __func__);
       abort ();
     }
 
@@ -15321,7 +15321,7 @@ init_manage_process (const gchar *database)
   if (manage_create_sql_functions ())
     {
       lockfile_unlock (&lockfile);
-      g_warning ("%s: failed to create functions", __FUNCTION__);
+      g_warning ("%s: failed to create functions", __func__);
       abort ();
     }
   lockfile_unlock (&lockfile);
@@ -16669,10 +16669,10 @@ check_db_versions ()
                   G_STRINGIFY (GVMD_DATABASE_VERSION)))
         {
           g_message ("%s: database version of database: %s",
-                     __FUNCTION__,
+                     __func__,
                      database_version);
           g_message ("%s: database version supported by manager: %s",
-                     __FUNCTION__,
+                     __func__,
                      G_STRINGIFY (GVMD_DATABASE_VERSION));
           g_free (database_version);
           return -2;
@@ -16705,10 +16705,10 @@ check_db_versions ()
   else if (scap_db_version != manage_scap_db_supported_version ())
     {
       g_message ("%s: database version of SCAP database: %i",
-                 __FUNCTION__,
+                 __func__,
                  scap_db_version);
       g_message ("%s: SCAP database version supported by manager: %s",
-                 __FUNCTION__,
+                 __func__,
                  G_STRINGIFY (GVMD_SCAP_DATABASE_VERSION));
       return -2;
     }
@@ -16721,10 +16721,10 @@ check_db_versions ()
   else if (cert_db_version != manage_cert_db_supported_version ())
     {
       g_message ("%s: database version of CERT database: %i",
-                 __FUNCTION__,
+                 __func__,
                  cert_db_version);
       g_message ("%s: CERT database version supported by manager: %s",
-                 __FUNCTION__,
+                 __func__,
                  G_STRINGIFY (GVMD_CERT_DATABASE_VERSION));
       return -2;
     }
@@ -17112,17 +17112,17 @@ make_report_format_uuids_unique ()
             {
               /* Presume dir missing, just log a warning. */
               g_warning ("%s: cp %s to %s failed",
-                         __FUNCTION__, dir, new_dir);
+                         __func__, dir, new_dir);
             }
           else
-            g_debug ("%s: copied %s to %s", __FUNCTION__, dir, new_dir);
+            g_debug ("%s: copied %s to %s", __func__, dir, new_dir);
         }
       else
         {
           if (rename (dir, new_dir))
             {
               g_warning ("%s: rename %s to %s: %s",
-                         __FUNCTION__, dir, new_dir, strerror (errno));
+                         __func__, dir, new_dir, strerror (errno));
               if (errno != ENOENT)
                 {
                   g_free (dir);
@@ -17132,7 +17132,7 @@ make_report_format_uuids_unique ()
                 }
             }
           else
-            g_debug ("%s: moved %s to %s", __FUNCTION__, dir, new_dir);
+            g_debug ("%s: moved %s to %s", __func__, dir, new_dir);
         }
       g_free (dir);
       g_free (new_dir);
@@ -17146,7 +17146,7 @@ make_report_format_uuids_unique ()
 
   if (sql_changes () > 0)
     g_debug ("%s: gave %d report format(s) new UUID(s) to keep UUIDs unique.",
-             __FUNCTION__, sql_changes ());
+             __func__, sql_changes ());
 
   sql ("DROP TABLE duplicates;");
 
@@ -17176,7 +17176,7 @@ check_db_trash_report_formats ()
       if (errno != ENOENT)
         {
           g_warning ("%s: g_lstat (%s) failed: %s",
-                     __FUNCTION__, dir, g_strerror (errno));
+                     __func__, dir, g_strerror (errno));
           g_free (dir);
           return -1;
         }
@@ -17258,7 +17258,7 @@ check_db_report_formats ()
   if (dir == NULL)
     {
       g_warning ("%s: Failed to open directory '%s': %s",
-                 __FUNCTION__, path, error->message);
+                 __func__, path, error->message);
       g_error_free (error);
       g_free (path);
       return -1;
@@ -17416,7 +17416,7 @@ check_db_report_formats_trash ()
               if (ret)
                 {
                   g_warning ("%s: failed to remove %s from %s",
-                             __FUNCTION__, entry, dir);
+                             __func__, entry, dir);
                   g_dir_close (directory);
                   g_free (dir);
                   return -1;
@@ -17865,7 +17865,7 @@ check_generate_scripts ()
 
           if (chmod (path, 0755 /* rwxr-xr-x */))
             g_warning ("%s: chmod %s failed: %s",
-                       __FUNCTION__,
+                       __func__,
                        path,
                        strerror (errno));
 
@@ -18273,7 +18273,7 @@ manage_cleanup_process_error (int signal)
       if (current_scanner_task)
         {
           g_warning ("%s: Error exit, setting running task to Interrupted",
-                     __FUNCTION__);
+                     __func__);
           set_task_interrupted (current_scanner_task,
                                 "Error exit, setting running task to"
                                 " Interrupted.");
@@ -20471,7 +20471,7 @@ auto_delete_reports ()
 {
   iterator_t tasks;
 
-  g_debug ("%s", __FUNCTION__);
+  g_debug ("%s", __func__);
 
   sql_begin_immediate ();
 
@@ -20511,7 +20511,7 @@ auto_delete_reports ()
       if (keep < AUTO_DELETE_KEEP_MIN || keep > AUTO_DELETE_KEEP_MAX)
         continue;
 
-      g_debug ("%s: %s (%i)", __FUNCTION__,
+      g_debug ("%s: %s (%i)", __func__,
               iterator_string (&tasks, 1),
               keep);
 
@@ -20532,18 +20532,18 @@ auto_delete_reports ()
           report = iterator_int64 (&reports, 0);
           assert (report);
 
-          g_debug ("%s: delete %llu", __FUNCTION__, report);
+          g_debug ("%s: delete %llu", __func__, report);
           ret = delete_report_internal (report);
           if (ret == 2)
             {
               /* Report is in use. */
-              g_debug ("%s: %llu is in use", __FUNCTION__, report);
+              g_debug ("%s: %llu is in use", __func__, report);
               continue;
             }
           if (ret)
             {
               g_warning ("%s: failed to delete %llu (%i)",
-                         __FUNCTION__, report, ret);
+                         __func__, report, ret);
               sql_rollback ();
             }
         }
@@ -20586,7 +20586,7 @@ reschedule_task (const gchar *task_id)
                      task_id))
     {
       case 0:
-        g_warning ("%s: rescheduling task '%s'", __FUNCTION__, task_id);
+        g_warning ("%s: rescheduling task '%s'", __func__, task_id);
         set_task_schedule_next_time (task, time (NULL) - 1);
         break;
       case 1:        /* Too few rows in result of query. */
@@ -20714,7 +20714,7 @@ make_osp_result (task_t task, const char *host, const char *hostname,
                     = g_strdup_printf ("%0.1f",
                                        setting_default_severity_dbl ());
                   g_debug ("%s: OSP CVE result without severity for '%s'",
-                           __FUNCTION__, nvt);
+                           __func__, nvt);
                 }
             }
           else
@@ -20725,7 +20725,7 @@ make_osp_result (task_t task, const char *host, const char *hostname,
                                    setting_default_severity_dbl ());
               */
               g_warning ("%s: Non-CVE OSP result without severity for test %s",
-                         __FUNCTION__, nvt ? nvt : "(unknown)");
+                         __func__, nvt ? nvt : "(unknown)");
               return 0;
             }
         }
@@ -21931,7 +21931,7 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
   if (in_assets_int && acl_user_may ("create_asset") == 0)
     return -6;
 
-  g_debug ("%s", __FUNCTION__);
+  g_debug ("%s", __func__);
 
   if (acl_user_may ("create_report") == 0)
     return 99;
@@ -22014,12 +22014,12 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
                 break;
               case -1:
                 /* Grandchild's parent when error. */
-                g_warning ("%s: fork: %s", __FUNCTION__, strerror (errno));
+                g_warning ("%s: fork: %s", __func__, strerror (errno));
                 exit (EXIT_FAILURE);
                 break;
               default:
                 /* Grandchild's parent.  Exit, to close parent's wait. */
-                g_debug ("%s: %i forked %i", __FUNCTION__, getpid (), pid);
+                g_debug ("%s: %i forked %i", __func__, getpid (), pid);
                 exit (EXIT_SUCCESS);
                 break;
             }
@@ -22027,7 +22027,7 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
         break;
       case -1:
         /* Parent when error. */
-        g_warning ("%s: fork: %s", __FUNCTION__, strerror (errno));
+        g_warning ("%s: fork: %s", __func__, strerror (errno));
         global_current_report = report;
         set_task_interrupted (task,
                               "Failed to fork child to import report."
@@ -22040,19 +22040,19 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
           int status;
 
           /* Parent.  Wait to prevent zombie, then return to respond to client. */
-          g_debug ("%s: %i forked %i", __FUNCTION__, getpid (), pid);
+          g_debug ("%s: %i forked %i", __func__, getpid (), pid);
           while (waitpid (pid, &status, 0) < 0)
             {
               if (errno == ECHILD)
                 {
                   g_warning ("%s: Failed to get child exit status",
-                             __FUNCTION__);
+                             __func__);
                   return -1;
                 }
               if (errno == EINTR)
                 continue;
               g_warning ("%s: waitpid: %s",
-                         __FUNCTION__,
+                         __func__,
                          strerror (errno));
               return -1;
             }
@@ -22069,12 +22069,12 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
                  "SELECT owner FROM tasks WHERE tasks.id = %llu",
                  task))
     {
-      g_warning ("%s: failed to get owner of task", __FUNCTION__);
+      g_warning ("%s: failed to get owner of task", __func__);
       return -1;
     }
 
   sql_begin_immediate ();
-  g_debug ("%s: add hosts", __FUNCTION__);
+  g_debug ("%s: add hosts", __func__);
   index = 0;
   while ((start = (create_report_result_t*) g_ptr_array_index (host_starts,
                                                                index++)))
@@ -22083,7 +22083,7 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
                               parse_iso_time (start->description),
                               0);
 
-  g_debug ("%s: add results", __FUNCTION__);
+  g_debug ("%s: add results", __func__);
   insert = g_string_new ("");
   index = 0;
   first = 1;
@@ -22096,7 +22096,7 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
       gchar *quoted_description, *quoted_scan_nvt_version, *quoted_severity;
       gchar *quoted_qod, *quoted_qod_type;
 
-      g_debug ("%s: add results: index: %i", __FUNCTION__, index);
+      g_debug ("%s: add results: index: %i", __func__, index);
 
       quoted_host = sql_quote (result->host ? result->host : "");
       quoted_hostname = sql_quote (result->hostname ? result->hostname : "");
@@ -22196,7 +22196,7 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
        report,
        report);
 
-  g_debug ("%s: add host ends", __FUNCTION__);
+  g_debug ("%s: add host ends", __func__);
   index = 0;
   count = 0;
   while ((end = (create_report_result_t*) g_ptr_array_index (host_ends,
@@ -22231,7 +22231,7 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
           }
       }
 
-  g_debug ("%s: add host details", __FUNCTION__);
+  g_debug ("%s: add host details", __func__);
   index = 0;
   first = 1;
   count = 0;
@@ -25907,7 +25907,7 @@ report_counts_id_full (report_t report, int* debugs, int* holes, int* infos,
 
   if (current_credentials.uuid == NULL
       || strcmp (current_credentials.uuid, "") == 0)
-    g_warning ("%s: called by NULL or dummy user", __FUNCTION__);
+    g_warning ("%s: called by NULL or dummy user", __func__);
 
   if (get->filt_id && strlen (get->filt_id)
       && strcmp (get->filt_id, FILT_ID_NONE))
@@ -26095,13 +26095,13 @@ report_severity (report_t report, int overrides, int min_qod)
   if (next (&iterator)
       && (iterator_null (&iterator, 0) == 0))
     {
-      g_debug ("%s: max(severity)=%s", __FUNCTION__,
+      g_debug ("%s: max(severity)=%s", __func__,
                iterator_string (&iterator, 0));
       severity = iterator_double (&iterator, 0);
     }
   else
     {
-      g_debug ("%s: could not get max from cache", __FUNCTION__);
+      g_debug ("%s: could not get max from cache", __func__);
       get_data_t *get = report_results_get_data (1, -1, overrides, 0, min_qod);
       report_counts_id (report, NULL, NULL, NULL, NULL, NULL,
                         NULL, &severity, get, NULL);
@@ -26151,7 +26151,7 @@ delete_report_internal (report_t report)
   /* Remove any associated slave task. */
 
   slave_task_uuid = report_slave_task_uuid (report);
-  g_debug ("%s: slave_task_uuid: %s", __FUNCTION__, slave_task_uuid);
+  g_debug ("%s: slave_task_uuid: %s", __func__, slave_task_uuid);
   if (slave_task_uuid)
     {
       scanner_t slave;
@@ -26733,8 +26733,8 @@ result_cmp (iterator_t *results, iterator_t *delta_results, int sort_order,
   if (sort_field == NULL)
     sort_field = "type";
 
-  g_debug ("   delta: %s: sort_order: %i", __FUNCTION__, sort_order);
-  g_debug ("   delta: %s: sort_field: %s", __FUNCTION__, sort_field);
+  g_debug ("   delta: %s: sort_order: %i", __func__, sort_order);
+  g_debug ("   delta: %s: sort_field: %s", __func__, sort_field);
 
   host = result_iterator_host (results);
   delta_host = result_iterator_host (delta_results);
@@ -26777,7 +26777,7 @@ result_cmp (iterator_t *results, iterator_t *delta_results, int sort_order,
       if (sort_order == 0)
         ret = -ret;
       g_debug ("   delta: %s: host (%s): %s VS %s (%i)",
-               __FUNCTION__, sort_order ? "desc" : "asc",
+               __func__, sort_order ? "desc" : "asc",
                host, delta_host, ret);
       if (ret)
         return ret;
@@ -26789,7 +26789,7 @@ result_cmp (iterator_t *results, iterator_t *delta_results, int sort_order,
       if (sort_order == 0)
         ret = -ret;
       g_debug ("   delta: %s: port (%s): %s VS %s (%i)",
-               __FUNCTION__, sort_order ? "desc" : "asc",
+               __func__, sort_order ? "desc" : "asc",
                port, delta_port, ret);
       if (ret)
         return ret;
@@ -26803,7 +26803,7 @@ result_cmp (iterator_t *results, iterator_t *delta_results, int sort_order,
       else
         ret = 0;
       g_debug ("   delta: %s: severity (%s): %f VS %f (%i)",
-               __FUNCTION__, sort_order ? "desc" : "asc",
+               __func__, sort_order ? "desc" : "asc",
                severity, delta_severity, ret);
       if (ret)
         return ret;
@@ -26814,7 +26814,7 @@ result_cmp (iterator_t *results, iterator_t *delta_results, int sort_order,
       if (sort_order)
         ret = -ret;
       g_debug ("   delta: %s: nvt (%s): %s VS %s (%i)",
-               __FUNCTION__, sort_order ? "desc" : "asc",
+               __func__, sort_order ? "desc" : "asc",
                nvt, delta_nvt, ret);
       if (ret)
         return ret;
@@ -26825,7 +26825,7 @@ result_cmp (iterator_t *results, iterator_t *delta_results, int sort_order,
       if (sort_order == 0)
         ret = -ret;
       g_debug ("   delta: %s: description (%s): %s VS %s (%i)",
-               __FUNCTION__, sort_order ? "desc" : "asc",
+               __func__, sort_order ? "desc" : "asc",
                descr, delta_descr, ret);
       if (ret)
         return ret;
@@ -26841,7 +26841,7 @@ result_cmp (iterator_t *results, iterator_t *delta_results, int sort_order,
       if (sort_order == 0)
         ret = -ret;
       g_debug ("   delta: %s: type (%s): %s VS %s (%i)",
-               __FUNCTION__, sort_order ? "desc" : "asc",
+               __func__, sort_order ? "desc" : "asc",
                descr, delta_descr, ret);
       if (ret)
         return ret;
@@ -26857,7 +26857,7 @@ result_cmp (iterator_t *results, iterator_t *delta_results, int sort_order,
       if (sort_order == 0)
         ret = -ret;
       g_debug ("   delta: %s: original_type (%s): %s VS %s (%i)",
-               __FUNCTION__, sort_order ? "desc" : "asc",
+               __func__, sort_order ? "desc" : "asc",
                descr, delta_descr, ret);
       if (ret)
         return ret;
@@ -26880,7 +26880,7 @@ result_cmp (iterator_t *results, iterator_t *delta_results, int sort_order,
       ret = collate_ip (NULL,
                         strlen (host), host, strlen (delta_host), delta_host);
       g_debug ("   delta: %s: host: %s VS %s (%i)",
-               __FUNCTION__, host, delta_host, ret);
+               __func__, host, delta_host, ret);
       if (ret)
         return ret;
     }
@@ -26889,7 +26889,7 @@ result_cmp (iterator_t *results, iterator_t *delta_results, int sort_order,
     {
       ret = strcmp (port, delta_port);
       g_debug ("   delta: %s: port: %s VS %s (%i)",
-               __FUNCTION__, port, delta_port, ret);
+               __func__, port, delta_port, ret);
       if (ret)
         return ret;
     }
@@ -26902,7 +26902,7 @@ result_cmp (iterator_t *results, iterator_t *delta_results, int sort_order,
       else
         ret = 0;
       g_debug ("   delta: %s: severity: %f VS %f (%i)",
-               __FUNCTION__, severity, delta_severity, ret);
+               __func__, severity, delta_severity, ret);
       if (ret)
         return ret;
     }
@@ -26910,7 +26910,7 @@ result_cmp (iterator_t *results, iterator_t *delta_results, int sort_order,
     {
       ret = strcmp (nvt, delta_nvt);
       g_debug ("   delta: %s: nvt: %s VS %s (%i)",
-               __FUNCTION__, nvt, delta_nvt, ret);
+               __func__, nvt, delta_nvt, ret);
       if (ret)
         return ret;
     }
@@ -26935,7 +26935,7 @@ compare_results (iterator_t *results, iterator_t *delta_results, int sort_order,
   int ret;
   const char *descr, *delta_descr;
 
-  g_debug ("   delta: %s", __FUNCTION__);
+  g_debug ("   delta: %s", __func__);
 
   ret = result_cmp (results, delta_results, sort_order, sort_field);
   if (ret > 0)
@@ -26949,7 +26949,7 @@ compare_results (iterator_t *results, iterator_t *delta_results, int sort_order,
   delta_descr = result_iterator_descr (delta_results);
 
   g_debug ("   delta: %s: descr: %s VS %s (%i)",
-          __FUNCTION__,
+          __func__,
           descr ? descr : "NULL",
           delta_descr ? delta_descr : "NULL",
           (descr && delta_descr) ? strcmp (descr, delta_descr) : 0);
@@ -27214,7 +27214,7 @@ add_port (GTree *ports, iterator_t *results)
   *severity = result_iterator_severity_double (results);
 
   old_severity = g_tree_lookup (host_ports, port);
-  g_debug ("   delta: %s: adding %s severity %1.1f on host %s", __FUNCTION__,
+  g_debug ("   delta: %s: adding %s severity %1.1f on host %s", __func__,
           port, *severity, host);
   if (old_severity == NULL)
     g_tree_insert (host_ports, g_strdup (port), severity);
@@ -27239,7 +27239,7 @@ print_host_port (gpointer key, gpointer value, gpointer data)
 {
   gpointer *host_and_stream;
   host_and_stream = (gpointer*) data;
-  g_debug ("   delta: %s: host %s port %s", __FUNCTION__,
+  g_debug ("   delta: %s: host %s port %s", __func__,
           (gchar*) host_and_stream[0], (gchar*) key);
   fprintf ((FILE*) host_and_stream[1],
            "<port>"
@@ -27270,7 +27270,7 @@ print_host_ports (gpointer key, gpointer value, gpointer stream)
   gpointer host_and_stream[2];
   host_and_stream[0] = key;
   host_and_stream[1] = stream;
-  g_debug ("   delta: %s: host %s", __FUNCTION__, (gchar*) key);
+  g_debug ("   delta: %s: host %s", __func__, (gchar*) key);
   g_tree_foreach ((GTree*) value, print_host_port, host_and_stream);
   return FALSE;
 }
@@ -27310,7 +27310,7 @@ print_host_ports_desc (gpointer key, gpointer value, gpointer stream)
   guint index;
   array_t *ports;
 
-  g_debug ("   delta: %s: host %s", __FUNCTION__, (gchar*) key);
+  g_debug ("   delta: %s: host %s", __func__, (gchar*) key);
 
   /* Convert tree to array. */
 
@@ -27403,7 +27403,7 @@ print_host_ports_by_severity (gpointer key, gpointer value, gpointer stream,
   guint index, len;
   array_t *ports;
 
-  g_debug ("   delta: %s: host %s", __FUNCTION__, (gchar*) key);
+  g_debug ("   delta: %s: host %s", __func__, (gchar*) key);
 
   /* Convert tree to array. */
 
@@ -28291,7 +28291,7 @@ tz_revert (gchar *zone, char *tz, char *old_tz_override)
         {
           if (setenv ("TZ", tz, 1) == -1)
             {
-              g_warning ("%s: Failed to switch to original TZ", __FUNCTION__);
+              g_warning ("%s: Failed to switch to original TZ", __func__);
               g_free (tz);
               g_free (zone);
               free (old_tz_override);
@@ -28336,13 +28336,13 @@ host_summary_append (GString *host_summary_buffer, const char *host,
           memset (&start_tm, 0, sizeof (struct tm));
           if (strptime (start_iso, "%FT%H:%M:%S", &start_tm) == NULL)
             {
-              g_warning ("%s: Failed to parse start", __FUNCTION__);
+              g_warning ("%s: Failed to parse start", __func__);
               return;
             }
 
           if (strftime (start, 200, "%b %d, %H:%M:%S", &start_tm) == 0)
             {
-              g_warning ("%s: Failed to format start", __FUNCTION__);
+              g_warning ("%s: Failed to format start", __func__);
               return;
             }
         }
@@ -28356,13 +28356,13 @@ host_summary_append (GString *host_summary_buffer, const char *host,
           memset (&end_tm, 0, sizeof (struct tm));
           if (strptime (end_iso, "%FT%H:%M:%S", &end_tm) == NULL)
             {
-              g_warning ("%s: Failed to parse end", __FUNCTION__);
+              g_warning ("%s: Failed to parse end", __func__);
               return;
             }
 
           if (strftime (end, 200, "%b %d, %H:%M:%S", &end_tm) == 0)
             {
-              g_warning ("%s: Failed to format end", __FUNCTION__);
+              g_warning ("%s: Failed to format end", __func__);
               return;
             }
         }
@@ -28434,29 +28434,29 @@ init_delta_iterators (report_t report, iterator_t *results, report_t delta,
   if (res)
     return -1;
 
-  g_debug ("   delta: %s: REPORT 1:", __FUNCTION__);
+  g_debug ("   delta: %s: REPORT 1:", __func__);
   while (next (results))
     g_debug ("   delta: %s: %s   %s   %s   %s   %.30s",
-            __FUNCTION__,
+            __func__,
             result_iterator_nvt_name (results),
             result_iterator_host (results),
             result_iterator_type (results),
             result_iterator_port (results),
             result_iterator_descr (results));
   cleanup_iterator (results);
-  g_debug ("   delta: %s: REPORT 1 END", __FUNCTION__);
+  g_debug ("   delta: %s: REPORT 1 END", __func__);
 
-  g_debug ("   delta: %s: REPORT 2:", __FUNCTION__);
+  g_debug ("   delta: %s: REPORT 2:", __func__);
   while (next (&results2))
     g_debug ("   delta: %s: %s   %s   %s   %s   %.30s",
-            __FUNCTION__,
+            __func__,
             result_iterator_nvt_name (&results2),
             result_iterator_host (&results2),
             result_iterator_type (&results2),
             result_iterator_port (&results2),
             result_iterator_descr (&results2));
   cleanup_iterator (&results2);
-  g_debug ("   delta: %s: REPORT 2 END", __FUNCTION__);
+  g_debug ("   delta: %s: REPORT 2 END", __func__);
 #endif
 
   res = init_result_get_iterator (results, &delta_get, report, NULL, order);
@@ -28561,10 +28561,10 @@ print_report_delta_xml (FILE *out, iterator_t *results,
 
   /* Compare the results in the two iterators, which are sorted. */
 
-  g_debug ("   delta: %s: start", __FUNCTION__);
-  g_debug ("   delta: %s: sort_field: %s", __FUNCTION__, sort_field);
-  g_debug ("   delta: %s: sort_order: %i", __FUNCTION__, sort_order);
-  g_debug ("   delta: %s: max_results: %i", __FUNCTION__, max_results);
+  g_debug ("   delta: %s: start", __func__);
+  g_debug ("   delta: %s: sort_field: %s", __func__, sort_field);
+  g_debug ("   delta: %s: sort_order: %i", __func__, sort_order);
+  g_debug ("   delta: %s: max_results: %i", __func__, max_results);
   done = !next (results);
   delta_done = !next (delta_results);
   while (1)
@@ -28587,7 +28587,7 @@ print_report_delta_xml (FILE *out, iterator_t *results,
                 const char *level;
 
                 g_debug ("   delta: %s: extra from report 2: %s",
-                        __FUNCTION__,
+                        __func__,
                         result_iterator_nvt_oid (results));
 
                 if (first_result)
@@ -28628,7 +28628,7 @@ print_report_delta_xml (FILE *out, iterator_t *results,
                   }
 
                 g_debug ("   delta: %s: extra from report 2: %s",
-                        __FUNCTION__,
+                        __func__,
                         result_iterator_nvt_oid (delta_results));
                 buffer = g_string_new ("");
                 buffer_results_xml (buffer,
@@ -28669,7 +28669,7 @@ print_report_delta_xml (FILE *out, iterator_t *results,
             do
               {
                 g_debug ("   delta: %s: extra from report 1: %s",
-                        __FUNCTION__,
+                        __func__,
                         result_iterator_nvt_oid (results));
                 if (first_result)
                   {
@@ -28769,7 +28769,7 @@ print_report_delta_xml (FILE *out, iterator_t *results,
       if (state == COMPARE_RESULTS_ERROR)
         {
           g_warning ("%s: compare_and_buffer_results failed",
-                     __FUNCTION__);
+                     __func__);
           return -1;
         }
       if (fprintf (out, "%s", buffer->str) < 0)
@@ -28947,7 +28947,7 @@ print_report_delta_xml (FILE *out, iterator_t *results,
 
   /* Compare remaining results, for the filtered report counts. */
 
-  g_debug ("   delta: %s: counting rest", __FUNCTION__);
+  g_debug ("   delta: %s: counting rest", __func__);
   while (1)
     {
       compare_results_t state;
@@ -28964,7 +28964,7 @@ print_report_delta_xml (FILE *out, iterator_t *results,
                 const char *level;
 
                 g_debug ("   delta: %s: extra from report 2: %s",
-                        __FUNCTION__,
+                        __func__,
                         result_iterator_nvt_oid (delta_results));
 
                 /* Increase the result count. */
@@ -29002,7 +29002,7 @@ print_report_delta_xml (FILE *out, iterator_t *results,
             do
               {
                 g_debug ("   delta: %s: extra from report 1: %s",
-                        __FUNCTION__,
+                        __func__,
                         result_iterator_nvt_oid (results));
 
                 /* It's in the count already. */
@@ -29064,7 +29064,7 @@ print_report_delta_xml (FILE *out, iterator_t *results,
       if (state == COMPARE_RESULTS_ERROR)
         {
           g_warning ("%s: compare_and_buffer_results failed",
-                     __FUNCTION__);
+                     __func__);
           return -1;
         }
 
@@ -29295,7 +29295,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
   if (out == NULL)
     {
       g_warning ("%s: fopen failed: %s",
-                 __FUNCTION__,
+                 __func__,
                  strerror (errno));
       return -1;
     }
@@ -29401,7 +29401,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
 
       if (setenv ("TZ", zone, 1) == -1)
         {
-          g_warning ("%s: Failed to switch to timezone", __FUNCTION__);
+          g_warning ("%s: Failed to switch to timezone", __func__);
           if (tz != NULL)
             setenv ("TZ", tz, 1);
           g_free (tz);
@@ -30448,7 +30448,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
   if (fclose (out))
     {
       g_warning ("%s: fclose failed: %s",
-                 __FUNCTION__,
+                 __func__,
                  strerror (errno));
       return -1;
     }
@@ -30474,7 +30474,7 @@ print_report_xml_end (gchar *xml_start, gchar *xml_full,
 
   if (gvm_file_copy (xml_start, xml_full) == FALSE)
     {
-      g_warning ("%s: failed to copy xml_start file", __FUNCTION__);
+      g_warning ("%s: failed to copy xml_start file", __func__);
       return -1;
     }
 
@@ -30482,7 +30482,7 @@ print_report_xml_end (gchar *xml_start, gchar *xml_full,
   if (out == NULL)
     {
       g_warning ("%s: fopen failed: %s",
-                 __FUNCTION__,
+                 __func__,
                  strerror (errno));
       return -1;
     }
@@ -30503,7 +30503,7 @@ print_report_xml_end (gchar *xml_start, gchar *xml_full,
   if (fclose (out))
     {
       g_warning ("%s: fclose failed: %s",
-                 __FUNCTION__,
+                 __func__,
                  strerror (errno));
       return -1;
     }
@@ -30561,7 +30561,7 @@ manage_report (report_t report, report_t delta_report, const get_data_t *get,
 
   if (mkdtemp (xml_dir) == NULL)
     {
-      g_warning ("%s: mkdtemp failed", __FUNCTION__);
+      g_warning ("%s: mkdtemp failed", __func__);
       return NULL;
     }
 
@@ -30590,7 +30590,7 @@ manage_report (report_t report, report_t delta_report, const get_data_t *get,
 
   if (output_file == NULL)
     {
-      g_warning ("%s: No file returned for report format", __FUNCTION__);
+      g_warning ("%s: No file returned for report format", __func__);
     }
   g_free (xml_file);
   g_free (xml_start);
@@ -30613,7 +30613,7 @@ manage_report (report_t report, report_t delta_report, const get_data_t *get,
     {
       g_free (report_format_id);
       g_warning ("%s: Failed to get output: %s",
-                  __FUNCTION__,
+                  __func__,
                   get_error->message);
       g_error_free (get_error);
       if (extension) g_free (*extension);
@@ -30731,7 +30731,7 @@ run_report_format_script (gchar *report_format_id,
                     G_FILE_TEST_EXISTS | G_FILE_TEST_IS_REGULAR))
     {
       g_warning ("%s: No generate script found at %s",
-                 __FUNCTION__, script);
+                 __func__, script);
       g_free (script);
       g_free (script_dir);
       return -1;
@@ -30740,7 +30740,7 @@ run_report_format_script (gchar *report_format_id,
                          G_FILE_TEST_IS_EXECUTABLE))
     {
       g_warning ("%s: script %s is not executable",
-                 __FUNCTION__, script);
+                 __func__, script);
       g_free (script);
       g_free (script_dir);
       return -1;
@@ -30752,7 +30752,7 @@ run_report_format_script (gchar *report_format_id,
   if (previous_dir == NULL)
     {
       g_warning ("%s: Failed to getcwd: %s",
-                  __FUNCTION__,
+                  __func__,
                   strerror (errno));
       g_free (previous_dir);
       g_free (script);
@@ -30763,7 +30763,7 @@ run_report_format_script (gchar *report_format_id,
   if (chdir (script_dir))
     {
       g_warning ("%s: Failed to chdir: %s",
-                  __FUNCTION__,
+                  __func__,
                   strerror (errno));
       g_free (previous_dir);
       g_free (script);
@@ -30798,7 +30798,7 @@ run_report_format_script (gchar *report_format_id,
           || chown (output_file, nobody->pw_uid, nobody->pw_gid))
         {
           g_warning ("%s: Failed to set dir permissions: %s",
-                      __FUNCTION__,
+                      __func__,
                       strerror (errno));
           g_free (previous_dir);
           return -1;
@@ -30818,20 +30818,20 @@ run_report_format_script (gchar *report_format_id,
               if (setgroups (0,NULL))
                 {
                   g_warning ("%s (child): setgroups: %s",
-                              __FUNCTION__, strerror (errno));
+                              __func__, strerror (errno));
                   exit (EXIT_FAILURE);
                 }
               if (setgid (nobody->pw_gid))
                 {
                   g_warning ("%s (child): setgid: %s",
-                              __FUNCTION__,
+                              __func__,
                               strerror (errno));
                   exit (EXIT_FAILURE);
                 }
               if (setuid (nobody->pw_uid))
                 {
                   g_warning ("%s (child): setuid: %s",
-                              __FUNCTION__,
+                              __func__,
                               strerror (errno));
                   exit (EXIT_FAILURE);
                 }
@@ -30843,7 +30843,7 @@ run_report_format_script (gchar *report_format_id,
                 {
                   g_warning ("%s (child):"
                               " system failed with ret %i, %i, %s",
-                              __FUNCTION__,
+                              __func__,
                               ret,
                               WEXITSTATUS (ret),
                               command);
@@ -30857,11 +30857,11 @@ run_report_format_script (gchar *report_format_id,
             /* Parent when error. */
 
             g_warning ("%s: Failed to fork: %s",
-                        __FUNCTION__,
+                        __func__,
                         strerror (errno));
             if (chdir (previous_dir))
               g_warning ("%s: and chdir failed",
-                          __FUNCTION__);
+                          __func__);
             g_free (previous_dir);
             g_free (command);
             return -1;
@@ -30880,21 +30880,21 @@ run_report_format_script (gchar *report_format_id,
                   if (errno == ECHILD)
                     {
                       g_warning ("%s: Failed to get child exit status",
-                                  __FUNCTION__);
+                                  __func__);
                       if (chdir (previous_dir))
                         g_warning ("%s: and chdir failed",
-                                    __FUNCTION__);
+                                    __func__);
                       g_free (previous_dir);
                       return -1;
                     }
                   if (errno == EINTR)
                     continue;
                   g_warning ("%s: wait: %s",
-                              __FUNCTION__,
+                              __func__,
                               strerror (errno));
                   if (chdir (previous_dir))
                     g_warning ("%s: and chdir failed",
-                                __FUNCTION__);
+                                __func__);
                   g_free (previous_dir);
                   return -1;
                 }
@@ -30906,22 +30906,22 @@ run_report_format_script (gchar *report_format_id,
                     case EXIT_FAILURE:
                     default:
                       g_warning ("%s: child failed, %s",
-                                  __FUNCTION__,
+                                  __func__,
                                   command);
                       if (chdir (previous_dir))
                         g_warning ("%s: and chdir failed",
-                                    __FUNCTION__);
+                                    __func__);
                       g_free (previous_dir);
                       return -1;
                   }
               else
                 {
                   g_warning ("%s: child failed, %s",
-                              __FUNCTION__,
+                              __func__,
                               command);
                   if (chdir (previous_dir))
                     g_warning ("%s: and chdir failed",
-                                __FUNCTION__);
+                                __func__);
                   g_free (previous_dir);
                   return -1;
                 }
@@ -30942,13 +30942,13 @@ run_report_format_script (gchar *report_format_id,
       if (ret == -1)
         {
           g_warning ("%s: system failed with ret %i, %i, %s",
-                      __FUNCTION__,
+                      __func__,
                       ret,
                       WEXITSTATUS (ret),
                       command);
           if (chdir (previous_dir))
             g_warning ("%s: and chdir failed",
-                        __FUNCTION__);
+                        __func__);
           g_free (previous_dir);
           g_free (command);
           return -1;
@@ -30962,7 +30962,7 @@ run_report_format_script (gchar *report_format_id,
   if (chdir (previous_dir))
     {
       g_warning ("%s: Failed to chdir back: %s",
-                  __FUNCTION__,
+                  __func__,
                   strerror (errno));
       g_free (previous_dir);
       return -1;
@@ -31009,7 +31009,7 @@ apply_report_format (gchar *report_format_id,
                              (GCompareFunc) strcmp))
     {
       g_message ("%s: Recursion loop for report_format '%s'",
-                 __FUNCTION__, report_format_id);
+                 __func__, report_format_id);
       return NULL;
     }
 
@@ -31019,7 +31019,7 @@ apply_report_format (gchar *report_format_id,
       || report_format == 0)
     {
       g_message ("%s: Report format '%s' not found",
-                 __FUNCTION__, report_format_id);
+                 __func__, report_format_id);
       return NULL;
     }
 
@@ -31027,7 +31027,7 @@ apply_report_format (gchar *report_format_id,
   if (report_format_active (report_format) == 0)
     {
       g_message ("%s: Report format '%s' is not active",
-                 __FUNCTION__, report_format_id);
+                 __func__, report_format_id);
       return NULL;
     }
 
@@ -31066,7 +31066,7 @@ apply_report_format (gchar *report_format_id,
 
           if (mkdtemp (subreport_dir) == NULL)
             {
-              g_warning ("%s: mkdtemp failed", __FUNCTION__);
+              g_warning ("%s: mkdtemp failed", __func__);
               g_free (subreport_dir);
               break;
             }
@@ -31160,7 +31160,7 @@ apply_report_format (gchar *report_format_id,
   output_fd = mkstemps (output_file, strlen (out_file_ext) + 1);
   if (output_fd == -1)
     {
-      g_warning ("%s: mkstemps failed: %s", __FUNCTION__, strerror (errno));
+      g_warning ("%s: mkstemps failed: %s", __func__, strerror (errno));
       g_free (output_file);
       output_file = NULL;
       goto cleanup;
@@ -31198,7 +31198,7 @@ apply_report_format (gchar *report_format_id,
   if (close (output_fd))
     {
       g_warning ("%s: close of output_fd failed: %s",
-                 __FUNCTION__, strerror (errno));
+                 __func__, strerror (errno));
       g_free (output_file);
       return NULL;
     }
@@ -31304,7 +31304,7 @@ manage_send_report (report_t report, report_t delta_report,
 
   if (mkdtemp (xml_dir) == NULL)
     {
-      g_warning ("%s: mkdtemp failed", __FUNCTION__);
+      g_warning ("%s: mkdtemp failed", __func__);
       return -1;
     }
 
@@ -31332,7 +31332,7 @@ manage_send_report (report_t report, report_t delta_report,
 
   if (output_file == NULL)
     {
-      g_warning ("%s: No file returned for report format", __FUNCTION__);
+      g_warning ("%s: No file returned for report format", __func__);
     }
   g_free (report_format_id);
 
@@ -31345,7 +31345,7 @@ manage_send_report (report_t report, report_t delta_report,
   if (stream == NULL)
     {
       g_warning ("%s: %s",
-                  __FUNCTION__,
+                  __func__,
                   strerror (errno));
       gvm_file_remove_recurse (xml_dir);
       return -1;
@@ -31354,7 +31354,7 @@ manage_send_report (report_t report, report_t delta_report,
   if (prefix && send (prefix, send_data_1, send_data_2))
     {
       fclose (stream);
-      g_warning ("%s: send prefix error", __FUNCTION__);
+      g_warning ("%s: send prefix error", __func__);
       gvm_file_remove_recurse (xml_dir);
       return -1;
     }
@@ -31374,7 +31374,7 @@ manage_send_report (report_t report, report_t delta_report,
           if (ferror (stream))
             {
               fclose (stream);
-              g_warning ("%s: error after fread", __FUNCTION__);
+              g_warning ("%s: error after fread", __func__);
               gvm_file_remove_recurse (xml_dir);
               return -1;
             }
@@ -31400,7 +31400,7 @@ manage_send_report (report_t report, report_t delta_report,
                 {
                   g_free (chunk64);
                   fclose (stream);
-                  g_warning ("%s: send error", __FUNCTION__);
+                  g_warning ("%s: send error", __func__);
                   gvm_file_remove_recurse (xml_dir);
                   return -1;
                 }
@@ -31412,7 +31412,7 @@ manage_send_report (report_t report, report_t delta_report,
               if (send (chunk, send_data_1, send_data_2))
                 {
                   fclose (stream);
-                  g_warning ("%s: send error", __FUNCTION__);
+                  g_warning ("%s: send error", __func__);
                   gvm_file_remove_recurse (xml_dir);
                   return -1;
                 }
@@ -31608,7 +31608,7 @@ parse_osp_report (task_t task, report_t report, const char *report_xml)
            */
           if (manage_report_host_detail (report, host, desc))
             g_warning ("%s: Failed to add report detail for host '%s': %s",
-                      __FUNCTION__,
+                      __func__,
                       host,
                       desc);
         }
@@ -35862,7 +35862,7 @@ static gchar *
 new_secinfo_list (event_t event, const void* event_data, alert_t alert,
                   int *count_return)
 {
-  g_debug ("%s: event_data: %s", __FUNCTION__, (gchar*) event_data);
+  g_debug ("%s: event_data: %s", __func__, (gchar*) event_data);
 
   if (strcasecmp (event_data, "nvt_example") == 0)
     return new_nvts_list (event, "nvt", alert, 1, count_return);
@@ -35896,7 +35896,7 @@ new_secinfo_list (event_t event, const void* event_data, alert_t alert,
 
   if (count_return)
     {
-      g_warning ("%s: Type error: %s", __FUNCTION__, (char *) event_data);
+      g_warning ("%s: Type error: %s", __func__, (char *) event_data);
       *count_return = 0;
     }
 
@@ -36349,7 +36349,7 @@ create_credential (const char* name, const char* comment, const char* login,
     quoted_type = g_strdup ("usk"); /* auto-generate */
   else
     {
-      g_warning ("%s: Cannot determine type of new credential", __FUNCTION__);
+      g_warning ("%s: Cannot determine type of new credential", __func__);
       return -1;
     }
 
@@ -37040,7 +37040,7 @@ modify_credential (const char *credential_id,
         }
       else
         {
-          g_warning ("%s: Unknown credential type: %s", __FUNCTION__, type);
+          g_warning ("%s: Unknown credential type: %s", __func__, type);
           sql_rollback ();
           cleanup_iterator (&iterator);
           g_free (key_private_truncated);
@@ -37051,7 +37051,7 @@ modify_credential (const char *credential_id,
     }
   else
     {
-      g_warning ("%s: credential iterator next() failed", __FUNCTION__);
+      g_warning ("%s: credential iterator next() failed", __func__);
       sql_rollback ();
       cleanup_iterator (&iterator);
       return -1;
@@ -37810,7 +37810,7 @@ credential_iterator_encrypted_data (iterator_t* iterator, const char* type)
   secret = iterator_string (iterator, GET_ITERATOR_COLUMN_COUNT + 7);
   if (type == NULL)
     {
-      g_warning ("%s: NULL data type given", __FUNCTION__);
+      g_warning ("%s: NULL data type given", __func__);
       return NULL;
     }
   else if (strcmp (type, "password") == 0)
@@ -37823,7 +37823,7 @@ credential_iterator_encrypted_data (iterator_t* iterator, const char* type)
     unencrypted  = iterator_string (iterator, GET_ITERATOR_COLUMN_COUNT + 11);
   else
     {
-      g_warning ("%s: unknown data type \"%s\"", __FUNCTION__, type);
+      g_warning ("%s: unknown data type \"%s\"", __func__, type);
       return NULL;
     }
   /* If we do not have a private key, there is no encrypted data.
@@ -38009,7 +38009,7 @@ credential_iterator_rpm (iterator_t *iterator)
     }
   else if (lsc_user_rpm_recreate (login, public_key, &rpm, &rpm_size))
     {
-      g_warning ("%s: Failed to create RPM", __FUNCTION__);
+      g_warning ("%s: Failed to create RPM", __func__);
       g_free (public_key);
       return NULL;
     }
@@ -38058,7 +38058,7 @@ credential_iterator_deb (iterator_t *iterator)
                                   maintainer ? maintainer : "",
                                   &deb, &deb_size))
     {
-      g_warning ("%s: Failed to create DEB", __FUNCTION__);
+      g_warning ("%s: Failed to create DEB", __func__);
       g_free (public_key);
       free (maintainer);
       return NULL;
@@ -38097,7 +38097,7 @@ credential_iterator_exe (iterator_t *iterator)
     return NULL;
   else if (lsc_user_exe_recreate (login, password, &exe, &exe_size))
     {
-      g_warning ("%s: Failed to create EXE", __FUNCTION__);
+      g_warning ("%s: Failed to create EXE", __func__);
       return NULL;
     }
   exe64 = (exe && exe_size)
@@ -38547,7 +38547,7 @@ find_signature (const gchar *location, const gchar *installer_filename,
             }
           else
             {
-              g_debug ("%s: failed to read %s: %s", __FUNCTION__,
+              g_debug ("%s: failed to read %s: %s", __func__,
                        signature_filename, error->message);
               g_free (signature_filename);
             }
@@ -38678,7 +38678,7 @@ verify_signature (const gchar *installer, gsize installer_size,
   cmd[8] = g_strdup (installer_file);
   cmd[9] = NULL;
   g_debug ("%s: Spawning in /tmp/: %s %s %s %s %s %s %s %s %s",
-           __FUNCTION__,
+           __func__,
            cmd[0], cmd[1], cmd[2], cmd[3], cmd[4], cmd[5],
            cmd[6], cmd[7], cmd[8]);
   if ((g_spawn_sync ("/tmp/",
@@ -38700,12 +38700,12 @@ verify_signature (const gchar *installer, gsize installer_size,
         {
 #if 0
           g_debug ("%s: failed to run gpgv(%s): %d (WIF %i, WEX %i)",
-                   __FUNCTION__, get_trustedkeys_name (),
+                   __func__, get_trustedkeys_name (),
                    exit_status,
                    WIFEXITED (exit_status),
                    WEXITSTATUS (exit_status));
-          g_debug ("%s: stdout: %s", __FUNCTION__, standard_out);
-          g_debug ("%s: stderr: %s", __FUNCTION__, standard_err);
+          g_debug ("%s: stdout: %s", __func__, standard_out);
+          g_debug ("%s: stderr: %s", __func__, standard_err);
           ret = -1;
 #endif
           /* This can be caused by the contents of the signature file, so
@@ -38870,7 +38870,7 @@ create_agent (const char* name, const char* comment, const char* installer_64,
         g_free (quoted_filename);
         if (stmt == NULL)
           {
-            g_warning ("%s: sql_prepare failed", __FUNCTION__);
+            g_warning ("%s: sql_prepare failed", __func__);
             g_free (installer);
             g_free (installer_signature);
             sql_rollback ();
@@ -38881,7 +38881,7 @@ create_agent (const char* name, const char* comment, const char* installer_64,
 
         if (sql_bind_text (stmt, 1, installer, installer_size))
           {
-            g_warning ("%s: sql_bind_text failed", __FUNCTION__);
+            g_warning ("%s: sql_bind_text failed", __func__);
             sql_rollback ();
             g_free (installer);
             g_free (installer_signature);
@@ -38891,7 +38891,7 @@ create_agent (const char* name, const char* comment, const char* installer_64,
 
         if (sql_bind_text (stmt, 2, installer_64, strlen (installer_64)))
           {
-            g_warning ("%s: sql_bind_text failed", __FUNCTION__);
+            g_warning ("%s: sql_bind_text failed", __func__);
             sql_rollback ();
             g_free (installer_signature);
             return -1;
@@ -38901,21 +38901,21 @@ create_agent (const char* name, const char* comment, const char* installer_64,
         if (sql_bind_text (stmt, 3, installer_signature_64,
                            strlen (installer_signature_64)))
           {
-            g_warning ("%s: sql_bind_text failed", __FUNCTION__);
+            g_warning ("%s: sql_bind_text failed", __func__);
             sql_rollback ();
             return -1;
           }
 
         if (sql_bind_text (stmt, 4, howto_install, strlen (howto_install)))
           {
-            g_warning ("%s: sql_bind_text failed", __FUNCTION__);
+            g_warning ("%s: sql_bind_text failed", __func__);
             sql_rollback ();
             return -1;
           }
 
         if (sql_bind_blob (stmt, 5, howto_use, strlen (howto_use)))
           {
-            g_warning ("%s: sql_bind_blob failed", __FUNCTION__);
+            g_warning ("%s: sql_bind_blob failed", __func__);
             sql_rollback ();
             return -1;
           }
@@ -38931,7 +38931,7 @@ create_agent (const char* name, const char* comment, const char* installer_64,
           }
         if (ret < 0)
           {
-            g_warning ("%s: sql_exec failed", __FUNCTION__);
+            g_warning ("%s: sql_exec failed", __func__);
             sql_rollback ();
             return -1;
           }
@@ -39554,7 +39554,7 @@ verify_agent (const char *agent_id)
 
       signature_64 = agent_iterator_installer_signature_64 (&agents);
 
-      g_debug ("%s: finding signature", __FUNCTION__);
+      g_debug ("%s: finding signature", __func__);
 
       find_signature ("agents",
                       agent_iterator_installer_filename (&agents),
@@ -39578,7 +39578,7 @@ verify_agent (const char *agent_id)
 
               /* Try the signature from the database. */
 
-              g_debug ("%s: trying database signature", __FUNCTION__);
+              g_debug ("%s: trying database signature", __func__);
 
               signature = (gchar*) g_base64_decode (signature_64,
                                                     &signature_length);
@@ -39586,7 +39586,7 @@ verify_agent (const char *agent_id)
               if (verify_signature (installer, installer_size, signature,
                                     signature_length, &agent_trust))
                 {
-                  g_warning ("%s: verify_signature error", __FUNCTION__);
+                  g_warning ("%s: verify_signature error", __func__);
                   cleanup_iterator (&agents);
                   g_free (agent_signature);
                   sql_rollback ();
@@ -39601,12 +39601,12 @@ verify_agent (const char *agent_id)
                || (agent_trust == TRUST_UNKNOWN))
               && agent_signature)
             {
-              g_debug ("%s: trying feed signature", __FUNCTION__);
+              g_debug ("%s: trying feed signature", __func__);
 
               if (verify_signature (installer, installer_size, agent_signature,
                                     strlen (agent_signature), &agent_trust))
                 {
-                  g_warning ("%s: verify_signature error", __FUNCTION__);
+                  g_warning ("%s: verify_signature error", __func__);
                   cleanup_iterator (&agents);
                   g_free (agent_signature);
                   sql_rollback ();
@@ -39634,7 +39634,7 @@ verify_agent (const char *agent_id)
     }
   else
     {
-      g_warning ("%s: agent iterator empty", __FUNCTION__);
+      g_warning ("%s: agent iterator empty", __func__);
       cleanup_iterator (&agents);
       sql_rollback ();
       return -1;
@@ -43809,7 +43809,7 @@ osp_scanner_relay_connect (const char *host, int port, const char *ca_pub,
         return NULL;
       default:
         g_warning ("%s: Error getting relay for Scanner at %s:%d",
-                   __FUNCTION__, host, port);
+                   __func__, host, port);
         return NULL;
     }
 
@@ -44123,7 +44123,7 @@ verify_scanner (const char *scanner_id, char **version)
           cleanup_iterator (&scanner);
           return 2;
         }
-      g_debug ("%s: *version: %s", __FUNCTION__, *version);
+      g_debug ("%s: *version: %s", __func__, *version);
       gvm_connection_close (&connection);
       cleanup_iterator (&scanner);
       return 0;
@@ -45927,7 +45927,7 @@ create_report_format (const char *uuid, const char *name,
                 {
                   g_free (real_old);
                   g_free (old);
-                  g_warning ("%s: readlink failed", __FUNCTION__);
+                  g_warning ("%s: readlink failed", __func__);
                   sql_rollback ();
                   return -1;
                 }
@@ -45946,7 +45946,7 @@ create_report_format (const char *uuid, const char *name,
       if (g_mkdir_with_parents (path, 0755 /* "rwxr-xr-x" */))
         {
           g_warning ("%s: failed to create dir %s: %s",
-                     __FUNCTION__, path, strerror (errno));
+                     __func__, path, strerror (errno));
           g_free (old);
           g_free (path);
           sql_rollback ();
@@ -45961,7 +45961,7 @@ create_report_format (const char *uuid, const char *name,
         {
           g_free (old);
           g_free (new);
-          g_warning ("%s: symlink failed: %s", __FUNCTION__, strerror (errno));
+          g_warning ("%s: symlink failed: %s", __func__, strerror (errno));
           sql_rollback ();
           return -1;
         }
@@ -46001,7 +46001,7 @@ create_report_format (const char *uuid, const char *name,
 
   if (g_file_test (dir, G_FILE_TEST_EXISTS) && gvm_file_remove_recurse (dir))
     {
-      g_warning ("%s: failed to remove dir %s", __FUNCTION__, dir);
+      g_warning ("%s: failed to remove dir %s", __func__, dir);
       g_free (dir);
       g_free (quoted_name);
       g_free (new_uuid);
@@ -46012,7 +46012,7 @@ create_report_format (const char *uuid, const char *name,
   if (g_mkdir_with_parents (dir, 0755 /* "rwxr-xr-x" */))
     {
       g_warning ("%s: failed to create dir %s: %s",
-                 __FUNCTION__, dir, strerror (errno));
+                 __func__, dir, strerror (errno));
       g_free (dir);
       g_free (quoted_name);
       g_free (new_uuid);
@@ -46034,7 +46034,7 @@ create_report_format (const char *uuid, const char *name,
       if (chmod (report_dir, 0755 /* rwxr-xr-x */))
         {
           g_warning ("%s: chmod failed: %s",
-                     __FUNCTION__,
+                     __func__,
                      strerror (errno));
           g_free (dir);
           g_free (report_dir);
@@ -46051,7 +46051,7 @@ create_report_format (const char *uuid, const char *name,
   if (chmod (dir, 0755 /* rwxr-xr-x */))
     {
       g_warning ("%s: chmod failed: %s",
-                 __FUNCTION__,
+                 __func__,
                  strerror (errno));
       g_free (dir);
       g_free (quoted_name);
@@ -46094,7 +46094,7 @@ create_report_format (const char *uuid, const char *name,
       g_free (contents);
       if (error)
         {
-          g_warning ("%s: %s", __FUNCTION__, error->message);
+          g_warning ("%s: %s", __func__, error->message);
           g_error_free (error);
           gvm_file_remove_recurse (dir);
           g_free (full_file_name);
@@ -46112,7 +46112,7 @@ create_report_format (const char *uuid, const char *name,
       if (ret)
         {
           g_warning ("%s: chmod failed: %s",
-                     __FUNCTION__,
+                     __func__,
                      strerror (errno));
           gvm_file_remove_recurse (dir);
           g_free (full_file_name);
@@ -46290,7 +46290,7 @@ create_report_format (const char *uuid, const char *name,
         options = (array_t*) g_ptr_array_index (params_options, index - 1);
         if (options == NULL)
           {
-            g_warning ("%s: options was NULL", __FUNCTION__);
+            g_warning ("%s: options was NULL", __func__);
             gvm_file_remove_recurse (dir);
             g_free (dir);
             sql_rollback ();
@@ -46414,7 +46414,7 @@ copy_report_format (const char* name, const char* source_uuid,
   if (!g_file_test (source_dir, G_FILE_TEST_EXISTS))
     {
       g_warning ("%s: report format directory %s not found",
-                 __FUNCTION__, source_dir);
+                 __func__, source_dir);
       g_free (source_dir);
       sql_rollback ();
       return -1;
@@ -46438,7 +46438,7 @@ copy_report_format (const char* name, const char* source_uuid,
   if (g_file_test (copy_dir, G_FILE_TEST_EXISTS)
       && gvm_file_remove_recurse (copy_dir))
     {
-      g_warning ("%s: failed to remove dir %s", __FUNCTION__, copy_dir);
+      g_warning ("%s: failed to remove dir %s", __func__, copy_dir);
       g_free (source_dir);
       g_free (copy_dir);
       g_free (copy_uuid);
@@ -46448,7 +46448,7 @@ copy_report_format (const char* name, const char* source_uuid,
 
   if (g_mkdir_with_parents (copy_dir, 0755 /* "rwxr-xr-x" */))
     {
-      g_warning ("%s: failed to create dir %s", __FUNCTION__, copy_dir);
+      g_warning ("%s: failed to create dir %s", __func__, copy_dir);
       g_free (source_dir);
       g_free (copy_dir);
       g_free (copy_uuid);
@@ -46466,7 +46466,7 @@ copy_report_format (const char* name, const char* source_uuid,
   if (chmod (tmp_dir, 0755 /* rwxr-xr-x */))
     {
       g_warning ("%s: chmod %s failed: %s",
-                 __FUNCTION__,
+                 __func__,
                  tmp_dir,
                  strerror (errno));
       g_free (source_dir);
@@ -46487,7 +46487,7 @@ copy_report_format (const char* name, const char* source_uuid,
   if (chmod (tmp_dir, 0755 /* rwxr-xr-x */))
     {
       g_warning ("%s: chmod %s failed: %s",
-                 __FUNCTION__,
+                 __func__,
                  tmp_dir,
                  strerror (errno));
       g_free (source_dir);
@@ -46534,7 +46534,7 @@ copy_report_format (const char* name, const char* source_uuid,
             if (gvm_file_copy (source_file, copy_file) == FALSE)
               {
                 g_warning ("%s: copy of %s to %s failed",
-                           __FUNCTION__, source_file, copy_file);
+                           __func__, source_file, copy_file);
                 g_free (source_file);
                 g_free (copy_file);
                 g_free (source_dir);
@@ -46675,7 +46675,7 @@ move_report_format_dir (const char *dir, const char *new_dir)
 
               if (g_mkdir_with_parents (new_dir, 0755 /* "rwxr-xr-x" */))
                 {
-                  g_warning ("%s: failed to create dir %s", __FUNCTION__,
+                  g_warning ("%s: failed to create dir %s", __func__,
                              new_dir);
                   return -1;
                 }
@@ -46686,7 +46686,7 @@ move_report_format_dir (const char *dir, const char *new_dir)
               if (directory == NULL)
                 {
                   g_warning ("%s: failed to g_dir_open %s: %s",
-                             __FUNCTION__, dir, error->message);
+                             __func__, dir, error->message);
                   g_error_free (error);
                   return -1;
                 }
@@ -46700,7 +46700,7 @@ move_report_format_dir (const char *dir, const char *new_dir)
                   if (gvm_file_move (entry_path, new_path) == FALSE)
                     {
                       g_warning ("%s: failed to move %s to %s",
-                                 __FUNCTION__, entry_path, new_path);
+                                 __func__, entry_path, new_path);
                       g_free (entry_path);
                       g_free (new_path);
                       g_dir_close (directory);
@@ -46717,7 +46717,7 @@ move_report_format_dir (const char *dir, const char *new_dir)
           else
             {
               g_warning ("%s: rename %s to %s: %s",
-                         __FUNCTION__, dir, new_dir, strerror (errno));
+                         __func__, dir, new_dir, strerror (errno));
               return -1;
             }
         }
@@ -46725,7 +46725,7 @@ move_report_format_dir (const char *dir, const char *new_dir)
   else
     {
       g_warning ("%s: report dir missing: %s",
-                 __FUNCTION__, dir);
+                 __func__, dir);
       return -1;
     }
   return 0;
@@ -46939,7 +46939,7 @@ delete_report_format (const char *report_format_id, int ultimate)
       trash_dir = report_format_trash_dir (NULL);
       if (g_mkdir_with_parents (trash_dir, 0755 /* "rwxr-xr-x" */))
         {
-          g_warning ("%s: failed to create dir %s", __FUNCTION__, trash_dir);
+          g_warning ("%s: failed to create dir %s", __func__, trash_dir);
           g_free (trash_dir);
           sql_rollback ();
           return -1;
@@ -48094,7 +48094,7 @@ check_report_format_create (const gchar *quoted_uuid, const gchar *name,
       case 1:        /* Too few rows in result of query. */
       case -1:
         g_warning ("%s: Report format missing: %s",
-                   __FUNCTION__, quoted_uuid);
+                   __func__, quoted_uuid);
         return -1;
     }
 
@@ -48123,7 +48123,7 @@ check_report_format_add_params (const gchar *quoted_uuid, const gchar *config_pa
   entities = entity->entities;
   while ((param = first_entity (entities)))
     {
-      g_debug ("%s: possible param: %s", __FUNCTION__, entity_name (param));
+      g_debug ("%s: possible param: %s", __func__, entity_name (param));
 
       if (strcmp (entity_name (param), "param") == 0)
         {
@@ -48140,7 +48140,7 @@ check_report_format_add_params (const gchar *quoted_uuid, const gchar *config_pa
           if (child == NULL)
             {
               g_warning ("%s: Param missing name in '%s'",
-                         __FUNCTION__, config_path);
+                         __func__, config_path);
               return -1;
             }
           name = entity_text (child);
@@ -48149,7 +48149,7 @@ check_report_format_add_params (const gchar *quoted_uuid, const gchar *config_pa
           if (child == NULL)
             {
               g_warning ("%s: Param missing default in '%s'",
-                         __FUNCTION__, config_path);
+                         __func__, config_path);
               return -1;
             }
           fallback = entity_text (child);
@@ -48158,7 +48158,7 @@ check_report_format_add_params (const gchar *quoted_uuid, const gchar *config_pa
           if (child == NULL)
             {
               g_warning ("%s: Param missing type in '%s'",
-                         __FUNCTION__, config_path);
+                         __func__, config_path);
               return -1;
             }
           type = g_strstrip (g_strdup (entity_text (child)));
@@ -48166,7 +48166,7 @@ check_report_format_add_params (const gchar *quoted_uuid, const gchar *config_pa
               == REPORT_FORMAT_PARAM_TYPE_ERROR)
             {
               g_warning ("%s: Error in param type in '%s'",
-                         __FUNCTION__, config_path);
+                         __func__, config_path);
               return -1;
             }
 
@@ -48187,7 +48187,7 @@ check_report_format_add_params (const gchar *quoted_uuid, const gchar *config_pa
                       || number == LLONG_MIN)
                     {
                       g_warning ("%s: Failed to parse min in '%s'",
-                                 __FUNCTION__, config_path);
+                                 __func__, config_path);
                       g_free (type);
                       return -1;
                     }
@@ -48206,7 +48206,7 @@ check_report_format_add_params (const gchar *quoted_uuid, const gchar *config_pa
                       || number == LLONG_MIN)
                     {
                       g_warning ("%s: Failed to parse max in '%s'",
-                                 __FUNCTION__, config_path);
+                                 __func__, config_path);
                       g_free (type);
                       return -1;
                     }
@@ -48221,7 +48221,7 @@ check_report_format_add_params (const gchar *quoted_uuid, const gchar *config_pa
                   if (options == NULL)
                     {
                       g_warning ("%s: Selection missing options in '%s'",
-                                 __FUNCTION__, config_path);
+                                 __func__, config_path);
                       g_free (type);
                       return -1;
                     }
@@ -48239,7 +48239,7 @@ check_report_format_add_params (const gchar *quoted_uuid, const gchar *config_pa
               if (child == NULL)
                 {
                   g_warning ("%s: Param missing value in '%s'",
-                             __FUNCTION__, config_path);
+                             __func__, config_path);
                   g_free (type);
                   return -1;
                 }
@@ -48254,7 +48254,7 @@ check_report_format_add_params (const gchar *quoted_uuid, const gchar *config_pa
               if (child == NULL)
                 {
                   g_warning ("%s: Param missing value in '%s'",
-                             __FUNCTION__, config_path);
+                             __func__, config_path);
                   g_free (type);
                   return -1;
                 }
@@ -48263,7 +48263,7 @@ check_report_format_add_params (const gchar *quoted_uuid, const gchar *config_pa
               if (report_format == NULL)
                 {
                   g_warning ("%s: Param missing report format in '%s'",
-                             __FUNCTION__, config_path);
+                             __func__, config_path);
                   g_free (type);
                   return -1;
                 }
@@ -48272,7 +48272,7 @@ check_report_format_add_params (const gchar *quoted_uuid, const gchar *config_pa
               if (value == NULL)
                 {
                   g_warning ("%s: Report format missing id in '%s'",
-                             __FUNCTION__, config_path);
+                             __func__, config_path);
                   g_free (type);
                   return -1;
                 }
@@ -48284,7 +48284,7 @@ check_report_format_add_params (const gchar *quoted_uuid, const gchar *config_pa
           quoted_value = g_strstrip (sql_quote (value));
           quoted_fallback = g_strstrip (sql_quote (fallback));
 
-          g_debug ("%s: param: %s", __FUNCTION__, name);
+          g_debug ("%s: param: %s", __func__, name);
 
           if (sql_int ("SELECT count (*) FROM report_format_params"
                        " WHERE name = '%s'"
@@ -48293,7 +48293,7 @@ check_report_format_add_params (const gchar *quoted_uuid, const gchar *config_pa
                        quoted_name,
                        quoted_uuid))
             {
-              g_debug ("%s: param: %s: updating", __FUNCTION__, name);
+              g_debug ("%s: param: %s: updating", __func__, name);
 
               sql ("UPDATE report_format_params"
                    " SET type = %u, value = '%s', type_min = %s,"
@@ -48353,7 +48353,7 @@ check_report_format_add_params (const gchar *quoted_uuid, const gchar *config_pa
             }
           else
             {
-              g_debug ("%s: param: %s: creating", __FUNCTION__, name);
+              g_debug ("%s: param: %s: creating", __func__, name);
 
               sql ("INSERT INTO report_format_params"
                    " (report_format, name, type, value, type_min, type_max,"
@@ -48445,7 +48445,7 @@ check_report_format_parse (entity_t entity, const char *config_path,
   child = entity_child (entity, "name");
   if (child == NULL)
     {
-      g_warning ("%s: Missing name in '%s'", __FUNCTION__, config_path);
+      g_warning ("%s: Missing name in '%s'", __func__, config_path);
       return -1;
     }
   *name = entity_text (child);
@@ -48453,7 +48453,7 @@ check_report_format_parse (entity_t entity, const char *config_path,
   child = entity_child (entity, "summary");
   if (child == NULL)
     {
-      g_warning ("%s: Missing summary in '%s'", __FUNCTION__, config_path);
+      g_warning ("%s: Missing summary in '%s'", __func__, config_path);
       return -1;
     }
   *summary = entity_text (child);
@@ -48462,7 +48462,7 @@ check_report_format_parse (entity_t entity, const char *config_path,
   if (child == NULL)
     {
       g_warning ("%s: Missing description in '%s'",
-                 __FUNCTION__, config_path);
+                 __func__, config_path);
       return -1;
     }
   *description = entity_text (child);
@@ -48470,7 +48470,7 @@ check_report_format_parse (entity_t entity, const char *config_path,
   child = entity_child (entity, "extension");
   if (child == NULL)
     {
-      g_warning ("%s: Missing extension in '%s'", __FUNCTION__, config_path);
+      g_warning ("%s: Missing extension in '%s'", __func__, config_path);
       return -1;
     }
   *extension = entity_text (child);
@@ -48479,7 +48479,7 @@ check_report_format_parse (entity_t entity, const char *config_path,
   if (child == NULL)
     {
       g_warning ("%s: Missing content_type in '%s'",
-                 __FUNCTION__, config_path);
+                 __func__, config_path);
       return -1;
     }
   *content_type = entity_text (child);
@@ -48505,11 +48505,11 @@ check_report_format (const gchar *uuid)
   int update_mod_time;
   report_format_t report_format;
 
-  g_debug ("%s: uuid: %s", __FUNCTION__, uuid);
+  g_debug ("%s: uuid: %s", __func__, uuid);
 
   update_mod_time = 0;
   path = predefined_report_format_dir (uuid);
-  g_debug ("%s: path: %s", __FUNCTION__, path);
+  g_debug ("%s: path: %s", __func__, path);
   config_path = g_build_filename (path, "report_format.xml", NULL);
   g_free (path);
 
@@ -48520,7 +48520,7 @@ check_report_format (const gchar *uuid)
   if (error)
     {
       g_warning ("%s: Failed to read '%s': %s",
-                  __FUNCTION__,
+                  __func__,
                  config_path,
                  error->message);
       g_error_free (error);
@@ -48532,7 +48532,7 @@ check_report_format (const gchar *uuid)
 
   if (parse_entity (xml, &entity))
     {
-      g_warning ("%s: Failed to parse '%s'", __FUNCTION__, config_path);
+      g_warning ("%s: Failed to parse '%s'", __func__, config_path);
       g_free (config_path);
       return -1;
     }
@@ -50278,7 +50278,7 @@ subject_where_clause (const char* subject_type, resource_t subject)
         {
           subject_where = strdup ("t()");
           g_warning ("%s: unknown subject_type %s",
-                     __FUNCTION__, subject_type);
+                     __func__, subject_type);
         }
     }
   return subject_where;
@@ -54615,7 +54615,7 @@ manage_schema (gchar *format, gchar **output_return, gsize *output_length,
 
     if (mkdtemp (output_dir) == NULL)
       {
-        g_warning ("%s: mkdtemp failed", __FUNCTION__);
+        g_warning ("%s: mkdtemp failed", __func__);
         return -1;
       }
 
@@ -54683,7 +54683,7 @@ manage_schema (gchar *format, gchar **output_return, gsize *output_length,
       if (previous_dir == NULL)
         {
           g_warning ("%s: Failed to getcwd: %s",
-                     __FUNCTION__,
+                     __func__,
                      strerror (errno));
           g_free (previous_dir);
           g_free (script);
@@ -54696,7 +54696,7 @@ manage_schema (gchar *format, gchar **output_return, gsize *output_length,
       if (chdir (script_dir))
         {
           g_warning ("%s: Failed to chdir: %s",
-                     __FUNCTION__,
+                     __func__,
                      strerror (errno));
           g_free (previous_dir);
           g_free (script);
@@ -54728,13 +54728,13 @@ manage_schema (gchar *format, gchar **output_return, gsize *output_length,
           || WEXITSTATUS (ret))
         {
           g_warning ("%s: system failed with ret %i, %i, %s",
-                     __FUNCTION__,
+                     __func__,
                      ret,
                      WEXITSTATUS (ret),
                      command);
           if (chdir (previous_dir))
             g_warning ("%s: and chdir failed",
-                       __FUNCTION__);
+                       __func__);
           g_free (previous_dir);
           g_free (command);
           g_free (output_file);
@@ -54755,7 +54755,7 @@ manage_schema (gchar *format, gchar **output_return, gsize *output_length,
         if (chdir (previous_dir))
           {
             g_warning ("%s: Failed to chdir back: %s",
-                       __FUNCTION__,
+                       __func__,
                        strerror (errno));
             g_free (previous_dir);
             if (extension) g_free (*extension);
@@ -54775,7 +54775,7 @@ manage_schema (gchar *format, gchar **output_return, gsize *output_length,
         if (get_error)
           {
             g_warning ("%s: Failed to get output: %s",
-                       __FUNCTION__,
+                       __func__,
                        get_error->message);
             g_error_free (get_error);
             if (extension) g_free (*extension);
@@ -56169,7 +56169,7 @@ manage_empty_trashcan ()
 
       if (g_file_test (dir, G_FILE_TEST_EXISTS) && gvm_file_remove_recurse (dir))
         {
-          g_warning ("%s: failed to remove trash dir %s", __FUNCTION__, dir);
+          g_warning ("%s: failed to remove trash dir %s", __func__, dir);
           g_free (dir);
           sql_rollback ();
           return -1;
@@ -58369,7 +58369,7 @@ add_assets_from_host_in_report (report_t report, const char *host_ip)
   if (report_id == NULL)
     {
       g_warning ("%s: report %llu not found.",
-                 __FUNCTION__, report);
+                 __func__, report);
       return -1;
     }
 
@@ -58384,7 +58384,7 @@ add_assets_from_host_in_report (report_t report, const char *host_ip)
   if (report_host == 0)
     {
       g_warning ("%s: report_host for host '%s' and report '%s' not found.",
-                 __FUNCTION__, host_ip, report_id);
+                 __func__, host_ip, report_id);
       free (report_id);
       return -1;
     }
@@ -60325,7 +60325,7 @@ create_user (const gchar * name, const gchar * password, const gchar *comment,
   uuid = user_uuid (user);
   if (uuid == NULL)
     {
-      g_warning ("%s: Failed to allocate UUID", __FUNCTION__);
+      g_warning ("%s: Failed to allocate UUID", __func__);
       sql_rollback ();
       return -1;
     }
@@ -60410,7 +60410,7 @@ copy_user (const char* name, const char* comment, const char *user_id,
   uuid = user_uuid (user);
   if (uuid == NULL)
     {
-      g_warning ("%s: Failed to allocate UUID", __FUNCTION__);
+      g_warning ("%s: Failed to allocate UUID", __func__);
       sql_rollback ();
       return -1;
     }
@@ -62584,7 +62584,7 @@ tag_add_resource (tag_t tag, const char *type, const char *uuid,
 
   if (already_added == 0)
     {
-      g_debug ("%s - adding %s %s", __FUNCTION__, type, uuid);
+      g_debug ("%s - adding %s %s", __func__, type, uuid);
       sql ("INSERT INTO tag_resources"
            " (tag, resource_type, resource, resource_uuid, resource_location)"
            " VALUES (%llu, '%s', %llu, %s, %d)",
@@ -62592,7 +62592,7 @@ tag_add_resource (tag_t tag, const char *type, const char *uuid,
     }
   else
     {
-      g_debug ("%s - skipping %s %s", __FUNCTION__, type, uuid);
+      g_debug ("%s - skipping %s %s", __func__, type, uuid);
     }
 
   g_free (quoted_resource_uuid);
@@ -62621,7 +62621,7 @@ tag_add_resource_uuid (tag_t tag, const char *type, const char *uuid,
                                      &resource, permission, 0))
     {
       g_warning ("%s: Failed to find %s %s",
-                 __FUNCTION__, type, uuid);
+                 __func__, type, uuid);
       return -1;
     }
   else if (resource == 0
@@ -62632,7 +62632,7 @@ tag_add_resource_uuid (tag_t tag, const char *type, const char *uuid,
                                          1))
         {
           g_warning ("%s: Failed to find trash %s %s",
-                     __FUNCTION__, type, uuid);
+                     __func__, type, uuid);
           return -1;
         }
       else if (resource != 0)
@@ -62720,7 +62720,7 @@ tag_add_resources_filter (tag_t tag, const char *type, const char *filter)
        * to contain each per-resource implementation in its own file. */
       if (init_ticket_iterator (&resources, &resources_get))
         {
-          g_warning ("%s: Failed to build filter SELECT", __FUNCTION__);
+          g_warning ("%s: Failed to build filter SELECT", __func__);
           sql_rollback ();
           g_free (resources_get.filter);
           g_free (resources_get.type);
@@ -62747,7 +62747,7 @@ tag_add_resources_filter (tag_t tag, const char *type, const char *filter)
         break;
       default:
         ignore_max_rows_per_page = 0;
-        g_warning ("%s: Failed to build filter SELECT", __FUNCTION__);
+        g_warning ("%s: Failed to build filter SELECT", __func__);
         sql_rollback ();
         g_free (resources_get.filter);
         g_free (resources_get.type);
@@ -62858,7 +62858,7 @@ tag_remove_resources_filter (tag_t tag, const char *type, const char *filter)
       if (init_ticket_iterator (&resources, &resources_get))
         {
           ignore_max_rows_per_page = 0;
-          g_warning ("%s: Failed to init ticket iterator", __FUNCTION__);
+          g_warning ("%s: Failed to init ticket iterator", __func__);
           sql_rollback ();
           g_free (resources_get.filter);
           g_free (resources_get.type);
@@ -62875,7 +62875,7 @@ tag_remove_resources_filter (tag_t tag, const char *type, const char *filter)
         break;
       default:
         ignore_max_rows_per_page = 0;
-        g_warning ("%s: Failed to build filter SELECT", __FUNCTION__);
+        g_warning ("%s: Failed to build filter SELECT", __func__);
         sql_rollback ();
         g_free (resources_get.filter);
         g_free (resources_get.type);
@@ -64455,7 +64455,7 @@ cache_permissions_for_resource (const char *type, resource_t resource,
 
   if (cache_users == NULL)
     {
-      g_debug ("%s: Getting all users", __FUNCTION__);
+      g_debug ("%s: Getting all users", __func__);
       free_users = 1;
       cache_users = all_users_array ();
     }
@@ -64472,7 +64472,7 @@ cache_permissions_for_resource (const char *type, resource_t resource,
       resource_id = resource_uuid (type, resource);
 
       g_debug ("%s: Caching permissions on %s \"%s\" for %d user(s)",
-               __FUNCTION__, type, resource_id, cache_users->len);
+               __func__, type, resource_id, cache_users->len);
 
       for (user_index = 0; user_index < cache_users->len; user_index++)
         {
@@ -64557,7 +64557,7 @@ cache_permissions_for_users (const char *type, GArray *cache_users)
 
   if (cache_users == NULL)
     {
-      g_debug ("%s: Getting all users", __FUNCTION__);
+      g_debug ("%s: Getting all users", __func__);
       free_users = 1;
       cache_users = all_users_array ();
     }
@@ -64596,7 +64596,7 @@ cache_all_permissions_for_users (GArray *cache_users)
 
   if (cache_users == NULL)
     {
-      g_debug ("%s: Getting all users", __FUNCTION__);
+      g_debug ("%s: Getting all users", __func__);
       free_users = 1;
       cache_users = all_users_array ();
     }
@@ -64689,7 +64689,7 @@ manage_optimize (GSList *log_config, const gchar *database, const gchar *name)
               break;
             default:
               g_warning ("%s: failed to stat database: %s",
-                          __FUNCTION__,
+                          __func__,
                           strerror (errno));
           }
       else
@@ -64705,7 +64705,7 @@ manage_optimize (GSList *log_config, const gchar *database, const gchar *name)
               break;
             default:
               g_warning ("%s: failed to stat database: %s",
-                          __FUNCTION__,
+                          __func__,
                           strerror (errno));
           }
       else
@@ -64948,6 +64948,6 @@ manage_optimize (GSList *log_config, const gchar *database, const gchar *name)
 int
 sql_cancel ()
 {
-  g_debug ("%s: cancelling current SQL statement", __FUNCTION__);
+  g_debug ("%s: cancelling current SQL statement", __func__);
   return sql_cancel_internal ();
 }

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -1205,7 +1205,7 @@ insert_nvt_selectors (const char *quoted_name,
                   g_warning ("%s: skipping NVT '%s' from import of config '%s'"
                              " because the NVT is missing a family in the"
                              " cache",
-                             __FUNCTION__,
+                             __func__,
                              selector->family_or_nvt,
                              quoted_name);
                   continue;
@@ -1215,7 +1215,7 @@ insert_nvt_selectors (const char *quoted_name,
             {
               g_warning ("%s: skipping NVT '%s' from import of config '%s'"
                          " because the NVT is missing from the cache",
-                         __FUNCTION__,
+                         __func__,
                          selector->family_or_nvt,
                          quoted_name);
               continue;
@@ -1244,7 +1244,7 @@ insert_nvt_selectors (const char *quoted_name,
             {
               g_warning ("%s: skipping NVT '%s' from import of config '%s'"
                          " because the type is wrong (expected family)",
-                         __FUNCTION__,
+                         __func__,
                          selector->family_or_nvt,
                          quoted_name);
               continue;
@@ -1270,7 +1270,7 @@ insert_nvt_selectors (const char *quoted_name,
             {
               g_warning ("%s: skipping NVT from import of config '%s'"
                          " because the type is wrong (expected all)",
-                         __FUNCTION__,
+                         __func__,
                          quoted_name);
               continue;
             }
@@ -1307,33 +1307,33 @@ config_update_nvt_family (resource_t config, const char *oid,
   selector = config_nvt_selector (config);
   if (selector == NULL)
     {
-      g_warning ("%s: Failed to get config selector", __FUNCTION__);
+      g_warning ("%s: Failed to get config selector", __func__);
       return -1;
     }
   quoted_selector = sql_quote (selector);
 
   constraining = config_families_growing (config);
 
-  g_debug ("%s: Updating NVT family for selector '%s'", __FUNCTION__, selector);
+  g_debug ("%s: Updating NVT family for selector '%s'", __func__, selector);
 
   if (constraining)
     {
       /* Constraining the universe. */
 
-      g_debug ("%s:   Selector constrains universe", __FUNCTION__);
+      g_debug ("%s:   Selector constrains universe", __func__);
 
       if (nvt_selector_family_growing (selector, old_family, constraining))
         {
           /* Old family is growing. */
 
-          g_debug ("%s:   Old family is growing", __FUNCTION__);
+          g_debug ("%s:   Old family is growing", __func__);
 
           if (nvt_selector_has (quoted_selector, oid, NVT_SELECTOR_TYPE_NVT,
                                 0 /* Included. */))
             {
               /* NVT explicitly included in old family, which is redundant, so
                * drop selector. */
-              g_debug ("%s:   Drop selector", __FUNCTION__);
+              g_debug ("%s:   Drop selector", __func__);
               nvt_selector_remove_selector (quoted_selector,
                                             oid,
                                             NVT_SELECTOR_TYPE_NVT);
@@ -1344,13 +1344,13 @@ config_update_nvt_family (resource_t config, const char *oid,
             {
               /* NVT explicitly excluded from old family. */
 
-              g_debug ("%s:   NVT excluded from old family", __FUNCTION__);
+              g_debug ("%s:   NVT excluded from old family", __func__);
 
               if (nvt_selector_family_growing (selector, new_family,
                                                constraining))
                 {
                   /* New family is growing, change NVT to new family. */
-                  g_debug ("%s:   Change family", __FUNCTION__);
+                  g_debug ("%s:   Change family", __func__);
                   nvt_selector_set_family (quoted_selector,
                                            oid,
                                            NVT_SELECTOR_TYPE_NVT,
@@ -1360,7 +1360,7 @@ config_update_nvt_family (resource_t config, const char *oid,
                 {
                   /* New family static, NVT excluded already, so drop NVT
                    * selector. */
-                  g_debug ("%s:   Remove selector", __FUNCTION__);
+                  g_debug ("%s:   Remove selector", __func__);
                   nvt_selector_remove_selector (quoted_selector,
                                                 oid,
                                                 NVT_SELECTOR_TYPE_NVT);
@@ -1371,21 +1371,21 @@ config_update_nvt_family (resource_t config, const char *oid,
         {
           /* Old family is static. */
 
-          g_debug ("%s:   Old family is static", __FUNCTION__);
+          g_debug ("%s:   Old family is static", __func__);
 
           if (nvt_selector_has (quoted_selector, oid, NVT_SELECTOR_TYPE_NVT,
                                 0 /* Included. */))
             {
               /* NVT explicitly included in old family. */
 
-              g_debug ("%s:   NVT included in old family", __FUNCTION__);
+              g_debug ("%s:   NVT included in old family", __func__);
 
               if (nvt_selector_family_growing (selector, new_family,
                                                constraining))
                 {
                   /* New family is growing so it already includes the NVT.
                    * Remove the NVT selector. */
-                  g_debug ("%s:   Remove selector", __FUNCTION__);
+                  g_debug ("%s:   Remove selector", __func__);
                   nvt_selector_remove_selector (quoted_selector,
                                                 oid,
                                                 NVT_SELECTOR_TYPE_NVT);
@@ -1393,7 +1393,7 @@ config_update_nvt_family (resource_t config, const char *oid,
               else
                 {
                   /* New family static, change NVT to new family. */
-                  g_debug ("%s:   Change family", __FUNCTION__);
+                  g_debug ("%s:   Change family", __func__);
                   nvt_selector_set_family (quoted_selector,
                                            oid,
                                            NVT_SELECTOR_TYPE_NVT,
@@ -1406,7 +1406,7 @@ config_update_nvt_family (resource_t config, const char *oid,
             {
               /* NVT explicitly excluded from old family, which is redundant, so
                * remove NVT selector. */
-              g_debug ("%s:   Remove selector", __FUNCTION__);
+              g_debug ("%s:   Remove selector", __func__);
               nvt_selector_remove_selector (quoted_selector,
                                             oid,
                                             NVT_SELECTOR_TYPE_NVT);
@@ -1417,20 +1417,20 @@ config_update_nvt_family (resource_t config, const char *oid,
     {
       /* Generating from empty. */
 
-      g_debug ("%s:   Selector generates from empty", __FUNCTION__);
+      g_debug ("%s:   Selector generates from empty", __func__);
 
       if (nvt_selector_family_growing (selector, old_family, constraining))
         {
           /* Old family is growing. */
 
-          g_debug ("%s:   Old family is growing", __FUNCTION__);
+          g_debug ("%s:   Old family is growing", __func__);
 
           if (nvt_selector_has (quoted_selector, oid, NVT_SELECTOR_TYPE_NVT,
                                 0 /* Included. */))
             {
               /* NVT explicitly included in old family.  This is redundant, so
                * just remove the NVT selector. */
-              g_debug ("%s:   Remove selector", __FUNCTION__);
+              g_debug ("%s:   Remove selector", __func__);
               nvt_selector_remove_selector (quoted_selector,
                                             oid,
                                             NVT_SELECTOR_TYPE_NVT);
@@ -1441,13 +1441,13 @@ config_update_nvt_family (resource_t config, const char *oid,
             {
               /* NVT explicitly excluded from old family. */
 
-              g_debug ("%s:   NVT excluded from old family", __FUNCTION__);
+              g_debug ("%s:   NVT excluded from old family", __func__);
 
               if (nvt_selector_family_growing (selector, new_family,
                                                constraining))
                 {
                   /* New family is growing, change NVT to new family. */
-                  g_debug ("%s:   Change family", __FUNCTION__);
+                  g_debug ("%s:   Change family", __func__);
                   nvt_selector_set_family (quoted_selector,
                                            oid,
                                            NVT_SELECTOR_TYPE_NVT,
@@ -1457,7 +1457,7 @@ config_update_nvt_family (resource_t config, const char *oid,
                 {
                   /* New family static, so the NVT is already excluded from the
                    * new family.  Remove the NVT selector. */
-                  g_debug ("%s:   Remove selector", __FUNCTION__);
+                  g_debug ("%s:   Remove selector", __func__);
                   nvt_selector_remove_selector (quoted_selector,
                                                 oid,
                                                 NVT_SELECTOR_TYPE_NVT);
@@ -1468,21 +1468,21 @@ config_update_nvt_family (resource_t config, const char *oid,
         {
           /* Old family is static. */
 
-          g_debug ("%s:   Old family is static", __FUNCTION__);
+          g_debug ("%s:   Old family is static", __func__);
 
           if (nvt_selector_has (quoted_selector, oid, NVT_SELECTOR_TYPE_NVT,
                                 0 /* Included. */))
             {
               /* NVT explicitly included in old family. */
 
-              g_debug ("%s:   NVT included in old family", __FUNCTION__);
+              g_debug ("%s:   NVT included in old family", __func__);
 
               if (nvt_selector_family_growing (selector, new_family,
                                                constraining))
                 {
                   /* New family growing, so the NVT is already in there.  Remove
                    * the NVT selector. */
-                  g_debug ("%s:   Remove selector", __FUNCTION__);
+                  g_debug ("%s:   Remove selector", __func__);
                   nvt_selector_remove_selector (quoted_selector,
                                                 oid,
                                                 NVT_SELECTOR_TYPE_NVT);
@@ -1490,7 +1490,7 @@ config_update_nvt_family (resource_t config, const char *oid,
               else
                 {
                   /* New family is static, change NVT to new family. */
-                  g_debug ("%s:   Change family", __FUNCTION__);
+                  g_debug ("%s:   Change family", __func__);
                   nvt_selector_set_family (quoted_selector,
                                            oid,
                                            NVT_SELECTOR_TYPE_NVT,
@@ -1504,7 +1504,7 @@ config_update_nvt_family (resource_t config, const char *oid,
               /* NVT explicitly excluded from old family.  This is redundant,
                * so just remove the NVT selector. */
               g_debug ("%s:   NVT exclude from old family, remove selector",
-                       __FUNCTION__);
+                       __func__);
               nvt_selector_remove_selector (quoted_selector,
                                             oid,
                                             NVT_SELECTOR_TYPE_NVT);

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1061,25 +1061,25 @@ update_preferences_from_vt (entity_t vt, const gchar *oid, GList **preferences)
           if (type == NULL)
             {
               GString *debug = g_string_new ("");
-              g_warning ("%s: PARAM missing type attribute", __FUNCTION__);
+              g_warning ("%s: PARAM missing type attribute", __func__);
               print_entity_to_string (param, debug);
-              g_warning ("%s: PARAM: %s", __FUNCTION__, debug->str);
+              g_warning ("%s: PARAM: %s", __func__, debug->str);
               g_string_free (debug, TRUE);
             }
           else if (id == NULL)
             {
               GString *debug = g_string_new ("");
-              g_warning ("%s: PARAM missing id attribute", __FUNCTION__);
+              g_warning ("%s: PARAM missing id attribute", __func__);
               print_entity_to_string (param, debug);
-              g_warning ("%s: PARAM: %s", __FUNCTION__, debug->str);
+              g_warning ("%s: PARAM: %s", __func__, debug->str);
               g_string_free (debug, TRUE);
             }
           else if (name == NULL)
             {
               GString *debug = g_string_new ("");
-              g_warning ("%s: PARAM missing NAME", __FUNCTION__);
+              g_warning ("%s: PARAM missing NAME", __func__);
               print_entity_to_string (param, debug);
-              g_warning ("%s: PARAM: %s", __FUNCTION__, debug->str);
+              g_warning ("%s: PARAM: %s", __func__, debug->str);
               g_string_free (debug, TRUE);
             }
           else
@@ -1132,7 +1132,7 @@ nvti_from_vt (entity_t vt)
   id = entity_attribute (vt, "id");
   if (id == NULL)
     {
-      g_warning ("%s: VT missing id attribute", __FUNCTION__);
+      g_warning ("%s: VT missing id attribute", __func__);
       nvti_free (nvti);
       return NULL;
     }
@@ -1141,7 +1141,7 @@ nvti_from_vt (entity_t vt)
   name = entity_child (vt, "name");
   if (name == NULL)
     {
-      g_warning ("%s: VT missing NAME", __FUNCTION__);
+      g_warning ("%s: VT missing NAME", __func__);
       nvti_free (nvti);
       return NULL;
     }
@@ -1189,7 +1189,7 @@ nvti_from_vt (entity_t vt)
 
       type = entity_attribute (solution, "type");
       if (type == NULL)
-        g_debug ("%s: SOLUTION missing type", __FUNCTION__);
+        g_debug ("%s: SOLUTION missing type", __func__);
       else
         nvti_set_solution_type (nvti, type);
     }
@@ -1197,7 +1197,7 @@ nvti_from_vt (entity_t vt)
   refs = entity_child (vt, "refs");
   if (refs == NULL)
     {
-      g_warning ("%s: VT missing REFS", __FUNCTION__);
+      g_warning ("%s: VT missing REFS", __func__);
       nvti_free (nvti);
       return NULL;
     }
@@ -1211,9 +1211,9 @@ nvti_from_vt (entity_t vt)
       if (ref_type == NULL)
         {
           GString *debug = g_string_new ("");
-          g_warning ("%s: REF missing type attribute", __FUNCTION__);
+          g_warning ("%s: REF missing type attribute", __func__);
           print_entity_to_string (ref, debug);
-          g_warning ("%s: ref: %s", __FUNCTION__, debug->str);
+          g_warning ("%s: ref: %s", __func__, debug->str);
           g_string_free (debug, TRUE);
         }
       else
@@ -1224,9 +1224,9 @@ nvti_from_vt (entity_t vt)
           if (ref_id == NULL)
             {
               GString *debug = g_string_new ("");
-              g_warning ("%s: REF missing id attribute", __FUNCTION__);
+              g_warning ("%s: REF missing id attribute", __func__);
               print_entity_to_string (ref, debug);
-              g_warning ("%s: ref: %s", __FUNCTION__, debug->str);
+              g_warning ("%s: ref: %s", __func__, debug->str);
               g_string_free (debug, TRUE);
             }
           else
@@ -1260,15 +1260,15 @@ nvti_from_vt (entity_t vt)
           g_free (cvss_base);
         }
       else
-        g_warning ("%s: no severity", __FUNCTION__);
+        g_warning ("%s: no severity", __func__);
     }
   else
-    g_warning ("%s: no severities", __FUNCTION__);
+    g_warning ("%s: no severities", __func__);
 
   custom = entity_child (vt, "custom");
   if (custom == NULL)
     {
-      g_warning ("%s: VT missing CUSTOM", __FUNCTION__);
+      g_warning ("%s: VT missing CUSTOM", __func__);
       nvti_free (nvti);
       return NULL;
     }
@@ -1276,7 +1276,7 @@ nvti_from_vt (entity_t vt)
   family = entity_child (custom, "family");
   if (family == NULL)
     {
-      g_warning ("%s: VT/CUSTOM missing FAMILY", __FUNCTION__);
+      g_warning ("%s: VT/CUSTOM missing FAMILY", __func__);
       nvti_free (nvti);
       return NULL;
     }
@@ -1285,7 +1285,7 @@ nvti_from_vt (entity_t vt)
   category = entity_child (custom, "category");
   if (category == NULL)
     {
-      g_warning ("%s: VT/CUSTOM missing CATEGORY", __FUNCTION__);
+      g_warning ("%s: VT/CUSTOM missing CATEGORY", __func__);
       nvti_free (nvti);
       return NULL;
     }
@@ -1318,7 +1318,7 @@ update_nvts_from_vts (entity_t *get_vts_response,
   vts = entity_child (*get_vts_response, "vts");
   if (vts == NULL)
     {
-      g_warning ("%s: VTS missing", __FUNCTION__);
+      g_warning ("%s: VTS missing", __func__);
       return;
     }
 
@@ -1376,7 +1376,7 @@ update_nvts_from_vts (entity_t *get_vts_response,
   if (check_config_families ())
     g_warning ("%s: Error updating config families."
                "  One or more configs refer to an outdated family of an NVT.",
-               __FUNCTION__);
+               __func__);
   update_all_config_caches ();
 
   g_info ("Updating VTs in database ... %i new VTs, %i changed VTs",
@@ -1433,21 +1433,21 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
   /* Try update VTs. */
 
   db_feed_version = nvts_feed_version ();
-  g_debug ("%s: db_feed_version: %s", __FUNCTION__, db_feed_version);
+  g_debug ("%s: db_feed_version: %s", __func__, db_feed_version);
 
   connection = osp_connection_new (update_socket, 0, NULL, NULL, NULL);
   if (!connection)
     {
-      g_warning ("%s: failed to connect to %s", __FUNCTION__, update_socket);
+      g_warning ("%s: failed to connect to %s", __func__, update_socket);
       return -1;
     }
 
   if (osp_get_vts_version (connection, &scanner_feed_version))
     {
-      g_warning ("%s: failed to get scanner_version", __FUNCTION__);
+      g_warning ("%s: failed to get scanner_version", __func__);
       return -1;
     }
-  g_debug ("%s: scanner_feed_version: %s", __FUNCTION__, scanner_feed_version);
+  g_debug ("%s: scanner_feed_version: %s", __func__, scanner_feed_version);
 
   osp_connection_close (connection);
 
@@ -1464,7 +1464,7 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
       connection = osp_connection_new (update_socket, 0, NULL, NULL, NULL);
       if (!connection)
         {
-          g_warning ("%s: failed to connect to %s (2)", __FUNCTION__,
+          g_warning ("%s: failed to connect to %s (2)", __func__,
                      update_socket);
           return -1;
         }
@@ -1475,7 +1475,7 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
         get_vts_opts.filter = NULL;
       if (osp_get_vts_ext (connection, get_vts_opts, &vts))
         {
-          g_warning ("%s: failed to get VTs", __FUNCTION__);
+          g_warning ("%s: failed to get VTs", __func__);
           g_free (get_vts_opts.filter);
           return -1;
         }
@@ -1491,14 +1491,14 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
       if (!connection)
         {
           g_warning ("%s: failed to connect to %s (3)",
-                    __FUNCTION__, update_socket);
+                    __func__, update_socket);
           return -1;
         }
 
       scanner_prefs = NULL;
       if (osp_get_scanner_details (connection, NULL, &scanner_prefs))
         {
-          g_warning ("%s: failed to get scanner preferences", __FUNCTION__);
+          g_warning ("%s: failed to get scanner preferences", __func__);
           osp_connection_close (connection);
           return -1;
         }

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -1157,14 +1157,14 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
   int transaction_size = 0;
 
   updated_dfn_cert = 0;
-  g_info ("%s: %s", __FUNCTION__, xml_path);
+  g_info ("%s: %s", __func__, xml_path);
 
   full_path = g_build_filename (GVM_CERT_DATA_DIR, xml_path, NULL);
 
   if (g_stat (full_path, &state))
     {
       g_warning ("%s: Failed to stat CERT file: %s",
-                 __FUNCTION__,
+                 __func__,
                  strerror (errno));
       return -1;
     }
@@ -1184,7 +1184,7 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
   if (error)
     {
       g_warning ("%s: Failed to get contents: %s",
-                 __FUNCTION__,
+                 __func__,
                  error->message);
       g_error_free (error);
       g_free (full_path);
@@ -1194,7 +1194,7 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
   if (parse_entity (xml, &entity))
     {
       g_free (xml);
-      g_warning ("%s: Failed to parse entity", __FUNCTION__);
+      g_warning ("%s: Failed to parse entity", __func__);
       g_free (full_path);
       return -1;
     }
@@ -1211,7 +1211,7 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
           updated = entity_child (child, "updated");
           if (updated == NULL)
             {
-              g_warning ("%s: UPDATED missing", __FUNCTION__);
+              g_warning ("%s: UPDATED missing", __func__);
               free_entity (entity);
               goto fail;
             }
@@ -1229,7 +1229,7 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
                   GString *string;
 
                   string = g_string_new ("");
-                  g_warning ("%s: REFNUM missing", __FUNCTION__);
+                  g_warning ("%s: REFNUM missing", __func__);
                   print_entity_to_string (child, string);
                   g_debug ("child:%s", string->str);
                   g_string_free (string, TRUE);
@@ -1240,7 +1240,7 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
               published = entity_child (child, "published");
               if (published == NULL)
                 {
-                  g_warning ("%s: PUBLISHED missing", __FUNCTION__);
+                  g_warning ("%s: PUBLISHED missing", __func__);
                   free_entity (entity);
                   goto fail;
                 }
@@ -1248,7 +1248,7 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
               title = entity_child (child, "title");
               if (title == NULL)
                 {
-                  g_warning ("%s: TITLE missing", __FUNCTION__);
+                  g_warning ("%s: TITLE missing", __func__);
                   free_entity (entity);
                   goto fail;
                 }
@@ -1256,7 +1256,7 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
               summary = entity_child (child, "summary");
               if (summary == NULL)
                 {
-                  g_warning ("%s: SUMMARY missing", __FUNCTION__);
+                  g_warning ("%s: SUMMARY missing", __func__);
                   free_entity (entity);
                   goto fail;
                 }
@@ -1373,7 +1373,7 @@ update_dfn_cert_advisories (int last_cert_update)
   if (dir == NULL)
     {
       g_warning ("%s: Failed to open directory '%s': %s",
-                 __FUNCTION__, GVM_CERT_DATA_DIR, error->message);
+                 __func__, GVM_CERT_DATA_DIR, error->message);
       g_error_free (error);
       return -1;
     }
@@ -1381,7 +1381,7 @@ update_dfn_cert_advisories (int last_cert_update)
   last_dfn_update = sql_int ("SELECT max (modification_time)"
                              " FROM cert.dfn_cert_advs;");
 
-  g_debug ("%s: VS: " GVM_CERT_DATA_DIR "/dfn-cert-*.xml", __FUNCTION__);
+  g_debug ("%s: VS: " GVM_CERT_DATA_DIR "/dfn-cert-*.xml", __func__);
   count = 0;
   updated_dfn_cert = 0;
   while ((xml_path = g_dir_read_name (dir)))
@@ -1439,7 +1439,7 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
   if (g_stat (full_path, &state))
     {
       g_warning ("%s: Failed to stat CERT file: %s",
-                 __FUNCTION__,
+                 __func__,
                  strerror (errno));
       return -1;
     }
@@ -1459,7 +1459,7 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
   if (error)
     {
       g_warning ("%s: Failed to get contents: %s",
-                 __FUNCTION__,
+                 __func__,
                  error->message);
       g_error_free (error);
       g_free (full_path);
@@ -1469,7 +1469,7 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
   if (parse_entity (xml, &entity))
     {
       g_free (xml);
-      g_warning ("%s: Failed to parse entity", __FUNCTION__);
+      g_warning ("%s: Failed to parse entity", __func__);
       g_free (full_path);
       return -1;
     }
@@ -1486,7 +1486,7 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
           date = entity_child (child, "Date");
           if (date == NULL)
             {
-              g_warning ("%s: Date missing", __FUNCTION__);
+              g_warning ("%s: Date missing", __func__);
               free_entity (entity);
               goto fail;
             }
@@ -1504,7 +1504,7 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
                   GString *string;
 
                   string = g_string_new ("");
-                  g_warning ("%s: Ref_Num missing", __FUNCTION__);
+                  g_warning ("%s: Ref_Num missing", __func__);
                   print_entity_to_string (child, string);
                   g_debug ("child:%s", string->str);
                   g_string_free (string, TRUE);
@@ -1515,7 +1515,7 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
               title = entity_child (child, "Title");
               if (title == NULL)
                 {
-                  g_warning ("%s: Title missing", __FUNCTION__);
+                  g_warning ("%s: Title missing", __func__);
                   free_entity (entity);
                   goto fail;
                 }
@@ -1643,7 +1643,7 @@ update_cert_bund_advisories (int last_cert_update)
   if (dir == NULL)
     {
       g_warning ("%s: Failed to open directory '%s': %s",
-                 __FUNCTION__, GVM_CERT_DATA_DIR, error->message);
+                 __func__, GVM_CERT_DATA_DIR, error->message);
       g_error_free (error);
       return -1;
     }
@@ -1707,7 +1707,7 @@ update_scap_cpes (int last_scap_update)
   if (g_stat (full_path, &state))
     {
       g_warning ("%s: No CPE dictionary found at %s",
-                 __FUNCTION__,
+                 __func__,
                  strerror (errno));
       return -1;
     }
@@ -1726,7 +1726,7 @@ update_scap_cpes (int last_scap_update)
   last_cve_update = sql_int ("SELECT max (modification_time)"
                              " FROM scap.cves;");
 
-  g_debug ("%s: parsing %s", __FUNCTION__, full_path);
+  g_debug ("%s: parsing %s", __func__, full_path);
 
   error = NULL;
   g_file_get_contents (full_path, &xml, &xml_len, &error);
@@ -1734,7 +1734,7 @@ update_scap_cpes (int last_scap_update)
   if (error)
     {
       g_warning ("%s: Failed to get contents: %s",
-                 __FUNCTION__,
+                 __func__,
                  error->message);
       g_error_free (error);
       return -1;
@@ -1743,7 +1743,7 @@ update_scap_cpes (int last_scap_update)
   if (parse_entity (xml, &entity))
     {
       g_free (xml);
-      g_warning ("%s: Failed to parse entity", __FUNCTION__);
+      g_warning ("%s: Failed to parse entity", __func__);
       return -1;
     }
   g_free (xml);
@@ -1752,7 +1752,7 @@ update_scap_cpes (int last_scap_update)
   if (strcmp (entity_name (cpe_list), "cpe-list"))
     {
       free_entity (entity);
-      g_warning ("%s: CPE dictionary missing CPE-LIST", __FUNCTION__);
+      g_warning ("%s: CPE dictionary missing CPE-LIST", __func__);
       return -1;
     }
 
@@ -1769,7 +1769,7 @@ update_scap_cpes (int last_scap_update)
           item_metadata = entity_child (cpe_item, "meta:item-metadata");
           if (item_metadata == NULL)
             {
-              g_warning ("%s: item-metadata missing", __FUNCTION__);
+              g_warning ("%s: item-metadata missing", __func__);
 
               free_entity (entity);
               goto fail;
@@ -1779,7 +1779,7 @@ update_scap_cpes (int last_scap_update)
                                                 "modification-date");
           if (modification_date == NULL)
             {
-              g_warning ("%s: modification-date missing", __FUNCTION__);
+              g_warning ("%s: modification-date missing", __func__);
               free_entity (entity);
               goto fail;
             }
@@ -1795,7 +1795,7 @@ update_scap_cpes (int last_scap_update)
               name = entity_attribute (cpe_item, "name");
               if (name == NULL)
                 {
-                  g_warning ("%s: name missing", __FUNCTION__);
+                  g_warning ("%s: name missing", __func__);
                   free_entity (entity);
                   goto fail;
                 }
@@ -1803,7 +1803,7 @@ update_scap_cpes (int last_scap_update)
               status = entity_attribute (item_metadata, "status");
               if (status == NULL)
                 {
-                  g_warning ("%s: status missing", __FUNCTION__);
+                  g_warning ("%s: status missing", __func__);
                   free_entity (entity);
                   goto fail;
                 }
@@ -1815,7 +1815,7 @@ update_scap_cpes (int last_scap_update)
                       == 0))
                 {
                   g_warning ("%s: invalid deprecated-by-nvd-id: %s",
-                             __FUNCTION__,
+                             __func__,
                              deprecated);
                   free_entity (entity);
                   goto fail;
@@ -1824,7 +1824,7 @@ update_scap_cpes (int last_scap_update)
               nvd_id = entity_attribute (item_metadata, "nvd-id");
               if (nvd_id == NULL)
                 {
-                  g_warning ("%s: nvd_id missing", __FUNCTION__);
+                  g_warning ("%s: nvd_id missing", __func__);
                   free_entity (entity);
                   goto fail;
                 }
@@ -1914,7 +1914,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
   if (g_stat (full_path, &state))
     {
       g_warning ("%s: Failed to stat SCAP file: %s",
-                 __FUNCTION__,
+                 __func__,
                  strerror (errno));
       return -1;
     }
@@ -1935,7 +1935,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
   if (error)
     {
       g_warning ("%s: Failed to get contents: %s",
-                 __FUNCTION__,
+                 __func__,
                  error->message);
       g_error_free (error);
       g_free (full_path);
@@ -1945,7 +1945,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
   if (parse_entity (xml, &entity))
     {
       g_free (xml);
-      g_warning ("%s: Failed to parse entity", __FUNCTION__);
+      g_warning ("%s: Failed to parse entity", __func__);
       g_free (full_path);
       return -1;
     }
@@ -1963,7 +1963,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
           if (last_modified == NULL)
             {
               g_warning ("%s: vuln:last-modified-datetime missing",
-                         __FUNCTION__);
+                         __func__);
               free_entity (entity);
               goto fail;
             }
@@ -1988,7 +1988,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
               if (id == NULL)
                 {
                   g_warning ("%s: id missing",
-                             __FUNCTION__);
+                             __func__);
                   free_entity (entity);
                   goto fail;
                 }
@@ -1997,7 +1997,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
               if (published == NULL)
                 {
                   g_warning ("%s: vuln:published-datetime missing",
-                             __FUNCTION__);
+                             __func__);
                   free_entity (entity);
                   goto fail;
                 }
@@ -2022,7 +2022,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                   score = entity_child (base_metrics, "cvss:score");
                   if (score == NULL)
                     {
-                      g_warning ("%s: cvss:score missing", __FUNCTION__);
+                      g_warning ("%s: cvss:score missing", __func__);
                       free_entity (entity);
                       goto fail;
                     }
@@ -2030,7 +2030,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                   access_vector = entity_child (base_metrics, "cvss:access-vector");
                   if (access_vector == NULL)
                     {
-                      g_warning ("%s: cvss:access-vector missing", __FUNCTION__);
+                      g_warning ("%s: cvss:access-vector missing", __func__);
                       free_entity (entity);
                       goto fail;
                     }
@@ -2040,7 +2040,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                   if (access_complexity == NULL)
                     {
                       g_warning ("%s: cvss:access-complexity missing",
-                                 __FUNCTION__);
+                                 __func__);
                       free_entity (entity);
                       goto fail;
                     }
@@ -2050,7 +2050,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                   if (authentication == NULL)
                     {
                       g_warning ("%s: cvss:authentication missing",
-                                 __FUNCTION__);
+                                 __func__);
                       free_entity (entity);
                       goto fail;
                     }
@@ -2061,7 +2061,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                   if (confidentiality_impact == NULL)
                     {
                       g_warning ("%s: cvss:confidentiality-impact missing",
-                                 __FUNCTION__);
+                                 __func__);
                       free_entity (entity);
                       goto fail;
                     }
@@ -2072,7 +2072,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                   if (integrity_impact == NULL)
                     {
                       g_warning ("%s: cvss:integrity-impact missing",
-                                 __FUNCTION__);
+                                 __func__);
                       free_entity (entity);
                       goto fail;
                     }
@@ -2083,7 +2083,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                   if (availability_impact == NULL)
                     {
                       g_warning ("%s: cvss:availability-impact missing",
-                                 __FUNCTION__);
+                                 __func__);
                       free_entity (entity);
                       goto fail;
                     }
@@ -2092,7 +2092,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
               summary = entity_child (entry, "vuln:summary");
               if (summary == NULL)
                 {
-                  g_warning ("%s: vuln:summary missing", __FUNCTION__);
+                  g_warning ("%s: vuln:summary missing", __func__);
                   free_entity (entity);
                   goto fail;
                 }
@@ -2267,7 +2267,7 @@ update_scap_cves (int last_scap_update)
   if (dir == NULL)
     {
       g_warning ("%s: Failed to open directory '%s': %s",
-                 __FUNCTION__, GVM_SCAP_DATA_DIR, error->message);
+                 __func__, GVM_SCAP_DATA_DIR, error->message);
       g_error_free (error);
       return -1;
     }
@@ -2330,7 +2330,7 @@ oval_definition_dates (entity_t definition, int *definition_date_newest,
   if (metadata == NULL)
     {
       g_warning ("%s: metadata missing",
-                 __FUNCTION__);
+                 __func__);
       return;
     }
 
@@ -2338,7 +2338,7 @@ oval_definition_dates (entity_t definition, int *definition_date_newest,
   if (oval_repository == NULL)
     {
       g_warning ("%s: oval_repository missing",
-                 __FUNCTION__);
+                 __func__);
       return;
     }
 
@@ -2346,7 +2346,7 @@ oval_definition_dates (entity_t definition, int *definition_date_newest,
   if (dates == NULL)
     {
       g_warning ("%s: dates missing",
-                 __FUNCTION__);
+                 __func__);
       return;
     }
 
@@ -2395,7 +2395,7 @@ oval_oval_definitions_date (entity_t entity, int *file_timestamp)
   if (generator == NULL)
     {
       g_warning ("%s: generator missing",
-                 __FUNCTION__);
+                 __func__);
       return;
     }
 
@@ -2403,7 +2403,7 @@ oval_oval_definitions_date (entity_t entity, int *file_timestamp)
   if (timestamp == NULL)
     {
       g_warning ("%s: oval:timestamp missing",
-                 __FUNCTION__);
+                 __func__);
       return;
     }
 
@@ -2430,7 +2430,7 @@ verify_oval_file (const gchar *full_path)
   if (error)
     {
       g_warning ("%s: Failed to get contents: %s",
-                 __FUNCTION__,
+                 __func__,
                  error->message);
       g_error_free (error);
       return -1;
@@ -2439,7 +2439,7 @@ verify_oval_file (const gchar *full_path)
   if (parse_entity (xml, &entity))
     {
       g_free (xml);
-      g_warning ("%s: Failed to parse entity", __FUNCTION__);
+      g_warning ("%s: Failed to parse entity", __func__);
       return -1;
     }
   g_free (xml);
@@ -2475,7 +2475,7 @@ verify_oval_file (const gchar *full_path)
       free_entity (entity);
       if (definition_count == 0)
         {
-          g_warning ("%s: No OVAL definitions found", __FUNCTION__);
+          g_warning ("%s: No OVAL definitions found", __func__);
           return -1;
         }
       else
@@ -2513,7 +2513,7 @@ verify_oval_file (const gchar *full_path)
       free_entity (entity);
       if (variable_count == 0)
         {
-          g_warning ("%s: No OVAL variables found", __FUNCTION__);
+          g_warning ("%s: No OVAL variables found", __func__);
           return -1;
         }
       else
@@ -2523,19 +2523,19 @@ verify_oval_file (const gchar *full_path)
   if (strcmp (entity_name (entity), "oval_system_characteristics") == 0)
     {
       g_warning ("%s: File is an OVAL System Characteristics file",
-                 __FUNCTION__);
+                 __func__);
       return -1;
     }
 
   if (strcmp (entity_name (entity), "oval_results") == 0)
     {
       g_warning ("%s: File is an OVAL Results one",
-                 __FUNCTION__);
+                 __func__);
       return -1;
     }
 
   g_warning ("%s: Root tag neither oval_definitions nor oval_variables",
-             __FUNCTION__);
+             __func__);
   free_entity (entity);
   return -1;
 }
@@ -2569,7 +2569,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
   xml_path = file_and_date[0];
   assert (xml_path);
 
-  g_debug ("%s: xml_path: %s", __FUNCTION__, xml_path);
+  g_debug ("%s: xml_path: %s", __func__, xml_path);
 
   /* The timestamp from the OVAL XML. */
   oval_timestamp = file_and_date[1];
@@ -2577,7 +2577,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
   if (g_stat (xml_path, &state))
     {
       g_warning ("%s: Failed to stat OVAL file %s: %s",
-                 __FUNCTION__,
+                 __func__,
                  xml_path,
                  strerror (errno));
       return -1;
@@ -2595,7 +2595,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
   if (xml_basename == NULL)
     {
       g_warning ("%s: xml_path missing GVM_SCAP_DATA_DIR: %s",
-                 __FUNCTION__,
+                 __func__,
                  xml_path);
       return -1;
     }
@@ -2641,7 +2641,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
   if (error)
     {
       g_warning ("%s: Failed to get contents: %s",
-                 __FUNCTION__,
+                 __func__,
                  error->message);
       g_error_free (error);
       g_free (quoted_xml_basename);
@@ -2651,7 +2651,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
   if (parse_entity (xml, &entity))
     {
       g_free (xml);
-      g_warning ("%s: Failed to parse entity", __FUNCTION__);
+      g_warning ("%s: Failed to parse entity", __func__);
       g_free (quoted_xml_basename);
       return -1;
     }
@@ -2706,7 +2706,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                   id = entity_attribute (definition, "id");
                   quoted_oval_id = sql_quote (id ? id : "");
                   g_info ("%s: Filtered %s (%i)",
-                          __FUNCTION__,
+                          __func__,
                           quoted_oval_id,
                           definition_date_oldest);
                   g_free (quoted_oval_id);
@@ -2724,7 +2724,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                   if (entity_attribute (definition, "id") == NULL)
                     {
                       g_warning ("%s: oval_definition missing id",
-                                 __FUNCTION__);
+                                 __func__);
                       free_entity (entity);
                       goto fail;
                     }
@@ -2733,7 +2733,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                   if (metadata == NULL)
                     {
                       g_warning ("%s: metadata missing",
-                                 __FUNCTION__);
+                                 __func__);
                       free_entity (entity);
                       goto fail;
                     }
@@ -2742,7 +2742,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                   if (title == NULL)
                     {
                       g_warning ("%s: title missing",
-                                 __FUNCTION__);
+                                 __func__);
                       free_entity (entity);
                       goto fail;
                     }
@@ -2751,7 +2751,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                   if (description == NULL)
                     {
                       g_warning ("%s: description missing",
-                                 __FUNCTION__);
+                                 __func__);
                       free_entity (entity);
                       goto fail;
                     }
@@ -2760,7 +2760,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                   if (repository == NULL)
                     {
                       g_warning ("%s: oval_repository missing",
-                                 __FUNCTION__);
+                                 __func__);
                       free_entity (entity);
                       goto fail;
                     }
@@ -2791,7 +2791,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                   if (g_regex_match_simple ("^[0-9]+$", (gchar *) version, 0, 0) == 0)
                     {
                       g_warning ("%s: invalid version: %s",
-                                 __FUNCTION__,
+                                 __func__,
                                  version);
                       free_entity (entity);
                       goto fail;
@@ -2931,7 +2931,7 @@ oval_timestamp (const gchar *xml)
 
   if (parse_entity (xml, &entity))
     {
-      g_warning ("%s: Failed to parse entity: %s", __FUNCTION__, xml);
+      g_warning ("%s: Failed to parse entity: %s", __func__, xml);
       return NULL;
     }
 
@@ -2972,7 +2972,7 @@ oval_timestamp (const gchar *xml)
         }
     }
 
-  g_warning ("%s: No timestamp: %s", __FUNCTION__, xml);
+  g_warning ("%s: No timestamp: %s", __func__, xml);
   return NULL;
 }
 
@@ -3007,14 +3007,14 @@ oval_files_add (const char *path, const struct stat *stat, int flag,
   if ((dot == NULL) || strcasecmp (dot, ".xml"))
     return 0;
 
-  g_debug ("%s: path: %s", __FUNCTION__, path);
+  g_debug ("%s: path: %s", __func__, path);
 
   error = NULL;
   g_file_get_contents (path, &oval_xml, &len, &error);
   if (error)
     {
       g_warning ("%s: Failed get contents of %s: %s",
-                 __FUNCTION__,
+                 __func__,
                  path,
                  error->message);
       g_error_free (error);
@@ -3131,8 +3131,8 @@ update_scap_ovaldefs (int last_scap_update, int private)
   else
     oval_dir = g_build_filename (GVM_SCAP_DATA_DIR, "oval", NULL);
 
-  g_debug ("%s: private: %i", __FUNCTION__, private);
-  g_debug ("%s: oval_dir: %s", __FUNCTION__, oval_dir);
+  g_debug ("%s: private: %i", __func__, private);
+  g_debug ("%s: oval_dir: %s", __func__, oval_dir);
 
   /* Pairs of pointers, pair[0]: absolute pathname, pair[1]: oval timestamp. */
   oval_files = make_array ();
@@ -3143,18 +3143,18 @@ update_scap_ovaldefs (int last_scap_update, int private)
         {
           if (private)
             g_debug ("%s: no private OVAL dir (%s)",
-                     __FUNCTION__,
+                     __func__,
                      oval_dir);
           else
             g_warning ("%s: no OVAL dir (%s)",
-                       __FUNCTION__,
+                       __func__,
                        oval_dir);
           g_free (oval_dir);
           oval_files_free ();
           return 0;
         }
       g_warning ("%s: failed to lstat '%s': %s",
-                  __FUNCTION__,
+                  __func__,
                  oval_dir,
                  strerror (errno));
       g_free (oval_dir);
@@ -3169,12 +3169,12 @@ update_scap_ovaldefs (int last_scap_update, int private)
         {
           if (private)
             g_debug ("%s: nftw of private '%s': %s",
-                     __FUNCTION__,
+                     __func__,
                      oval_dir,
                      strerror (errno));
           else
             g_warning ("%s: nftw of '%s': %s",
-                      __FUNCTION__,
+                      __func__,
                       oval_dir,
                       strerror (errno));
           g_free (oval_dir);
@@ -3182,7 +3182,7 @@ update_scap_ovaldefs (int last_scap_update, int private)
           return 0;
         }
       g_warning ("%s: failed to traverse '%s': %s",
-                  __FUNCTION__,
+                  __func__,
                  oval_dir,
                  strerror (errno));
       g_free (oval_dir);
@@ -3267,7 +3267,7 @@ update_scap_ovaldefs (int last_scap_update, int private)
     }
 
   if (count == 0)
-    g_warning ("%s: No XML files found in %s", __FUNCTION__, oval_dir);
+    g_warning ("%s: No XML files found in %s", __func__, oval_dir);
 
   if (private)
     {
@@ -3279,7 +3279,7 @@ update_scap_ovaldefs (int last_scap_update, int private)
 
       g_info ("Cleaning up user OVAL data");
 
-      g_debug ("%s: GVM_SCAP_DATA_DIR: %s", __FUNCTION__, GVM_SCAP_DATA_DIR);
+      g_debug ("%s: GVM_SCAP_DATA_DIR: %s", __func__, GVM_SCAP_DATA_DIR);
 
       oval_files_clause = g_string_new (" AND (xml_file NOT IN (");
       first = 1;
@@ -3289,12 +3289,12 @@ update_scap_ovaldefs (int last_scap_update, int private)
           char *suffix;
 
           pair = g_ptr_array_index (oval_files, index);
-          g_debug ("%s: pair[0]: %s", __FUNCTION__, pair[0]);
+          g_debug ("%s: pair[0]: %s", __func__, pair[0]);
           suffix = strstr (pair[0], GVM_SCAP_DATA_DIR);
           if (suffix == NULL)
             {
               g_warning ("%s: pair[0] missing GVM_SCAP_DATA_DIR: %s",
-                         __FUNCTION__,
+                         __func__,
                          pair[0]);
               g_free (oval_dir);
               oval_files_free ();
@@ -3367,7 +3367,7 @@ write_sync_start (int lockfile)
             /* Interrupted, try write again. */
             continue;
           g_warning ("%s: failed to write to lockfile: %s",
-                     __FUNCTION__,
+                     __func__,
                      strerror (errno));
           break;
         }
@@ -3437,7 +3437,7 @@ sync_secinfo (sigset_t *sigmask_current, int (*update) (int),
                          S_IWUSR | S_IRUSR | S_IROTH | S_IRGRP);
         if (lockfile == -1)
           {
-            g_warning ("%s: failed to open lock file '%s': %s", __FUNCTION__,
+            g_warning ("%s: failed to open lock file '%s': %s", __func__,
                        lockfile_name, strerror (errno));
             g_free (lockfile_name);
             exit (EXIT_FAILURE);
@@ -3446,9 +3446,9 @@ sync_secinfo (sigset_t *sigmask_current, int (*update) (int),
         if (flock (lockfile, LOCK_EX | LOCK_NB))  /* Exclusive, Non blocking. */
           {
             if (errno == EWOULDBLOCK)
-              g_debug ("%s: skipping, sync in progress", __FUNCTION__);
+              g_debug ("%s: skipping, sync in progress", __func__);
             else
-              g_debug ("%s: flock: %s", __FUNCTION__, strerror (errno));
+              g_debug ("%s: flock: %s", __func__, strerror (errno));
             g_free (lockfile_name);
             exit (EXIT_SUCCESS);
           }
@@ -3462,7 +3462,7 @@ sync_secinfo (sigset_t *sigmask_current, int (*update) (int),
 
       case -1:
         /* Parent on error.  Reschedule and continue to next task. */
-        g_warning ("%s: fork failed", __FUNCTION__);
+        g_warning ("%s: fork failed", __func__);
         return;
 
       default:
@@ -3483,7 +3483,7 @@ sync_secinfo (sigset_t *sigmask_current, int (*update) (int),
   if (close (lockfile))
     {
       g_free (lockfile_name);
-      g_warning ("%s: failed to close lock file: %s", __FUNCTION__,
+      g_warning ("%s: failed to close lock file: %s", __func__,
                  strerror (errno));
       exit (EXIT_FAILURE);
     }
@@ -3522,7 +3522,7 @@ manage_feed_timestamp (const gchar *name)
       else
         {
           g_warning ("%s: Failed to get timestamp: %s",
-                     __FUNCTION__,
+                     __func__,
                      error->message);
           return -1;
         }
@@ -3532,7 +3532,7 @@ manage_feed_timestamp (const gchar *name)
       if (strlen (timestamp) < 8)
         {
           g_warning ("%s: Feed timestamp too short: %s",
-                     __FUNCTION__,
+                     __func__,
                      timestamp);
           g_free (timestamp);
           return -1;
@@ -3597,7 +3597,7 @@ update_cert_timestamp ()
       else
         {
           g_warning ("%s: Failed to get timestamp: %s",
-                     __FUNCTION__,
+                     __func__,
                      error->message);
           return -1;
         }
@@ -3607,21 +3607,21 @@ update_cert_timestamp ()
       if (strlen (timestamp) < 8)
         {
           g_warning ("%s: Feed timestamp too short: %s",
-                     __FUNCTION__,
+                     __func__,
                      timestamp);
           g_free (timestamp);
           return -1;
         }
 
       timestamp[8] = '\0';
-      g_debug ("%s: parsing: %s", __FUNCTION__, timestamp);
+      g_debug ("%s: parsing: %s", __func__, timestamp);
       stamp = parse_feed_timestamp (timestamp);
       g_free (timestamp);
       if (stamp == 0)
         return -1;
     }
 
-  g_debug ("%s: setting last_update: %lld", __FUNCTION__, (long long) stamp);
+  g_debug ("%s: setting last_update: %lld", __func__, (long long) stamp);
   sql ("UPDATE cert.meta SET value = '%lld' WHERE name = 'last_update';",
        (long long) stamp);
 
@@ -3715,7 +3715,7 @@ sync_cert (int lockfile)
       g_info ("Initializing CERT database");
       if (manage_db_init ("cert"))
         {
-          g_warning ("%s: Could not initialize CERT database", __FUNCTION__);
+          g_warning ("%s: Could not initialize CERT database", __func__);
           return -1;
         }
     }
@@ -3729,10 +3729,10 @@ sync_cert (int lockfile)
   if (last_cert_update == -1)
     {
       g_warning ("%s: Inconsistent data. Resetting CERT database.",
-                 __FUNCTION__);
+                 __func__);
       if (manage_db_reinit ("cert"))
         {
-          g_warning ("%s: could not reinitialize CERT database", __FUNCTION__);
+          g_warning ("%s: could not reinitialize CERT database", __func__);
           return -1;
         }
       last_cert_update = 0;
@@ -3745,7 +3745,7 @@ sync_cert (int lockfile)
   if (last_cert_update >= last_feed_update)
     return -1;
 
-  g_debug ("%s: sync", __FUNCTION__);
+  g_debug ("%s: sync", __func__);
 
   write_sync_start (lockfile);
 
@@ -3754,11 +3754,11 @@ sync_cert (int lockfile)
   if (manage_db_check ("cert"))
     {
       g_warning ("%s: Database broken, resetting CERT database",
-                 __FUNCTION__);
+                 __func__);
       if (manage_db_reinit ("cert"))
         {
           g_warning ("%s: could not reinitialize CERT database",
-                     __FUNCTION__);
+                     __func__);
           goto fail;
         }
     }
@@ -3766,9 +3766,9 @@ sync_cert (int lockfile)
   if (manage_update_cert_db_init ())
     goto fail;
 
-  g_info ("%s: Updating data from feed", __FUNCTION__);
+  g_info ("%s: Updating data from feed", __func__);
 
-  g_debug ("%s: update dfn", __FUNCTION__);
+  g_debug ("%s: update dfn", __func__);
 
   updated_dfn_cert = update_dfn_cert_advisories (last_cert_update);
   if (updated_dfn_cert == -1)
@@ -3777,7 +3777,7 @@ sync_cert (int lockfile)
       goto fail;
     }
 
-  g_debug ("%s: update bund", __FUNCTION__);
+  g_debug ("%s: update bund", __func__);
 
   updated_cert_bund = update_cert_bund_advisories (last_cert_update);
   if (updated_cert_bund == -1)
@@ -3786,19 +3786,19 @@ sync_cert (int lockfile)
       goto fail;
     }
 
-  g_debug ("%s: update cvss", __FUNCTION__);
+  g_debug ("%s: update cvss", __func__);
 
   last_scap_update = 0;
   if (manage_scap_loaded ())
     last_scap_update = sql_int ("SELECT coalesce ((SELECT value FROM scap.meta"
                                 "                  WHERE name = 'last_update'),"
                                 "                 '0');");
-  g_debug ("%s: last_scap_update: %i", __FUNCTION__, last_scap_update);
+  g_debug ("%s: last_scap_update: %i", __func__, last_scap_update);
 
   update_cvss_dfn_cert (updated_dfn_cert, last_cert_update, last_scap_update);
   update_cvss_cert_bund (updated_cert_bund, last_cert_update, last_scap_update);
 
-  g_debug ("%s: update timestamp", __FUNCTION__);
+  g_debug ("%s: update timestamp", __func__);
 
   if (update_cert_timestamp ())
     {
@@ -3806,7 +3806,7 @@ sync_cert (int lockfile)
       goto fail;
     }
 
-  g_info ("%s: Updating CERT info succeeded.", __FUNCTION__);
+  g_info ("%s: Updating CERT info succeeded.", __func__);
 
   manage_update_cert_db_cleanup ();
 
@@ -3814,7 +3814,7 @@ sync_cert (int lockfile)
 
   if (ftruncate (lockfile, 0))
     g_warning ("%s: failed to ftruncate lockfile: %s",
-               __FUNCTION__,
+               __func__,
                strerror (errno));
 
   return 0;
@@ -3824,7 +3824,7 @@ sync_cert (int lockfile)
 
   if (ftruncate (lockfile, 0))
     g_warning ("%s: failed to ftruncate lockfile: %s",
-               __FUNCTION__,
+               __func__,
                strerror (errno));
 
   return -1;
@@ -3903,7 +3903,7 @@ update_scap_timestamp ()
       else
         {
           g_warning ("%s: Failed to get timestamp: %s",
-                     __FUNCTION__,
+                     __func__,
                      error->message);
           return -1;
         }
@@ -3913,21 +3913,21 @@ update_scap_timestamp ()
       if (strlen (timestamp) < 8)
         {
           g_warning ("%s: Feed timestamp too short: %s",
-                     __FUNCTION__,
+                     __func__,
                      timestamp);
           g_free (timestamp);
           return -1;
         }
 
       timestamp[8] = '\0';
-      g_debug ("%s: parsing: %s", __FUNCTION__, timestamp);
+      g_debug ("%s: parsing: %s", __func__, timestamp);
       stamp = parse_feed_timestamp (timestamp);
       g_free (timestamp);
       if (stamp == 0)
         return -1;
     }
 
-  g_debug ("%s: setting last_update: %lld", __FUNCTION__, (long long) stamp);
+  g_debug ("%s: setting last_update: %lld", __func__, (long long) stamp);
   sql ("UPDATE scap.meta SET value = '%lld' WHERE name = 'last_update';",
        (long long) stamp);
 
@@ -4030,11 +4030,11 @@ sync_scap (int lockfile)
     }
   else
     {
-      g_info ("%s: Initializing SCAP database", __FUNCTION__);
+      g_info ("%s: Initializing SCAP database", __func__);
 
       if (manage_db_init ("scap"))
         {
-          g_warning ("%s: Could not initialize SCAP database", __FUNCTION__);
+          g_warning ("%s: Could not initialize SCAP database", __func__);
           return -1;
         }
     }
@@ -4048,10 +4048,10 @@ sync_scap (int lockfile)
   if (last_scap_update == -1)
     {
       g_warning ("%s: Inconsistent data, resetting SCAP database",
-                 __FUNCTION__);
+                 __func__);
       if (manage_db_reinit ("scap"))
         {
-          g_warning ("%s: could not reinitialize SCAP database", __FUNCTION__);
+          g_warning ("%s: could not reinitialize SCAP database", __func__);
           return -1;
         }
       last_scap_update = 0;
@@ -4064,7 +4064,7 @@ sync_scap (int lockfile)
   if (last_scap_update >= last_feed_update)
     return -1;
 
-  g_debug ("%s: sync", __FUNCTION__);
+  g_debug ("%s: sync", __func__);
 
   write_sync_start (lockfile);
 
@@ -4073,11 +4073,11 @@ sync_scap (int lockfile)
   if (manage_db_check ("scap"))
     {
       g_warning ("%s: Database broken, resetting SCAP database",
-                 __FUNCTION__);
+                 __func__);
       if (manage_db_reinit ("scap"))
         {
           g_warning ("%s: could not reinitialize SCAP database",
-                     __FUNCTION__);
+                     __func__);
           goto fail;
         }
     }
@@ -4085,9 +4085,9 @@ sync_scap (int lockfile)
   if (manage_update_scap_db_init ())
      goto fail;
 
-  g_info ("%s: Updating data from feed", __FUNCTION__);
+  g_info ("%s: Updating data from feed", __func__);
 
-  g_debug ("%s: update cpes", __FUNCTION__);
+  g_debug ("%s: update cpes", __func__);
 
   updated_scap_cpes = update_scap_cpes (last_scap_update);
   if (updated_scap_cpes == -1)
@@ -4096,7 +4096,7 @@ sync_scap (int lockfile)
       goto fail;
     }
 
-  g_debug ("%s: update cves", __FUNCTION__);
+  g_debug ("%s: update cves", __func__);
 
   updated_scap_cves = update_scap_cves (last_scap_update);
   if (updated_scap_cves == -1)
@@ -4105,7 +4105,7 @@ sync_scap (int lockfile)
       goto fail;
     }
 
-  g_debug ("%s: update ovaldefs", __FUNCTION__);
+  g_debug ("%s: update ovaldefs", __func__);
 
   updated_scap_ovaldefs = update_scap_ovaldefs (last_scap_update,
                                                 0 /* Feed data. */);
@@ -4115,7 +4115,7 @@ sync_scap (int lockfile)
       goto fail;
     }
 
-  g_debug ("%s: updating user defined data", __FUNCTION__);
+  g_debug ("%s: updating user defined data", __func__);
 
   switch (update_scap_ovaldefs (last_scap_update,
                                 1 /* Private data. */))
@@ -4134,7 +4134,7 @@ sync_scap (int lockfile)
                     updated_scap_ovaldefs);
   update_scap_placeholders (updated_scap_cves);
 
-  g_debug ("%s: update timestamp", __FUNCTION__);
+  g_debug ("%s: update timestamp", __func__);
 
   if (update_scap_timestamp ())
     {
@@ -4142,7 +4142,7 @@ sync_scap (int lockfile)
       goto fail;
     }
 
-  g_info ("%s: Updating SCAP info succeeded", __FUNCTION__);
+  g_info ("%s: Updating SCAP info succeeded", __func__);
 
   manage_update_scap_db_cleanup ();
 
@@ -4150,7 +4150,7 @@ sync_scap (int lockfile)
 
   if (ftruncate (lockfile, 0))
     g_warning ("%s: failed to ftruncate lockfile: %s",
-               __FUNCTION__,
+               __func__,
                strerror (errno));
 
   return 0;
@@ -4160,7 +4160,7 @@ sync_scap (int lockfile)
 
   if (ftruncate (lockfile, 0))
     g_warning ("%s: failed to ftruncate lockfile: %s",
-               __FUNCTION__,
+               __func__,
                strerror (errno));
 
   return -1;

--- a/src/manage_sql_tickets.c
+++ b/src/manage_sql_tickets.c
@@ -1475,7 +1475,7 @@ check_tickets (task_t task)
     {
       g_warning ("%s: failed to get last report of task %llu,"
                  " skipping ticket check",
-                 __FUNCTION__,
+                 __func__,
                  task);
       return;
     }

--- a/src/manage_sql_tls_certificates.c
+++ b/src/manage_sql_tls_certificates.c
@@ -525,7 +525,7 @@ make_tls_certificate (const char *name,
 
   if (sha256_fingerprint == NULL || strcmp (sha256_fingerprint, "") == 0)
     {
-      g_warning ("%s: Missing/empty sha256_fingerprint", __FUNCTION__);
+      g_warning ("%s: Missing/empty sha256_fingerprint", __func__);
       return -1;
     }
 
@@ -1304,7 +1304,7 @@ get_or_make_tls_certificate_source (tls_certificate_t tls_certificate,
 
   if (tls_certificate == 0)
     {
-      g_warning ("%s: No TLS certificate given", __FUNCTION__);
+      g_warning ("%s: No TLS certificate given", __func__);
       return 0;
     }
 
@@ -1502,7 +1502,7 @@ add_tls_certificates_from_report_host (report_host_t report_host,
       source_name = iterator_string (&tls_certs, 2);
 
       g_debug ("%s: Handling certificate %s on %s in report %s",
-               __FUNCTION__, scanner_fpr, host_ip, report_id);
+               __func__, scanner_fpr, host_ip, report_id);
 
       tls_certificate = 0;
       activation_time = -1;
@@ -1545,7 +1545,7 @@ add_tls_certificates_from_report_host (report_host_t report_host,
                           &serial);
       else
         g_warning ("%s: No SSLDetails found for fingerprint %s",
-                   __FUNCTION__,
+                   __func__,
                    scanner_fpr);
 
       free (ssldetails);
@@ -1568,7 +1568,7 @@ add_tls_certificates_from_report_host (report_host_t report_host,
         {
           g_warning ("%s: Could not create TLS certificate"
                      " or get existing one for fingerprint '%s'.",
-                     __FUNCTION__, scanner_fpr);
+                     __func__, scanner_fpr);
 
           g_free (certificate);
           g_free (md5_fingerprint);

--- a/src/manage_tls_certificates.c
+++ b/src/manage_tls_certificates.c
@@ -58,7 +58,7 @@ parse_ssldetails (const char *ssldetails,
 
   if (ssldetails == NULL)
     {
-      g_warning ("%s: ssldetails is NULL", __FUNCTION__);
+      g_warning ("%s: ssldetails is NULL", __func__);
       return;
     }
 

--- a/src/manage_utils.c
+++ b/src/manage_utils.c
@@ -74,7 +74,7 @@ time_offset (const char *zone, time_t time)
 
   if (setenv ("TZ", zone, 1) == -1)
     {
-      g_warning ("%s: Failed to switch to timezone", __FUNCTION__);
+      g_warning ("%s: Failed to switch to timezone", __func__);
       if (tz != NULL)
         setenv ("TZ", tz, 1);
       g_free (tz);
@@ -86,7 +86,7 @@ time_offset (const char *zone, time_t time)
   time_broken = localtime (&time);
   if (time_broken == NULL)
     {
-      g_warning ("%s: localtime failed", __FUNCTION__);
+      g_warning ("%s: localtime failed", __func__);
       if (tz != NULL)
         setenv ("TZ", tz, 1);
       g_free (tz);
@@ -94,7 +94,7 @@ time_offset (const char *zone, time_t time)
     }
   if (strftime (buf, 100, "%z", time_broken) == 0)
     {
-      g_warning ("%s: Failed to format timezone", __FUNCTION__);
+      g_warning ("%s: Failed to format timezone", __func__);
       if (tz != NULL)
         setenv ("TZ", tz, 1);
       g_free (tz);
@@ -116,7 +116,7 @@ time_offset (const char *zone, time_t time)
     {
       if (setenv ("TZ", tz, 1) == -1)
         {
-          g_warning ("%s: Failed to switch to original TZ", __FUNCTION__);
+          g_warning ("%s: Failed to switch to original TZ", __func__);
           g_free (tz);
           return mins * 60;
         }
@@ -151,7 +151,7 @@ current_offset (const char *zone)
 
   if (setenv ("TZ", zone, 1) == -1)
     {
-      g_warning ("%s: Failed to switch to timezone", __FUNCTION__);
+      g_warning ("%s: Failed to switch to timezone", __func__);
       if (tz != NULL)
         setenv ("TZ", tz, 1);
       g_free (tz);
@@ -164,7 +164,7 @@ current_offset (const char *zone)
   now_broken = localtime (&now);
   if (now_broken == NULL)
     {
-      g_warning ("%s: localtime failed", __FUNCTION__);
+      g_warning ("%s: localtime failed", __func__);
       if (tz != NULL)
         setenv ("TZ", tz, 1);
       g_free (tz);
@@ -172,7 +172,7 @@ current_offset (const char *zone)
     }
   if (setenv ("TZ", "UTC", 1) == -1)
     {
-      g_warning ("%s: Failed to switch to UTC", __FUNCTION__);
+      g_warning ("%s: Failed to switch to UTC", __func__);
       if (tz != NULL)
         setenv ("TZ", tz, 1);
       g_free (tz);
@@ -186,7 +186,7 @@ current_offset (const char *zone)
     {
       if (setenv ("TZ", tz, 1) == -1)
         {
-          g_warning ("%s: Failed to switch to original TZ", __FUNCTION__);
+          g_warning ("%s: Failed to switch to original TZ", __func__);
           g_free (tz);
           return 0;
         }
@@ -242,7 +242,7 @@ months_between (time_t time1, time_t time2)
   if ((localtime_r (&time1, &broken1) == NULL)
       || (broken2 == NULL))
     {
-      g_warning ("%s: localtime failed", __FUNCTION__);
+      g_warning ("%s: localtime failed", __func__);
       return 0;
     }
 
@@ -304,7 +304,7 @@ add_months (time_t time, int months)
   struct tm *broken = localtime (&time);
   if (broken == NULL)
     {
-      g_warning ("%s: localtime failed", __FUNCTION__);
+      g_warning ("%s: localtime failed", __func__);
       return 0;
     }
   broken->tm_mon += months;
@@ -327,7 +327,7 @@ day_of_week (time_t time)
   tm = gmtime (&time);
   if (tm == NULL)
     {
-      g_warning ("%s: gmtime failed", __FUNCTION__);
+      g_warning ("%s: gmtime failed", __func__);
       return 0;
     }
 
@@ -413,7 +413,7 @@ next_time (time_t first, int period, int period_months, int byday,
 
       assert (now > first);
 
-      g_debug ("%s: byday: %i", __FUNCTION__, byday);
+      g_debug ("%s: byday: %i", __func__, byday);
 
       /* TODO does this need timezone offsetting? */
 
@@ -427,13 +427,13 @@ next_time (time_t first, int period, int period_months, int byday,
       next_day_multiple = now + (SECS_PER_DAY - ((now - first) % SECS_PER_DAY));
 
       g_debug ("%s: next_day_multiple: %lli",
-               __FUNCTION__,
+               __func__,
                (long long) next_day_multiple);
       g_debug ("%s: day_of_week (next_day_multiple): %i",
-               __FUNCTION__,
+               __func__,
                day_of_week (next_day_multiple));
       g_debug ("%s: next_day (^, byday): %i",
-               __FUNCTION__,
+               __func__,
                next_day (day_of_week (next_day_multiple), byday));
 
       /* Return the next possible daily time, offset according the next day of
@@ -460,7 +460,7 @@ next_time (time_t first, int period, int period_months, int byday,
 
       if (setenv ("TZ", zone ? zone : "UTC", 1) == -1)
         {
-          g_warning ("%s: Failed to switch to timezone", __FUNCTION__);
+          g_warning ("%s: Failed to switch to timezone", __func__);
           if (tz != NULL)
             setenv ("TZ", tz, 1);
           g_free (tz);
@@ -479,7 +479,7 @@ next_time (time_t first, int period, int period_months, int byday,
       if (tz)
         {
           if (setenv ("TZ", tz, 1) == -1)
-            g_warning ("%s: Failed to switch to original TZ", __FUNCTION__);
+            g_warning ("%s: Failed to switch to original TZ", __func__);
 
           g_free (tz);
         }

--- a/src/sql.c
+++ b/src/sql.c
@@ -174,7 +174,7 @@ sqlv (int retry, char* sql, va_list args)
       ret = sql_prepare_internal (retry, 1, sql, args_copy, &stmt);
       va_end (args_copy);
       if (ret == -1)
-        g_warning ("%s: sql_prepare_internal failed", __FUNCTION__);
+        g_warning ("%s: sql_prepare_internal failed", __func__);
       if (ret)
         return ret;
 
@@ -182,7 +182,7 @@ sqlv (int retry, char* sql, va_list args)
 
       while ((ret = sql_exec_internal (retry, stmt)) == 1);
       if ((ret == -1) && log_errors)
-        g_warning ("%s: sql_exec_internal failed", __FUNCTION__);
+        g_warning ("%s: sql_exec_internal failed", __func__);
       sql_finalize (stmt);
       if (ret == 2)
         continue;
@@ -307,7 +307,7 @@ sql_x_internal (int log, char* sql, va_list args, sql_stmt_t** stmt_return)
 
       if (ret)
         {
-          g_warning ("%s: sql_prepare failed", __FUNCTION__);
+          g_warning ("%s: sql_prepare failed", __func__);
           return -1;
         }
 
@@ -317,7 +317,7 @@ sql_x_internal (int log, char* sql, va_list args, sql_stmt_t** stmt_return)
       if (ret == -1 || ret == -4)
         {
           if (log_errors)
-            g_warning ("%s: sql_exec_internal failed", __FUNCTION__);
+            g_warning ("%s: sql_exec_internal failed", __func__);
           return -1;
         }
       if (ret == 0)
@@ -587,7 +587,7 @@ init_iterator (iterator_t* iterator, const char* sql, ...)
   va_end (args);
   if (ret)
     {
-      g_warning ("%s: sql_prepare failed", __FUNCTION__);
+      g_warning ("%s: sql_prepare failed", __func__);
       abort ();
     }
   iterator->stmt = stmt;
@@ -682,7 +682,7 @@ cleanup_iterator (iterator_t* iterator)
 {
   if (iterator == NULL)
     {
-      g_warning ("%s: null iterator pointer", __FUNCTION__);
+      g_warning ("%s: null iterator pointer", __func__);
       return;
     }
 
@@ -722,14 +722,14 @@ next (iterator_t* iterator)
       if (ret == -1 || ret == -4)
         {
           if (log_errors)
-            g_warning ("%s: sql_exec_internal failed", __FUNCTION__);
+            g_warning ("%s: sql_exec_internal failed", __func__);
           abort ();
         }
       if (ret == -3 || ret == -2)
         {
           /* Busy or locked, with statement reset.  Just try step again like
            * we used to do in sql_exec_internal. */
-          g_warning ("%s: stepping after reset", __FUNCTION__);
+          g_warning ("%s: stepping after reset", __func__);
           continue;
         }
       break;

--- a/src/sql_pg.c
+++ b/src/sql_pg.c
@@ -124,7 +124,7 @@ sql_select_limit (int max)
     return "ALL";
   if (snprintf (string, 19, "%i", max) < 0)
     {
-      g_warning ("%s: snprintf failed", __FUNCTION__);
+      g_warning ("%s: snprintf failed", __func__);
       abort ();
     }
   string[19] = '\0';
@@ -267,13 +267,13 @@ sql_open (const char *database)
   if (conn == NULL)
     {
       g_warning ("%s: PQconnectStart failed to allocate conn",
-                 __FUNCTION__);
+                 __func__);
       return -1;
     }
   if (PQstatus (conn) == CONNECTION_BAD)
     {
       g_warning ("%s: PQconnectStart to '%s' failed: %s",
-                 __FUNCTION__,
+                 __func__,
                  database ? database : sql_default_database (),
                  PQerrorMessage (conn));
       goto fail;
@@ -282,13 +282,13 @@ sql_open (const char *database)
   socket = PQsocket (conn);
   if (socket == 0)
     {
-      g_warning ("%s: PQsocket 0", __FUNCTION__);
+      g_warning ("%s: PQsocket 0", __func__);
       goto fail;
     }
 
   poll_status = PGRES_POLLING_WRITING;
 
-  g_debug ("%s: polling", __FUNCTION__);
+  g_debug ("%s: polling", __func__);
 
   while (1)
     {
@@ -306,7 +306,7 @@ sql_open (const char *database)
           if (ret < 0)
             {
               g_warning ("%s: write select failed: %s",
-                         __FUNCTION__, strerror (errno));
+                         __func__, strerror (errno));
               goto fail;
             }
           /* Poll again. */
@@ -325,7 +325,7 @@ sql_open (const char *database)
           if (ret < 0)
             {
               g_warning ("%s: read select failed: %s",
-                         __FUNCTION__, strerror (errno));
+                         __func__, strerror (errno));
               goto fail;
             }
           /* Poll again. */
@@ -333,8 +333,8 @@ sql_open (const char *database)
       else if (poll_status == PGRES_POLLING_FAILED)
         {
           g_warning ("%s: PQconnectPoll failed",
-                     __FUNCTION__);
-          g_warning ("%s: PQerrorMessage (conn): %s", __FUNCTION__,
+                     __func__);
+          g_warning ("%s: PQerrorMessage (conn): %s", __func__,
                      PQerrorMessage (conn));
           goto fail;
         }
@@ -347,12 +347,12 @@ sql_open (const char *database)
 
   PQsetNoticeProcessor (conn, log_notice, NULL);
 
-  g_debug ("%s:   db: %s", __FUNCTION__, PQdb (conn));
-  g_debug ("%s: user: %s", __FUNCTION__, PQuser (conn));
-  g_debug ("%s: host: %s", __FUNCTION__, PQhost (conn));
-  g_debug ("%s: port: %s", __FUNCTION__, PQport (conn));
-  g_debug ("%s: socket: %i", __FUNCTION__, PQsocket (conn));
-  g_debug ("%s: postgres version: %i", __FUNCTION__, PQserverVersion (conn));
+  g_debug ("%s:   db: %s", __func__, PQdb (conn));
+  g_debug ("%s: user: %s", __func__, PQuser (conn));
+  g_debug ("%s: host: %s", __func__, PQhost (conn));
+  g_debug ("%s: port: %s", __func__, PQport (conn));
+  g_debug ("%s: socket: %i", __func__, PQsocket (conn));
+  g_debug ("%s: postgres version: %i", __func__, PQserverVersion (conn));
 
   return 0;
 
@@ -512,18 +512,18 @@ sql_exec_internal (int retry, sql_stmt_t *stmt)
           char *sqlstate;
 
           sqlstate = PQresultErrorField (result, PG_DIAG_SQLSTATE);
-          g_debug ("%s: sqlstate: %s", __FUNCTION__, sqlstate);
+          g_debug ("%s: sqlstate: %s", __func__, sqlstate);
           if (sqlstate && (strcmp (sqlstate, "57014") == 0))
             {
               /* query_canceled */
               log_errors = 0;
-              g_debug ("%s: canceled SQL: %s", __FUNCTION__, stmt->sql);
+              g_debug ("%s: canceled SQL: %s", __func__, stmt->sql);
             }
           else if (sqlstate && (strcmp (sqlstate, "55P03") == 0))
             {
               /* lock_not_available */
               g_debug ("%s: lock unavailable: %s",
-                       __FUNCTION__,
+                       __func__,
                        PQresultErrorMessage(result));
               return -3;
             }
@@ -531,19 +531,19 @@ sql_exec_internal (int retry, sql_stmt_t *stmt)
             {
               /* unique_violation */
               g_warning ("%s: constraint violation: %s",
-                         __FUNCTION__,
+                         __func__,
                          PQresultErrorMessage (result));
-              g_warning ("%s: SQL: %s", __FUNCTION__, stmt->sql);
+              g_warning ("%s: SQL: %s", __func__, stmt->sql);
               return -4;
             }
 
           if (log_errors)
             {
               g_warning ("%s: PQexec failed: %s (%i)",
-                         __FUNCTION__,
+                         __func__,
                          PQresultErrorMessage (result),
                          PQresultStatus (result));
-              g_warning ("%s: SQL: %s", __FUNCTION__, stmt->sql);
+              g_warning ("%s: SQL: %s", __func__, stmt->sql);
             }
 #if 0
           // FIX ?
@@ -585,7 +585,7 @@ sql_explain_internal (const char* sql, va_list args)
   if (sql_prepare_internal (1, 1, explain_sql, args, &explain_stmt))
     {
       if (log_errors)
-        g_warning ("%s : Failed to prepare EXPLAIN statement", __FUNCTION__);
+        g_warning ("%s : Failed to prepare EXPLAIN statement", __func__);
       g_free (explain_sql);
       return -1;
     }
@@ -595,7 +595,7 @@ sql_explain_internal (const char* sql, va_list args)
       explain_ret = sql_exec_internal (1, explain_stmt);
       if (explain_ret == 1)
         g_debug ("%s : %s",
-                __FUNCTION__,
+                __func__,
                 PQgetvalue (explain_stmt->result,
                             explain_stmt->current_row,
                             0));
@@ -603,7 +603,7 @@ sql_explain_internal (const char* sql, va_list args)
         break;
       else
         {
-          g_warning ("%s : Failed to get EXPLAIN row", __FUNCTION__);
+          g_warning ("%s : Failed to get EXPLAIN row", __func__);
           sql_finalize (explain_stmt);
           g_free (explain_sql);
           return -1;
@@ -713,7 +713,7 @@ bind_param (sql_stmt_t *stmt, int position, const void *param_value,
   if (position > stmt->param_values->len + 1)
     {
       g_critical ("%s: binding out of order: parameter %i after %i",
-                  __FUNCTION__,
+                  __func__,
                   position,
                   stmt->param_values->len);
       abort ();
@@ -940,7 +940,7 @@ sql_column_array (sql_stmt_t *stmt, int position)
           last_element = *last;
           if (*last_element == '\0')
             /* Weird, last element should always have a }. */
-            g_warning ("%s: last element missing closing }", __FUNCTION__);
+            g_warning ("%s: last element missing closing }", __func__);
           else
             {
               while (*last_element)
@@ -956,7 +956,7 @@ sql_column_array (sql_stmt_t *stmt, int position)
   /* This shouldn't happen. */
   assert (0);
   g_warning ("%s: array column not NULL and does not contain array",
-             __FUNCTION__);
+             __func__);
   return NULL;
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -127,7 +127,7 @@ parse_utc_time (const char *format, const char *text_time)
 
   if (setenv ("TZ", "UTC", 1) == -1)
     {
-      g_warning ("%s: Failed to switch to UTC", __FUNCTION__);
+      g_warning ("%s: Failed to switch to UTC", __func__);
       if (tz != NULL)
         setenv ("TZ", tz, 1);
       g_free (tz);
@@ -137,7 +137,7 @@ parse_utc_time (const char *format, const char *text_time)
   memset (&tm, 0, sizeof (struct tm));
   if (strptime ((char*) text_time, format, &tm) == NULL)
     {
-      g_warning ("%s: Failed to parse time", __FUNCTION__);
+      g_warning ("%s: Failed to parse time", __func__);
       if (tz != NULL)
         setenv ("TZ", tz, 1);
       g_free (tz);
@@ -146,7 +146,7 @@ parse_utc_time (const char *format, const char *text_time)
   epoch_time = mktime (&tm);
   if (epoch_time == -1)
     {
-      g_warning ("%s: Failed to make time", __FUNCTION__);
+      g_warning ("%s: Failed to make time", __func__);
       if (tz != NULL)
         setenv ("TZ", tz, 1);
       g_free (tz);
@@ -158,7 +158,7 @@ parse_utc_time (const char *format, const char *text_time)
     {
       if (setenv ("TZ", tz, 1) == -1)
         {
-          g_warning ("%s: Failed to switch to original TZ", __FUNCTION__);
+          g_warning ("%s: Failed to switch to original TZ", __func__);
           g_free (tz);
           return 0;
         }
@@ -216,13 +216,13 @@ parse_ctime (const char *text_time)
   memset (&tm, 0, sizeof (struct tm));
   if (strptime ((char*) text_time, "%a %b %d %H:%M:%S %Y", &tm) == NULL)
     {
-      g_warning ("%s: Failed to parse time '%s'", __FUNCTION__, text_time);
+      g_warning ("%s: Failed to parse time '%s'", __func__, text_time);
       return 0;
     }
   epoch_time = mktime (&tm);
   if (epoch_time == -1)
     {
-      g_warning ("%s: Failed to make time '%s'", __FUNCTION__, text_time);
+      g_warning ("%s: Failed to make time '%s'", __func__, text_time);
       return 0;
     }
 
@@ -338,7 +338,7 @@ iso_time_tz (time_t *epoch_time, const char *zone, const char **abbrev)
 
   if (setenv ("TZ", zone, 1) == -1)
     {
-      g_warning ("%s: Failed to switch to zone", __FUNCTION__);
+      g_warning ("%s: Failed to switch to zone", __func__);
       if (tz != NULL)
         setenv ("TZ", tz, 1);
       g_free (tz);
@@ -353,7 +353,7 @@ iso_time_tz (time_t *epoch_time, const char *zone, const char **abbrev)
     {
       if (setenv ("TZ", tz, 1) == -1)
         {
-          g_warning ("%s: Failed to switch to original TZ", __FUNCTION__);
+          g_warning ("%s: Failed to switch to original TZ", __func__);
           g_free (tz);
           return ret;
         }
@@ -412,11 +412,11 @@ lock_internal (lockfile_t *lockfile, const gchar *lockfile_basename,
       g_free (lockfile_name);
       if (close (fd))
         g_warning ("%s: failed to close lock file fd: %s",
-                   __FUNCTION__,
+                   __func__,
                    strerror (errno));
       if (flock_errno == EWOULDBLOCK)
         return 1;
-      g_warning ("%s: flock: %s", __FUNCTION__, strerror (flock_errno));
+      g_warning ("%s: flock: %s", __func__, strerror (flock_errno));
       return -1;
     }
 
@@ -439,7 +439,7 @@ lock_internal (lockfile_t *lockfile, const gchar *lockfile_basename,
 int
 lockfile_lock (lockfile_t *lockfile, const gchar *lockfile_basename)
 {
-  g_debug ("%s: lock '%s'", __FUNCTION__, lockfile_basename);
+  g_debug ("%s: lock '%s'", __func__, lockfile_basename);
   return lock_internal (lockfile, lockfile_basename, LOCK_EX);
 }
 
@@ -454,7 +454,7 @@ lockfile_lock (lockfile_t *lockfile, const gchar *lockfile_basename)
 int
 lockfile_lock_nb (lockfile_t *lockfile, const gchar *lockfile_basename)
 {
-  g_debug ("%s: lock '%s'", __FUNCTION__, lockfile_basename);
+  g_debug ("%s: lock '%s'", __func__, lockfile_basename);
   return lock_internal (lockfile, lockfile_basename, LOCK_EX | LOCK_NB);
 }
 
@@ -469,7 +469,7 @@ lockfile_lock_nb (lockfile_t *lockfile, const gchar *lockfile_basename)
 int
 lockfile_lock_shared_nb (lockfile_t *lockfile, const gchar *lockfile_basename)
 {
-  g_debug ("%s: lock '%s'", __FUNCTION__, lockfile_basename);
+  g_debug ("%s: lock '%s'", __func__, lockfile_basename);
   return lock_internal (lockfile, lockfile_basename, LOCK_SH | LOCK_NB);
 }
 
@@ -488,7 +488,7 @@ lockfile_unlock (lockfile_t *lockfile)
 
   assert (lockfile->fd);
 
-  g_debug ("%s: unlock '%s'", __FUNCTION__, lockfile->name);
+  g_debug ("%s: unlock '%s'", __func__, lockfile->name);
 
   /* Close the lock file. */
 
@@ -521,7 +521,7 @@ lockfile_locked (const gchar *lockfile_basename)
   int ret;
   lockfile_t lockfile;
 
-  g_debug ("%s: check '%s'", __FUNCTION__, lockfile_basename);
+  g_debug ("%s: check '%s'", __func__, lockfile_basename);
 
   ret = lockfile_lock_nb (&lockfile, lockfile_basename);
   if ((ret == 0) && lockfile_unlock (&lockfile))


### PR DESCRIPTION
We were mixing `__func__` and `__FUNCTION__`, especially in the other modules, so we're
switching all to `__func__`.

GCC manual: `__FUNCTION__` is another name for `__func__`, provided for backward compatibility with old versions of GCC. 

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
