### PR TITLE
Fix ignoring white space in delta reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix asset host details insertion SQL [#839](https://github.com/greenbone/gvmd/pull/839)
 - Fix notes XML for lean reports [#836](https://github.com/greenbone/gvmd/pull/836)
 - MODIFY_USER saves comment when COMMENT is empty [#842](https://github.com/greenbone/gvmd/pull/842)
+- Fix result diff generation to ignore white space in delta reports [#861](https://github.com/greenbone/gvmd/pull/861)
 
 ### Removed
 - Remove 1.3.6.1.4.1.25623.1.0.90011 from Discovery config (9.0) [#847](https://github.com/greenbone/gvmd/pull/847)

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -9853,7 +9853,7 @@ strdiff (const gchar *one, const gchar *two)
   cmd = (gchar **) g_malloc (7 * sizeof (gchar *));
 
   cmd[0] = g_strdup ("diff");
-  cmd[1] = g_strdup ("--ignore-space");
+  cmd[1] = g_strdup ("--ignore-all-space");
   cmd[2] = g_strdup ("--ignore-blank-lines");
   cmd[3] = g_strdup ("-u");
   cmd[4] = g_strdup ("Report 1");


### PR DESCRIPTION
There is no diff --ignore-space argument. It must be --ignore-all-space.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [n/a] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
