### PR TITLE
Extend vt xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Refuse to import config with missing NVT preference ID [#853](https://github.com/greenbone/gvmd/pull/853) [#860](https://github.com/greenbone/gvmd/pull/860)
 - Add "Base" scan config [#862](https://github.com/greenbone/gvmd/pull/862)
 - Add setting "BPM Data" [#915](https://github.com/greenbone/gvmd/pull/915)
+- Extend GMP nvt element with "summary", "insight", "affected" and "impact" [#885](https://github.com/greenbone/gvmd/pull/885)
 
 ### Changed
 - Update SCAP and CERT feed info in sync scripts [#810](https://github.com/greenbone/gvmd/pull/810)

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -10260,6 +10260,22 @@ results_xml_append_nvt (iterator_t *results, GString *buffer, int cert_loaded)
                                     cvss_base ?: "",
                                     tags->str ?: "");
 
+          if (result_iterator_nvt_summary (results))
+            buffer_xml_append_printf (buffer, "<summary>%s</summary>",
+                                      result_iterator_nvt_summary (results));
+
+          if (result_iterator_nvt_insight (results))
+            buffer_xml_append_printf (buffer, "<insight>%s</insight>",
+                                      result_iterator_nvt_insight (results));
+
+          if (result_iterator_nvt_affected (results))
+            buffer_xml_append_printf (buffer, "<affected>%s</affected>",
+                                      result_iterator_nvt_affected (results));
+
+          if (result_iterator_nvt_impact (results))
+            buffer_xml_append_printf (buffer, "<impact>%s</impact>",
+                                      result_iterator_nvt_impact (results));
+
           if (result_iterator_nvt_solution (results)
               || result_iterator_nvt_solution_type (results)
               || result_iterator_nvt_solution_method (results))

--- a/src/manage.c
+++ b/src/manage.c
@@ -8165,7 +8165,33 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count,
                               "<nvt oid=\"%s\">"
                               "<name>%s</name>"
                               "<creation_time>%s</creation_time>"
-                              "<modification_time>%s</modification_time>"
+                              "<modification_time>%s</modification_time>",
+                              oid,
+                              name_text,
+                              get_iterator_creation_time (nvts)
+                               ? get_iterator_creation_time (nvts)
+                               : "",
+                              get_iterator_modification_time (nvts)
+                               ? get_iterator_modification_time (nvts)
+                               : "");
+
+      if (nvt_iterator_summary (nvts) && nvt_iterator_summary (nvts)[0])
+          g_string_append_printf (buffer, "<summary>%s</summary>",
+                                  nvt_iterator_summary (nvts));
+
+      if (nvt_iterator_insight (nvts) && nvt_iterator_insight (nvts)[0])
+          g_string_append_printf (buffer, "<insight>%s</insight>",
+                                  nvt_iterator_insight (nvts));
+
+      if (nvt_iterator_affected (nvts) && nvt_iterator_affected (nvts)[0])
+          g_string_append_printf (buffer, "<affected>%s</affected>",
+                                  nvt_iterator_affected (nvts));
+
+      if (nvt_iterator_impact (nvts) && nvt_iterator_impact (nvts)[0])
+          g_string_append_printf (buffer, "<impact>%s</impact>",
+                                  nvt_iterator_impact (nvts));
+
+      g_string_append_printf (buffer,
                               "%s" // user_tags
                               "<category>%d</category>"
                               "<family>%s</family>"
@@ -8179,14 +8205,6 @@ get_nvti_xml (iterator_t *nvts, int details, int pref_count,
                               "<preference_count>%i</preference_count>"
                               "<timeout>%s</timeout>"
                               "<default_timeout>%s</default_timeout>",
-                              oid,
-                              name_text,
-                              get_iterator_creation_time (nvts)
-                               ? get_iterator_creation_time (nvts)
-                               : "",
-                              get_iterator_modification_time (nvts)
-                               ? get_iterator_modification_time (nvts)
-                               : "",
                               tags_str->str,
                               nvt_iterator_category (nvts),
                               family_text,

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -15576,6 +15576,8 @@ update_nvti_cache ()
   init_iterator (&nvts,
                  "SELECT nvts.oid, nvts.name, nvts.family, nvts.cvss_base,"
                  "       nvts.tag, nvts.solution, nvts.solution_type,"
+                 "       nvts.summary, nvts.insight, nvts.affected,"
+                 "       nvts.impact,"
                  "       vt_refs.type, vt_refs.ref_id, vt_refs.ref_text"
                  " FROM nvts"
                  " LEFT OUTER JOIN vt_refs ON nvts.oid = vt_refs.vt_oid;");
@@ -15595,17 +15597,21 @@ update_nvti_cache ()
           nvti_set_tag (nvti, iterator_string (&nvts, 4));
           nvti_set_solution (nvti, iterator_string (&nvts, 5));
           nvti_set_solution_type (nvti, iterator_string (&nvts, 6));
+          nvti_set_summary (nvti, iterator_string (&nvts, 7));
+          nvti_set_insight (nvti, iterator_string (&nvts, 8));
+          nvti_set_affected (nvti, iterator_string (&nvts, 9));
+          nvti_set_impact (nvti, iterator_string (&nvts, 10));
 
           nvtis_add (nvti_cache, nvti);
         }
 
-      if (iterator_null (&nvts, 8))
+      if (iterator_null (&nvts, 12))
         /* No refs. */;
       else
         nvti_add_vtref (nvti,
-                        vtref_new (iterator_string (&nvts, 7),
-                                   iterator_string (&nvts, 8),
-                                   iterator_string (&nvts, 9)));
+                        vtref_new (iterator_string (&nvts, 11),
+                                   iterator_string (&nvts, 12),
+                                   iterator_string (&nvts, 13)));
     }
 
   cleanup_iterator (&nvts);

--- a/src/report_formats/CSV_Results/CSV_Results.xsl
+++ b/src/report_formats/CSV_Results/CSV_Results.xsl
@@ -155,11 +155,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 <!-- MATCH RESULT -->
 <xsl:template match="result">
   <xsl:variable name="ip" select="host/text()"/>
-  <xsl:variable name="summary-tag" select="gvm:get-nvt-tag (nvt/tags, 'summary')"/>
   <xsl:variable name="summary">
     <xsl:choose>
-      <xsl:when test="string-length ($summary-tag) &gt; 0">
-        <xsl:value-of select="$summary-tag"/>
+      <xsl:when test="nvt/summary/text()">
+        <xsl:value-of select="nvt/summary"/>
       </xsl:when>
       <xsl:otherwise>
         <xsl:value-of select="description"/>
@@ -225,21 +224,15 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   <xsl:text>,</xsl:text>
   <xsl:value-of select="gvm:formula_quote (@id)"/>
   <xsl:text>,"</xsl:text>
-  <xsl:if test="gvm:get-nvt-tag (nvt/tags, 'impact') != 'N/A'">
-    <xsl:value-of select="gvm:formula_quote (str:replace (gvm:get-nvt-tag (nvt/tags, 'impact'), $quote, $two-quotes))"/>
-  </xsl:if>
+  <xsl:value-of select="gvm:formula_quote (str:replace (nvt/impact/text(), $quote, $two-quotes))"/>
   <xsl:text>","</xsl:text>
   <xsl:if test="nvt/solution/text()">
     <xsl:value-of select="gvm:formula_quote (str:replace (nvt/solution/text(), $quote, $two-quotes))"/>
   </xsl:if>
   <xsl:text>","</xsl:text>
-  <xsl:if test="gvm:get-nvt-tag (nvt/tags, 'affected') != 'N/A'">
-    <xsl:value-of select="gvm:formula_quote (str:replace (gvm:get-nvt-tag (nvt/tags, 'affected'), $quote, $two-quotes))"/>
-  </xsl:if>
+  <xsl:value-of select="gvm:formula_quote (str:replace (nvt/affected/text(), $quote, $two-quotes))"/>
   <xsl:text>","</xsl:text>
-  <xsl:if test="gvm:get-nvt-tag (nvt/tags, 'insight') != 'N/A'">
-    <xsl:value-of select="gvm:formula_quote (str:replace (gvm:get-nvt-tag (nvt/tags, 'insight'), $quote, $two-quotes))"/>
-  </xsl:if>
+  <xsl:value-of select="gvm:formula_quote (str:replace (nvt/insight/text(), $quote, $two-quotes))"/>
   <xsl:text>","</xsl:text>
   <xsl:if test="gvm:get-nvt-tag (nvt/tags, 'vuldetect') != 'N/A'">
     <xsl:value-of select="gvm:formula_quote (str:replace (gvm:get-nvt-tag (nvt/tags, 'vuldetect'), $quote, $two-quotes))"/>
@@ -371,6 +364,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   <xsl:text>IP,Hostname,Port,Port Protocol,CVSS,Severity,Solution Type,NVT Name,Summary,Specific Result,NVT OID,CVEs,Task ID,Task Name,Timestamp,Result ID,Impact,Solution,Affected Software/OS,Vulnerability Insight,Vulnerability Detection Method,Product Detection Result,BIDs,CERTs,Other References
 </xsl:text>
   <xsl:apply-templates select="results"/>
+  <xsl:apply-templates select="report/results"/>
 </xsl:template>
 
 </xsl:stylesheet>

--- a/src/report_formats/LaTeX/latex.xsl
+++ b/src/report_formats/LaTeX/latex.xsl
@@ -1211,12 +1211,12 @@ advice given in each description, in order to rectify the issue.
         </xsl:if>
 
         <!-- Summary -->
-        <xsl:if test="string-length (gvm:get-nvt-tag (nvt/tags, 'summary')) &gt; 0">
+	<xsl:if test="nvt/summary/text()">
           <xsl:call-template name="latex-newline"/>
           <xsl:text>\textbf{Summary}</xsl:text>
           <xsl:call-template name="latex-newline"/>
           <xsl:call-template name="structured-text">
-            <xsl:with-param name="string" select="gvm:get-nvt-tag (nvt/tags, 'summary')"/>
+            <xsl:with-param name="string" select="nvt/summary"/>
           </xsl:call-template>
         </xsl:if>
 
@@ -1244,13 +1244,13 @@ advice given in each description, in order to rectify the issue.
           </xsl:otherwise>
         </xsl:choose>
 
-        <xsl:if test="string-length (gvm:get-nvt-tag (nvt/tags, 'impact')) &gt; 0 and gvm:get-nvt-tag (nvt/tags, 'impact') != 'N/A'">
+	<xsl:if test="nvt/impact/text()">
           \hline
           <xsl:call-template name="latex-newline"/>
           <xsl:text>\textbf{Impact}</xsl:text>
           <xsl:call-template name="latex-newline"/>
           <xsl:call-template name="structured-text">
-            <xsl:with-param name="string" select="gvm:get-nvt-tag (nvt/tags, 'impact')"/>
+            <xsl:with-param name="string" select="nvt/impact"/>
           </xsl:call-template>
         </xsl:if>
 
@@ -1276,23 +1276,23 @@ advice given in each description, in order to rectify the issue.
           </xsl:if>
         </xsl:if>
 
-        <xsl:if test="string-length (gvm:get-nvt-tag (nvt/tags, 'affected')) &gt; 0 and gvm:get-nvt-tag (nvt/tags, 'affected') != 'N/A'">
+	<xsl:if test="nvt/affected/text()">
           \hline
           <xsl:call-template name="latex-newline"/>
           <xsl:text>\textbf{Affected Software/OS}</xsl:text>
           <xsl:call-template name="latex-newline"/>
           <xsl:call-template name="structured-text">
-            <xsl:with-param name="string" select="gvm:get-nvt-tag (nvt/tags, 'affected')"/>
+            <xsl:with-param name="string" select="nvt/affected"/>
           </xsl:call-template>
         </xsl:if>
 
-        <xsl:if test="string-length (gvm:get-nvt-tag (nvt/tags, 'insight')) &gt; 0 and gvm:get-nvt-tag (nvt/tags, 'insight') != 'N/A'">
+	<xsl:if test="nvt/insight/text()">
           \hline
           <xsl:call-template name="latex-newline"/>
           <xsl:text>\textbf{Vulnerability Insight}</xsl:text>
           <xsl:call-template name="latex-newline"/>
           <xsl:call-template name="structured-text">
-            <xsl:with-param name="string" select="gvm:get-nvt-tag (nvt/tags, 'insight')"/>
+            <xsl:with-param name="string" select="nvt/insight"/>
           </xsl:call-template>
         </xsl:if>
 

--- a/src/report_formats/NBE/NBE.xsl
+++ b/src/report_formats/NBE/NBE.xsl
@@ -130,10 +130,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   <xsl:text>|</xsl:text>
 
   <!-- Summary -->
-  <xsl:if test="string-length (gvm:get-nvt-tag (nvt/tags, 'summary')) &gt; 0">
+  <xsl:if test="nvt/summary/text()">
     <xsl:text>Summary:</xsl:text>
     <xsl:text>\n</xsl:text>
-    <xsl:value-of select="str:replace (gvm:get-nvt-tag (nvt/tags, 'summary'), '&#10;', '\n')"/>
+    <xsl:value-of select="str:replace (nvt/summary/text(), '&#10;', '\n')"/>
     <xsl:text>\n\n</xsl:text>
   </xsl:if>
 
@@ -156,10 +156,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   </xsl:choose>
   <xsl:text>\n</xsl:text>
 
-  <xsl:if test="string-length (gvm:get-nvt-tag (nvt/tags, 'impact')) &gt; 0 and gvm:get-nvt-tag (nvt/tags, 'impact') != 'N/A'">
+  <xsl:if test="nvt/impact/text()">
     <xsl:text>Impact:</xsl:text>
     <xsl:text>\n</xsl:text>
-    <xsl:value-of select="str:replace (gvm:get-nvt-tag (nvt/tags, 'impact'), '&#10;', '\n')"/>
+    <xsl:value-of select="str:replace (nvt/impact/text(), '&#10;', '\n')"/>
     <xsl:text>\n\n</xsl:text>
   </xsl:if>
 
@@ -182,17 +182,17 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </xsl:if>
   </xsl:if>
 
-  <xsl:if test="string-length (gvm:get-nvt-tag (nvt/tags, 'affected')) &gt; 0 and gvm:get-nvt-tag (nvt/tags, 'affected') != 'N/A'">
+  <xsl:if test="nvt/affected/text()">
     <xsl:text>Affected Software/OS:</xsl:text>
     <xsl:text>\n</xsl:text>
-    <xsl:value-of select="str:replace (gvm:get-nvt-tag (nvt/tags, 'affected'), '&#10;', '\n')"/>
+    <xsl:value-of select="str:replace (nvt/affected/text(), '&#10;', '\n')"/>
     <xsl:text>\n\n</xsl:text>
   </xsl:if>
 
-  <xsl:if test="string-length (gvm:get-nvt-tag (nvt/tags, 'insight')) &gt; 0 and gvm:get-nvt-tag (nvt/tags, 'insight') != 'N/A'">
+  <xsl:if test="nvt/insight/text()">
     <xsl:text>Vulnerability Insight:</xsl:text>
     <xsl:text>\n</xsl:text>
-    <xsl:value-of select="str:replace (gvm:get-nvt-tag (nvt/tags, 'insight'), '&#10;', '\n')"/>
+    <xsl:value-of select="str:replace (nvt/insight/text(), '&#10;', '\n')"/>
     <xsl:text>\n\n</xsl:text>
   </xsl:if>
 

--- a/src/report_formats/TXT/TXT.xsl
+++ b/src/report_formats/TXT/TXT.xsl
@@ -415,12 +415,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </xsl:if>
 
     <!-- Summary -->
-    <xsl:if test="string-length (gvm:get-nvt-tag (nvt/tags, 'summary')) &gt; 0">
+    <xsl:if test="nvt/summary/text()">
       <xsl:text>Summary:</xsl:text>
       <xsl:call-template name="newline"/>
       <xsl:call-template name="wrap">
         <xsl:with-param name="string"
-                        select="gvm:get-nvt-tag (nvt/tags, 'summary')"/>
+                        select="nvt/summary"/>
       </xsl:call-template>
       <xsl:call-template name="newline"/>
     </xsl:if>
@@ -447,11 +447,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </xsl:choose>
     <xsl:call-template name="newline"/>
 
-    <xsl:if test="string-length (gvm:get-nvt-tag (nvt/tags, 'impact')) &gt; 0 and gvm:get-nvt-tag (nvt/tags, 'impact') != 'N/A'">
+    <xsl:if test="nvt/impact/text()">
       <xsl:text>Impact:</xsl:text>
       <xsl:call-template name="newline"/>
       <xsl:call-template name="wrap">
-        <xsl:with-param name="string" select="gvm:get-nvt-tag (nvt/tags, 'impact')"/>
+        <xsl:with-param name="string" select="nvt/impact"/>
       </xsl:call-template>
       <xsl:call-template name="newline"/>
     </xsl:if>
@@ -477,20 +477,20 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       </xsl:if>
     </xsl:if>
 
-    <xsl:if test="string-length (gvm:get-nvt-tag (nvt/tags, 'affected')) &gt; 0 and gvm:get-nvt-tag (nvt/tags, 'affected') != 'N/A'">
+    <xsl:if test="nvt/affected/text()">
       <xsl:text>Affected Software/OS:</xsl:text>
       <xsl:call-template name="newline"/>
       <xsl:call-template name="wrap">
-        <xsl:with-param name="string" select="gvm:get-nvt-tag (nvt/tags, 'affected')"/>
+        <xsl:with-param name="string" select="nvt/affected"/>
       </xsl:call-template>
       <xsl:call-template name="newline"/>
     </xsl:if>
 
-    <xsl:if test="string-length (gvm:get-nvt-tag (nvt/tags, 'insight')) &gt; 0 and gvm:get-nvt-tag (nvt/tags, 'insight') != 'N/A'">
+    <xsl:if test="nvt/insight/text()">
       <xsl:text>Vulnerability Insight:</xsl:text>
       <xsl:call-template name="newline"/>
       <xsl:call-template name="wrap">
-        <xsl:with-param name="string" select="gvm:get-nvt-tag (nvt/tags, 'insight')"/>
+        <xsl:with-param name="string" select="nvt/insight"/>
       </xsl:call-template>
       <xsl:call-template name="newline"/>
     </xsl:if>

--- a/src/report_formats/Verinice_ISM/Verinice_ISM.xsl
+++ b/src/report_formats/Verinice_ISM/Verinice_ISM.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (C) 2011-2019 Greenbone Networks GmbH
+Copyright (C) 2011-2020 Greenbone Networks GmbH
 
 SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -62,11 +62,11 @@ Parameters:
   <func:function name="gvm:newstyle-nvt">
     <xsl:param name="nvt"/>
     <xsl:choose>
-      <xsl:when test="string-length (gvm:get-nvt-tag ($nvt/tags, 'summary'))
-                      and string-length (gvm:get-nvt-tag ($nvt/tags, 'affected'))
-                      and string-length (gvm:get-nvt-tag ($nvt/tags, 'insight'))
+	    <xsl:when test="$nvt/summary/text()
+                      and $nvt/tags/affected/text()
+                      and $nvt/insight/text()
+                      and $nvt/impact/text()
                       and string-length (gvm:get-nvt-tag ($nvt/tags, 'vuldetect'))
-                      and string-length (gvm:get-nvt-tag ($nvt/tags, 'impact'))
                       and $nvt/solution">
         <func:result select="1"/>
       </xsl:when>
@@ -552,7 +552,7 @@ CIS</value>
           <xsl:if test="gvm:newstyle-nvt (nvt)">
             <xsl:text>Summary:</xsl:text>
             <xsl:call-template name="newline"/>
-            <xsl:value-of select="gvm:get-nvt-tag (nvt/tags, 'summary')"/>
+	    <xsl:value-of select="nvt/summary/text()"/>
             <xsl:call-template name="newline"/>
             <xsl:call-template name="newline"/>
           </xsl:if>
@@ -593,21 +593,17 @@ CIS</value>
           <xsl:call-template name="newline"/>
 
           <xsl:if test="gvm:newstyle-nvt (nvt)">
-            <xsl:if test="gvm:get-nvt-tag (nvt/tags, 'impact') != 'N/A'">
-              <xsl:text>Impact:</xsl:text>
-              <xsl:call-template name="newline"/>
-              <xsl:value-of select="gvm:get-nvt-tag (nvt/tags, 'impact')"/>
-              <xsl:call-template name="newline"/>
-              <xsl:call-template name="newline"/>
-            </xsl:if>
+            <xsl:text>Impact:</xsl:text>
+            <xsl:call-template name="newline"/>
+	    <xsl:value-of select="nvt/impact/text()"/>
+            <xsl:call-template name="newline"/>
+            <xsl:call-template name="newline"/>
 
-            <xsl:if test="gvm:get-nvt-tag (nvt/tags, 'affected') != 'N/A'">
-              <xsl:text>Affected Software/OS:</xsl:text>
-              <xsl:call-template name="newline"/>
-              <xsl:value-of name="string" select="gvm:get-nvt-tag (nvt/tags, 'affected')"/>
-              <xsl:call-template name="newline"/>
-              <xsl:call-template name="newline"/>
-            </xsl:if>
+            <xsl:text>Affected Software/OS:</xsl:text>
+            <xsl:call-template name="newline"/>
+	    <xsl:value-of name="string" select="nvt/affected/text()"/>
+            <xsl:call-template name="newline"/>
+            <xsl:call-template name="newline"/>
 
             <xsl:if test="nvt/solution/text() or nvt/solution/@type or nvt/solution/@method">
               <xsl:text>Solution:</xsl:text>
@@ -629,13 +625,11 @@ CIS</value>
               </xsl:if>
             </xsl:if>
 
-            <xsl:if test="gvm:get-nvt-tag (nvt/tags, 'insight') != 'N/A'">
-              <xsl:text>Vulnerability Insight:</xsl:text>
-              <xsl:call-template name="newline"/>
-              <xsl:value-of select="gvm:get-nvt-tag (nvt/tags, 'insight')"/>
-              <xsl:call-template name="newline"/>
-              <xsl:call-template name="newline"/>
-            </xsl:if>
+            <xsl:text>Vulnerability Insight:</xsl:text>
+            <xsl:call-template name="newline"/>
+	    <xsl:value-of select="nvt/insight/text()"/>
+            <xsl:call-template name="newline"/>
+            <xsl:call-template name="newline"/>
           </xsl:if>
 
           <xsl:choose>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -1,5 +1,5 @@
 <!--
-Copyright (C) 2010-2019 Greenbone Networks GmbH
+Copyright (C) 2010-2020 Greenbone Networks GmbH
 
 SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -545,6 +545,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       <e>name</e>
       <e>creation_time</e>
       <e>modification_time</e>
+      <e>summary</e>
+      <e>insight</e>
+      <e>affected</e>
+      <e>impact</e>
       <e>category</e>
       <e>family</e>
       <e>cvss_base</e>
@@ -571,6 +575,26 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       <name>modification_time</name>
       <summary>Date and time the vulnerability test was last modified</summary>
       <pattern><t>iso_time</t></pattern>
+    </ele>
+    <ele>
+      <name>summary</name>
+      <summary>Summary about the vulnerability test</summary>
+      <pattern><t>text</t></pattern>
+    </ele>
+    <ele>
+      <name>insight</name>
+      <summary>Insights into details of the vulnerability test</summary>
+      <pattern><t>text</t></pattern>
+    </ele>
+    <ele>
+      <name>affected</name>
+      <summary>Describes the affected products covered by this vulnerability test</summary>
+      <pattern><t>text</t></pattern>
+    </ele>
+    <ele>
+      <name>impact</name>
+      <summary>Describes the impact that a successful exploitation could mean.</summary>
+      <pattern><t>text</t></pattern>
     </ele>
     <ele>
       <name>category</name>


### PR DESCRIPTION
This adds the elements "summary", "insight", "affected" and "impact" to the
"nvt" elements.

These are optional, so if a information  is not found in the database, the element
will not occur in the XML.

The elements are actually also in the tags element in a pipe-separated syntax.
Eventually they can be dropped from that tags element.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
