### PR TITLE
Always use details testing alerts with a report (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use stop_osp_task for SCANNER_TYPE_OSP_SENSOR [#955](https://github.com/greenbone/gvmd/pull/955)
 - Setup target's reverse_lookup_* settings to launch an osp openvas task (9.0) [#958](https://github.com/greenbone/gvmd/pull/958)
 - Always use details testing alerts with a report [#964](https://github.com/greenbone/gvmd/pull/964)
-- Fix Verinice ISM report format and update version [#962](https://github.com/greenbone/gvmd/pull/962)
 
 ### Removed
 - Remove 1.3.6.1.4.1.25623.1.0.90011 from Discovery config (9.0) [#847](https://github.com/greenbone/gvmd/pull/847)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use stop_osp_task for SCANNER_TYPE_OSP_SENSOR [#955](https://github.com/greenbone/gvmd/pull/955)
 - Setup target's reverse_lookup_* settings to launch an osp openvas task (9.0) [#958](https://github.com/greenbone/gvmd/pull/958)
 - Always use details testing alerts with a report [#964](https://github.com/greenbone/gvmd/pull/964)
+- Fix Verinice ISM report format and update version [#962](https://github.com/greenbone/gvmd/pull/962)
 
 ### Removed
 - Remove 1.3.6.1.4.1.25623.1.0.90011 from Discovery config (9.0) [#847](https://github.com/greenbone/gvmd/pull/847)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix get_system_reports for GMP scanners [#949](https://github.com/greenbone/gvmd/pull/949)
 - Use stop_osp_task for SCANNER_TYPE_OSP_SENSOR [#955](https://github.com/greenbone/gvmd/pull/955)
 - Setup target's reverse_lookup_* settings to launch an osp openvas task (9.0) [#958](https://github.com/greenbone/gvmd/pull/958)
+- Always use details testing alerts with a report [#964](https://github.com/greenbone/gvmd/pull/964)
 
 ### Removed
 - Remove 1.3.6.1.4.1.25623.1.0.90011 from Discovery config (9.0) [#847](https://github.com/greenbone/gvmd/pull/847)

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -15847,6 +15847,10 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
       if (request_report)
         cleanup_iterator (&reports);
 
+      /* Always enable details when using a report to test an alert. */
+      if (get_reports_data->alert_id)
+        get_reports_data->get.details = 1;
+
       ret = manage_send_report (report,
                                 delta_report,
                                 report_format,


### PR DESCRIPTION
When using get_reports to test an alert, details will always be enabled
as events and test_alert also always include report details.

**Checklist**:
- [] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
