### PR TITLE
Add tags used for result NVTs to update_nvti_cache (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use right format specifier for merge_ovaldef version [#874](https://github.com/greenbone/gvmd/pull/874)
 - Fix creation of "Super" permissions [#892](https://github.com/greenbone/gvmd/pull/892)
 - Setup general task preferences to launch an osp openvas task. [#898](https://github.com/greenbone/gvmd/pull/898)
+- Add tags used for result NVTs to update_nvti_cache [#916](https://github.com/greenbone/gvmd/pull/916)
 
 ### Removed
 - Remove 1.3.6.1.4.1.25623.1.0.90011 from Discovery config (9.0) [#847](https://github.com/greenbone/gvmd/pull/847)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -15732,7 +15732,10 @@ update_nvti_cache ()
   nvti_cache = nvtis_new ();
 
   init_iterator (&nvts,
-                 "SELECT oid, name, family, cvss_base, tag, solution, solution_type FROM nvts;");
+                 "SELECT oid, name, family, cvss_base, tag,"
+                 "       solution, solution_type, summary, insight, affected,"
+                 "       impact, detection"
+                 " FROM nvts;");
   while (next (&nvts))
     {
       iterator_t refs;
@@ -15745,6 +15748,11 @@ update_nvti_cache ()
       nvti_set_tag (nvti, iterator_string (&nvts, 4));
       nvti_set_solution (nvti, iterator_string (&nvts, 5));
       nvti_set_solution_type (nvti, iterator_string (&nvts, 6));
+      nvti_set_summary (nvti, iterator_string (&nvts, 7));
+      nvti_set_insight (nvti, iterator_string (&nvts, 8));
+      nvti_set_affected (nvti, iterator_string (&nvts, 9));
+      nvti_set_impact (nvti, iterator_string (&nvts, 10));
+      nvti_set_detection (nvti, iterator_string (&nvts, 11));
 
       init_iterator (&refs,
                      "SELECT type, ref_id, ref_text"


### PR DESCRIPTION
When getting NVTs for results, some tags that were previously included
in "tag" are still fetched from the NVTi cache, so update_nvti_cache has
to fetch them from the nvts table.
These are: summary, insight, affected, impact and detection.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
