### PR TITLE
Allow "Start Task" alert method for SecInfo events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Change rows of built-in default filters to -2 (use "Rows Per Page" setting) [#896](https://github.com/greenbone/gvmd/pull/896)
 - Force NVT update in migrate_219_to_220 [#895](https://github.com/greenbone/gvmd/pull/895)
 - Use temp tables to speed up migrate_213_to_214 [#911](https://github.com/greenbone/gvmd/pull/911)
+- Allow "Start Task" alert method for SecInfo events [#960](https://github.com/greenbone/gvmd/pull/960)
 
 ### Fixed
 - Add NULL check in nvts_feed_version_epoch [#768](https://github.com/greenbone/gvmd/pull/768)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -7333,7 +7333,6 @@ check_alert_params (event_t event, alert_condition_t condition,
     {
       if (method == ALERT_METHOD_HTTP_GET
           || method == ALERT_METHOD_SOURCEFIRE
-          || method == ALERT_METHOD_START_TASK
           || method == ALERT_METHOD_VERINICE)
         return 20;
 
@@ -13757,15 +13756,6 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
           gvm_connection_t connection;
           char *task_id, *report_id, *owner_id, *owner_name;
           gmp_authenticate_info_opts_t auth_opts;
-
-          if (event == EVENT_NEW_SECINFO || event == EVENT_UPDATED_SECINFO)
-            {
-              g_warning ("%s: Event \"%s NVTs arrived\" with method"
-                         " \"Start Task\" not support",
-                         __func__,
-                         event == EVENT_NEW_SECINFO ? "New" : "Updated");
-              return -1;
-            }
 
           /* Run the callback to fork a child connected to the Manager. */
 


### PR DESCRIPTION
The method can now be used with the events "New SecInfo arrived" and
"Updated SecInfo arrived".

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
