### PR TITLE
Add setting "BPM Data" (master)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Allow use of public key auth in SCP alert [#845](https://github.com/greenbone/gvmd/pull/845)
 - Refuse to import config with missing NVT preference ID [#853](https://github.com/greenbone/gvmd/pull/853) [#860](https://github.com/greenbone/gvmd/pull/860)
 - Add "Base" scan config [#862](https://github.com/greenbone/gvmd/pull/862)
+- Add setting "BPM Data" [#915](https://github.com/greenbone/gvmd/pull/915)
 
 ### Changed
 - Update SCAP and CERT feed info in sync scripts [#810](https://github.com/greenbone/gvmd/pull/810)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -59764,6 +59764,12 @@ modify_setting (const gchar *uuid, const gchar *name,
       /* Business Process Model (BPM) */
       else if (strcmp (uuid, "3232d608-e5bb-415e-99aa-019f16eede8d") == 0)
         setting_name = g_strdup ("BPM Dashboard Configuration");
+
+      /*
+       * Client data for Business Process Modeling (BPM)
+       */
+      else if (strcmp (uuid, "3ce2d136-bb52-448a-93f0-20069566f877") == 0)
+        setting_name = g_strdup ("BPM Data");
     }
 
   if (setting_name)


### PR DESCRIPTION
This setting with UUID 3ce2d136-bb52-448a-93f0-20069566f877 is used for
storing data used by GSA to manage business process maps.

**Checklist**:

- N/A Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
