### PR TITLE
Accept expanded scheme OIDs in parse_osp_report (master)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Always use details testing alerts with a report [#964](https://github.com/greenbone/gvmd/pull/964)
 - Remove extra XML declaration in Anonymous XML [#965](https://github.com/greenbone/gvmd/pull/965)
 - Fix SecInfo alert filter conditions [#971](https://github.com/greenbone/gvmd/pull/971)
+- Accept expanded scheme OIDs in parse_osp_report [#984](https://github.com/greenbone/gvmd/pull/984)
 
 ### Removed
 - Remove support for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -29526,7 +29526,7 @@ parse_osp_report (task_t task, report_t report, const char *report_xml)
           results = next_entities (results);
           continue;
         }
-      else if (g_str_has_prefix (test_id, "1.3.6.1.4.1.25623.1.0."))
+      else if (g_str_has_prefix (test_id, "1.3.6.1.4.1.25623.1."))
         {
           nvt_id = g_strdup (test_id);
           severity_str = nvt_severity (test_id, type);


### PR DESCRIPTION
The OID prefix for vulnerability tests is "1.3.6.1.4.1.25623.1"
so the previous longer prefix "1.3.6.1.4.1.25623.1.0" limited the
selection to legacy tests while new categories like
"1.3.6.1.4.1.25623.1.1" for VTs based on OS vendor advisories were
not recognized as valid OIDs when adding results.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
