### PR TITLE
Add setting "BPM Data" (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add explicit columns for the NVT tags "summary", "insight", "detection", "impact" and "affected" [#719](https://github.com/greenbone/gvmd/pull/719) [#746](https://github.com/greenbone/gvmd/pull/746)
 - Add lean option to GET_REPORTS [#745](https://github.com/greenbone/gvmd/pull/745)
 - Add scanner relays and OSP sensor scanner type [#756](https://github.com/greenbone/gvmd/pull/756) [#759](https://github.com/greenbone/gvmd/pull/759)
+- Add setting "BPM Data" [#914](https://github.com/greenbone/gvmd/pull/914)
 
 ### Changed
 - Always convert iCalendar strings to use UTC. [#777](https://github.com/greenbone/gvmd/pull/777)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -59846,6 +59846,12 @@ modify_setting (const gchar *uuid, const gchar *name,
       /* Tickets */
       else if (strcmp (uuid, "70b0626f-a835-478e-8194-e09f97887a15") == 0)
         setting_name = g_strdup ("Tickets Top Dashboard Configuration");
+
+      /*
+       * Client data for business process maps
+       */
+      else if (strcmp (uuid, "3ce2d136-bb52-448a-93f0-20069566f877") == 0)
+        setting_name = g_strdup ("BPM Data");
     }
 
   if (setting_name)


### PR DESCRIPTION
This setting with UUID 3ce2d136-bb52-448a-93f0-20069566f877 is used for
storing data used by GSA to manage business process maps.

**Checklist**:

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
