### PR TITLE
Fix creation of Super permissions (8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix array index error when modifying roles and groups [#763](https://github.com/greenbone/gvmd/pull/763)
 - Fix percent sign escaping in report_port_count [#781](https://github.com/greenbone/gvmd/pull/781)
 - Consider results_trash when deleting users [#804](https://github.com/greenbone/gvmd/pull/804)
+- Fix creation of "Super" permissions [#893](https://github.com/greenbone/gvmd/pull/893)
 
 ### Removed
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -55748,6 +55748,7 @@ create_permission_internal (const char *name_arg, const char *comment,
   assert ((resource_id == resource_id_arg) || (resource_id == NULL));
 
   quoted_name = sql_quote (name);
+  g_free (name);
   quoted_comment = sql_quote (comment ? comment : "");
 
   sql ("INSERT INTO permissions"
@@ -55776,7 +55777,7 @@ create_permission_internal (const char *name_arg, const char *comment,
     *permission = sql_last_insert_id ();
 
   /* Update Permissions cache */
-  if (strcasecmp (name, "super") == 0)
+  if (strcasecmp (quoted_name, "super") == 0)
     cache_all_permissions_for_users (NULL);
   else if (resource_type && resource)
     cache_permissions_for_resource (resource_type, resource, NULL);
@@ -55820,7 +55821,6 @@ create_permission_internal (const char *name_arg, const char *comment,
   g_free (quoted_name);
   g_free (resource_type);
   g_free (subject_where);
-  g_free (name);
 
   return 0;
 }

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -55748,7 +55748,6 @@ create_permission_internal (const char *name_arg, const char *comment,
   assert ((resource_id == resource_id_arg) || (resource_id == NULL));
 
   quoted_name = sql_quote (name);
-  g_free (name);
   quoted_comment = sql_quote (comment ? comment : "");
 
   sql ("INSERT INTO permissions"
@@ -55821,6 +55820,7 @@ create_permission_internal (const char *name_arg, const char *comment,
   g_free (quoted_name);
   g_free (resource_type);
   g_free (subject_where);
+  g_free (name);
 
   return 0;
 }


### PR DESCRIPTION
The permission name variable was freed too early so the comparison for
when to cache the permissions was not working as intended.

**Checklist**:

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
