### PR TITLE
Update all the CPEs in a single statement (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Refuse to import config with missing NVT preference ID [#856](https://github.com/greenbone/gvmd/pull/856) [#860](https://github.com/greenbone/gvmd/pull/860)
 - Add "Base" scan config [#862](https://github.com/greenbone/gvmd/pull/862)
 - Use single insert per CVE for CPEs and affected products [#877](https://github.com/greenbone/gvmd/pull/877)
+- Update all the CPEs in a single statement [#879](https://github.com/greenbone/gvmd/pull/879)
 
 ### Changed
 - Extend command line options for managing scanners [#815](https://github.com/greenbone/gvmd/pull/815)

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -2011,7 +2011,6 @@ update_scap_cpes (int last_scap_update)
   gsize xml_len;
   GStatBuf state;
   int updated_scap_cpes, last_cve_update;
-  int transaction_size = 0;
 
   updated_scap_cpes = 0;
   full_path = g_build_filename (GVM_SCAP_DATA_DIR,
@@ -2211,7 +2210,6 @@ update_scap_cpes (int last_scap_update)
                    quoted_status,
                    deprecated ? deprecated : "NULL",
                    quoted_nvd_id);
-              increment_transaction_size (&transaction_size);
               g_free (quoted_title);
               g_free (quoted_name);
               g_free (quoted_status);

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -2083,8 +2083,6 @@ update_scap_cpes (int last_scap_update)
           if (item_metadata == NULL)
             {
               g_warning ("%s: item-metadata missing", __FUNCTION__);
-
-              element_free (element);
               goto fail;
             }
 
@@ -2093,7 +2091,6 @@ update_scap_cpes (int last_scap_update)
           if (modification_date == NULL)
             {
               g_warning ("%s: modification-date missing", __FUNCTION__);
-              element_free (element);
               goto fail;
             }
 
@@ -2108,7 +2105,6 @@ update_scap_cpes (int last_scap_update)
               if (name == NULL)
                 {
                   g_warning ("%s: name missing", __FUNCTION__);
-                  element_free (element);
                   g_free (modification_date);
                   goto fail;
                 }
@@ -2117,7 +2113,6 @@ update_scap_cpes (int last_scap_update)
               if (status == NULL)
                 {
                   g_warning ("%s: status missing", __FUNCTION__);
-                  element_free (element);
                   g_free (modification_date);
                   g_free (name);
                   goto fail;
@@ -2132,7 +2127,6 @@ update_scap_cpes (int last_scap_update)
                   g_warning ("%s: invalid deprecated-by-nvd-id: %s",
                              __FUNCTION__,
                              deprecated);
-                  element_free (element);
                   g_free (modification_date);
                   g_free (name);
                   g_free (status);
@@ -2143,7 +2137,6 @@ update_scap_cpes (int last_scap_update)
               if (nvd_id == NULL)
                 {
                   g_warning ("%s: nvd_id missing", __FUNCTION__);
-                  element_free (element);
                   g_free (modification_date);
                   g_free (name);
                   g_free (status);
@@ -2229,6 +2222,7 @@ update_scap_cpes (int last_scap_update)
   return updated_scap_cpes;
 
  fail:
+  element_free (element);
   g_warning ("Update of CPEs failed");
   sql_commit ();
   return -1;

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -2151,7 +2151,7 @@ update_scap_cpes (int last_scap_update)
       g_warning ("%s: No CPE dictionary found at %s",
                  __FUNCTION__,
                  strerror (errno));
-      goto fail;
+      return -1;
     }
 
   if ((state.st_mtime - (state.st_mtime % 60)) <= last_scap_update)
@@ -2159,7 +2159,7 @@ update_scap_cpes (int last_scap_update)
       g_info ("Skipping CPEs, file is older than last revision"
               " (this is not an error)");
       g_free (full_path);
-      goto fail;
+      return -1;
     }
 
   g_info ("Updating CPEs");


### PR DESCRIPTION
This is for the base CPE update during the SCAP sync, which is adding all the CPEs from official-cpe-dictionary_v2.2.xml.  Using a single big INSERT is faster than using an INSERT per CPE.

Note that this is different from the "batching" that was being done via increment_transaction_size, which was using an INSERT per CPE but splitting the INSERTS across multiple transactions.

The single big INSERT takes only a few seconds, so it should not affect responsiveness.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
