### PR TITLE
Adjust report format dir handling for new ownership model

### DIFF
--- a/src/manage_report_formats.c
+++ b/src/manage_report_formats.c
@@ -236,22 +236,6 @@ get_report_format_files (const char *dir_name, GPtrArray **start)
 }
 
 /**
- * @brief Get the directory of a report format.
- *
- * @param[in]  uuid  Report format UUID.  NULL to get parent dir.
- *
- * @return Freshly allocated dir name.
- */
-gchar *
-predefined_report_format_dir (const gchar *uuid)
-{
-  return g_build_filename (GVMD_DATA_DIR,
-                           "report_formats",
-                           uuid,
-                           NULL);
-}
-
-/**
  * @brief Initialise a report format file iterator.
  *
  * @param[in]  iterator       Iterator.

--- a/src/manage_report_formats.c
+++ b/src/manage_report_formats.c
@@ -264,29 +264,21 @@ int
 init_report_format_file_iterator (file_iterator_t* iterator,
                                   report_format_t report_format)
 {
-  gchar *dir_name, *uuid;
+  gchar *dir_name, *uuid, *owner_uuid;
 
   uuid = report_format_uuid (report_format);
   if (uuid == NULL)
     return -1;
 
-  if (report_format_predefined (report_format))
-    dir_name = predefined_report_format_dir (uuid);
-  else
-    {
-      gchar *owner_uuid;
-
-      owner_uuid = report_format_owner_uuid (report_format);
-      if (owner_uuid == NULL)
-        return -1;
-      dir_name = g_build_filename (GVMD_STATE_DIR,
-                                   "report_formats",
-                                   owner_uuid,
-                                   uuid,
-                                   NULL);
-      g_free (owner_uuid);
-    }
-
+  owner_uuid = report_format_owner_uuid (report_format);
+  if (owner_uuid == NULL)
+    return -1;
+  dir_name = g_build_filename (GVMD_STATE_DIR,
+                               "report_formats",
+                               owner_uuid,
+                               uuid,
+                               NULL);
+  g_free (owner_uuid);
   g_free (uuid);
 
   if (get_report_format_files (dir_name, &iterator->start))

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -51714,7 +51714,12 @@ manage_modify_setting (GSList *log_config, const gchar *database,
             {
               migrate_predefined_configs ();
               migrate_predefined_port_lists ();
-              migrate_predefined_report_formats ();
+              if (migrate_predefined_report_formats ())
+                {
+                  sql_rollback ();
+                  manage_option_cleanup ();
+                  return -1;
+                }
             }
         }
     }

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -56,9 +56,6 @@
 
 /* Non-SQL internals defined in manage_report_formats.c. */
 
