### PR TITLE
Only set new_tag_return if copy_resource succeeds

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -59961,11 +59961,11 @@ copy_tag (const char* name, const char* comment, const char *tag_id,
                        "value, resource_type, active",
                        1, &new_tag, &old_tag);
 
-  if (new_tag_return)
-    *new_tag_return = new_tag;
-
   if (ret)
     return ret;
+
+  if (new_tag_return)
+    *new_tag_return = new_tag;
 
   sql ("INSERT INTO tag_resources"
        " (tag, resource_type, resource, resource_uuid, resource_location)"


### PR DESCRIPTION
This is not a real issue because copy_tag's caller only uses new_tag_return on success.  But the build checks picked up the error in https://github.com/greenbone/gvmd/pull/952, so fixing.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
