### PR TITLE
Parse XML files in SecInfo sync using libxml2

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,7 @@ pkg_check_modules (LIBGVM_GMP REQUIRED libgvm_gmp>=20.4)
 pkg_check_modules (GNUTLS REQUIRED gnutls>=3.2.15)
 pkg_check_modules (GLIB REQUIRED glib-2.0>=2.42)
 pkg_check_modules (LIBICAL REQUIRED libical>=1.00)
+pkg_check_modules (LIBXML2 REQUIRED libxml-2.0>=2.0)
 
 message (STATUS "Looking for PostgreSQL...")
 find_program (PG_CONFIG_EXECUTABLE pg_config DOC "pg_config")
@@ -62,7 +63,8 @@ endif (NOT GPGME)
 
 include_directories (${LIBGVM_GMP_INCLUDE_DIRS}
                      ${LIBGVM_BASE_INCLUDE_DIRS} ${LIBGVM_UTIL_INCLUDE_DIRS}
-                     ${LIBGVM_OSP_INCLUDE_DIRS}  ${GLIB_INCLUDE_DIRS})
+                     ${LIBGVM_OSP_INCLUDE_DIRS}  ${GLIB_INCLUDE_DIRS}
+                     ${LIBXML2_INCLUDE_DIRS})
 
 add_library (gvm-pg-server SHARED
              manage_pg_server.c manage_utils.c)

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -3593,6 +3593,7 @@ manage_db_init (const gchar *name)
       sql ("CREATE TABLE scap.affected_products"
            " (cve INTEGER NOT NULL,"
            "  cpe INTEGER NOT NULL,"
+           "  UNIQUE (cve, cpe),"
            "  FOREIGN KEY(cve) REFERENCES cves(id),"
            "  FOREIGN KEY(cpe) REFERENCES cpes(id));");
       sql ("CREATE INDEX afp_cpe_idx"

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -64,6 +64,8 @@
  */
 static int secinfo_commit_size = SECINFO_COMMIT_SIZE_DEFAULT;
 
+xml_doc_t xml_doc;
+
 
 /* Headers. */
 
@@ -1148,8 +1150,8 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
                 int last_dfn_update)
 {
   GError *error;
-  entity_t entity, child;
-  entities_t children;
+  entity2_t entity, child;
+  entities2_t children;
   gchar *xml, *full_path;
   gsize xml_len;
   GStatBuf state;
@@ -1191,93 +1193,97 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
       return -1;
     }
 
-  if (parse_entity (xml, &entity))
+  g_debug ("%s: parsing xml", __func__);
+
+  if (parse_entity2 (xml, &xml_doc, &entity))
     {
       g_free (xml);
       g_warning ("%s: Failed to parse entity", __func__);
       g_free (full_path);
       return -1;
     }
-  g_free (xml);
+  //g_free (xml);
+
+  g_debug ("%s: parsing xml done", __func__);
 
   sql_begin_immediate ();
-  children = entity->entities;
-  while ((child = first_entity (children)))
+  children = entity2_children (entity);
+  while ((child = first_entity2 (children)))
     {
-      if (strcmp (entity_name (child), "entry") == 0)
+      if (strcmp (entity2_name (child), "entry") == 0)
         {
-          entity_t updated;
+          entity2_t updated;
 
-          updated = entity_child (child, "updated");
+          updated = entity2_child (child, "updated");
           if (updated == NULL)
             {
               g_warning ("%s: UPDATED missing", __func__);
-              free_entity (entity);
+              //free_entity (entity);
               goto fail;
             }
 
-          if (parse_iso_time (entity_text (updated)) > last_dfn_update)
+          if (parse_iso_time (entity2_text (xml_doc, updated)) > last_dfn_update)
             {
-              entity_t refnum, published, summary, title, cve;
-              entities_t cves;
+              entity2_t refnum, published, summary, title, cve;
+              entities2_t cves;
               gchar *quoted_refnum, *quoted_title, *quoted_summary;
               int cve_refs;
 
-              refnum = entity_child (child, "dfncert:refnum");
+              refnum = entity2_child (child, "dfncert:refnum");
               if (refnum == NULL)
                 {
                   GString *string;
 
                   string = g_string_new ("");
                   g_warning ("%s: REFNUM missing", __func__);
-                  print_entity_to_string (child, string);
+                  //print_entity_to_string (child, string);
                   g_debug ("child:%s", string->str);
                   g_string_free (string, TRUE);
-                  free_entity (entity);
+                  //free_entity (entity);
                   goto fail;
                 }
 
-              published = entity_child (child, "published");
+              published = entity2_child (child, "published");
               if (published == NULL)
                 {
                   g_warning ("%s: PUBLISHED missing", __func__);
-                  free_entity (entity);
+                  //free_entity (entity);
                   goto fail;
                 }
 
-              title = entity_child (child, "title");
+              title = entity2_child (child, "title");
               if (title == NULL)
                 {
                   g_warning ("%s: TITLE missing", __func__);
-                  free_entity (entity);
+                  //free_entity (entity);
                   goto fail;
                 }
 
-              summary = entity_child (child, "summary");
+              summary = entity2_child (child, "summary");
               if (summary == NULL)
                 {
                   g_warning ("%s: SUMMARY missing", __func__);
-                  free_entity (entity);
+                  //free_entity (entity);
                   goto fail;
                 }
 
               cve_refs = 0;
-              cves = child->entities;
-              while ((cve = first_entity (cves)))
+              cves = entity2_children (child);
+              while ((cve = first_entity2 (cves)))
                 {
-                  if (strcmp (entity_name (cve), "dfncert:cve") == 0)
+                  if (strcmp (entity2_name (cve), "dfncert:cve") == 0)
                     cve_refs++;
-                  cves = next_entities (cves);
+                  cves = next_entities2 (cves);
                 }
 
-              quoted_refnum = sql_quote (entity_text (refnum));
-              quoted_title = sql_quote (entity_text (title));
-              quoted_summary = sql_quote (entity_text (summary));
+              quoted_refnum = sql_quote (entity2_text (xml_doc, refnum));
+              quoted_title = sql_quote (entity2_text (xml_doc, title));
+              quoted_summary = sql_quote (entity2_text (xml_doc, summary));
               sql ("SELECT merge_dfn_cert_adv"
                    "        ('%s', %i, %i, '%s', '%s', %i);",
                    quoted_refnum,
-                   parse_iso_time (entity_text (published)),
-                   parse_iso_time (entity_text (updated)),
+                   parse_iso_time (entity2_text (xml_doc, published)),
+                   parse_iso_time (entity2_text (xml_doc, updated)),
                    quoted_title,
                    quoted_summary,
                    cve_refs);
@@ -1285,15 +1291,15 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
               g_free (quoted_title);
               g_free (quoted_summary);
 
-              cves = child->entities;
-              while ((cve = first_entity (cves)))
+              cves = entity2_children (child);
+              while ((cve = first_entity2 (cves)))
                 {
-                  if (strcmp (entity_name (cve), "dfncert:cve") == 0)
+                  if (strcmp (entity2_name (cve), "dfncert:cve") == 0)
                     {
                       gchar **split, **point;
                       gchar *text, *start;
 
-                      text = g_strdup (entity_text (cve));
+                      text = g_strdup (entity2_text (xml_doc, cve));
                       start = text;
                       while ((start = strstr (start, "CVE ")))
                         start[3] = '-';
@@ -1328,17 +1334,17 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
                       g_strfreev (split);
                     }
 
-                  cves = next_entities (cves);
+                  cves = next_entities2 (cves);
                 }
 
               updated_dfn_cert = 1;
               g_free (quoted_refnum);
             }
         }
-      children = next_entities (children);
+      children = next_entities2 (children);
     }
 
-  free_entity (entity);
+  //free_entity (entity);
   g_free (full_path);
   sql_commit ();
   return updated_dfn_cert;
@@ -1425,8 +1431,8 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
                  int last_bund_update)
 {
   GError *error;
-  entity_t entity, child;
-  entities_t children;
+  entity2_t entity, child;
+  entities2_t children;
   gchar *xml, *full_path;
   gsize xml_len;
   GStatBuf state;
@@ -1466,104 +1472,108 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
       return -1;
     }
 
-  if (parse_entity (xml, &entity))
+  g_debug ("%s: parsing xml", __func__);
+
+  if (parse_entity2 (xml, &xml_doc, &entity))
     {
       g_free (xml);
       g_warning ("%s: Failed to parse entity", __func__);
       g_free (full_path);
       return -1;
     }
-  g_free (xml);
+  //g_free (xml);
+
+  g_debug ("%s: parsing xml done", __func__);
 
   sql_begin_immediate ();
