### PR TITLE
Fix resource type checks for permissions (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix notes XML for lean reports [#836](https://github.com/greenbone/gvmd/pull/836)
 - MODIFY_USER saves comment when COMMENT is empty [#842](https://github.com/greenbone/gvmd/pull/842)
 - Fix result diff generation to ignore white space in delta reports [#861](https://github.com/greenbone/gvmd/pull/861)
+- Fix resource type checks for permissions [#863](https://github.com/greenbone/gvmd/pull/863)
 
 ### Removed
 - Remove 1.3.6.1.4.1.25623.1.0.90011 from Discovery config (9.0) [#847](https://github.com/greenbone/gvmd/pull/847)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -50447,9 +50447,16 @@ check_permission_args (const char *name_arg, const char *resource_type_arg,
     return 9;
 
   if (resource_type_arg
+      && strcasecmp (name_arg, "super") == 0
       && strcmp (resource_type_arg, "group")
       && strcmp (resource_type_arg, "role")
       && strcmp (resource_type_arg, "user"))
+    return 5;
+
+  if (resource_type_arg
+      && strcasecmp (name_arg, "super")
+      && (valid_db_resource_type (resource_type_arg) == 0
+          || gmp_command_takes_resource (name_arg) == 0))
     return 5;
 
   if (subject_type


### PR DESCRIPTION
In check_permission_args the type must only be "group", "role" or "user"
for "super" permissions while it can be any valid type for others that
can be assigned a resource.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
