### PR TITLE
Split CPE file to reduce sync memory usage (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Try importing private keys with libssh if GnuTLS fails [#841](https://github.com/greenbone/gvmd/pull/841)
 - Allow resuming OSPd-based OpenVAS tasks [#869](https://github.com/greenbone/gvmd/pull/869)
 - Require Postgres 9.6 as a minimum [#872](https://github.com/greenbone/gvmd/pull/872)
-- Speed up the SCAP sync [#875](https://github.com/greenbone/gvmd/pull/875) [#877](https://github.com/greenbone/gvmd/pull/877) [#879](https://github.com/greenbone/gvmd/pull/879) [#881](https://github.com/greenbone/gvmd/pull/881) [#883](https://github.com/greenbone/gvmd/pull/883) [#887](https://github.com/greenbone/gvmd/pull/887) [#889](https://github.com/greenbone/gvmd/pull/889) [#890](https://github.com/greenbone/gvmd/pull/890) [#891](https://github.com/greenbone/gvmd/pull/891)
+- Speed up the SCAP sync [#875](https://github.com/greenbone/gvmd/pull/875) [#877](https://github.com/greenbone/gvmd/pull/877) [#879](https://github.com/greenbone/gvmd/pull/879) [#881](https://github.com/greenbone/gvmd/pull/881) [#883](https://github.com/greenbone/gvmd/pull/883) [#887](https://github.com/greenbone/gvmd/pull/887) [#889](https://github.com/greenbone/gvmd/pull/889) [#890](https://github.com/greenbone/gvmd/pull/890) [#891](https://github.com/greenbone/gvmd/pull/891) [#901](https://github.com/greenbone/gvmd/pull/901)
 - Change rows of built-in default filters to -2 (use "Rows Per Page" setting) [#896](https://github.com/greenbone/gvmd/pull/896)
 - Force NVT update in migrate_219_to_220 [#895](https://github.com/greenbone/gvmd/pull/895)
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,6 +20,7 @@ Prerequisites:
 * PostgreSQL database >= 9.6
 * pkg-config
 * libical >= 1.0.0
+* xml_split (optional, lowers sync memory usage, Debian package: xml-twig-tools)
 
 Prerequisites for certificate generation:
 * GnuTLS certtool

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -198,7 +198,7 @@ split_xml_file (gchar *path, const gchar *size)
   if (previous_dir == NULL)
     {
       g_warning ("%s: Failed to getcwd: %s",
-                 __FUNCTION__,
+                 __func__,
                  strerror (errno));
       return NULL;
     }
@@ -253,7 +253,7 @@ split_xml_file (gchar *path, const gchar *size)
 
   if (chdir (previous_dir))
     g_warning ("%s: Failed to chdir back (will continue anyway)",
-               __FUNCTION__);
+               __func__);
 
   g_free (previous_dir);
 
@@ -2365,7 +2365,7 @@ update_scap_cpes_from_file (const gchar *path, int last_cve_update)
   int updated_scap_cpes;
   inserts_t inserts;
 
-  g_debug ("%s: parsing %s", __FUNCTION__, path);
+  g_debug ("%s: parsing %s", __func__, path);
 
   updated_scap_cpes = 0;
 
@@ -2374,7 +2374,7 @@ update_scap_cpes_from_file (const gchar *path, int last_cve_update)
   if (error)
     {
       g_warning ("%s: Failed to get contents: %s",
-                 __FUNCTION__,
+                 __func__,
                  error->message);
       g_error_free (error);
       return -1;
@@ -2383,7 +2383,7 @@ update_scap_cpes_from_file (const gchar *path, int last_cve_update)
   if (parse_element (xml, &element))
     {
       g_free (xml);
-      g_warning ("%s: Failed to parse element", __FUNCTION__);
+      g_warning ("%s: Failed to parse element", __func__);
       return -1;
     }
   g_free (xml);
@@ -2392,7 +2392,7 @@ update_scap_cpes_from_file (const gchar *path, int last_cve_update)
   if (strcmp (element_name (cpe_list), "cpe-list"))
     {
       element_free (element);
-      g_warning ("%s: CPE dictionary missing CPE-LIST", __FUNCTION__);
+      g_warning ("%s: CPE dictionary missing CPE-LIST", __func__);
       return -1;
     }
 
@@ -2429,7 +2429,7 @@ update_scap_cpes_from_file (const gchar *path, int last_cve_update)
       item_metadata = element_child (cpe_item, "meta:item-metadata");
       if (item_metadata == NULL)
         {
-          g_warning ("%s: item-metadata missing", __FUNCTION__);
+          g_warning ("%s: item-metadata missing", __func__);
           goto fail;
         }
 
@@ -2437,7 +2437,7 @@ update_scap_cpes_from_file (const gchar *path, int last_cve_update)
                                             "modification-date");
       if (modification_date == NULL)
         {
-          g_warning ("%s: modification-date missing", __FUNCTION__);
+          g_warning ("%s: modification-date missing", __func__);
           goto fail;
         }
 
@@ -2493,7 +2493,7 @@ update_scap_cpes (int last_scap_update)
   if (g_stat (full_path, &state))
     {
       g_warning ("%s: No CPE dictionary found at %s",
-                 __FUNCTION__,
+                 __func__,
                  strerror (errno));
       return -1;
     }

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -4987,6 +4987,7 @@ sync_scap (int lockfile)
   g_info ("%s: Updating data from feed", __FUNCTION__);
 
   g_debug ("%s: update cpes", __FUNCTION__);
+  proctitle_set ("gvmd: Syncing SCAP: Updating CPEs");
 
   updated_scap_cpes = update_scap_cpes (last_scap_update);
   if (updated_scap_cpes == -1)
@@ -4996,6 +4997,7 @@ sync_scap (int lockfile)
     }
 
   g_debug ("%s: update cves", __FUNCTION__);
+  proctitle_set ("gvmd: Syncing SCAP: Updating CVEs");
 
   updated_scap_cves = update_scap_cves (last_scap_update);
   if (updated_scap_cves == -1)
@@ -5005,6 +5007,7 @@ sync_scap (int lockfile)
     }
 
   g_debug ("%s: update ovaldefs", __FUNCTION__);
+  proctitle_set ("gvmd: Syncing SCAP: Updating OVALdefs");
 
   updated_scap_ovaldefs = update_scap_ovaldefs (last_scap_update,
                                                 0 /* Feed data. */);
@@ -5015,6 +5018,7 @@ sync_scap (int lockfile)
     }
 
   g_debug ("%s: updating user defined data", __FUNCTION__);
+  proctitle_set ("gvmd: Syncing SCAP: Updating private OVALdefs");
 
   switch (update_scap_ovaldefs (last_scap_update,
                                 1 /* Private data. */))
@@ -5030,11 +5034,13 @@ sync_scap (int lockfile)
     }
 
   g_debug ("%s: update max cvss", __FUNCTION__);
+  proctitle_set ("gvmd: Syncing SCAP: Updating max CVSS");
 
   update_scap_cvss (updated_scap_cves, updated_scap_cpes,
                     updated_scap_ovaldefs);
 
   g_debug ("%s: update placeholders", __FUNCTION__);
+  proctitle_set ("gvmd: Syncing SCAP: Updating placeholders");
 
   update_scap_placeholders (updated_scap_cves);
 
@@ -5047,6 +5053,7 @@ sync_scap (int lockfile)
     }
 
   g_info ("%s: Updating SCAP info succeeded", __FUNCTION__);
+  proctitle_set ("gvmd: Syncing SCAP: done");
 
   manage_update_scap_db_cleanup ();
 

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -175,7 +175,8 @@ increment_transaction_size (int* current_size)
  * @brief Split a file.
  *
  * @param[in]  path  Path to file.
- * @param[in]  size  Approx size of split files.
+ * @param[in]  size  Approx size of split files.  In same format that
+ *                   xml_split accepts, eg "200Kb".
  * @param[in]  tail  Text to replace last line of split files.
  *
  * @return Temp dir holding split files.

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -2367,6 +2367,8 @@ update_scap_cpes_from_file (const gchar *path, int last_cve_update)
 
   g_debug ("%s: parsing %s", __FUNCTION__, path);
 
+  updated_scap_cpes = 0;
+
   error = NULL;
   g_file_get_contents (path, &xml, &xml_len, &error);
   if (error)

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -219,6 +219,35 @@ split_xml_file (gchar *path, const gchar *size, const gchar *tail)
       return NULL;
     }
 
+  /* xml_split will chop split.xml into files that are roughly 'size' big.
+   *
+   * The generated files are always put in the directory that holds
+   * split.xml, as follows:
+   *
+   * split.xml      Source XML.
+   * split-00.xml   Master generated XML.  No content, just includes other
+   *                files.  The include statements are wrapped in the
+   *                root element from split.xml.
+   * split-01.xml   Generated XML content.  Wrapped in an <xml_split:root>
+   *                element.
+   * split-02.xml   Second generated content file.
+   * ...
+   * split-112.xml  Last content, for example.
+   *
+   * Parsing the generated files independently will only work if the files
+   * contain the original root element (for example, because the parser
+   * requires the namespace definitions to be present).
+   *
+   * So the command below needs to mess around a little bit to replace the
+   * wrapper XML element in split-01.xml, split-02.xml, etc with the root
+   * element from split-00.xml.
+   *
+   * Using tail and head is not super robust, but it's simple and it will
+   * work as long as xml_split keeps the opening of the wrapper element
+   * in split-00.xml on a dedicated line.  (It doesn't do this for the
+   * closing element, so we use the tail argument instead.)
+   */
+
   command = g_strdup_printf
              ("xml_split -s%s split.xml"
               " && head -n 2 split-00.xml > head.xml"

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -176,11 +176,12 @@ increment_transaction_size (int* current_size)
  *
  * @param[in]  path  Path to file.
  * @param[in]  size  Approx size of split files.
+ * @param[in]  tail  Text to replace last line of split files.
  *
  * @return Temp dir holding split files.
  */
 static const gchar *
-split_xml_file (gchar *path, const gchar *size)
+split_xml_file (gchar *path, const gchar *size, const gchar *tail)
 {
   int ret;
   static gchar dir[] = "/tmp/gvmd-split-xml-file-XXXXXX";
@@ -221,7 +222,7 @@ split_xml_file (gchar *path, const gchar *size)
   command = g_strdup_printf
              ("xml_split -s%s split.xml"
               " && head -n 2 split-00.xml > head.xml"
-              " && echo '</cpe-list>' > tail.xml"
+              " && echo '%s' > tail.xml"
               " && for F in split-*.xml; do"
               "    tail -n +3 $F"
               "    | head -n -1"
@@ -229,7 +230,8 @@ split_xml_file (gchar *path, const gchar *size)
               "    > new.xml;"
               "    mv new.xml $F;"
               "    done",
-              size);
+              size,
+              tail);
 
   g_debug ("%s: command: %s", __func__, command);
   ret = system (command);
@@ -2512,7 +2514,7 @@ update_scap_cpes (int last_scap_update)
   last_cve_update = sql_int ("SELECT max (modification_time)"
                              " FROM scap.cves;");
 
-  split_dir = split_xml_file (full_path, "40Mb");
+  split_dir = split_xml_file (full_path, "40Mb", "</cpe-list>");
   if (split_dir == NULL)
     {
       g_warning ("%s: Failed to split CPEs, attempting with full file",


### PR DESCRIPTION
This reduces the maximum amount of memory used by the CPE update during the SCAP sync, by parsing 40Mb chunks of the CPE dictionary at a time, instead of parsing the whole 162Mb dictionary.

My gvmd sync process is now maxing at about 3.5% of 16GB where it was 9% before.

gvmd creates the chunks itself, in a temp directory, using system to run a shell command.  Not the best, but g_spawn_sync has trouble here because we're already handling child signals (because we've forked a process to run the sync).  Also the XML wrapper replacements done by the shell command would be tedious to do in C.

This also add details to the proctitle during sync to make it easier to see where memory is spiking.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
