### PR TITLE
Remove extra XML declaration in Anonymous XML (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix get_system_reports for GMP scanners [#949](https://github.com/greenbone/gvmd/pull/949)
 - Use stop_osp_task for SCANNER_TYPE_OSP_SENSOR [#955](https://github.com/greenbone/gvmd/pull/955)
 - Setup target's reverse_lookup_* settings to launch an osp openvas task (9.0) [#958](https://github.com/greenbone/gvmd/pull/958)
+- Remove extra XML declaration in Anonymous XML [#965](https://github.com/greenbone/gvmd/pull/965)
 
 ### Removed
 - Remove 1.3.6.1.4.1.25623.1.0.90011 from Discovery config (9.0) [#847](https://github.com/greenbone/gvmd/pull/847)

--- a/src/report_formats/Anonymous_XML/Anonymous_XML.xsl
+++ b/src/report_formats/Anonymous_XML/Anonymous_XML.xsl
@@ -10,6 +10,7 @@
     extension-element-prefixes="str date func gvm exslt">
   <xsl:output method="xml"
               indent="yes"
+              omit-xml-declaration="yes"
               encoding="UTF-8" />
 
 <!--


### PR DESCRIPTION
The XML generated by the XSL stylesheet would be embedded into the GMP
element, so the XML declaration should be omitted.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
