### PR TITLE
Remove header comments

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -33,15 +33,13 @@
 #include <glib.h>
 #include <gnutls/gnutls.h>
 
-#include <gvm/base/array.h>       /* for array_t */
-#include <gvm/base/credentials.h> /* for credentials_t */
-#include <gvm/base/nvti.h>        /* for nvti_t */
-#include <gvm/base/networking.h>  /* for port_protocol_t */
-#include <gvm/util/serverutils.h> /* for gvm_connection_t */
-#include <gvm/util/authutils.h>   /* for auth_method_t */
-#include <gvm/osp/osp.h>          /* for osp_connection_t */
-
-
+#include <gvm/base/array.h>
+#include <gvm/base/credentials.h>
+#include <gvm/base/nvti.h>
+#include <gvm/base/networking.h>
+#include <gvm/util/serverutils.h>
+#include <gvm/util/authutils.h>
+#include <gvm/osp/osp.h>
 
 /**
  * @brief OID of ping_host.nasl

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -25,7 +25,7 @@
 #ifndef _GVMD_MANAGE_SQL_H
 #define _GVMD_MANAGE_SQL_H
 
-#include <gvm/util/xmlutils.h> /* for entity_t */
+#include <gvm/util/xmlutils.h>
 
 #include "manage.h"
 #include "manage_utils.h"


### PR DESCRIPTION
We do not use this type of comment for all include statements, and they add
maintenance overhead without adding much benefit, so better to remove them.
The reference for gvm/base/networking.h was out of date, for instance.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
