### PR TITLE
Fix creation of "Super" permissions (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix resource type checks for permissions [#863](https://github.com/greenbone/gvmd/pull/863)
 - Fix result_nvt for new OSP and slave results [#865](https://github.com/greenbone/gvmd/pull/865)
 - Use right format specifier for merge_ovaldef version [#874](https://github.com/greenbone/gvmd/pull/874)
+- Fix creation of "Super" permissions [#892](https://github.com/greenbone/gvmd/pull/892)
 
 ### Removed
 - Remove 1.3.6.1.4.1.25623.1.0.90011 from Discovery config (9.0) [#847](https://github.com/greenbone/gvmd/pull/847)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -50850,6 +50850,7 @@ create_permission_internal (const char *name_arg, const char *comment,
   assert ((resource_id == resource_id_arg) || (resource_id == NULL));
 
   quoted_name = sql_quote (name);
+  g_free (name);
   quoted_comment = sql_quote (comment ? comment : "");
 
   sql ("INSERT INTO permissions"
@@ -50878,7 +50879,7 @@ create_permission_internal (const char *name_arg, const char *comment,
     *permission = sql_last_insert_id ();
 
   /* Update Permissions cache */
-  if (strcasecmp (name, "super") == 0)
+  if (strcasecmp (quoted_name, "super") == 0)
     cache_all_permissions_for_users (NULL);
   else if (resource_type && resource)
     cache_permissions_for_resource (resource_type, resource, NULL);
@@ -50922,7 +50923,6 @@ create_permission_internal (const char *name_arg, const char *comment,
   g_free (quoted_name);
   g_free (resource_type);
   g_free (subject_where);
-  g_free (name);
 
   return 0;
 }

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -50850,7 +50850,6 @@ create_permission_internal (const char *name_arg, const char *comment,
   assert ((resource_id == resource_id_arg) || (resource_id == NULL));
 
   quoted_name = sql_quote (name);
-  g_free (name);
   quoted_comment = sql_quote (comment ? comment : "");
 
   sql ("INSERT INTO permissions"
@@ -50923,6 +50922,7 @@ create_permission_internal (const char *name_arg, const char *comment,
   g_free (quoted_name);
   g_free (resource_type);
   g_free (subject_where);
+  g_free (name);
 
   return 0;
 }


### PR DESCRIPTION
The permission name variable was freed too early so the comparison for
when to cache the permissions was not working as intended.

**Checklist**:

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
