### PR TITLE
Setup general task preferences to launch an osp openvas task.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix result_nvt for new OSP and slave results [#865](https://github.com/greenbone/gvmd/pull/865)
 - Use right format specifier for merge_ovaldef version [#874](https://github.com/greenbone/gvmd/pull/874)
 - Fix creation of "Super" permissions [#892](https://github.com/greenbone/gvmd/pull/892)
+- Setup general task preferences to launch an osp openvas task. [#898](https://github.com/greenbone/gvmd/pull/898)
 
 ### Removed
 - Remove 1.3.6.1.4.1.25623.1.0.90011 from Discovery config (9.0) [#847](https://github.com/greenbone/gvmd/pull/847)

--- a/src/manage.c
+++ b/src/manage.c
@@ -4072,6 +4072,7 @@ launch_osp_openvas_task (task_t task, target_t target, const char *scan_id,
   GHashTable *vts_hash_table;
   osp_credential_t *ssh_credential, *smb_credential, *esxi_credential;
   osp_credential_t *snmp_credential;
+  gchar *max_checks, *max_hosts, *source_iface, *hosts_ordering;
   GHashTable *scanner_options;
   int ret;
   config_t config;
@@ -4161,6 +4162,25 @@ launch_osp_openvas_task (task_t task, target_t target, const char *scan_id,
                                 g_strdup (osp_value));
         }
     }
+
+  /* Setup general task preferences */
+  max_checks = task_preference_value (task, "max_checks");
+  g_hash_table_insert (scanner_options, g_strdup ("max_checks"),
+                       max_checks ? max_checks : g_strdup (MAX_CHECKS_DEFAULT));
+
+  max_hosts = task_preference_value (task, "max_hosts");
+  g_hash_table_insert (scanner_options, g_strdup ("max_hosts"),
+                       max_hosts ? max_hosts : g_strdup (MAX_HOSTS_DEFAULT));
+
+  source_iface = task_preference_value (task, "source_iface");
+  if (source_iface)
+    g_hash_table_insert (scanner_options, g_strdup ("source_ifae"),
+                        source_iface);
+
+  hosts_ordering = task_hosts_ordering (task);
+  if (hosts_ordering)
+    g_hash_table_insert (scanner_options, g_strdup ("host_ordering"),
+                         hosts_ordering);
 
   /* Setup vulnerability tests (without preferences) */
   vts = NULL;


### PR DESCRIPTION
When a task is started, it sends now the max_checks, max_hosts, source_iface and hosts_ordering options to the scanner.