### PR TITLE
Add "_and_report_id" to get_results filter options (8.0)

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -24663,6 +24663,12 @@ init_result_get_iterator (iterator_t* iterator, const get_data_t *get,
 
   gchar *extra_tables, *extra_where;
 
+  if (report == -1)
+    {
+      init_iterator (iterator, "SELECT NULL WHERE false;");
+      return 0;
+    }
+
   if (get->filt_id && strcmp (get->filt_id, FILT_ID_NONE))
     {
       filter = filter_term (get->filt_id);
@@ -24726,6 +24732,9 @@ result_count (const get_data_t *get, report_t report, const char* host)
   gchar *filter;
   int apply_overrides, autofp, dynamic_severity;
   gchar *extra_tables, *extra_where;
+
+  if (report == -1)
+    return 0;
 
   if (get->filt_id && strcmp (get->filt_id, FILT_ID_NONE))
     {

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -69656,11 +69656,36 @@ type_extra_where (const char *type, int trash, const char *filter)
   else if (strcasecmp (type, "RESULT") == 0)
     {
       int autofp, apply_overrides;
+      gchar *report_id;
+      report_t report;
+
+      /* Note: This keyword may be removed or renamed at any time once there
+       * is a better solution like an operator for conditions that must always
+       * apply or support for parentheses in filters. */
+      report_id = filter_term_value (filter,
+                                     "_and_report_id");
+      report = 0;
+
+      if (report_id)
+        {
+          if (find_report_with_permission (report_id,
+                                           &report,
+                                           NULL))
+            {
+              g_free (report_id);
+              g_warning ("Failed to get report");
+              return NULL;
+            }
+
+          if (report == 0)
+            report = -1;
+        }
+      g_free (report_id);
 
       autofp = filter_term_autofp (filter);
       apply_overrides = filter_term_apply_overrides (filter);
 
-      extra_where = results_extra_where (trash, 0, NULL,
+      extra_where = results_extra_where (trash, report, NULL,
                                          autofp, apply_overrides,
                                          setting_dynamic_severity_int (),
                                          filter);


### PR DESCRIPTION
This keyword makes the GMP get_results command return only results for a
given report.

This keyword may be removed or renamed at any time once there is a
better solution like an operator for conditions that must always apply
or support for parentheses in filters.

**Checklist**:

- Tests N/A
- [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
