### PR TITLE
Ignore feed configs that are in the trash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix creation of "Super" permissions [#892](https://github.com/greenbone/gvmd/pull/892)
 - Add tags used for result NVTs to update_nvti_cache [#916](https://github.com/greenbone/gvmd/pull/916)
 - Apply usage_type of tasks in get_aggregates (9.0) [#912](https://github.com/greenbone/gvmd/pull/912)
+- Correct pref ID in migrate_219_to_220 [#941](https://github.com/greenbone/gvmd/pull/941)
 
 ### Removed
 - Remove support for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)

--- a/src/manage_configs.c
+++ b/src/manage_configs.c
@@ -432,6 +432,16 @@ sync_config_with_feed (const gchar *path)
       g_free (full_path);
       return;
     }
+
+  if (find_trash_config_no_acl (uuid, &config) == 0
+      && config)
+    {
+      g_warning ("%s: ignoring config '%s', as it is in the trashcan",
+                 __func__, uuid);
+      g_free (uuid);
+      return;
+    }
+
   g_free (uuid);
 
   g_debug ("%s: adding %s", __func__, path);

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -2037,6 +2037,43 @@ find_config_no_acl (const char *uuid, config_t *config)
 }
 
 /**
+ * @brief Find a trash config given a UUID.
+ *
+ * This does not do any permission checks.
+ *
+ * @param[in]   uuid     UUID of resource.
+ * @param[out]  config   Config return, 0 if no such config.
+ *
+ * @return FALSE on success (including if no such config), TRUE on error.
+ */
+gboolean
+find_trash_config_no_acl (const char *uuid, config_t *config)
+{
+  gchar *quoted_uuid;
+
+  quoted_uuid = sql_quote (uuid);
+  switch (sql_int64 (config,
+                     "SELECT id FROM configs_trash WHERE uuid = '%s';",
+                     quoted_uuid))
+    {
+      case 0:
+        break;
+      case 1:        /* Too few rows in result of query. */
+        *config = 0;
+        break;
+      default:       /* Programming error. */
+        assert (0);
+      case -1:
+        g_free (quoted_uuid);
+        return TRUE;
+        break;
+    }
+
+  g_free (quoted_uuid);
+  return FALSE;
+}
+
+/**
  * @brief Gets an NVT preference by id or by name.
  *
  * Note: This currently only gets the fields needed by create_config.

--- a/src/manage_sql_configs.h
+++ b/src/manage_sql_configs.h
@@ -78,6 +78,9 @@ configs_extra_where (const char *);
 gboolean
 find_config_no_acl (const char *, config_t *);
 
+gboolean
+find_trash_config_no_acl (const char *, config_t *);
+
 int
 config_updated_in_feed (config_t, const gchar *);
 


### PR DESCRIPTION
We do this because we can't add another config with the same UUID.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
