### PR TITLE
Add "_and_report_id" to get_results filter options (9.0)

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -16397,6 +16397,8 @@ handle_get_results (gmp_parser_t *gmp_parser, GError **error)
       iterator_t results;
       int notes, overrides;
       int count, ret, first;
+      gchar *report_id;
+      report_t report;
 
       if (get_results_data->get.filt_id
           && strcmp (get_results_data->get.filt_id, FILT_ID_NONE))
@@ -16414,8 +16416,32 @@ handle_get_results (gmp_parser_t *gmp_parser, GError **error)
       // Do not allow ignore_pagination here
       get_results_data->get.ignore_pagination = 0;
 
+      /* Note: This keyword may be removed or renamed at any time once there
+       * is a better solution like an operator for conditions that must always
+       * apply or support for parentheses in filters. */
+      report_id = filter_term_value (filter,
+                                     "_and_report_id");
+      report = 0;
+
+      if (report_id)
+        {
+          if (find_report_with_permission (report_id,
+                                           &report,
+                                           NULL))
+            {
+              g_free (report_id);
+              g_warning ("Failed to get report");
+              SEND_TO_CLIENT_OR_FAIL (XML_INTERNAL_ERROR ("get_results"));
+              return;
+            }
+
+          if (report == 0)
+            report = -1;
+        }
+      g_free (report_id);
+
       init_result_get_iterator (&results, &get_results_data->get,
-                                0,  /* No report restriction */
+                                report,  /* report restriction */
                                 NULL, /* No host restriction */
                                 NULL);  /* No extra order SQL. */
 
@@ -16489,7 +16515,7 @@ handle_get_results (gmp_parser_t *gmp_parser, GError **error)
 
           filtered = get_results_data->get.id
                       ? 1 : result_count (&get_results_data->get,
-                                          0 /* No report */,
+                                          report /* No report */,
                                           NULL /* No host */);
 
           if (send_get_end ("result", &get_results_data->get, count, filtered,

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -64744,11 +64744,36 @@ type_extra_where (const char *type, int trash, const char *filter,
   else if (strcasecmp (type, "RESULT") == 0)
     {
       int autofp, apply_overrides;
+      gchar *report_id;
+      report_t report;
+
+      /* Note: This keyword may be removed or renamed at any time once there
+       * is a better solution like an operator for conditions that must always
+       * apply or support for parentheses in filters. */
+      report_id = filter_term_value (filter,
+                                     "_and_report_id");
+      report = 0;
+
+      if (report_id)
+        {
+          if (find_report_with_permission (report_id,
+                                           &report,
+                                           NULL))
+            {
+              g_free (report_id);
+              g_warning ("Failed to get report");
+              return NULL;
+            }
+
+          if (report == 0)
+            report = -1;
+        }
+      g_free (report_id);
 
       autofp = filter_term_autofp (filter);
       apply_overrides = filter_term_apply_overrides (filter);
 
-      extra_where = results_extra_where (trash, 0, NULL,
+      extra_where = results_extra_where (trash, report, NULL,
                                          autofp, apply_overrides,
                                          setting_dynamic_severity_int (),
                                          filter);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -24352,6 +24352,12 @@ init_result_get_iterator (iterator_t* iterator, const get_data_t *get,
 
   gchar *extra_tables, *extra_where;
 
+  if (report == -1)
+    {
+      init_iterator (iterator, "SELECT NULL WHERE false;");
+      return 0;
+    }
+
   if (get->filt_id && strcmp (get->filt_id, FILT_ID_NONE))
     {
       filter = filter_term (get->filt_id);
@@ -24415,6 +24421,9 @@ result_count (const get_data_t *get, report_t report, const char* host)
   gchar *filter;
   int apply_overrides, autofp, dynamic_severity;
   gchar *extra_tables, *extra_where;
+
+  if (report == -1)
+    return 0;
 
   if (get->filt_id && strcmp (get->filt_id, FILT_ID_NONE))
     {


### PR DESCRIPTION
This keyword makes the GMP get_results command return only results for a
given report.

This keyword may be removed or renamed at any time once there is a
better solution like an operator for conditions that must always apply
or support for parentheses in filters.

**Checklist**:
- Tests N/A
- [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
