### PR TITLE
Fix get_system_reports for GMP scanners (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove incorrect duplicates from config preference migrator [#940](https://github.com/greenbone/gvmd/pull/940)
 - Correct pref ID in migrate_219_to_220 [#941](https://github.com/greenbone/gvmd/pull/941)
 - Set run status only after getting OSP-OpenVAS scan [#948](https://github.com/greenbone/gvmd/pull/948)
+- Fix get_system_reports for GMP scanners [#949](https://github.com/greenbone/gvmd/pull/949)
 
 ### Removed
 - Remove 1.3.6.1.4.1.25623.1.0.90011 from Discovery config (9.0) [#847](https://github.com/greenbone/gvmd/pull/847)

--- a/src/manage.c
+++ b/src/manage.c
@@ -6216,7 +6216,6 @@ get_system_report_types (const char *required_type, gchar ***start,
       scanner_type_t slave_type;
 
       slave = 0;
-      slave_type = SCANNER_TYPE_NONE;
 
       if (find_scanner_with_permission (slave_id, &slave, "get_scanners"))
         return -1;

--- a/src/manage.c
+++ b/src/manage.c
@@ -6223,6 +6223,7 @@ get_system_report_types (const char *required_type, gchar ***start,
       if (slave == 0)
         return 2;
 
+      slave_type = scanner_type (slave);
       if (slave_type == SCANNER_TYPE_GMP)
         return get_slave_system_report_types (required_type, start, types,
                                               slave);


### PR DESCRIPTION
The get_system_report_types function did not fetch the scanner type so
it erroneously assumed it was handling an OSP scanner instead.

**Checklist**:
- [] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