-  children = entity->entities;
-  while ((child = first_entity (children)))
+  children = entity2_children (entity);
+  while ((child = first_entity2 (children)))
     {
-      if (strcmp (entity_name (child), "Advisory") == 0)
+      if (strcmp (entity2_name (child), "Advisory") == 0)
         {
-          entity_t date;
+          entity2_t date;
 
-          date = entity_child (child, "Date");
+          date = entity2_child (child, "Date");
           if (date == NULL)
             {
               g_warning ("%s: Date missing", __func__);
-              free_entity (entity);
+              //free_entity (entity);
               goto fail;
             }
 
-          if (parse_iso_time (entity_text (date)) > last_bund_update)
+          if (parse_iso_time (entity2_text (xml_doc, date)) > last_bund_update)
             {
-              entity_t refnum, description, title, cve, cve_list;
+              entity2_t refnum, description, title, cve, cve_list;
               gchar *quoted_refnum, *quoted_title, *quoted_summary;
               int cve_refs;
               GString *summary;
 
-              refnum = entity_child (child, "Ref_Num");
+              refnum = entity2_child (child, "Ref_Num");
               if (refnum == NULL)
                 {
                   GString *string;
 
                   string = g_string_new ("");
                   g_warning ("%s: Ref_Num missing", __func__);
-                  print_entity_to_string (child, string);
+                  //print_entity_to_string (child, string);
                   g_debug ("child:%s", string->str);
                   g_string_free (string, TRUE);
-                  free_entity (entity);
+                  //free_entity (entity);
                   goto fail;
                 }
 
-              title = entity_child (child, "Title");
+              title = entity2_child (child, "Title");
               if (title == NULL)
                 {
                   g_warning ("%s: Title missing", __func__);
-                  free_entity (entity);
+                  //free_entity (entity);
                   goto fail;
                 }
 
               summary = g_string_new ("");
-              description = entity_child (child, "Description");
+              description = entity2_child (child, "Description");
               if (description)
                 {
-                  entities_t elements;
-                  entity_t element;
+                  entities2_t elements;
+                  entity2_t element;
 
-                  elements = description->entities;
-                  while ((element = first_entity (elements)))
+                  elements = entity2_children (description);
+                  while ((element = first_entity2 (elements)))
                     {
-                      if (strcmp (entity_name (element), "Element") == 0)
+                      if (strcmp (entity2_name (element), "Element") == 0)
                         {
-                          entity_t text_block;
-                          text_block = entity_child (element, "TextBlock");
+                          entity2_t text_block;
+                          text_block = entity2_child (element, "TextBlock");
                           if (text_block)
-                            g_string_append (summary, entity_text (text_block));
+                            g_string_append (summary, entity2_text (xml_doc, text_block));
                         }
-                      elements = next_entities (elements);
+                      elements = next_entities2 (elements);
                     }
                 }
 
               cve_refs = 0;
-              cve_list = entity_child (child, "CVEList");
+              cve_list = entity2_child (child, "CVEList");
               if (cve_list)
                 {
-                  entities_t cves;
-                  cves = cve_list->entities;
-                  while ((cve = first_entity (cves)))
+                  entities2_t cves;
+                  cves = entity2_children (cve_list);
+                  while ((cve = first_entity2 (cves)))
                     {
-                      if (strcmp (entity_name (cve), "CVE") == 0)
+                      if (strcmp (entity2_name (cve), "CVE") == 0)
                         cve_refs++;
-                      cves = next_entities (cves);
+                      cves = next_entities2 (cves);
                     }
                 }
 
-              quoted_refnum = sql_quote (entity_text (refnum));
-              quoted_title = sql_quote (entity_text (title));
+              quoted_refnum = sql_quote (entity2_text (xml_doc, refnum));
+              quoted_title = sql_quote (entity2_text (xml_doc, title));
               quoted_summary = sql_quote (summary->str);
               g_string_free (summary, TRUE);
               sql ("SELECT merge_bund_adv"
                    "        ('%s', %i, %i, '%s', '%s', %i);",
                    quoted_refnum,
-                   parse_iso_time (entity_text (date)),
-                   parse_iso_time (entity_text (date)),
+                   parse_iso_time (entity2_text (xml_doc, date)),
+                   parse_iso_time (entity2_text (xml_doc, date)),
                    quoted_title,
                    quoted_summary,
                    cve_refs);
@@ -1571,18 +1581,18 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
               g_free (quoted_title);
               g_free (quoted_summary);
 
-              cve_list = entity_child (child, "CVEList");
+              cve_list = entity2_child (child, "CVEList");
               if (cve_list)
                 {
-                  entities_t cves;
-                  cves = cve_list->entities;
-                  while ((cve = first_entity (cves)))
+                  entities2_t cves;
+                  cves = entity2_children (cve_list);
+                  while ((cve = first_entity2 (cves)))
                     {
-                      if ((strcmp (entity_name (cve), "CVE") == 0)
-                          && strlen (entity_text (cve)))
+                      if ((strcmp (entity2_name (cve), "CVE") == 0)
+                          && strlen (entity2_text (xml_doc, cve)))
                         {
                           gchar *quoted_cve;
-                          quoted_cve = sql_quote (entity_text (cve));
+                          quoted_cve = sql_quote (entity2_text (xml_doc, cve));
                           /* There's no primary key, so just INSERT, even
                            * for Postgres. */
                           sql ("INSERT INTO cert_bund_cves"
@@ -1597,7 +1607,7 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
                           g_free (quoted_cve);
                         }
 
-                      cves = next_entities (cves);
+                      cves = next_entities2 (cves);
                     }
                 }
 
@@ -1605,10 +1615,10 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
               g_free (quoted_refnum);
             }
         }
-      children = next_entities (children);
+      children = next_entities2 (children);
     }
 
-  free_entity (entity);
+  //free_entity (entity);
   g_free (full_path);
   sql_commit ();
   return updated_cert_bund;
@@ -1691,8 +1701,8 @@ static int
 update_scap_cpes (int last_scap_update)
 {
   GError *error;
-  entity_t entity, cpe_list, cpe_item;
-  entities_t children;
+  entity2_t entity, cpe_list, cpe_item;
+  entities2_t children;
   gchar *xml, *full_path;
   gsize xml_len;
   GStatBuf state;
@@ -1728,6 +1738,8 @@ update_scap_cpes (int last_scap_update)
 
   g_debug ("%s: parsing %s", __func__, full_path);
 
+  g_debug ("%s: loading xml", __func__);
+
   error = NULL;
   g_file_get_contents (full_path, &xml, &xml_len, &error);
   g_free (full_path);
@@ -1740,47 +1752,56 @@ update_scap_cpes (int last_scap_update)
       return -1;
     }
 
-  if (parse_entity (xml, &entity))
+  g_debug ("%s: parsing xml", __func__);
+
+  if (parse_entity2 (xml, &xml_doc, &entity))
     {
       g_free (xml);
       g_warning ("%s: Failed to parse entity", __func__);
       return -1;
     }
-  g_free (xml);
+  //g_free (xml);
+
+  g_debug ("%s: parsing xml done", __func__);
+
+  g_debug ("%s: checking cpe-list", __func__);
 
   cpe_list = entity;
-  if (strcmp (entity_name (cpe_list), "cpe-list"))
+  if (strcmp (entity2_name (cpe_list), "cpe-list"))
     {
-      free_entity (entity);
+      xml_doc_free (xml_doc);
       g_warning ("%s: CPE dictionary missing CPE-LIST", __func__);
       return -1;
     }
 
   sql_begin_immediate ();
 
-  children = cpe_list->entities;
-  while ((cpe_item = first_entity (children)))
+  g_debug ("%s: adding cpes", __func__);
+
+  children = entity2_children (cpe_list);
+  while ((cpe_item = first_entity2 (children)))
     {
-      if (strcmp (entity_name (cpe_item), "cpe-item") == 0)
+      if (strcmp (entity2_name (cpe_item), "cpe-item") == 0)
         {
           const char *modification_date;
-          entity_t item_metadata;
+          entity2_t item_metadata;
 
-          item_metadata = entity_child (cpe_item, "meta:item-metadata");
+          item_metadata = entity2_child (cpe_item, "meta:item-metadata");
           if (item_metadata == NULL)
             {
               g_warning ("%s: item-metadata missing", __func__);
 
-              free_entity (entity);
+              xml_doc_free (xml_doc);
               goto fail;
             }
 
-          modification_date = entity_attribute (item_metadata,
+          // FIX leaking attrs and text
+          modification_date = entity2_attribute (item_metadata,
                                                 "modification-date");
           if (modification_date == NULL)
             {
               g_warning ("%s: modification-date missing", __func__);
-              free_entity (entity);
+              xml_doc_free (xml_doc);
               goto fail;
             }
 
@@ -1789,26 +1810,26 @@ update_scap_cpes (int last_scap_update)
               const char *name, *status, *deprecated, *nvd_id;
               gchar *quoted_name, *quoted_title, *quoted_status, *quoted_nvd_id;
               gchar *name_decoded, *name_tilde;
-              entities_t titles;
-              entity_t title;
+              entities2_t titles;
+              entity2_t title;
 
-              name = entity_attribute (cpe_item, "name");
+              name = entity2_attribute (cpe_item, "name");
               if (name == NULL)
                 {
                   g_warning ("%s: name missing", __func__);
-                  free_entity (entity);
+                  xml_doc_free (xml_doc);
                   goto fail;
                 }
 
-              status = entity_attribute (item_metadata, "status");
+              status = entity2_attribute (item_metadata, "status");
               if (status == NULL)
                 {
                   g_warning ("%s: status missing", __func__);
-                  free_entity (entity);
+                  xml_doc_free (xml_doc);
                   goto fail;
                 }
 
-              deprecated = entity_attribute (item_metadata,
+              deprecated = entity2_attribute (item_metadata,
                                              "deprecated-by-nvd-id");
               if (deprecated
                   && (g_regex_match_simple ("^[0-9]+$", (gchar *) deprecated, 0, 0)
@@ -1817,31 +1838,31 @@ update_scap_cpes (int last_scap_update)
                   g_warning ("%s: invalid deprecated-by-nvd-id: %s",
                              __func__,
                              deprecated);
-                  free_entity (entity);
+                  xml_doc_free (xml_doc);
                   goto fail;
                 }
 
-              nvd_id = entity_attribute (item_metadata, "nvd-id");
+              nvd_id = entity2_attribute (item_metadata, "nvd-id");
               if (nvd_id == NULL)
                 {
                   g_warning ("%s: nvd_id missing", __func__);
-                  free_entity (entity);
+                  xml_doc_free (xml_doc);
                   goto fail;
                 }
 
-              titles = cpe_item->entities;
+              titles = entity2_children (cpe_item);
               quoted_title = g_strdup ("");
-              while ((title = first_entity (titles)))
+              while ((title = first_entity2 (titles)))
                 {
-                  if (strcmp (entity_name (title), "title") == 0
-                      && entity_attribute (title, "xml:lang")
-                      && strcmp (entity_attribute (title, "xml:lang"), "en-US") == 0)
+                  if (strcmp (entity2_name (title), "title") == 0
+                      && entity2_attribute (title, "xml:lang")
+                      && strcmp (entity2_attribute (title, "xml:lang"), "en-US") == 0)
                     {
                       g_free (quoted_title);
-                      quoted_title = sql_quote (entity_text (title));
+                      quoted_title = sql_quote (entity2_text (xml_doc, title));
                       break;
                     }
-                  titles = next_entities (titles);
+                  titles = next_entities2 (titles);
                 }
 
               name_decoded = g_uri_unescape_string (name, NULL);
@@ -1870,10 +1891,12 @@ update_scap_cpes (int last_scap_update)
               updated_scap_cpes = 1;
             }
         }
-      children = next_entities (children);
+      children = next_entities2 (children);
     }
 
-  free_entity (entity);
+  g_debug ("%s: done", __func__);
+
+  xml_doc_free (xml_doc);
   sql_commit ();
   return updated_scap_cpes;
 
@@ -1900,8 +1923,8 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                 int last_cve_update)
 {
   GError *error;
-  entity_t entity, entry;
-  entities_t children;
+  entity2_t entity, entry;
+  entities2_t children;
   gchar *xml, *full_path;
   gsize xml_len;
   GStatBuf state;
@@ -1942,38 +1965,42 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
       return -1;
     }
 
-  if (parse_entity (xml, &entity))
+  g_debug ("%s: parsing xml", __func__);
+
+  if (parse_entity2 (xml, &xml_doc, &entity))
     {
       g_free (xml);
       g_warning ("%s: Failed to parse entity", __func__);
       g_free (full_path);
       return -1;
     }
-  g_free (xml);
+  //g_free (xml);
+
+  g_debug ("%s: parsing xml done", __func__);
 
   sql_begin_immediate ();
-  children = entity->entities;
-  while ((entry = first_entity (children)))
+  children = entity2_children (entity);
+  while ((entry = first_entity2 (children)))
     {
-      if (strcmp (entity_name (entry), "entry") == 0)
+      if (strcmp (entity2_name (entry), "entry") == 0)
         {
-          entity_t last_modified;
+          entity2_t last_modified;
 
-          last_modified = entity_child (entry, "vuln:last-modified-datetime");
+          last_modified = entity2_child (entry, "vuln:last-modified-datetime");
           if (last_modified == NULL)
             {
               g_warning ("%s: vuln:last-modified-datetime missing",
                          __func__);
-              free_entity (entity);
+              //free_entity (entity);
               goto fail;
             }
 
-          if (parse_iso_time (entity_text (last_modified)) > last_cve_update)
+          if (parse_iso_time (entity2_text (xml_doc, last_modified)) > last_cve_update)
             {
-              entity_t published, summary, cvss, score, base_metrics;
-              entity_t access_vector, access_complexity, authentication;
-              entity_t confidentiality_impact, integrity_impact;
-              entity_t availability_impact, list;
+              entity2_t published, summary, cvss, score, base_metrics;
+              entity2_t access_vector, access_complexity, authentication;
+              entity2_t confidentiality_impact, integrity_impact;
+              entity2_t availability_impact, list;
               gchar *quoted_id, *quoted_summary;
               gchar *quoted_access_vector, *quoted_access_complexity;
               gchar *quoted_authentication, *quoted_confidentiality_impact;
@@ -1984,29 +2011,29 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
               gchar *software_unescaped, *software_tilde;
               int time_modified, time_published;
 
-              id = entity_attribute (entry, "id");
+              id = entity2_attribute (entry, "id");
               if (id == NULL)
                 {
                   g_warning ("%s: id missing",
                              __func__);
-                  free_entity (entity);
+                  //free_entity (entity);
                   goto fail;
                 }
 
-              published = entity_child (entry, "vuln:published-datetime");
+              published = entity2_child (entry, "vuln:published-datetime");
               if (published == NULL)
                 {
                   g_warning ("%s: vuln:published-datetime missing",
                              __func__);
-                  free_entity (entity);
+                  //free_entity (entity);
                   goto fail;
                 }
 
-              cvss = entity_child (entry, "vuln:cvss");
+              cvss = entity2_child (entry, "vuln:cvss");
               if (cvss == NULL)
                 base_metrics = NULL;
               else
-                base_metrics = entity_child (cvss, "cvss:base_metrics");
+                base_metrics = entity2_child (cvss, "cvss:base_metrics");
               if (base_metrics == NULL)
                 {
                   score = NULL;
@@ -2019,127 +2046,127 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                 }
               else
                 {
-                  score = entity_child (base_metrics, "cvss:score");
+                  score = entity2_child (base_metrics, "cvss:score");
                   if (score == NULL)
                     {
                       g_warning ("%s: cvss:score missing", __func__);
-                      free_entity (entity);
+                      //free_entity (entity);
                       goto fail;
                     }
 
-                  access_vector = entity_child (base_metrics, "cvss:access-vector");
+                  access_vector = entity2_child (base_metrics, "cvss:access-vector");
                   if (access_vector == NULL)
                     {
                       g_warning ("%s: cvss:access-vector missing", __func__);
-                      free_entity (entity);
+                      //free_entity (entity);
                       goto fail;
                     }
 
-                  access_complexity = entity_child (base_metrics,
+                  access_complexity = entity2_child (base_metrics,
                                                     "cvss:access-complexity");
                   if (access_complexity == NULL)
                     {
                       g_warning ("%s: cvss:access-complexity missing",
                                  __func__);
-                      free_entity (entity);
+                      //free_entity (entity);
                       goto fail;
                     }
 
-                  authentication = entity_child (base_metrics,
+                  authentication = entity2_child (base_metrics,
                                                  "cvss:authentication");
                   if (authentication == NULL)
                     {
                       g_warning ("%s: cvss:authentication missing",
                                  __func__);
-                      free_entity (entity);
+                      //free_entity (entity);
                       goto fail;
                     }
 
-                  confidentiality_impact = entity_child
+                  confidentiality_impact = entity2_child
                                             (base_metrics,
                                              "cvss:confidentiality-impact");
                   if (confidentiality_impact == NULL)
                     {
                       g_warning ("%s: cvss:confidentiality-impact missing",
                                  __func__);
-                      free_entity (entity);
+                      //free_entity (entity);
                       goto fail;
                     }
 
-                  integrity_impact = entity_child
+                  integrity_impact = entity2_child
                                       (base_metrics,
                                        "cvss:integrity-impact");
                   if (integrity_impact == NULL)
                     {
                       g_warning ("%s: cvss:integrity-impact missing",
                                  __func__);
-                      free_entity (entity);
+                      //free_entity (entity);
                       goto fail;
                     }
 
-                  availability_impact = entity_child
+                  availability_impact = entity2_child
                                          (base_metrics,
                                           "cvss:availability-impact");
                   if (availability_impact == NULL)
                     {
                       g_warning ("%s: cvss:availability-impact missing",
                                  __func__);
-                      free_entity (entity);
+                      //free_entity (entity);
                       goto fail;
                     }
                 }
 
-              summary = entity_child (entry, "vuln:summary");
+              summary = entity2_child (entry, "vuln:summary");
               if (summary == NULL)
                 {
                   g_warning ("%s: vuln:summary missing", __func__);
-                  free_entity (entity);
+                  //free_entity (entity);
                   goto fail;
                 }
 
               software = g_string_new ("");
-              list = entity_child (entry, "vuln:vulnerable-software-list");
+              list = entity2_child (entry, "vuln:vulnerable-software-list");
               if (list)
                 {
-                  entity_t product;
-                  entities_t products;
-                  products = list->entities;
-                  while ((product = first_entity (products)))
+                  entity2_t product;
+                  entities2_t products;
+                  products = entity2_children (list);
+                  while ((product = first_entity2 (products)))
                     {
-                      if (strcmp (entity_name (product), "vuln:product") == 0)
+                      if (strcmp (entity2_name (product), "vuln:product") == 0)
                         g_string_append_printf (software,
                                                 "%s ",
-                                                entity_text (product));
-                      products = next_entities (products);
+                                                entity2_text (xml_doc, product));
+                      products = next_entities2 (products);
                     }
                 }
 
               quoted_id = sql_quote (id);
-              quoted_summary = sql_quote (summary ? entity_text (summary) : "");
+              quoted_summary = sql_quote (summary ? entity2_text (xml_doc, summary) : "");
               quoted_access_vector = sql_quote (access_vector
-                                                 ? entity_text (access_vector)
+                                                 ? entity2_text (xml_doc, access_vector)
                                                  : "");
               quoted_access_complexity = sql_quote
                                           (access_complexity
-                                            ? entity_text (access_complexity)
+                                            ? entity2_text (xml_doc, access_complexity)
                                             : "");
               quoted_authentication = sql_quote
                                        (authentication
-                                         ? entity_text (authentication)
+                                         ? entity2_text (xml_doc, authentication)
                                          : "");
               quoted_confidentiality_impact = sql_quote
                                                (confidentiality_impact
-                                                 ? entity_text
-                                                    (confidentiality_impact)
+                                                 ? entity2_text
+                                                    (xml_doc, confidentiality_impact)
                                                  : "");
               quoted_integrity_impact = sql_quote
                                          (integrity_impact
-                                           ? entity_text (integrity_impact)
+                                           ? entity2_text (xml_doc, integrity_impact)
                                            : "");
               quoted_availability_impact = sql_quote
                                             (availability_impact
-                                              ? entity_text
-                                                 (availability_impact)
+                                              ? entity2_text
+                                                 (xml_doc, availability_impact)
                                               : "");
               software_unescaped = g_uri_unescape_string (software->str, NULL);
               g_string_free (software, TRUE);
@@ -2148,8 +2175,8 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
               g_free (software_unescaped);
               quoted_software = sql_quote (software_tilde);
               g_free (software_tilde);
-              time_modified = parse_iso_time (entity_text (last_modified));
-              time_published = parse_iso_time (entity_text (published));
+              time_modified = parse_iso_time (entity2_text (xml_doc, last_modified));
+              time_published = parse_iso_time (entity2_text (xml_doc, published));
               sql ("SELECT merge_cve"
                    "        ('%s', '%s', %i, %i, %s, '%s', '%s', '%s', '%s',"
                    "         '%s', '%s', '%s', '%s');",
@@ -2157,7 +2184,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                    quoted_id,
                    time_published,
                    time_modified,
-                   score ? entity_text (score) : "NULL",
+                   score ? entity2_text (xml_doc, score) : "NULL",
                    quoted_summary,
                    quoted_access_vector,
                    quoted_access_complexity,
@@ -2177,29 +2204,29 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
 
               if (list)
                 {
-                  entity_t product;
-                  entities_t products;
+                  entity2_t product;
+                  entities2_t products;
                   resource_t cve_rowid;
 
-                  products = list->entities;
+                  products = entity2_children (list);
 
-                  if (first_entity (products))
+                  if (first_entity2 (products))
                     {
                       sql_int64 (&cve_rowid,
                                  "SELECT id FROM cves WHERE uuid='%s';",
                                  quoted_id);
 
-                      while ((product = first_entity (products)))
+                      while ((product = first_entity2 (products)))
                         {
-                          if ((strcmp (entity_name (product), "vuln:product")
+                          if ((strcmp (entity2_name (product), "vuln:product")
                                == 0)
-                              && strlen (entity_text (product)))
+                              && strlen (entity2_text (xml_doc, product)))
                             {
                               gchar *quoted_product, *product_decoded;
                               gchar *product_tilde;
 
                               product_decoded = g_uri_unescape_string
-                                                 (entity_text (product), NULL);
+                                                 (entity2_text (xml_doc, product), NULL);
                               product_tilde = string_replace (product_decoded,
                                                               "~", "%7E", "%7e",
                                                               NULL);
@@ -2220,7 +2247,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                               g_free (quoted_product);
                             }
 
-                          products = next_entities (products);
+                          products = next_entities2 (products);
                         }
                     }
                 }
@@ -2229,10 +2256,10 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
               g_free (quoted_id);
             }
         }
-      children = next_entities (children);
+      children = next_entities2 (children);
     }
 
-  free_entity (entity);
+  //free_entity (entity);
   g_free (full_path);
   sql_commit ();
   return updated_scap_bund;
@@ -2312,11 +2339,11 @@ update_scap_cves (int last_scap_update)
  * @param[out] definition_date_oldest  Oldest date.
  */
 static void
-oval_definition_dates (entity_t definition, int *definition_date_newest,
+oval_definition_dates (entity2_t definition, int *definition_date_newest,
                        int *definition_date_oldest)
 {
-  entity_t metadata, oval_repository, date, dates;
-  entities_t children;
+  entity2_t metadata, oval_repository, date, dates;
+  entities2_t children;
   int first;
   const char *oldest, *newest;
 
@@ -2326,7 +2353,7 @@ oval_definition_dates (entity_t definition, int *definition_date_newest,
   *definition_date_newest = 0;
   *definition_date_oldest = 0;
 
-  metadata = entity_child (definition, "metadata");
+  metadata = entity2_child (definition, "metadata");
   if (metadata == NULL)
     {
       g_warning ("%s: metadata missing",
@@ -2334,7 +2361,7 @@ oval_definition_dates (entity_t definition, int *definition_date_newest,
       return;
     }
 
-  oval_repository = entity_child (metadata, "oval_repository");
+  oval_repository = entity2_child (metadata, "oval_repository");
   if (oval_repository == NULL)
     {
       g_warning ("%s: oval_repository missing",
@@ -2342,7 +2369,7 @@ oval_definition_dates (entity_t definition, int *definition_date_newest,
       return;
     }
 
-  dates = entity_child (oval_repository, "dates");
+  dates = entity2_child (oval_repository, "dates");
   if (dates == NULL)
     {
       g_warning ("%s: dates missing",
@@ -2353,21 +2380,21 @@ oval_definition_dates (entity_t definition, int *definition_date_newest,
   newest = NULL;
   oldest = NULL;
   first = 1;
-  children = dates->entities;
-  while ((date = first_entity (children)))
+  children = entity2_children (dates);
+  while ((date = first_entity2 (children)))
     {
-      if ((strcmp (entity_name (date), "submitted") == 0)
-          || (strcmp (entity_name (date), "status_change") == 0)
-          || (strcmp (entity_name (date), "modified") == 0))
+      if ((strcmp (entity2_name (date), "submitted") == 0)
+          || (strcmp (entity2_name (date), "status_change") == 0)
+          || (strcmp (entity2_name (date), "modified") == 0))
         {
           if (first)
             {
-              newest = entity_attribute (date, "date");
+              newest = entity2_attribute (date, "date");
               first = 0;
             }
-          oldest = entity_attribute (date, "date");
+          oldest = entity2_attribute (date, "date");
         }
-      children = next_entities (children);
+      children = next_entities2 (children);
     }
 
   if (newest)
@@ -2383,15 +2410,15 @@ oval_definition_dates (entity_t definition, int *definition_date_newest,
  * @param[out] file_timestamp  Timestamp.
  */
 static void
-oval_oval_definitions_date (entity_t entity, int *file_timestamp)
+oval_oval_definitions_date (entity2_t entity, int *file_timestamp)
 {
-  entity_t generator, timestamp;
+  entity2_t generator, timestamp;
 
   assert (file_timestamp);
 
   *file_timestamp = 0;
 
-  generator = entity_child (entity, "generator");
+  generator = entity2_child (entity, "generator");
   if (generator == NULL)
     {
       g_warning ("%s: generator missing",
@@ -2399,7 +2426,7 @@ oval_oval_definitions_date (entity_t entity, int *file_timestamp)
       return;
     }
 
-  timestamp = entity_child (generator, "oval:timestamp");
+  timestamp = entity2_child (generator, "oval:timestamp");
   if (timestamp == NULL)
     {
       g_warning ("%s: oval:timestamp missing",
@@ -2407,7 +2434,7 @@ oval_oval_definitions_date (entity_t entity, int *file_timestamp)
       return;
     }
 
-  *file_timestamp = parse_iso_time (entity_text (timestamp));
+  *file_timestamp = parse_iso_time (entity2_text (xml_doc, timestamp));
 }
 
 /**
@@ -2423,7 +2450,7 @@ verify_oval_file (const gchar *full_path)
   GError *error;
   gchar *xml;
   gsize xml_len;
-  entity_t entity;
+  entity2_t entity;
 
   error = NULL;
   g_file_get_contents (full_path, &xml, &xml_len, &error);
@@ -2436,43 +2463,47 @@ verify_oval_file (const gchar *full_path)
       return -1;
     }
 
-  if (parse_entity (xml, &entity))
+  g_debug ("%s: parsing xml", __func__);
+
+  if (parse_entity2 (xml, &xml_doc, &entity))
     {
       g_free (xml);
       g_warning ("%s: Failed to parse entity", __func__);
       return -1;
     }
-  g_free (xml);
+  //g_free (xml);
 
-  if (strcmp (entity_name (entity), "oval_definitions") == 0)
+  g_debug ("%s: parsing xml done", __func__);
+
+  if (strcmp (entity2_name (entity), "oval_definitions") == 0)
     {
       int definition_count;
-      entities_t children;
-      entity_t definitions;
+      entities2_t children;
+      entity2_t definitions;
 
       definition_count = 0;
-      children = entity->entities;
-      while ((definitions = first_entity (children)))
+      children = entity2_children (entity);
+      while ((definitions = first_entity2 (children)))
         {
-          if (strcmp (entity_name (definitions), "definitions")
+          if (strcmp (entity2_name (definitions), "definitions")
               == 0)
             {
-              entity_t definition;
-              entities_t grandchildren;
+              entity2_t definition;
+              entities2_t grandchildren;
 
-              grandchildren = definitions->entities;
-              while ((definition = first_entity (grandchildren)))
+              grandchildren = entity2_children (definitions);
+              while ((definition = first_entity2 (grandchildren)))
                 {
-                  if (strcmp (entity_name (definition), "definition")
+                  if (strcmp (entity2_name (definition), "definition")
                       == 0)
                     definition_count++;
-                  grandchildren = next_entities (grandchildren);
+                  grandchildren = next_entities2 (grandchildren);
                 }
             }
-          children = next_entities (children);
+          children = next_entities2 (children);
         }
 
-      free_entity (entity);
+      //free_entity (entity);
       if (definition_count == 0)
         {
           g_warning ("%s: No OVAL definitions found", __func__);
@@ -2482,35 +2513,35 @@ verify_oval_file (const gchar *full_path)
         return 0;
     }
 
-  if (strcmp (entity_name (entity), "oval_variables") == 0)
+  if (strcmp (entity2_name (entity), "oval_variables") == 0)
     {
       int variable_count;
-      entities_t children;
-      entity_t variables;
+      entities2_t children;
+      entity2_t variables;
 
       variable_count = 0;
-      children = entity->entities;
-      while ((variables = first_entity (children)))
+      children = entity2_children (entity);
+      while ((variables = first_entity2 (children)))
         {
-          if (strcmp (entity_name (variables), "variables")
+          if (strcmp (entity2_name (variables), "variables")
               == 0)
             {
-              entity_t variable;
-              entities_t grandchildren;
+              entity2_t variable;
+              entities2_t grandchildren;
 
-              grandchildren = variables->entities;
-              while ((variable = first_entity (grandchildren)))
+              grandchildren = entity2_children (variables);
+              while ((variable = first_entity2 (grandchildren)))
                 {
-                  if (strcmp (entity_name (variable), "variable")
+                  if (strcmp (entity2_name (variable), "variable")
                       == 0)
                     variable_count++;
-                  grandchildren = next_entities (grandchildren);
+                  grandchildren = next_entities2 (grandchildren);
                 }
             }
-          children = next_entities (children);
+          children = next_entities2 (children);
         }
 
-      free_entity (entity);
+      //free_entity (entity);
       if (variable_count == 0)
         {
           g_warning ("%s: No OVAL variables found", __func__);
@@ -2520,14 +2551,14 @@ verify_oval_file (const gchar *full_path)
         return 0;
     }
 
-  if (strcmp (entity_name (entity), "oval_system_characteristics") == 0)
+  if (strcmp (entity2_name (entity), "oval_system_characteristics") == 0)
     {
       g_warning ("%s: File is an OVAL System Characteristics file",
                  __func__);
       return -1;
     }
 
-  if (strcmp (entity_name (entity), "oval_results") == 0)
+  if (strcmp (entity2_name (entity), "oval_results") == 0)
     {
       g_warning ("%s: File is an OVAL Results one",
                  __func__);
@@ -2536,7 +2567,7 @@ verify_oval_file (const gchar *full_path)
 
   g_warning ("%s: Root tag neither oval_definitions nor oval_variables",
              __func__);
-  free_entity (entity);
+  //free_entity (entity);
   return -1;
 }
 
@@ -2555,8 +2586,8 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                     int last_ovaldef_update, int private)
 {
   GError *error;
-  entity_t entity, child;
-  entities_t children;
+  entity2_t entity, child;
+  entities2_t children;
   const gchar *xml_path, *oval_timestamp;
   gchar *xml_basename, *xml, *quoted_xml_basename;
   gsize xml_len;
@@ -2648,14 +2679,18 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
       return -1;
     }
 
-  if (parse_entity (xml, &entity))
+  g_debug ("%s: parsing xml", __func__);
+
+  if (parse_entity2 (xml, &xml_doc, &entity))
     {
       g_free (xml);
       g_warning ("%s: Failed to parse entity", __func__);
       g_free (quoted_xml_basename);
       return -1;
     }
-  g_free (xml);
+  //g_free (xml);
+
+  g_debug ("%s: parsing xml done", __func__);
 
   /* Fill the db according to the XML. */
 
@@ -2672,22 +2707,22 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
 
   oval_oval_definitions_date (entity, &file_timestamp);
 
-  children = entity->entities;
-  while ((child = first_entity (children)))
+  children = entity2_children (entity);
+  while ((child = first_entity2 (children)))
     {
-      entities_t definitions;
-      entity_t definition;
+      entities2_t definitions;
+      entity2_t definition;
 
-      if (strcmp (entity_name (child), "definitions"))
+      if (strcmp (entity2_name (child), "definitions"))
         {
-          children = next_entities (children);
+          children = next_entities2 (children);
           continue;
         }
 
-      definitions = child->entities;
-      while ((definition = first_entity (definitions)))
+      definitions = entity2_children (child);
+      while ((definition = first_entity2 (definitions)))
         {
-          if (strcmp (entity_name (definition), "definition") == 0)
+          if (strcmp (entity2_name (definition), "definition") == 0)
             {
               int definition_date_newest, definition_date_oldest;
               gchar *quoted_id, *quoted_oval_id;
@@ -2703,7 +2738,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                 {
                   const char *id;
 
-                  id = entity_attribute (definition, "id");
+                  id = entity2_attribute (definition, "id");
                   quoted_oval_id = sql_quote (id ? id : "");
                   g_info ("%s: Filtered %s (%i)",
                           __func__,
@@ -2713,96 +2748,96 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                 }
               else
                 {
-                  entity_t metadata, title, description, repository, reference;
-                  entity_t status;
-                  entities_t references;
+                  entity2_t metadata, title, description, repository, reference;
+                  entity2_t status;
+                  entities2_t references;
                   const char *deprecated, *version;
                   gchar *id, *quoted_title, *quoted_class, *quoted_description;
                   gchar *quoted_status;
                   int cve_count;
 
-                  if (entity_attribute (definition, "id") == NULL)
+                  if (entity2_attribute (definition, "id") == NULL)
                     {
                       g_warning ("%s: oval_definition missing id",
                                  __func__);
-                      free_entity (entity);
+                      //free_entity (entity);
                       goto fail;
                     }
 
-                  metadata = entity_child (definition, "metadata");
+                  metadata = entity2_child (definition, "metadata");
                   if (metadata == NULL)
                     {
                       g_warning ("%s: metadata missing",
                                  __func__);
-                      free_entity (entity);
+                      //free_entity (entity);
                       goto fail;
                     }
 
-                  title = entity_child (metadata, "title");
+                  title = entity2_child (metadata, "title");
                   if (title == NULL)
                     {
                       g_warning ("%s: title missing",
                                  __func__);
-                      free_entity (entity);
+                      //free_entity (entity);
                       goto fail;
                     }
 
-                  description = entity_child (metadata, "description");
+                  description = entity2_child (metadata, "description");
                   if (description == NULL)
                     {
                       g_warning ("%s: description missing",
                                  __func__);
-                      free_entity (entity);
+                      //free_entity (entity);
                       goto fail;
                     }
 
-                  repository = entity_child (metadata, "oval_repository");
+                  repository = entity2_child (metadata, "oval_repository");
                   if (repository == NULL)
                     {
                       g_warning ("%s: oval_repository missing",
                                  __func__);
-                      free_entity (entity);
+                      //free_entity (entity);
                       goto fail;
                     }
 
                   cve_count = 0;
-                  references = metadata->entities;
-                  while ((reference = first_entity (references)))
+                  references = entity2_children (metadata);
+                  while ((reference = first_entity2 (references)))
                     {
-                      if ((strcmp (entity_name (reference),
+                      if ((strcmp (entity2_name (reference),
                                    "reference")
                            == 0)
-                          && entity_attribute (reference, "source")
-                          && (strcasecmp (entity_attribute (reference, "source"), "cve")
+                          && entity2_attribute (reference, "source")
+                          && (strcasecmp (entity2_attribute (reference, "source"), "cve")
                               == 0))
                         cve_count++;
-                      references = next_entities (references);
+                      references = next_entities2 (references);
                     }
 
-                  deprecated = entity_attribute (definition, "deprecated");
+                  deprecated = entity2_attribute (definition, "deprecated");
 
-                  id = g_strdup_printf ("%s_%s", entity_attribute (definition, "id"),
+                  id = g_strdup_printf ("%s_%s", entity2_attribute (definition, "id"),
                                         xml_basename);
                   quoted_id = sql_quote (id);
                   g_free (id);
-                  quoted_oval_id = sql_quote (entity_attribute (definition, "id"));
+                  quoted_oval_id = sql_quote (entity2_attribute (definition, "id"));
 
-                  version = entity_attribute (definition, "version");
+                  version = entity2_attribute (definition, "version");
                   if (g_regex_match_simple ("^[0-9]+$", (gchar *) version, 0, 0) == 0)
                     {
                       g_warning ("%s: invalid version: %s",
                                  __func__,
                                  version);
-                      free_entity (entity);
+                      //free_entity (entity);
                       goto fail;
                     }
 
-                  quoted_class = sql_quote (entity_attribute (definition, "class"));
-                  quoted_title = sql_quote (entity_text (title));
-                  quoted_description = sql_quote (entity_text (description));
-                  status = entity_child (repository, "status");
-                  if (status && strlen (entity_text (status)))
-                    quoted_status = sql_quote (entity_text (status));
+                  quoted_class = sql_quote (entity2_attribute (definition, "class"));
+                  quoted_title = sql_quote (entity2_text (xml_doc, title));
+                  quoted_description = sql_quote (entity2_text (xml_doc, description));
+                  status = entity2_child (repository, "status");
+                  if (status && strlen (entity2_text (xml_doc, status)))
+                    quoted_status = sql_quote (entity2_text (xml_doc, status));
                   else if (deprecated && strcasecmp (deprecated, "TRUE"))
                     quoted_status = sql_quote ("DEPRECATED");
                   else
@@ -2834,19 +2869,19 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                   g_free (quoted_description);
                   g_free (quoted_status);
 
-                  references = metadata->entities;
-                  while ((reference = first_entity (references)))
+                  references = entity2_children (metadata);
+                  while ((reference = first_entity2 (references)))
                     {
-                      if ((strcmp (entity_name (reference), "reference")
+                      if ((strcmp (entity2_name (reference), "reference")
                            == 0)
-                          && entity_attribute (reference, "source")
-                          && (strcasecmp (entity_attribute (reference, "source"), "cve")
+                          && entity2_attribute (reference, "source")
+                          && (strcasecmp (entity2_attribute (reference, "source"), "cve")
                               == 0)
-                          && entity_attribute (reference, "ref_id"))
+                          && entity2_attribute (reference, "ref_id"))
                         {
                           gchar *quoted_ref_id;
 
-                          quoted_ref_id = sql_quote (entity_attribute (reference,
+                          quoted_ref_id = sql_quote (entity2_attribute (reference,
                                                                        "ref_id"));
                           sql ("INSERT INTO affected_ovaldefs (cve, ovaldef)"
                                " SELECT cves.id, ovaldefs.id"
@@ -2860,21 +2895,21 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                                quoted_oval_id);
                           increment_transaction_size (&transaction_size);
                         }
-                      references = next_entities (references);
+                      references = next_entities2 (references);
                     }
 
                   g_free (quoted_oval_id);
                 }
             }
-          definitions = next_entities (definitions);
+          definitions = next_entities2 (definitions);
         }
-      children = next_entities (children);
+      children = next_entities2 (children);
     }
 
   /* Cleanup. */
 
   g_free (quoted_xml_basename);
-  free_entity (entity);
+  //free_entity (entity);
   sql_commit ();
   return 1;
 
@@ -2894,22 +2929,22 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
  * @return Freshly allocated timestamp if found, else NULL.
  */
 static gchar *
-oval_generator_timestamp (entity_t entity)
+oval_generator_timestamp (entity2_t entity)
 {
   gchar *generator_name;
-  entity_t generator;
+  entity2_t generator;
 
   generator_name = g_strdup ("generator");
-  generator = entity_child (entity, generator_name);
+  generator = entity2_child (entity, generator_name);
   g_free (generator_name);
   if (generator)
     {
-      entity_t timestamp;
-      timestamp = entity_child (generator, "oval:timestamp");
+      entity2_t timestamp;
+      timestamp = entity2_child (generator, "oval:timestamp");
       if (timestamp)
         {
           gchar *ret;
-          ret = g_strdup (entity_text (timestamp));
+          ret = g_strdup (entity2_text (xml_doc, timestamp));
           return ret;
         }
     }
@@ -2927,39 +2962,43 @@ oval_generator_timestamp (entity_t entity)
 static gchar *
 oval_timestamp (const gchar *xml)
 {
-  entity_t entity;
+  entity2_t entity;
 
-  if (parse_entity (xml, &entity))
+  g_debug ("%s: parsing xml", __func__);
+
+  if (parse_entity2 (xml, &xml_doc, &entity))
     {
       g_warning ("%s: Failed to parse entity: %s", __func__, xml);
       return NULL;
     }
 
-  if (strcmp (entity_name (entity), "oval_definitions") == 0)
+  g_debug ("%s: parsing xml done", __func__);
+
+  if (strcmp (entity2_name (entity), "oval_definitions") == 0)
     {
       gchar *timestamp;
 
       timestamp = oval_generator_timestamp (entity);
       if (timestamp)
         {
-          free_entity (entity);
+          //free_entity (entity);
           return timestamp;
         }
     }
 
-  if (strcmp (entity_name (entity), "oval_variables") == 0)
+  if (strcmp (entity2_name (entity), "oval_variables") == 0)
     {
       gchar *timestamp;
 
       timestamp = oval_generator_timestamp (entity);
       if (timestamp)
         {
-          free_entity (entity);
+          //free_entity (entity);
           return timestamp;
         }
     }
 
-  if (strcmp (entity_name (entity), "oval_system_characteristics")
+  if (strcmp (entity2_name (entity), "oval_system_characteristics")
       == 0)
     {
       gchar *timestamp;
@@ -2967,7 +3006,7 @@ oval_timestamp (const gchar *xml)
       timestamp = oval_generator_timestamp (entity);
       if (timestamp)
         {
-          free_entity (entity);
+          //free_entity (entity);
           return timestamp;
         }
     }
@@ -4061,6 +4100,8 @@ sync_scap (int lockfile)
   if (last_feed_update == -1)
     return -1;
 
+  g_debug ("%s: last_scap_update: %i", __func__, last_scap_update);
+  g_debug ("%s: last_feed_update: %i", __func__, last_feed_update);
   if (last_scap_update >= last_feed_update)
     return -1;
 

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -1436,6 +1436,8 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
   int updated_cert_bund;
   int transaction_size = 0;
 
+  g_debug ("XXXTIME: %s", __func__);
+
   updated_cert_bund = 0;
   full_path = g_build_filename (GVM_CERT_DATA_DIR, xml_path, NULL);
 
@@ -1615,6 +1617,7 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
   sql_commit ();
   xml_doc_free (xml_doc);
   g_free (xml);
+  g_debug ("XXXTIME: %s done", __func__);
   return updated_cert_bund;
 
  fail:
@@ -1643,6 +1646,8 @@ update_cert_bund_advisories (int last_cert_update)
   int count, last_bund_update, updated_cert_bund;
   GDir *dir;
   const gchar *xml_path;
+
+  g_debug ("XXXTIME: %s", __func__);
 
   error = NULL;
   dir = g_dir_open (GVM_CERT_DATA_DIR, 0, &error);
@@ -1680,6 +1685,7 @@ update_cert_bund_advisories (int last_cert_update)
     g_warning ("No CERT-Bund advisories found in %s", GVM_CERT_DATA_DIR);
 
   g_dir_close (dir);
+  g_debug ("XXXTIME: %s done", __func__);
   return updated_cert_bund;
 }
 
@@ -1705,6 +1711,8 @@ update_scap_cpes (int last_scap_update)
   GStatBuf state;
   int updated_scap_cpes, last_cve_update, first;
   GString *inserts;
+
+  g_debug ("XXXTIME: %s", __func__);
 
   updated_scap_cpes = 0;
   full_path = g_build_filename (GVM_SCAP_DATA_DIR,
@@ -1931,6 +1939,7 @@ update_scap_cpes (int last_scap_update)
   g_free (xml);
   sql_commit ();
   g_info ("Updated %d CPEs", updated_scap_cpes);
+  g_debug ("XXXTIME: %s done", __func__);
   return updated_scap_cpes > 0;
 
  fail:
@@ -1966,6 +1975,8 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
   GStatBuf state;
   int updated_scap_bund;
   int transaction_size = 0;
+
+  g_debug ("XXXTIME: %s", __func__);
 
   updated_scap_bund = 0;
   full_path = g_build_filename (GVM_SCAP_DATA_DIR, xml_path, NULL);
@@ -2201,6 +2212,13 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
               g_free (software_tilde);
               time_modified = parse_iso_time (entity2_text (xml_doc, last_modified));
               time_published = parse_iso_time (entity2_text (xml_doc, published));
+
+/// FIX
+/// buffer all cpes (in iter)  they were inserted in update_scap_cpes
+/// loop once, just inserting cves  (single statement, possibly chunked)
+/// loop again, just inserting cpes (single st; only cpes not same as buffered cpes; buffer the ids)
+/// loop again, affected_products   (single st; use ids from cpe_id_buffer; )
+
               sql ("SELECT merge_cve"
                    "        ('%s', '%s', %i, %i, %s, '%s', '%s', '%s', '%s',"
                    "         '%s', '%s', '%s', '%s');",
@@ -2404,6 +2422,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
   g_free (xml);
   g_free (full_path);
   sql_commit ();
+  g_debug ("XXXTIME: %s done", __func__);
   return updated_scap_bund;
 
  fail:
@@ -2747,6 +2766,8 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
   int last_oval_update, file_timestamp;
   int transaction_size = 0;
 
+  g_debug ("XXXTIME: %s", __func__);
+
   /* Setup variables. */
 
   xml_path = file_and_date[0];
@@ -3058,6 +3079,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
   xml_doc_free (xml_doc);
   g_free (xml);
   sql_commit ();
+  g_debug ("XXXTIME: %s done", __func__);
   return 1;
 
  fail:
@@ -3298,6 +3320,8 @@ update_scap_ovaldefs (int last_scap_update, int private)
   guint index;
   struct stat state;
 
+  g_debug ("XXXTIME: %s", __func__);
+
   assert (oval_files == NULL);
 
   if (private)
@@ -3526,6 +3550,7 @@ update_scap_ovaldefs (int last_scap_update, int private)
 
   g_free (oval_dir);
   oval_files_free ();
+  g_debug ("XXXTIME: %s done", __func__);
   return updated_scap_ovaldefs;
 }
 
@@ -4029,10 +4054,12 @@ sync_cert (int lockfile)
 void
 manage_sync_cert (sigset_t *sigmask_current)
 {
+  g_debug ("XXXTIME: %s", __func__);
   sync_secinfo (sigmask_current,
                 sync_cert,
                 "gvmd: Syncing CERT",
                 "gvm-sync-cert");
+  g_debug ("XXXTIME: %s done", __func__);
 }
 
 
@@ -4366,10 +4393,12 @@ sync_scap (int lockfile)
 void
 manage_sync_scap (sigset_t *sigmask_current)
 {
+  g_debug ("XXXTIME: %s", __func__);
   sync_secinfo (sigmask_current,
                 sync_scap,
                 "gvmd: Syncing SCAP",
                 "gvm-sync-scap");
+  g_debug ("XXXTIME: %s done", __func__);
 }
 
 /**

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -4110,14 +4110,13 @@ update_scap_cvss (int updated_cves, int updated_cpes, int updated_ovaldefs)
       g_info ("Updating CVSS scores and CVE counts for CPEs");
       sql_recursive_triggers_off ();
       sql ("UPDATE scap.cpes"
-           " SET max_cvss = (SELECT max (cvss)"
-           "                 FROM scap.cves"
-           "                 WHERE id IN (SELECT cve"
-           "                              FROM scap.affected_products"
-           "                              WHERE cpe=cpes.id)),"
-           "     cve_refs = (SELECT count (cve)"
-           "                 FROM scap.affected_products"
-           "                 WHERE cpe=cpes.id);");
+           " SET (max_cvss, cve_refs)"
+           "     = (WITH affected_cves"
+           "        AS (SELECT cve FROM scap.affected_products"
+           "            WHERE cpe=cpes.id)"
+           "        SELECT (SELECT max (cvss) FROM scap.cves"
+           "                WHERE id IN (SELECT cve FROM affected_cves)),"
+           "               (SELECT count (*) FROM affected_cves));");
     }
   else
     g_info ("No CPEs or CVEs updated, skipping CVSS and CVE recount for CPEs.");

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -2843,7 +2843,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                   else
                     quoted_status = sql_quote ("");
 
-                  sql ("SELECT merge_ovaldef ('%s', '%s', '', %i, %i, %i, %i,"
+                  sql ("SELECT merge_ovaldef ('%s', '%s', '', %i, %i, %s, %i,"
                        "                      '%s', '%s', '%s', '%s', '%s',"
                        "                      %i);",
                        quoted_id,

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -1271,7 +1271,7 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
               cves = entity2_children (child);
               while ((cve = first_entity2 (cves)))
                 {
-                  if (strcmp (entity2_name (cve), "dfncert:cve") == 0)
+                  if (strcmp (entity2_name (cve), "cve") == 0)
                     cve_refs++;
                   cves = next_entities2 (cves);
                 }
@@ -1294,7 +1294,7 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
               cves = entity2_children (child);
               while ((cve = first_entity2 (cves)))
                 {
-                  if (strcmp (entity2_name (cve), "dfncert:cve") == 0)
+                  if (strcmp (entity2_name (cve), "cve") == 0)
                     {
                       gchar **split, **point;
                       gchar *text, *start;
@@ -2133,7 +2133,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                   products = entity2_children (list);
                   while ((product = first_entity2 (products)))
                     {
-                      if (strcmp (entity2_name (product), "vuln:product") == 0)
+                      if (strcmp (entity2_name (product), "product") == 0)
                         g_string_append_printf (software,
                                                 "%s ",
                                                 entity2_text (xml_doc, product));
@@ -2218,7 +2218,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
 
                       while ((product = first_entity2 (products)))
                         {
-                          if ((strcmp (entity2_name (product), "vuln:product")
+                          if ((strcmp (entity2_name (product), "product")
                                == 0)
                               && strlen (entity2_text (xml_doc, product)))
                             {

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -2399,7 +2399,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                           if (sql_has_on_conflict ())
                             g_string_append
                              (sql_affected,
-                              " ON CONFLICT DO NOTHING");
+                              " ON CONFLICT (cve, cpe) DO NOTHING");
                           g_string_append (sql_affected, ";");
                           sql ("%s", sql_affected->str);
 

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -64,8 +64,6 @@
  */
 static int secinfo_commit_size = SECINFO_COMMIT_SIZE_DEFAULT;
 
-xml_doc_t xml_doc;
-
 
 /* Headers. */
 
@@ -1149,6 +1147,7 @@ static int
 update_dfn_xml (const gchar *xml_path, int last_cert_update,
                 int last_dfn_update)
 {
+  xml_doc_t xml_doc;
   GError *error;
   entity2_t entity, child;
   entities2_t children;
@@ -1202,7 +1201,6 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
       g_free (full_path);
       return -1;
     }
-  //g_free (xml);
 
   g_debug ("%s: parsing xml done", __func__);
 
@@ -1218,7 +1216,6 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
           if (updated == NULL)
             {
               g_warning ("%s: UPDATED missing", __func__);
-              //free_entity (entity);
               goto fail;
             }
 
@@ -1239,7 +1236,6 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
                   //print_entity_to_string (child, string);
                   g_debug ("child:%s", string->str);
                   g_string_free (string, TRUE);
-                  //free_entity (entity);
                   goto fail;
                 }
 
@@ -1247,7 +1243,6 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
               if (published == NULL)
                 {
                   g_warning ("%s: PUBLISHED missing", __func__);
-                  //free_entity (entity);
                   goto fail;
                 }
 
@@ -1255,7 +1250,6 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
               if (title == NULL)
                 {
                   g_warning ("%s: TITLE missing", __func__);
-                  //free_entity (entity);
                   goto fail;
                 }
 
@@ -1263,7 +1257,6 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
               if (summary == NULL)
                 {
                   g_warning ("%s: SUMMARY missing", __func__);
-                  //free_entity (entity);
                   goto fail;
                 }
 
@@ -1344,9 +1337,10 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
       children = next_entities2 (children);
     }
 
-  //free_entity (entity);
   g_free (full_path);
   sql_commit ();
+  xml_doc_free (xml_doc);
+  g_free (xml);
   return updated_dfn_cert;
 
  fail:
@@ -1354,6 +1348,8 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
              full_path);
   g_free (full_path);
   sql_commit ();
+  xml_doc_free (xml_doc);
+  g_free (xml);
   return -1;
 }
 
@@ -1430,6 +1426,7 @@ static int
 update_bund_xml (const gchar *xml_path, int last_cert_update,
                  int last_bund_update)
 {
+  xml_doc_t xml_doc;
   GError *error;
   entity2_t entity, child;
   entities2_t children;
@@ -1481,7 +1478,6 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
       g_free (full_path);
       return -1;
     }
-  //g_free (xml);
 
   g_debug ("%s: parsing xml done", __func__);
 
@@ -1497,7 +1493,6 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
           if (date == NULL)
             {
               g_warning ("%s: Date missing", __func__);
-              //free_entity (entity);
               goto fail;
             }
 
@@ -1518,7 +1513,6 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
                   //print_entity_to_string (child, string);
                   g_debug ("child:%s", string->str);
                   g_string_free (string, TRUE);
-                  //free_entity (entity);
                   goto fail;
                 }
 
@@ -1526,7 +1520,6 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
               if (title == NULL)
                 {
                   g_warning ("%s: Title missing", __func__);
-                  //free_entity (entity);
                   goto fail;
                 }
 
@@ -1618,9 +1611,10 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
       children = next_entities2 (children);
     }
 
-  //free_entity (entity);
   g_free (full_path);
   sql_commit ();
+  xml_doc_free (xml_doc);
+  g_free (xml);
   return updated_cert_bund;
 
  fail:
@@ -1628,6 +1622,8 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
              full_path);
   g_free (full_path);
   sql_commit ();
+  xml_doc_free (xml_doc);
+  g_free (xml);
   return -1;
 }
 
@@ -1700,6 +1696,7 @@ update_cert_bund_advisories (int last_cert_update)
 static int
 update_scap_cpes (int last_scap_update)
 {
+  xml_doc_t xml_doc;
   GError *error;
   entity2_t entity, cpe_list, cpe_item;
   entities2_t children;
@@ -1760,7 +1757,6 @@ update_scap_cpes (int last_scap_update)
       g_warning ("%s: Failed to parse entity", __func__);
       return -1;
     }
-  //g_free (xml);
 
   g_debug ("%s: parsing xml done", __func__);
 
@@ -1769,6 +1765,7 @@ update_scap_cpes (int last_scap_update)
   cpe_list = entity;
   if (strcmp (entity2_name (cpe_list), "cpe-list"))
     {
+      g_free (xml);
       xml_doc_free (xml_doc);
       g_warning ("%s: CPE dictionary missing CPE-LIST", __func__);
       return -1;
@@ -1790,8 +1787,6 @@ update_scap_cpes (int last_scap_update)
           if (item_metadata == NULL)
             {
               g_warning ("%s: item-metadata missing", __func__);
-
-              xml_doc_free (xml_doc);
               goto fail;
             }
 
@@ -1801,7 +1796,6 @@ update_scap_cpes (int last_scap_update)
           if (modification_date == NULL)
             {
               g_warning ("%s: modification-date missing", __func__);
-              xml_doc_free (xml_doc);
               goto fail;
             }
 
@@ -1817,7 +1811,6 @@ update_scap_cpes (int last_scap_update)
               if (name == NULL)
                 {
                   g_warning ("%s: name missing", __func__);
-                  xml_doc_free (xml_doc);
                   goto fail;
                 }
 
@@ -1825,7 +1818,6 @@ update_scap_cpes (int last_scap_update)
               if (status == NULL)
                 {
                   g_warning ("%s: status missing", __func__);
-                  xml_doc_free (xml_doc);
                   goto fail;
                 }
 
@@ -1838,7 +1830,6 @@ update_scap_cpes (int last_scap_update)
                   g_warning ("%s: invalid deprecated-by-nvd-id: %s",
                              __func__,
                              deprecated);
-                  xml_doc_free (xml_doc);
                   goto fail;
                 }
 
@@ -1846,7 +1837,6 @@ update_scap_cpes (int last_scap_update)
               if (nvd_id == NULL)
                 {
                   g_warning ("%s: nvd_id missing", __func__);
-                  xml_doc_free (xml_doc);
                   goto fail;
                 }
 
@@ -1921,12 +1911,15 @@ update_scap_cpes (int last_scap_update)
   g_debug ("%s: done", __func__);
 
   xml_doc_free (xml_doc);
+  g_free (xml);
   sql_commit ();
   g_info ("Updated %d CPEs", updated_scap_cpes);
   return updated_scap_cpes > 0;
 
  fail:
   g_warning ("Update of CPEs failed");
+  xml_doc_free (xml_doc);
+  g_free (xml);
   sql_commit ();
   return -1;
 }
@@ -1947,6 +1940,7 @@ static int
 update_cve_xml (const gchar *xml_path, int last_scap_update,
                 int last_cve_update)
 {
+  xml_doc_t xml_doc;
   GError *error;
   entity2_t entity, entry;
   entities2_t children;
@@ -1999,7 +1993,6 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
       g_free (full_path);
       return -1;
     }
-  //g_free (xml);
 
   g_debug ("%s: parsing xml done", __func__);
 
@@ -2016,7 +2009,6 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
             {
               g_warning ("%s: vuln:last-modified-datetime missing",
                          __func__);
-              //free_entity (entity);
               goto fail;
             }
 
@@ -2041,7 +2033,6 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                 {
                   g_warning ("%s: id missing",
                              __func__);
-                  //free_entity (entity);
                   goto fail;
                 }
 
@@ -2050,7 +2041,6 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                 {
                   g_warning ("%s: vuln:published-datetime missing",
                              __func__);
-                  //free_entity (entity);
                   goto fail;
                 }
 
@@ -2075,7 +2065,6 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                   if (score == NULL)
                     {
                       g_warning ("%s: cvss:score missing", __func__);
-                      //free_entity (entity);
                       goto fail;
                     }
 
@@ -2083,7 +2072,6 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                   if (access_vector == NULL)
                     {
                       g_warning ("%s: cvss:access-vector missing", __func__);
-                      //free_entity (entity);
                       goto fail;
                     }
 
@@ -2093,7 +2081,6 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                     {
                       g_warning ("%s: cvss:access-complexity missing",
                                  __func__);
-                      //free_entity (entity);
                       goto fail;
                     }
 
@@ -2103,7 +2090,6 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                     {
                       g_warning ("%s: cvss:authentication missing",
                                  __func__);
-                      //free_entity (entity);
                       goto fail;
                     }
 
@@ -2114,7 +2100,6 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                     {
                       g_warning ("%s: cvss:confidentiality-impact missing",
                                  __func__);
-                      //free_entity (entity);
                       goto fail;
                     }
 
@@ -2125,7 +2110,6 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                     {
                       g_warning ("%s: cvss:integrity-impact missing",
                                  __func__);
-                      //free_entity (entity);
                       goto fail;
                     }
 
@@ -2136,7 +2120,6 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                     {
                       g_warning ("%s: cvss:availability-impact missing",
                                  __func__);
-                      //free_entity (entity);
                       goto fail;
                     }
                 }
@@ -2145,7 +2128,6 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
               if (summary == NULL)
                 {
                   g_warning ("%s: vuln:summary missing", __func__);
-                  //free_entity (entity);
                   goto fail;
                 }
 
@@ -2401,7 +2383,8 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
       children = next_entities2 (children);
     }
 
-  //free_entity (entity);
+  xml_doc_free (xml_doc);
+  g_free (xml);
   g_free (full_path);
   sql_commit ();
   return updated_scap_bund;
@@ -2409,6 +2392,8 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
  fail:
   g_warning ("Update of CVEs failed at file '%s'",
              full_path);
+  xml_doc_free (xml_doc);
+  g_free (xml);
   g_free (full_path);
   sql_commit ();
   return -1;
@@ -2552,7 +2537,7 @@ oval_definition_dates (entity2_t definition, int *definition_date_newest,
  * @param[out] file_timestamp  Timestamp.
  */
 static void
-oval_oval_definitions_date (entity2_t entity, int *file_timestamp)
+oval_oval_definitions_date (xml_doc_t xml_doc, entity2_t entity, int *file_timestamp)
 {
   entity2_t generator, timestamp;
 
@@ -2589,6 +2574,7 @@ oval_oval_definitions_date (entity2_t entity, int *file_timestamp)
 static int
 verify_oval_file (const gchar *full_path)
 {
+  xml_doc_t xml_doc;
   GError *error;
   gchar *xml;
   gsize xml_len;
@@ -2613,7 +2599,6 @@ verify_oval_file (const gchar *full_path)
       g_warning ("%s: Failed to parse entity", __func__);
       return -1;
     }
-  //g_free (xml);
 
   g_debug ("%s: parsing xml done", __func__);
 
@@ -2645,7 +2630,8 @@ verify_oval_file (const gchar *full_path)
           children = next_entities2 (children);
         }
 
-      //free_entity (entity);
+      xml_doc_free (xml_doc);
+      g_free (xml);
       if (definition_count == 0)
         {
           g_warning ("%s: No OVAL definitions found", __func__);
@@ -2683,7 +2669,8 @@ verify_oval_file (const gchar *full_path)
           children = next_entities2 (children);
         }
 
-      //free_entity (entity);
+      xml_doc_free (xml_doc);
+      g_free (xml);
       if (variable_count == 0)
         {
           g_warning ("%s: No OVAL variables found", __func__);
@@ -2697,6 +2684,8 @@ verify_oval_file (const gchar *full_path)
     {
       g_warning ("%s: File is an OVAL System Characteristics file",
                  __func__);
+      xml_doc_free (xml_doc);
+      g_free (xml);
       return -1;
     }
 
@@ -2704,12 +2693,15 @@ verify_oval_file (const gchar *full_path)
     {
       g_warning ("%s: File is an OVAL Results one",
                  __func__);
+      xml_doc_free (xml_doc);
+      g_free (xml);
       return -1;
     }
 
   g_warning ("%s: Root tag neither oval_definitions nor oval_variables",
              __func__);
-  //free_entity (entity);
+  xml_doc_free (xml_doc);
+  g_free (xml);
   return -1;
 }
 
@@ -2727,6 +2719,7 @@ static int
 update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                     int last_ovaldef_update, int private)
 {
+  xml_doc_t xml_doc;
   GError *error;
   entity2_t entity, child;
   entities2_t children;
@@ -2830,7 +2823,6 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
       g_free (quoted_xml_basename);
       return -1;
     }
-  //g_free (xml);
 
   g_debug ("%s: parsing xml done", __func__);
 
@@ -2847,7 +2839,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
   sql_commit();
   sql_begin_immediate();
 
-  oval_oval_definitions_date (entity, &file_timestamp);
+  oval_oval_definitions_date (xml_doc, entity, &file_timestamp);
 
   children = entity2_children (entity);
   while ((child = first_entity2 (children)))
@@ -2902,7 +2894,6 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                     {
                       g_warning ("%s: oval_definition missing id",
                                  __func__);
-                      //free_entity (entity);
                       goto fail;
                     }
 
@@ -2911,7 +2902,6 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                     {
                       g_warning ("%s: metadata missing",
                                  __func__);
-                      //free_entity (entity);
                       goto fail;
                     }
 
@@ -2920,7 +2910,6 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                     {
                       g_warning ("%s: title missing",
                                  __func__);
-                      //free_entity (entity);
                       goto fail;
                     }
 
@@ -2929,7 +2918,6 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                     {
                       g_warning ("%s: description missing",
                                  __func__);
-                      //free_entity (entity);
                       goto fail;
                     }
 
@@ -2938,7 +2926,6 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                     {
                       g_warning ("%s: oval_repository missing",
                                  __func__);
-                      //free_entity (entity);
                       goto fail;
                     }
 
@@ -2970,7 +2957,6 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                       g_warning ("%s: invalid version: %s",
                                  __func__,
                                  version);
-                      //free_entity (entity);
                       goto fail;
                     }
 
@@ -3052,7 +3038,8 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
   /* Cleanup. */
 
   g_free (quoted_xml_basename);
-  //free_entity (entity);
+  xml_doc_free (xml_doc);
+  g_free (xml);
   sql_commit ();
   return 1;
 
@@ -3060,6 +3047,8 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
   g_free (quoted_xml_basename);
   g_warning ("Update of OVAL definitions failed at file '%s'",
              xml_path);
+  xml_doc_free (xml_doc);
+  g_free (xml);
   sql_commit ();
   return -1;
 }
@@ -3072,7 +3061,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
  * @return Freshly allocated timestamp if found, else NULL.
  */
 static gchar *
-oval_generator_timestamp (entity2_t entity)
+oval_generator_timestamp (xml_doc_t xml_doc, entity2_t entity)
 {
   gchar *generator_name;
   entity2_t generator;
@@ -3105,6 +3094,7 @@ oval_generator_timestamp (entity2_t entity)
 static gchar *
 oval_timestamp (const gchar *xml)
 {
+  xml_doc_t xml_doc;
   entity2_t entity;
 
   g_debug ("%s: parsing xml", __func__);
@@ -3121,10 +3111,10 @@ oval_timestamp (const gchar *xml)
     {
       gchar *timestamp;
 
-      timestamp = oval_generator_timestamp (entity);
+      timestamp = oval_generator_timestamp (xml_doc, entity);
       if (timestamp)
         {
-          //free_entity (entity);
+          xml_doc_free (xml_doc);
           return timestamp;
         }
     }
@@ -3133,10 +3123,10 @@ oval_timestamp (const gchar *xml)
     {
       gchar *timestamp;
 
-      timestamp = oval_generator_timestamp (entity);
+      timestamp = oval_generator_timestamp (xml_doc, entity);
       if (timestamp)
         {
-          //free_entity (entity);
+          xml_doc_free (xml_doc);
           return timestamp;
         }
     }
@@ -3146,15 +3136,16 @@ oval_timestamp (const gchar *xml)
     {
       gchar *timestamp;
 
-      timestamp = oval_generator_timestamp (entity);
+      timestamp = oval_generator_timestamp (xml_doc, entity);
       if (timestamp)
         {
-          //free_entity (entity);
+          xml_doc_free (xml_doc);
           return timestamp;
         }
     }
 
   g_warning ("%s: No timestamp: %s", __func__, xml);
+  xml_doc_free (xml_doc);
   return NULL;
 }
 

--- a/src/sql.h
+++ b/src/sql.h
@@ -46,6 +46,9 @@ sql_regexp_op ();
 const char *
 sql_ilike_op ();
 
+int
+sql_has_on_conflict ();
+
 const char *
 sql_database ();
 

--- a/src/sql_pg.c
+++ b/src/sql_pg.c
@@ -186,6 +186,27 @@ sql_regexp_op ()
 }
 
 /**
+ * @brief Check whether "ON CONFLICT" is supported.
+ *
+ * Aborts if there is not database connection.
+ *
+ * @return 0 no, else yes.
+ */
+int
+sql_has_on_conflict ()
+{
+  static int ver = 0;
+
+  if (sql_is_open () == 0)
+    abort ();
+
+  if (ver == 0)
+    ver = sql_int ("SELECT current_setting ('server_version_num')::integer;");
+
+  return ver >= 90500;
+}
+
+/**
  * @brief Check whether the database is open.
  *
  * @return 1 if open, else 0.

--- a/tools/diff_scap
+++ b/tools/diff_scap
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+echo diffing $1 and $2
+
+diff $1.cpes $2.cpes > /tmp/db-cpes.diff
+diff $1.cves $2.cves > /tmp/db-cves.diff
+diff $1.ovaldefs $2.ovaldefs > /tmp/db-ovaldefs.diff
+diff $1.ovalfiles $2.ovalfiles > /tmp/db-ovalfiles.diff
+diff $1.affected_products $2.affected_products > /tmp/db-affected_products.diff
+diff $1.affected_ovaldefs $2.affected_ovaldefs > /tmp/db-affected_ovaldefs.diff
+
+echo done

--- a/tools/dump_scap
+++ b/tools/dump_scap
@@ -2,7 +2,7 @@
 
 echo dumping from $1 to $2
 
-psql -q --pset pager=off gvmd --command="\COPY (SELECT uuid, name, comment, creation_time, modification_time, title, status, deprecated_by_id, max_cvss, cve_refs, nvd_id FROM ${1}.cpes order by nvd_id) TO stdout WITH CSV;" | sed '/^[[:space:]]*$/d' > $2.cpes
+psql -q --pset pager=off gvmd --command="\COPY (SELECT uuid, name, comment, creation_time, modification_time, title, status, deprecated_by_id, max_cvss, cve_refs, nvd_id FROM ${1}.cpes order by uuid) TO stdout WITH CSV;" | sed '/^[[:space:]]*$/d' > $2.cpes
 psql -q --pset pager=off gvmd --command="\COPY (SELECT  uuid, name, comment, description, creation_time, modification_time, vector , complexity, authentication, confidentiality_impact, integrity_impact, availability_impact, products, cvss FROM ${1}.cves order by uuid) TO stdout WITH CSV;" | sed '/^[[:space:]]*$/d' > $2.cves
 psql -q --pset pager=off gvmd --command="\COPY (SELECT uuid, name, comment, creation_time, modification_time, version, deprecated, def_class, title, description, xml_file, status, max_cvss, cve_refs FROM ${1}.ovaldefs order by uuid) TO stdout WITH CSV;" | sed '/^[[:space:]]*$/d' > $2.ovaldefs
 psql -q --pset pager=off gvmd --command="\COPY (SELECT xml_file FROM ${1}.ovalfiles order by xml_file) TO stdout WITH CSV;" | sed '/^[[:space:]]*$/d' > $2.ovalfiles

--- a/tools/dump_scap
+++ b/tools/dump_scap
@@ -6,7 +6,7 @@ psql -q --pset pager=off gvmd --command="\COPY (SELECT uuid, name, comment, crea
 psql -q --pset pager=off gvmd --command="\COPY (SELECT  uuid, name, comment, description, creation_time, modification_time, vector , complexity, authentication, confidentiality_impact, integrity_impact, availability_impact, products, cvss FROM ${1}.cves order by uuid) TO stdout WITH CSV;" | sed '/^[[:space:]]*$/d' > $2.cves
 psql -q --pset pager=off gvmd --command="\COPY (SELECT uuid, name, comment, creation_time, modification_time, version, deprecated, def_class, title, description, xml_file, status, max_cvss, cve_refs FROM ${1}.ovaldefs order by uuid) TO stdout WITH CSV;" | sed '/^[[:space:]]*$/d' > $2.ovaldefs
 psql -q --pset pager=off gvmd --command="\COPY (SELECT xml_file FROM ${1}.ovalfiles order by xml_file) TO stdout WITH CSV;" | sed '/^[[:space:]]*$/d' > $2.ovalfiles
-psql -q --pset pager=off gvmd --command="\COPY (SELECT (SELECT uuid FROM ${1}.cves WHERE id = cve) AS cve_uuid, (SELECT uuid FROM ${1}.cpes WHERE id = cpe) AS cpe_uuid FROM ${1}.affected_products order by cve_uuid, cpe_uuid) TO stdout WITH CSV;" | sed '/^[[:space:]]*$/d' > $2.affected_products
+psql -q --pset pager=off gvmd --command="\COPY (SELECT cves.uuid, cpes.uuid FROM ${1}.affected_products, ${1}.cves, ${1}.cpes WHERE ${1}.affected_products.cpe = ${1}.cpes.id AND ${1}.affected_products.cve = ${1}.cves.id order by cves.uuid, cpes.uuid) TO stdout WITH CSV;" | sed '/^[[:space:]]*$/d' > $2.affected_products
 psql -q --pset pager=off gvmd --command="\COPY (SELECT cve, ovaldef FROM ${1}.affected_ovaldefs order by cve, ovaldef) TO stdout WITH CSV;" | sed '/^[[:space:]]*$/d' > $2.affected_ovaldefs
 
 echo done $1

--- a/tools/dump_scap
+++ b/tools/dump_scap
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+echo dumping from $1 to $2
+
+psql -q --pset pager=off gvmd --command="\COPY (SELECT uuid, name, comment, creation_time, modification_time, title, status, deprecated_by_id, max_cvss, cve_refs, nvd_id FROM ${1}.cpes order by nvd_id) TO stdout WITH CSV;" | sed '/^[[:space:]]*$/d' > $2.cpes
+psql -q --pset pager=off gvmd --command="\COPY (SELECT  uuid, name, comment, description, creation_time, modification_time, vector , complexity, authentication, confidentiality_impact, integrity_impact, availability_impact, products, cvss FROM ${1}.cves order by uuid) TO stdout WITH CSV;" | sed '/^[[:space:]]*$/d' > $2.cves
+psql -q --pset pager=off gvmd --command="\COPY (SELECT uuid, name, comment, creation_time, modification_time, version, deprecated, def_class, title, description, xml_file, status, max_cvss, cve_refs FROM ${1}.ovaldefs order by uuid) TO stdout WITH CSV;" | sed '/^[[:space:]]*$/d' > $2.ovaldefs
+psql -q --pset pager=off gvmd --command="\COPY (SELECT xml_file FROM ${1}.ovalfiles order by xml_file) TO stdout WITH CSV;" | sed '/^[[:space:]]*$/d' > $2.ovalfiles
+psql -q --pset pager=off gvmd --command="\COPY (SELECT (SELECT uuid FROM ${1}.cves WHERE id = cve) AS cve_uuid, (SELECT uuid FROM ${1}.cpes WHERE id = cpe) AS cpe_uuid FROM ${1}.affected_products order by cve_uuid, cpe_uuid) TO stdout WITH CSV;" | sed '/^[[:space:]]*$/d' > $2.affected_products
+psql -q --pset pager=off gvmd --command="\COPY (SELECT cve, ovaldef FROM ${1}.affected_ovaldefs order by cve, ovaldef) TO stdout WITH CSV;" | sed '/^[[:space:]]*$/d' > $2.affected_ovaldefs
+
+echo done $1


### PR DESCRIPTION
Requires https://github.com/greenbone/gvm-libs/pull/297.

Full sync:
Original master: 2h40m
\+ libxml2 parsing: 2h00m
\+ ON CONFLICT for slow merges: 0h40m
\+ single insert per CVE for CPEs and affected products, WITH to access affected_products: 32m
\+ check if CPE insertion is need on gvmd side: 17m
\+ avoid CPE ID queries: 15m

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
