### PR TITLE
Change rows of built-in default filters to -2 (8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Change get_tickets to use the status text for filtering. [#698](https://github.com/greenbone/gvmd/pull/698)
 - Also consider 0 of n NVTS as busy loading [#706](https://github.com/greenbone/gvmd/pull/706)
 - Check whether hosts are alive and have results when adding them in slave scans. [#718](https://github.com/greenbone/gvmd/pull/718) [#737](https://github.com/greenbone/gvmd/pull/737)
+- Change rows of built-in default filters to -2 (use "Rows Per Page" setting) [#897](https://github.com/greenbone/gvmd/pull/897)
 
 ### Fixed
 - A PostgreSQL statement order issue [#611](https://github.com/greenbone/gvmd/issues/611) has been addressed [#691](https://github.com/greenbone/gvmd/pull/691)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -2015,14 +2015,7 @@ split_filter_add_specials (array_t *parts, const gchar* given_filter)
     {
       keyword = g_malloc0 (sizeof (keyword_t));
       keyword->column = g_strdup ("rows");
-      /* If there was a filter, make max_return default to Rows Per
-       * Page.  This keeps the pre-filters GMP behaviour when the filter
-       * is empty, but is more convenenient for clients that set the
-       * filter. */
-      if (strlen (given_filter))
-        keyword->string = g_strdup ("-2");
-      else
-        keyword->string = g_strdup ("-1");
+      keyword->string = g_strdup ("-2");
       keyword->type = KEYWORD_TYPE_STRING;
       keyword->relation = KEYWORD_RELATION_COLUMN_EQUAL;
       array_add (parts, keyword);
@@ -2243,7 +2236,7 @@ manage_filter_controls (const gchar *filter, int *first, int *max,
       if (first)
         *first = 1;
       if (max)
-        *max = -1;
+        *max = -2;
       if (sort_field)
         *sort_field = g_strdup ("name");
       if (sort_order)
@@ -2275,7 +2268,7 @@ manage_filter_controls (const gchar *filter, int *first, int *max,
   point = (keyword_t**) split->pdata;
   if (max)
     {
-      *max = -1;
+      *max = -2;
       while (*point)
         {
           keyword_t *keyword;
@@ -3375,7 +3368,7 @@ filter_clause (const char* type, const char* filter,
   /* Add SQL to the clause for each keyword or phrase. */
 
   if (max_return)
-    *max_return = -1;
+    *max_return = -2;
 
   clause = g_string_new ("");
   order = g_string_new ("");

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -26589,7 +26589,24 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   </command>
 
   <!-- Compatibility changes between versions. -->
-
+  <change>
+    <command>GET_... Commands using filters</command>
+    <summary>GET_... commands will default to "rows=-2" filter</summary>
+    <description>
+      <p>
+        If no filter or a filter without a rows keyword is given, the various
+        GET_... commands using filters will behave as if "rows=-2" was given
+        instead of "rows=-1".
+      </p>
+      <p>
+        This means they will only return the number of rows defined by the
+        "Rows Per Page" setting and the maximum amount of rows has to be
+        requested explicitly with a "rows=-1" filter keyword or 
+        (where available) the ignore_pagination option.
+      </p>
+    </description>
+    <version>9.0</version>
+  </change>
   <change>
     <command>GET_TASKS</command>
     <summary>HOST_PROGRESS only shown with active details</summary>


### PR DESCRIPTION
If no filter or a filter without a rows keyword is given, the various
GET_... commands using filters will behave as if "rows=-2" was given
instead of "rows=-1".

This means they will only return the number of rows defined by the
"Rows Per Page" setting and the maximum amount of rows has to be
requested explicitly with a "rows=-1" filter keyword or
(where available) the ignore_pagination option.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
