### PR TITLE
Use single INSERT per CVE for CPEs and affected products (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Allow use of public key auth in SCP alert [#845](https://github.com/greenbone/gvmd/pull/845)
 - Refuse to import config with missing NVT preference ID [#856](https://github.com/greenbone/gvmd/pull/856) [#860](https://github.com/greenbone/gvmd/pull/860)
 - Add "Base" scan config [#862](https://github.com/greenbone/gvmd/pull/862)
+- Use single insert per CVE for CPEs and affected products [#877](https://github.com/greenbone/gvmd/pull/877)
 
 ### Changed
 - Extend command line options for managing scanners [#815](https://github.com/greenbone/gvmd/pull/815)

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -2270,50 +2270,52 @@ insert_cve_products (element_t list, const gchar *quoted_id,
 
   while (product)
     {
-      if (strcmp (element_name (product), "product")
-          == 0)
+      gchar *product_text;
+
+      if (strcmp (element_name (product), "product"))
         {
-          gchar *product_text;
-
-          product_text = element_text (product);
-          if (strlen (product_text))
-            {
-              gchar *quoted_product, *product_decoded;
-              gchar *product_tilde;
-
-              product_decoded = g_uri_unescape_string
-                                 (element_text (product), NULL);
-              product_tilde = string_replace (product_decoded,
-                                              "~", "%7E", "%7e",
-                                              NULL);
-              g_free (product_decoded);
-              quoted_product = sql_quote (product_tilde);
-              g_free (product_tilde);
-
-              sql ("INSERT INTO scap.cpes"
-                   " (uuid, name, creation_time,"
-                   "  modification_time)"
-                   " VALUES"
-                   " ('%s', '%s', %i, %i)"
-                   " ON CONFLICT (uuid)"
-                   " DO UPDATE SET name = EXCLUDED.name;",
-                   quoted_product, quoted_product, time_published,
-                   time_modified);
-              sql ("INSERT INTO scap.affected_products"
-                   " (cve, cpe)"
-                   " VALUES"
-                   " (%llu,"
-                   "  (SELECT id FROM cpes"
-                   "   WHERE name='%s'))"
-                   " ON CONFLICT (cve, cpe) DO NOTHING;",
-                   cve_rowid, quoted_product);
-              (*transaction_size)++;
-              increment_transaction_size (transaction_size);
-              g_free (quoted_product);
-            }
-
-          g_free (product_text);
+          product = element_next (product);
+          continue;
         }
+
+      product_text = element_text (product);
+      if (strlen (product_text))
+        {
+          gchar *quoted_product, *product_decoded;
+          gchar *product_tilde;
+
+          product_decoded = g_uri_unescape_string
+                             (element_text (product), NULL);
+          product_tilde = string_replace (product_decoded,
+                                          "~", "%7E", "%7e",
+                                          NULL);
+          g_free (product_decoded);
+          quoted_product = sql_quote (product_tilde);
+          g_free (product_tilde);
+
+          sql ("INSERT INTO scap.cpes"
+               " (uuid, name, creation_time,"
+               "  modification_time)"
+               " VALUES"
+               " ('%s', '%s', %i, %i)"
+               " ON CONFLICT (uuid)"
+               " DO UPDATE SET name = EXCLUDED.name;",
+               quoted_product, quoted_product, time_published,
+               time_modified);
+          sql ("INSERT INTO scap.affected_products"
+               " (cve, cpe)"
+               " VALUES"
+               " (%llu,"
+               "  (SELECT id FROM cpes"
+               "   WHERE name='%s'))"
+               " ON CONFLICT (cve, cpe) DO NOTHING;",
+               cve_rowid, quoted_product);
+          (*transaction_size)++;
+          increment_transaction_size (transaction_size);
+          g_free (quoted_product);
+        }
+
+      g_free (product_text);
 
       product = element_next (product);
     }

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -2240,6 +2240,86 @@ update_scap_cpes (int last_scap_update)
 /* SCAP update: CVEs. */
 
 /**
+ * @brief Insert products for a CVE.
+ *
+ * @param[in]  list              XML product list.
+ * @param[in]  quoted_id         UUID of CVE.
+ * @param[in]  time_published    Time published.
+ * @param[in]  time_modified     Time modified.
+ * @param[in]  transaction_size  Statement counter for batching.
+ */
+static void
+insert_cve_products (element_t list, const gchar *quoted_id,
+                     int time_modified, int time_published,
+                     int *transaction_size)
+{
+  element_t product;
+  resource_t cve_rowid;
+
+  if (list == NULL)
+    return;
+
+  product = element_first_child (list);
+
+  if (product == NULL)
+    return;
+
+  sql_int64 (&cve_rowid,
+             "SELECT id FROM cves WHERE uuid='%s';",
+             quoted_id);
+
+  while (product)
+    {
+      if (strcmp (element_name (product), "product")
+          == 0)
+        {
+          gchar *product_text;
+
+          product_text = element_text (product);
+          if (strlen (product_text))
+            {
+              gchar *quoted_product, *product_decoded;
+              gchar *product_tilde;
+
+              product_decoded = g_uri_unescape_string
+                                 (element_text (product), NULL);
+              product_tilde = string_replace (product_decoded,
+                                              "~", "%7E", "%7e",
+                                              NULL);
+              g_free (product_decoded);
+              quoted_product = sql_quote (product_tilde);
+              g_free (product_tilde);
+
+              sql ("INSERT INTO scap.cpes"
+                   " (uuid, name, creation_time,"
+                   "  modification_time)"
+                   " VALUES"
+                   " ('%s', '%s', %i, %i)"
+                   " ON CONFLICT (uuid)"
+                   " DO UPDATE SET name = EXCLUDED.name;",
+                   quoted_product, quoted_product, time_published,
+                   time_modified);
+              sql ("INSERT INTO scap.affected_products"
+                   " (cve, cpe)"
+                   " VALUES"
+                   " (%llu,"
+                   "  (SELECT id FROM cpes"
+                   "   WHERE name='%s'))"
+                   " ON CONFLICT (cve, cpe) DO NOTHING;",
+                   cve_rowid, quoted_product);
+              (*transaction_size)++;
+              increment_transaction_size (transaction_size);
+              g_free (quoted_product);
+            }
+
+          g_free (product_text);
+        }
+
+      product = element_next (product);
+    }
+}
+
+/**
  * @brief Insert a CVE.
  *
  * @param[in]  entry             XML entry.
@@ -2464,71 +2544,8 @@ insert_cve_from_entry (element_t entry, element_t last_modified,
   g_free (quoted_availability_impact);
   g_free (score_text);
 
-  if (list)
-    {
-      element_t product;
-
-      product = element_first_child (list);
-
-      if (product)
-        {
-          resource_t cve_rowid;
-
-          sql_int64 (&cve_rowid,
-                     "SELECT id FROM cves WHERE uuid='%s';",
-                     quoted_id);
-
-          while (product)
-            {
-              if (strcmp (element_name (product), "product")
-                  == 0)
-                {
-                  gchar *product_text;
-
-                  product_text = element_text (product);
-                  if (strlen (product_text))
-                    {
-                      gchar *quoted_product, *product_decoded;
-                      gchar *product_tilde;
-
-                      product_decoded = g_uri_unescape_string
-                                         (element_text (product), NULL);
-                      product_tilde = string_replace (product_decoded,
-                                                      "~", "%7E", "%7e",
-                                                      NULL);
-                      g_free (product_decoded);
-                      quoted_product = sql_quote (product_tilde);
-                      g_free (product_tilde);
-
-                      sql ("INSERT INTO scap.cpes"
-                           " (uuid, name, creation_time,"
-                           "  modification_time)"
-                           " VALUES"
-                           " ('%s', '%s', %i, %i)"
-                           " ON CONFLICT (uuid)"
-                           " DO UPDATE SET name = EXCLUDED.name;",
-                           quoted_product, quoted_product, time_published,
-                           time_modified);
-                      sql ("INSERT INTO scap.affected_products"
-                           " (cve, cpe)"
-                           " VALUES"
-                           " (%llu,"
-                           "  (SELECT id FROM cpes"
-                           "   WHERE name='%s'))"
-                           " ON CONFLICT (cve, cpe) DO NOTHING;",
-                           cve_rowid, quoted_product);
-                      (*transaction_size)++;
-                      increment_transaction_size (transaction_size);
-                      g_free (quoted_product);
-                    }
-
-                  g_free (product_text);
-                }
-
-              product = element_next (product);
-            }
-        }
-    }
+  insert_cve_products (list, quoted_id, time_published, time_modified,
+                       transaction_size);
 
   g_free (quoted_id);
   return 0;


### PR DESCRIPTION
This makes insert_cve_products use a single INSERT for all the CVE's
CPEs, and a single INSERT for all the CVE's affected_products, instead
of using an INSERT for every single CPE and affected_product.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
