### PR TITLE
Make CI check out the gvm-libs-11.0 branch for gvmd-9.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - run:
           working_directory: ~/gvm-libs
           name: Checkout gvm-libs
-          command: git clone --depth 1 https://github.com/greenbone/gvm-libs.git
+          command: git clone --depth 1 https://github.com/greenbone/gvm-libs.git -b gvm-libs-11.0
       - run:
           working_directory: ~/gvm-libs
           name: Configure and compile gvm-libs (Release)
@@ -31,7 +31,7 @@ jobs:
       - run:
           working_directory: ~/gvm-libs
           name: Checkout gvm-libs
-          command: git clone --depth 1 https://github.com/greenbone/gvm-libs.git
+          command: git clone --depth 1 https://github.com/greenbone/gvm-libs.git -b gvm-libs-11.0
       - run:
           working_directory: ~/gvm-libs
           name: Configure and compile gvm-libs (Debug)
@@ -47,7 +47,7 @@ jobs:
       - run:
           working_directory: ~/gvm-libs
           name: Checkout gvm-libs
-          command: git clone --depth 1 https://github.com/greenbone/gvm-libs.git
+          command: git clone --depth 1 https://github.com/greenbone/gvm-libs.git -b gvm-libs-11.0
       - run:
           working_directory: ~/gvm-libs
           name: Configure and compile gvm-libs (Release)
@@ -63,7 +63,7 @@ jobs:
       - run:
           working_directory: ~/gvm-libs
           name: Checkout gvm-libs
-          command: git clone --depth 1 https://github.com/greenbone/gvm-libs.git
+          command: git clone --depth 1 https://github.com/greenbone/gvm-libs.git -b gvm-libs-11.0
       - run:
           working_directory: ~/gvm-libs
           name: Configure and compile gvm-libs (Release)
@@ -79,7 +79,7 @@ jobs:
       - run:
           working_directory: ~/gvm-libs
           name: Checkout gvm-libs
-          command: git clone --depth 1 https://github.com/greenbone/gvm-libs.git
+          command: git clone --depth 1 https://github.com/greenbone/gvm-libs.git -b gvm-libs-11.0
       - run:
           working_directory: ~/gvm-libs
           name: Configure and compile gvm-libs (Release)


### PR DESCRIPTION
For gvmd-9.0 it should be using this instead of the master branch
of the libraries.

**Checklist**:

- N/A Tests
- N/A [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
