### PR TITLE
Set started variable in handle_osp_scan (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Setup target's alive test setting to launch an osp openvas task (9.0) [#936](https://github.com/greenbone/gvmd/pull/936)
 - Remove incorrect duplicates from config preference migrator [#940](https://github.com/greenbone/gvmd/pull/940)
 - Correct pref ID in migrate_219_to_220 [#941](https://github.com/greenbone/gvmd/pull/941)
-- Set run status only after getting OSP-OpenVAS scan [#948](https://github.com/greenbone/gvmd/pull/948)
+- Set run status only after getting OSP-OpenVAS scan [#948](https://github.com/greenbone/gvmd/pull/948) [#951](https://github.com/greenbone/gvmd/pull/951)
 - Fix get_system_reports for GMP scanners [#949](https://github.com/greenbone/gvmd/pull/949)
 
 ### Removed

--- a/src/manage.c
+++ b/src/manage.c
@@ -3650,6 +3650,7 @@ handle_osp_scan (task_t task, report_t report, const char *scan_id)
                   set_task_run_status (task, TASK_STATUS_RUNNING);
                   set_report_scan_run_status (global_current_report,
                                               TASK_STATUS_RUNNING);
+                  started = TRUE;
                 }
             }
         }


### PR DESCRIPTION
This is meant to prevent repeating status changes to "Running".

**Checklist**:

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
