### PR TITLE
Force NVT update in migrate_219_to_220 (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Allow resuming OSPd-based OpenVAS tasks [#869](https://github.com/greenbone/gvmd/pull/869)
 - Require Postgres 9.6 as a minimum [#872](https://github.com/greenbone/gvmd/pull/872)
 - Speed up the SCAP sync [#875](https://github.com/greenbone/gvmd/pull/875) [#877](https://github.com/greenbone/gvmd/pull/877) [#879](https://github.com/greenbone/gvmd/pull/879) [#881](https://github.com/greenbone/gvmd/pull/881) [#883](https://github.com/greenbone/gvmd/pull/883) [#887](https://github.com/greenbone/gvmd/pull/887) [#889](https://github.com/greenbone/gvmd/pull/889) [#890](https://github.com/greenbone/gvmd/pull/890) [#891](https://github.com/greenbone/gvmd/pull/891)
+- Force NVT update in migrate_219_to_220 [#895](https://github.com/greenbone/gvmd/pull/895)
 
 ### Fixed
 - Consider results_trash when deleting users [#799](https://github.com/greenbone/gvmd/pull/799)

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -1472,6 +1472,10 @@ migrate_219_to_220 ()
   replace_preference_names_219_to_220 ("config_preferences");
   replace_preference_names_219_to_220 ("config_preferences_trash");
 
+  /* Force an NVT update to update newer NVTs not covered by the
+   *  hardcoded list in case the feed update was run just before migration. */
+  sql ("UPDATE meta SET value='0' WHERE name='nvts_feed_version';");
+
   /* Set the database version to 220. */
 
   set_db_version (220);


### PR DESCRIPTION
If the NVTs were updated shortly before the migration the NVTs not
handled in the hardcoded list remain with incorrect preferences until
the feed version is updated.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
