### PR TITLE
Fix SCAP update not finishing when CPEs are older (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix Verinice ISM report format and update version [#962](https://github.com/greenbone/gvmd/pull/962)
 - Fix SCP alert authentication and logging [#972](https://github.com/greenbone/gvmd/pull/972)
 - Accept expanded scheme OIDs in parse_osp_report [#983](https://github.com/greenbone/gvmd/pull/983)
+- Fix SCAP update not finishing when CPEs are older [#985](https://github.com/greenbone/gvmd/pull/985)
 
 ### Removed
 - Remove 1.3.6.1.4.1.25623.1.0.90011 from Discovery config (9.0) [#847](https://github.com/greenbone/gvmd/pull/847)

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -2535,7 +2535,7 @@ update_scap_cpes (int last_scap_update)
       g_info ("Skipping CPEs, file is older than last revision"
               " (this is not an error)");
       g_free (full_path);
-      return -1;
+      return 0;
     }
 
   g_info ("Updating CPEs");


### PR DESCRIPTION
The function update_scap_cpes handled the case where the CPEs file was
not changed with the last SCAP feed update as an error, so the update
never finished until the CPEs file was updated, causing gvmd to retry
again and again.

**Checklist**:

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
