### PR TITLE
get_info nvt: Don't add solution elements to tags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix severity_in_level SQL function [#1312](https://github.com/greenbone/gvmd/pull/1312)
 
 ### Removed
+- Remove solution element from VT tags [#886](https://github.com/greenbone/gvmd/pull/886)
 - Drop GMP scanners [#1269](https://github.com/greenbone/gvmd/pull/1269)
 - Reduce Severity Classes [#1285](https://github.com/greenbone/gvmd/pull/1285)
 - Removed Severity Classes [#1288](https://github.com/greenbone/gvmd/pull/1288)

--- a/src/manage.c
+++ b/src/manage.c
@@ -5346,25 +5346,6 @@ get_nvt_xml (iterator_t *nvts, int details, int pref_count,
             xml_string_append (nvt_tags, "impact=%s",
                                nvt_iterator_impact (nvts));
         }
-      if (nvt_iterator_solution (nvts) && nvt_iterator_solution (nvts)[0])
-        {
-          if (nvt_tags->str)
-            xml_string_append (nvt_tags, "|solution=%s",
-                                nvt_iterator_solution (nvts));
-          else
-            xml_string_append (nvt_tags, "solution=%s",
-                               nvt_iterator_solution (nvts));
-        }
-      if (nvt_iterator_solution_type (nvts)
-          && nvt_iterator_solution_type (nvts)[0])
-        {
-          if (nvt_tags->str)
-            xml_string_append (nvt_tags, "|solution_type=%s",
-                               nvt_iterator_solution_type (nvts));
-          else
-            xml_string_append (nvt_tags, "solution_type=%s",
-                               nvt_iterator_solution_type (nvts));
-        }
       if (nvt_iterator_detection (nvts) && nvt_iterator_detection (nvts)[0])
         {
           if (nvt_tags->str)


### PR DESCRIPTION
Since the solution and solution_type are now in a element
of its own, we do not need them in the tags element of the nvt
for the get_info response.

This change should be merged after GSA parses the solution and
solution_type properly from the new element for the get_info command.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
