### PR TITLE
Fix SCP alert authentication and logging (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Always use details testing alerts with a report [#964](https://github.com/greenbone/gvmd/pull/964)
 - Remove extra XML declaration in Anonymous XML [#965](https://github.com/greenbone/gvmd/pull/965)
 - Fix Verinice ISM report format and update version [#962](https://github.com/greenbone/gvmd/pull/962)
+- Fix SCP alert authentication and logging [#972](https://github.com/greenbone/gvmd/pull/972)
 
 ### Removed
 - Remove 1.3.6.1.4.1.25623.1.0.90011 from Discovery config (9.0) [#847](https://github.com/greenbone/gvmd/pull/847)

--- a/src/alert_methods/SCP/alert
+++ b/src/alert_methods/SCP/alert
@@ -33,16 +33,19 @@ echo $KNOWN_HOSTS > $KNOWN_HOSTS_FILE
 ERROR_FILE=`mktemp` || exit 1
 
 log_error() {
-  logger "SCP alert: $1"
-  echo "$1" >&2
+  # remove \r used in line feed by scp or sshpass (\r\n)
+  # which can make journalctl interpret the output as blob data
+  MESSAGE=`echo "$1" | tr -d '\r'`
+  logger "SCP alert: $MESSAGE"
+  echo "$MESSAGE" >&2
 }
 
 # Escape destination twice because it is also expanded on the remote end.
 if [ -z "$PRIVATE_KEY_FILE" ]
 then
-  sshpass -f ${PASSWORD_FILE} scp -o BatchMode=yes -o HashKnownHosts=no -o UserKnownHostsFile="${KNOWN_HOSTS_FILE} ~/.ssh/known_hosts ~/.ssh/known_hosts2 /etc/ssh/ssh_known_hosts" "${REPORT_FILE}" "${USERNAME}@${HOST}:'${DEST}'" 2>$ERROR_FILE
+  sshpass -f ${PASSWORD_FILE} scp -o HashKnownHosts=no -o UserKnownHostsFile="${KNOWN_HOSTS_FILE} ~/.ssh/known_hosts ~/.ssh/known_hosts2 /etc/ssh/ssh_known_hosts" "${REPORT_FILE}" "${USERNAME}@${HOST}:'${DEST}'" 2>$ERROR_FILE
 else
-  sshpass -f ${PASSWORD_FILE} scp -i "$PRIVATE_KEY_FILE" -o PasswordAuthentication=no -o BatchMode=yes -o HashKnownHosts=no -o UserKnownHostsFile="${KNOWN_HOSTS_FILE} ~/.ssh/known_hosts ~/.ssh/known_hosts2 /etc/ssh/ssh_known_hosts" "${REPORT_FILE}" "${USERNAME}@${HOST}:'${DEST}'" 2>$ERROR_FILE
+  sshpass -f ${PASSWORD_FILE} -P "passphrase" scp -i "$PRIVATE_KEY_FILE" -o PasswordAuthentication=no -o HashKnownHosts=no -o UserKnownHostsFile="${KNOWN_HOSTS_FILE} ~/.ssh/known_hosts ~/.ssh/known_hosts2 /etc/ssh/ssh_known_hosts" "${REPORT_FILE}" "${USERNAME}@${HOST}:'${DEST}'" 2>$ERROR_FILE
 fi
 
 EXIT_CODE=$?


### PR DESCRIPTION
The BatchMode=yes option for scp is removed to make sshpass work and the
prompt expected by sshpass is adjusted for public key auth.

Carriage return characters are removed from the log output as they
can make journalctl interpret it as blob data.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
