### PR TITLE
Fix Verinice ISM report format and update version (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix get_system_reports for GMP scanners [#949](https://github.com/greenbone/gvmd/pull/949)
 - Use stop_osp_task for SCANNER_TYPE_OSP_SENSOR [#955](https://github.com/greenbone/gvmd/pull/955)
 - Setup target's reverse_lookup_* settings to launch an osp openvas task (9.0) [#958](https://github.com/greenbone/gvmd/pull/958)
+- Fix Verinice ISM report format and update version [#962](https://github.com/greenbone/gvmd/pull/962)
 
 ### Removed
 - Remove 1.3.6.1.4.1.25623.1.0.90011 from Discovery config (9.0) [#847](https://github.com/greenbone/gvmd/pull/847)

--- a/src/report_formats/Verinice_ISM/Verinice_ISM.xsl
+++ b/src/report_formats/Verinice_ISM/Verinice_ISM.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (C) 2011-2019 Greenbone Networks GmbH
+Copyright (C) 2011-2020 Greenbone Networks GmbH
 
 SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -93,8 +93,8 @@ Parameters:
     <xsl:value-of select="@id"/>
   </xsl:template>
 
-  <xsl:key name="scenarios" match="/report/results/result/nvt/@oid" use="." />
-  <xsl:key name="vulnerabilities" match="/report/results/result/nvt/@oid" use="." />
+  <xsl:key name="scenarios" match="/report/results/result[count(notes/note) &gt; 0 and threat != 'False Positive']/nvt/@oid" use="." />
+  <xsl:key name="vulnerabilities" match="/report/results/result[count(notes/note) &gt; 0 and threat != 'False Positive']/nvt/@oid" use="." />
   <xsl:key name="controls" match="/report/results/result/notes/note/@id" use="." />
 
   <xsl:template name="extract_organization">
@@ -469,7 +469,7 @@ CIS</value>
   <xsl:template match="report/host">
     <xsl:param name="task_id"/>
     <xsl:variable name="addr">
-      <xsl:value-of select="host"/>
+      <xsl:value-of select="ip"/>
     </xsl:variable>
     <xsl:variable name="extid">
       <xsl:choose>
@@ -839,15 +839,17 @@ CIS</value>
     </xsl:call-template>
 
     <xsl:for-each select="/report/results/result[nvt/@oid = $cur_oid]">
-      <syncLink>
-        <dependant><xsl:value-of select="$task_id"/>-<xsl:value-of select="$cur_oid"/>-scenario</dependant>
-        <dependency><xsl:value-of select="$task_id"/>-<xsl:value-of select="$cur_oid"/>-vulnerability</dependency>
-        <relationId>rel_incscen_vulnerability</relationId>
-      </syncLink>
+      <xsl:if test="generate-id(nvt/@oid) = generate-id(key('vulnerabilities', nvt/@oid)[1])">
+        <syncLink>
+          <dependant><xsl:value-of select="$task_id"/>-<xsl:value-of select="$cur_oid"/>-scenario</dependant>
+          <dependency><xsl:value-of select="$task_id"/>-<xsl:value-of select="$cur_oid"/>-vulnerability</dependency>
+          <relationId>rel_incscen_vulnerability</relationId>
+        </syncLink>
+      </xsl:if>
       <syncLink>
         <dependant><xsl:value-of select="$task_id"/>-<xsl:value-of select="$cur_oid"/>-scenario</dependant>
         <xsl:variable name="addr">
-          <xsl:value-of select="host"/>
+          <xsl:value-of select="host/text()"/>
         </xsl:variable>
         <xsl:variable name="extid">
           <xsl:choose>

--- a/src/report_formats/Verinice_ISM/report_format.xml
+++ b/src/report_formats/Verinice_ISM/report_format.xml
@@ -1,8 +1,8 @@
 <report_format id="c15ad349-bd8d-457a-880a-c7056532ee15">
   <name>Verinice ISM</name>
-  <summary>Greenbone Verinice ISM Report, v3.0.0.</summary>
+  <summary>Greenbone Verinice ISM Report, v3.2.0.</summary>
   <description>
-    Information Security Management Report for Verinice import, version 3.0.0.
+    Information Security Management Report for Verinice import, version 3.2.0.
   </description>
   <extension>vna</extension>
   <content_type>application/zip</content_type>


### PR DESCRIPTION
This fixes hosts not being added to the assets correctly,
vulnerabilities not being included or duplicated in the syncAttribute
elements if the same vulnerability was found multiple times on different
hosts.
The version number is updated to 3.2.0.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
