### PR TITLE
Fix alive test. Target's alive test setting has priority over scan config (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Setup general task preferences to launch an osp openvas task. [#898](https://github.com/greenbone/gvmd/pull/898)
 - Add tags used for result NVTs to update_nvti_cache [#916](https://github.com/greenbone/gvmd/pull/916)
 - Apply usage_type of tasks in get_aggregates (9.0) [#912](https://github.com/greenbone/gvmd/pull/912)
-- Setup target's alive test setting to launch an osp openvas task (9.0) [#936](https://github.com/greenbone/gvmd/pull/936)
+- Setup target's alive test setting to launch an osp openvas task (9.0) [#936](https://github.com/greenbone/gvmd/pull/936)[#943](https://github.com/greenbone/gvmd/pull/943)
 
 ### Removed
 - Remove 1.3.6.1.4.1.25623.1.0.90011 from Discovery config (9.0) [#847](https://github.com/greenbone/gvmd/pull/847)

--- a/src/manage.c
+++ b/src/manage.c
@@ -4261,19 +4261,19 @@ launch_osp_openvas_task (task_t task, target_t target, const char *scan_id,
     }
   cleanup_iterator (&prefs);
 
-  /* Setup alive tests */
+  /* Setup alive tests. This has priority over scan config settings */
   alive_test = target_alive_tests (target);
-
-  /* If ping_host test was added manually, the alive test target setting
-     is skipped to avoid reset the its nvt preferences */
-  alive_test_vt = g_hash_table_lookup (vts_hash_table, OID_PING_HOST);
-
-  if (alive_test != 0 && alive_test_vt == NULL)
+  if (alive_test != 0)
     {
-      alive_test_vt = osp_vt_single_new (OID_PING_HOST);
-      vts = g_slist_prepend (vts, alive_test_vt);
-      g_hash_table_replace (vts_hash_table, g_strdup (OID_PING_HOST),
-                            alive_test_vt);
+      alive_test_vt = g_hash_table_lookup (vts_hash_table, OID_PING_HOST);
+      if (alive_test_vt == NULL)
+        {
+          alive_test_vt = osp_vt_single_new (OID_PING_HOST);
+          vts = g_slist_prepend (vts, alive_test_vt);
+          g_hash_table_replace (vts_hash_table, g_strdup (OID_PING_HOST),
+                                alive_test_vt);
+
+        }
 
       osp_vt_single_add_value (alive_test_vt, "1",
                                (alive_test & ALIVE_TEST_TCP_ACK_SERVICE


### PR DESCRIPTION
Target's alive test setting has priority over the base settings in the scan config. If alive test in target is set, it will overwrite the scan config settings.
