### PR TITLE
Apply usage_type of tasks in get_aggregates (master)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix result_nvt for new OSP and slave results [#873](https://github.com/greenbone/gvmd/pull/873)
 - Use right format specifier for merge_ovaldef version [#874](https://github.com/greenbone/gvmd/pull/874)
 - Fix creation of "Super" permissions [#892](https://github.com/greenbone/gvmd/pull/892)
+- Apply usage_type of tasks in get_aggregates (9.0) [#929](https://github.com/greenbone/gvmd/pull/929)
 
 ### Removed
 - Remove support for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -64630,14 +64630,24 @@ type_extra_where (const char *type, int trash, const char *filter,
 
   if (strcasecmp (type, "CONFIG") == 0 && extra_params)
     {
-      gchar *usage_type = g_hash_table_lookup (extra_params, "usage_type");
+      gchar *usage_type;
+      if (extra_params)
+        usage_type = g_hash_table_lookup (extra_params, "usage_type");
+      else
+        usage_type = NULL;
+
       extra_where = configs_extra_where (usage_type);
       if (extra_where == NULL)
         extra_where = g_strdup ("");
     }
   else if (strcasecmp (type, "TASK") == 0)
     {
-      gchar *usage_type = g_hash_table_lookup (extra_params, "usage_type");
+      gchar *usage_type;
+      if (extra_params)
+        usage_type = g_hash_table_lookup (extra_params, "usage_type");
+      else
+        usage_type = NULL;
+
       extra_where = tasks_extra_where (trash, usage_type);
     }
   else if (strcasecmp (type, "TLS_CERTIFICATE") == 0)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -64637,10 +64637,8 @@ type_extra_where (const char *type, int trash, const char *filter,
     }
   else if (strcasecmp (type, "TASK") == 0)
     {
-      if (trash)
-        extra_where = g_strdup (" AND hidden = 2");
-      else
-        extra_where = g_strdup (" AND hidden = 0");
+      gchar *usage_type = g_hash_table_lookup (extra_params, "usage_type");
+      extra_where = tasks_extra_where (trash, usage_type);
     }
   else if (strcasecmp (type, "TLS_CERTIFICATE") == 0)
     {


### PR DESCRIPTION
This is a port of #912 to master.
The option was only applied for configs and ignored for tasks before.

**Checklist**:

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
