### PR TITLE
Accept expanded scheme OIDs in parse_osp_report (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove extra XML declaration in Anonymous XML [#965](https://github.com/greenbone/gvmd/pull/965)
 - Fix Verinice ISM report format and update version [#962](https://github.com/greenbone/gvmd/pull/962)
 - Fix SCP alert authentication and logging [#972](https://github.com/greenbone/gvmd/pull/972)
+- Accept expanded scheme OIDs in parse_osp_report [#983](https://github.com/greenbone/gvmd/pull/983)
 
 ### Removed
 - Remove 1.3.6.1.4.1.25623.1.0.90011 from Discovery config (9.0) [#847](https://github.com/greenbone/gvmd/pull/847)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -31976,7 +31976,7 @@ parse_osp_report (task_t task, report_t report, const char *report_xml)
           results = next_entities (results);
           continue;
         }
-      else if (g_str_has_prefix (test_id, "1.3.6.1.4.1.25623.1.0."))
+      else if (g_str_has_prefix (test_id, "1.3.6.1.4.1.25623.1."))
         {
           nvt_id = g_strdup (test_id);
           severity_str = nvt_severity (test_id, type);


### PR DESCRIPTION
The OID prefix for vulnerability tests is "1.3.6.1.4.1.25623.1"
so the previous longer prefix "1.3.6.1.4.1.25623.1.0" limited the
selection to legacy tests while new categories like
"1.3.6.1.4.1.25623.1.1" for VTs based on OS vendor advisories were
not recognized as valid OIDs when adding results.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
