### PR TITLE
Change rows of built-in default filters to -2 (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Allow resuming OSPd-based OpenVAS tasks [#869](https://github.com/greenbone/gvmd/pull/869)
 - Require Postgres 9.6 as a minimum [#872](https://github.com/greenbone/gvmd/pull/872)
 - Speed up the SCAP sync [#875](https://github.com/greenbone/gvmd/pull/875) [#877](https://github.com/greenbone/gvmd/pull/877) [#879](https://github.com/greenbone/gvmd/pull/879) [#881](https://github.com/greenbone/gvmd/pull/881) [#883](https://github.com/greenbone/gvmd/pull/883) [#887](https://github.com/greenbone/gvmd/pull/887) [#889](https://github.com/greenbone/gvmd/pull/889) [#890](https://github.com/greenbone/gvmd/pull/890) [#891](https://github.com/greenbone/gvmd/pull/891)
+- Change rows of built-in default filters to -2 (use "Rows Per Page" setting) [#896](https://github.com/greenbone/gvmd/pull/896)
 
 ### Fixed
 - Consider results_trash when deleting users [#799](https://github.com/greenbone/gvmd/pull/799)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -1975,14 +1975,7 @@ split_filter_add_specials (array_t *parts, const gchar* given_filter)
     {
       keyword = g_malloc0 (sizeof (keyword_t));
       keyword->column = g_strdup ("rows");
-      /* If there was a filter, make max_return default to Rows Per
-       * Page.  This keeps the pre-filters GMP behaviour when the filter
-       * is empty, but is more convenenient for clients that set the
-       * filter. */
-      if (strlen (given_filter))
-        keyword->string = g_strdup ("-2");
-      else
-        keyword->string = g_strdup ("-1");
+      keyword->string = g_strdup ("-2");
       keyword->type = KEYWORD_TYPE_STRING;
       keyword->relation = KEYWORD_RELATION_COLUMN_EQUAL;
       array_add (parts, keyword);
@@ -2203,7 +2196,7 @@ manage_filter_controls (const gchar *filter, int *first, int *max,
       if (first)
         *first = 1;
       if (max)
-        *max = -1;
+        *max = -2;
       if (sort_field)
         *sort_field = g_strdup ("name");
       if (sort_order)
@@ -2235,7 +2228,7 @@ manage_filter_controls (const gchar *filter, int *first, int *max,
   point = (keyword_t**) split->pdata;
   if (max)
     {
-      *max = -1;
+      *max = -2;
       while (*point)
         {
           keyword_t *keyword;
@@ -3335,7 +3328,7 @@ filter_clause (const char* type, const char* filter,
   /* Add SQL to the clause for each keyword or phrase. */
 
   if (max_return)
-    *max_return = -1;
+    *max_return = -2;
 
   clause = g_string_new ("");
   order = g_string_new ("");

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -28167,7 +28167,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <description>
       <p>
         The command COMMANDS was used to send multiple commands in one request.
-        This was meant to avoid multiple server-roundtrips. Since the rountripsget_agents, get_configs, get_aggregates, get_alerts, get_assets, get_credentials, get_filters, get_groups, get_info, get_notes, get_overrides, get_permissions, get_port_lists, get_reports, get_report_formats, get_results, get_roles, get_scanners, get_schedules, get_settings, get_system_reports, get_tags, get_targets, get_tasks, get_tickets, get_users, get_tls_certificates, get_vulns
+        This was meant to avoid multiple server-roundtrips. Since the rountrips
         are not expensive anymore, GMP clients should send each command in
         a separate request.
       </p>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -27256,7 +27256,24 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   </command>
 
   <!-- Compatibility changes between versions. -->
-
+  <change>
+    <command>GET_... Commands using filters</command>
+    <summary>GET_... commands will default to "rows=-2" filter</summary>
+    <description>
+      <p>
+        If no filter or a filter without a rows keyword is given, the various
+        GET_... commands using filters will behave as if "rows=-2" was given
+        instead of "rows=-1".
+      </p>
+      <p>
+        This means they will only return the number of rows defined by the
+        "Rows Per Page" setting and the maximum amount of rows has to be
+        requested explicitly with a "rows=-1" filter keyword or 
+        (where available) the ignore_pagination option.
+      </p>
+    </description>
+    <version>9.0</version>
+  </change>
   <change>
     <command>CREATE_CONFIG</command>
     <summary>NVT preferences without IDs are no longer accepted</summary>
@@ -28150,7 +28167,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <description>
       <p>
         The command COMMANDS was used to send multiple commands in one request.
-        This was meant to avoid multiple server-roundtrips. Since the rountrips
+        This was meant to avoid multiple server-roundtrips. Since the rountripsget_agents, get_configs, get_aggregates, get_alerts, get_assets, get_credentials, get_filters, get_groups, get_info, get_notes, get_overrides, get_permissions, get_port_lists, get_reports, get_report_formats, get_results, get_roles, get_scanners, get_schedules, get_settings, get_system_reports, get_tags, get_targets, get_tasks, get_tickets, get_users, get_tls_certificates, get_vulns
         are not expensive anymore, GMP clients should send each command in
         a separate request.
       </p>


### PR DESCRIPTION
If no filter or a filter without a rows keyword is given, the various
GET_... commands using filters will behave as if "rows=-2" was given
instead of "rows=-1".

This means they will only return the number of rows defined by the
"Rows Per Page" setting and the maximum amount of rows has to be
requested explicitly with a "rows=-1" filter keyword or
(where available) the ignore_pagination option.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
