### PR TITLE
Remove REPORTS from GET_TASKS GMP doc

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -20833,7 +20833,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
               <e>trend</e>
               <o><e>current_report</e></o>
               <o><e>last_report</e></o>
-              <any><e>reports</e></any>
               <o><e>average_duration</e></o>
               <e>result_count</e>
               <e>preferences</e>
@@ -21297,81 +21296,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <ele>
               <name>scan_end</name>
               <pattern><t>iso_time</t></pattern>
-            </ele>
-            <ele>
-              <name>result_count</name>
-              <summary>Result counts for this report</summary>
-              <pattern>
-                <e>debug</e>
-                <e>false_positive</e>
-                <e>log</e>
-                <e>info</e>
-                <e>warning</e>
-                <e>hole</e>
-              </pattern>
-              <ele>
-                <name>debug</name>
-                <pattern><t>integer</t></pattern>
-              </ele>
-              <ele>
-                <name>false_positive</name>
-                <pattern><t>integer</t></pattern>
-              </ele>
-              <ele>
-                <name>log</name>
-                <pattern><t>integer</t></pattern>
-              </ele>
-              <ele>
-                <name>info</name>
-                <pattern><t>integer</t></pattern>
-              </ele>
-              <ele>
-                <name>warning</name>
-                <pattern><t>integer</t></pattern>
-              </ele>
-              <ele>
-                <name>hole</name>
-                <pattern><t>integer</t></pattern>
-              </ele>
-            </ele>
-            <ele>
-              <name>severity</name>
-              <pattern><t>severity</t></pattern>
-              <summary>Maximum severity of the report</summary>
-            </ele>
-          </ele>
-        </ele>
-        <ele>
-          <name>reports</name>
-          <pattern>
-            <any><e>report</e></any>
-          </pattern>
-          <ele>
-            <name>report</name>
-            <pattern>
-              <attrib>
-                <name>id</name>
-                <type>uuid</type>
-                <required>1</required>
-              </attrib>
-              <e>timestamp</e>
-              <e>scan_end</e>
-              <e>scan_run_status</e>
-              <e>result_count</e>
-              <e>severity</e>
-            </pattern>
-            <ele>
-              <name>timestamp</name>
-              <pattern><t>iso_time</t></pattern>
-            </ele>
-            <ele>
-              <name>scan_end</name>
-              <pattern><t>iso_time</t></pattern>
-            </ele>
-            <ele>
-              <name>scan_run_status</name>
-              <summary>Run status of task scan</summary>
-              <pattern><t>task_status</t></pattern>
             </ele>
             <ele>
               <name>result_count</name>


### PR DESCRIPTION
This element was removed in [r28136](https://github.com/greenbone/gvmd/commit/bed8f3683d0a472fba632bfa759648e855dfa32f) in early 2017.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