-gchar *
-predefined_report_format_dir (const gchar *);
-
 int
 sync_report_formats_with_feed ();
 

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -3256,7 +3256,7 @@ run_report_format_script (gchar *report_format_id,
 {
   iterator_t formats;
   report_format_t report_format;
-  gchar *script, *script_dir;
+  gchar *script, *script_dir, *owner;
   get_data_t report_format_get;
 
   gchar *command;
@@ -3277,24 +3277,16 @@ run_report_format_script (gchar *report_format_id,
 
   report_format = get_iterator_resource (&formats);
 
-  if (report_format_predefined (report_format))
-    {
-      script_dir = predefined_report_format_dir (report_format_id);
-    }
-  else
-    {
-      gchar *owner;
-      owner = sql_string ("SELECT uuid FROM users"
-                          " WHERE id = (SELECT owner FROM"
-                          "             report_formats WHERE id = %llu);",
-                          report_format);
-      script_dir = g_build_filename (GVMD_STATE_DIR,
-                                     "report_formats",
-                                     owner,
-                                     report_format_id,
-                                     NULL);
-      g_free (owner);
-    }
+  owner = sql_string ("SELECT uuid FROM users"
+                      " WHERE id = (SELECT owner FROM"
+                      "             report_formats WHERE id = %llu);",
+                      report_format);
+  script_dir = g_build_filename (GVMD_STATE_DIR,
+                                 "report_formats",
+                                 owner,
+                                 report_format_id,
+                                 NULL);
+  g_free (owner);
 
   cleanup_iterator (&formats);
 

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -4098,78 +4098,6 @@ migrate_predefined_report_formats ()
 /* Startup. */
 
 /**
- * @brief Bring UUIDs for single predefined report format up to date.
- *
- * @param[in]  old  Old UUID.
- * @param[in]  new  New UUID.
- */
-static void
-update_report_format_uuid (const char *old, const char *new)
-{
-  gchar *dir;
-
-  dir = predefined_report_format_dir (old);
-  if (g_file_test (dir, G_FILE_TEST_EXISTS))
-    gvm_file_remove_recurse (dir);
-  g_free (dir);
-
-  sql ("UPDATE report_formats"
-       " SET uuid = '%s', modification_time = m_now ()"
-       " WHERE uuid = '%s';",
-       new,
-       old);
-
-  sql ("UPDATE alert_method_data"
-       " SET data = '%s'"
-       " WHERE data = '%s';",
-       new,
-       old);
-}
-
-/**
- * @brief Bring report format UUIDs in database up to date.
- */
-static void
-update_report_format_uuids ()
-{
-  /* Same as migrate_58_to_59, to enable backporting r13519 to OpenVAS-5
-   * without backporting the 58 to 59 migrator.  In future these should be
-   * done here instead of in a migrator. */
-
-  update_report_format_uuid ("a0704abb-2120-489f-959f-251c9f4ffebd",
-                             "5ceff8ba-1f62-11e1-ab9f-406186ea4fc5");
-
-  update_report_format_uuid ("b993b6f5-f9fb-4e6e-9c94-dd46c00e058d",
-                             "6c248850-1f62-11e1-b082-406186ea4fc5");
-
-  update_report_format_uuid ("929884c6-c2c4-41e7-befb-2f6aa163b458",
-                             "77bd6c4a-1f62-11e1-abf0-406186ea4fc5");
-
-  update_report_format_uuid ("9f1ab17b-aaaa-411a-8c57-12df446f5588",
-                             "7fcc3a1a-1f62-11e1-86bf-406186ea4fc5");
-
-  update_report_format_uuid ("f5c2a364-47d2-4700-b21d-0a7693daddab",
-                             "9ca6fe72-1f62-11e1-9e7c-406186ea4fc5");
-
-  update_report_format_uuid ("1a60a67e-97d0-4cbf-bc77-f71b08e7043d",
-                             "a0b5bfb2-1f62-11e1-85db-406186ea4fc5");
-
-  update_report_format_uuid ("19f6f1b3-7128-4433-888c-ccc764fe6ed5",
-                             "a3810a62-1f62-11e1-9219-406186ea4fc5");
-
-  update_report_format_uuid ("d5da9f67-8551-4e51-807b-b6a873d70e34",
-                             "a994b278-1f62-11e1-96ac-406186ea4fc5");
-
-  /* New updates go here.  Oldest must come first, so add at the end. */
-
-  update_report_format_uuid ("7fcc3a1a-1f62-11e1-86bf-406186ea4fc5",
-                             "a684c02c-b531-11e1-bdc2-406186ea4fc5");
-
-  update_report_format_uuid ("a0b5bfb2-1f62-11e1-85db-406186ea4fc5",
-                             "c402cc3e-b531-11e1-9163-406186ea4fc5");
-}
-
-/**
  * @brief Ensure every report format has a unique UUID.
  *
  * @return 0 success, -1 error.
@@ -4414,8 +4342,6 @@ check_db_report_formats ()
   if (check_db_trash_report_formats ())
     return -1;
 
-  /* Bring report format UUIDs in database up to date. */
-  update_report_format_uuids ();
   if (make_report_format_uuids_unique ())
     return -1;
 

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -1312,9 +1312,9 @@ copy_report_format (const char* name, const char* source_uuid,
                     report_format_t* new_report_format)
 {
   report_format_t new, old;
-  gchar *copy_uuid, *source_dir, *copy_dir;
+  gchar *copy_uuid, *source_dir, *copy_dir, *owner_uuid;
   gchar *tmp_dir;
-  int predefined, ret;
+  int ret;
 
   assert (current_credentials.uuid);
 
@@ -1350,21 +1350,14 @@ copy_report_format (const char* name, const char* source_uuid,
 
   /* Copy files on disk. */
 
-  predefined = report_format_predefined (old);
-  if (predefined)
-    source_dir = predefined_report_format_dir (source_uuid);
-  else
-    {
-      gchar *owner_uuid;
-      owner_uuid = report_format_owner_uuid (old);
-      assert (owner_uuid);
-      source_dir = g_build_filename (GVMD_STATE_DIR,
-                                     "report_formats",
-                                     owner_uuid,
-                                     source_uuid,
-                                     NULL);
-      g_free (owner_uuid);
-    }
+  owner_uuid = report_format_owner_uuid (old);
+  assert (owner_uuid);
+  source_dir = g_build_filename (GVMD_STATE_DIR,
+                                 "report_formats",
+                                 owner_uuid,
+                                 source_uuid,
+                                 NULL);
+  g_free (owner_uuid);
 
   /* Check that the source directory exists. */
 

--- a/src/manage_sql_report_formats.h
+++ b/src/manage_sql_report_formats.h
@@ -71,7 +71,7 @@ update_report_format (report_format_t, const gchar *, const gchar *,
 int
 report_format_updated_in_feed (report_format_t, const gchar *);
 
-void
+int
 migrate_predefined_report_formats ();
 
 int


### PR DESCRIPTION
This removes special handling of "predefined" report formats.  They are now feed report formats, so they mostly work like regular report formats.

Also adds a missing step to the startup migration for the predefined report formats, that was exposed with the special handling removed.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
