### PR TITLE
Fix preference ID in "Host Discovery" config (master)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove incorrect duplicates from config preference migrator [#830](https://github.com/greenbone/gvmd/pull/830)
 - MODIFY_USER saves comment when COMMENT is empty [#838](https://github.com/greenbone/gvmd/pull/838)
 - Prevent HOSTS_ORDERING from being '(null)' [#859](https://github.com/greenbone/gvmd/pull/859)
+- Fix preference ID in "Host Discovery" config [#867](https://github.com/greenbone/gvmd/pull/867)
 
 ### Removed
 - Remove support for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)

--- a/src/manage_config_host_discovery.c
+++ b/src/manage_config_host_discovery.c
@@ -91,7 +91,7 @@ make_config_host_discovery (char *const uuid, char *const selector_name)
   sql ("INSERT INTO config_preferences (config, type, name, value)"
        " VALUES (%llu,"
        "         'PLUGINS_PREFS',"
-       "         '" OID_PING_HOST ":6:checkbox:Report about reachable Hosts',"
+       "         '" OID_PING_HOST ":9:checkbox:Report about reachable Hosts',"
        "         'yes');",
        config);
 


### PR DESCRIPTION
This is a port of #828.
The ID of the "Report about reachable Hosts" preference of the
"Ping Host" NVT must be 9, not 6.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- N/A Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
