### PR TITLE
Delete report format dirs when deleting user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Accept expanded scheme OIDs in parse_osp_report [#984](https://github.com/greenbone/gvmd/pull/984)
 - Fix SCAP update not finishing when CPEs are older [#986](https://github.com/greenbone/gvmd/pull/986)
 - Move report format dirs when inheriting user [#989](https://github.com/greenbone/gvmd/pull/989)
+- Delete report format dirs when deleting user [#993](https://github.com/greenbone/gvmd/pull/993)
 
 ### Removed
 - Remove support for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -53086,6 +53086,16 @@ delete_user (const char *user_id_arg, const char *name_arg, int ultimate,
     }
   delete_port_lists_user (user);
 
+  /* Check credentials before deleting report formats, because we can't
+   * rollback the deletion of the report format dirs. */
+  if (user_resources_in_use (user,
+                             "credentials", credential_in_use,
+                             "credentials_trash", trash_credential_in_use))
+    {
+      sql_rollback ();
+      return 9;
+    }
+
   /* Report formats (used by alerts). */
   if (user_resources_in_use (user,
                              "report_formats",
@@ -53100,13 +53110,6 @@ delete_user (const char *user_id_arg, const char *name_arg, int ultimate,
 
   /* Delete credentials last because they can be used in various places */
 
-  if (user_resources_in_use (user,
-                             "credentials", credential_in_use,
-                             "credentials_trash", trash_credential_in_use))
-    {
-      sql_rollback ();
-      return 9;
-    }
   sql ("DELETE FROM credentials_data WHERE credential IN"
        " (SELECT id FROM credentials WHERE owner = %llu);",
        user);


### PR DESCRIPTION
We had forgotten to delete the report format files that are stored on disk when deleting a user.  The report formats themselves were deleted fine from the db.

This has been like this for ages, but it's not so serious because the directory that holds the report formats are named using the user's UUID.  So at worst the directory will just hang around forever.

The trash directories are shared so there is potential for a clash there but I think gvmd will just overwrite the old dir.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
