### PR TITLE
Add --rebuild and --update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Automatically load predefined report formats from the feed [#968](https://github.com/greenbone/gvmd/pull/968) [#970](https://github.com/greenbone/gvmd/pull/970)
 - Print UUIDs in --get-users when --verbose given [#991](https://github.com/greenbone/gvmd/pull/991)
 - Add --get-roles [#992](https://github.com/greenbone/gvmd/pull/992)
-- Add --rebuild and --update [#998](https://github.com/greenbone/gvmd/pull/998)
+- Add --rebuild [#998](https://github.com/greenbone/gvmd/pull/998)
 
 ### Changed
 - Update SCAP and CERT feed info in sync scripts [#810](https://github.com/greenbone/gvmd/pull/810)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Automatically load predefined report formats from the feed [#968](https://github.com/greenbone/gvmd/pull/968) [#970](https://github.com/greenbone/gvmd/pull/970)
 - Print UUIDs in --get-users when --verbose given [#991](https://github.com/greenbone/gvmd/pull/991)
 - Add --get-roles [#992](https://github.com/greenbone/gvmd/pull/992)
+- Add --rebuild and --update [#998](https://github.com/greenbone/gvmd/pull/998)
 
 ### Changed
 - Update SCAP and CERT feed info in sync scripts [#810](https://github.com/greenbone/gvmd/pull/810)

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -2777,29 +2777,13 @@ gvmd (int argc, char** argv)
   if (gvm_auth_init ())
     exit (EXIT_FAILURE);
 
-  /* Try to get OSP VT update socket from default OpenVAS if it
-   *  was not set with the --osp-vt-update option.
-   */
-  if (get_osp_vt_update_socket () == NULL)
+  if (check_osp_vt_update_socket ())
     {
-      char *default_socket = openvas_default_scanner_host ();
-      if (default_socket)
-        {
-          g_debug ("%s: Using OSP VT update socket from default OpenVAS"
-                   " scanner: %s",
-                   __func__,
-                   default_socket);
-          set_osp_vt_update_socket (default_socket);
-        }
-      else
-        {
-          g_critical ("%s: No OSP VT update socket found."
-                      " Use --osp-vt-update or change the 'OpenVAS Default'"
-                      " scanner to use the main ospd-openvas socket.",
-                      __func__);
-          return EXIT_FAILURE;
-        }
-      free (default_socket);
+      g_critical ("%s: No OSP VT update socket found."
+                  " Use --osp-vt-update or change the 'OpenVAS Default'"
+                  " scanner to use the main ospd-openvas socket.",
+                  __func__);
+      exit (EXIT_FAILURE);
     }
 
   /* Enter the main forever-loop. */

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1635,7 +1635,9 @@ gvmd (int argc, char** argv)
   static gchar *scanner_name = NULL;
   static gchar *rc_name = NULL;
   static gchar *relay_mapper = NULL;
+  static gboolean rebuild = FALSE;
   static gchar *role = NULL;
+  static gboolean update = FALSE;
   static gchar *disable = NULL;
   static gchar *value = NULL;
   GError *error = NULL;
@@ -1804,6 +1806,10 @@ gvmd (int argc, char** argv)
           &manager_port_string_2,
           "Use port number <number> for address 2.",
           "<number>" },
+        { "rebuild", 'm', 0, G_OPTION_ARG_NONE,
+          &rebuild,
+          "Remove NVT db, and rebuild it from the scanner.",
+          NULL },
         { "relay-mapper", '\0', 0, G_OPTION_ARG_FILENAME,
           &relay_mapper,
           "Executable for mapping scanner hosts to relays."
@@ -1874,6 +1880,10 @@ gvmd (int argc, char** argv)
           &manager_address_string_unix,
           "Listen on UNIX socket at <filename>.",
           "<filename>" },
+        { "update", 'm', 0, G_OPTION_ARG_NONE,
+          &update,
+          "Update entire NVT db from the scanner, without removing it first.",
+          NULL },
         { "user", '\0', 0, G_OPTION_ARG_STRING,
           &user,
           "User for --new-password.",
@@ -2228,6 +2238,38 @@ gvmd (int argc, char** argv)
         return EXIT_FAILURE;
 
       ret = manage_optimize (log_config, database, optimize);
+      log_config_free ();
+      if (ret)
+        return EXIT_FAILURE;
+      return EXIT_SUCCESS;
+    }
+
+  if (rebuild)
+    {
+      int ret;
+
+      proctitle_set ("gvmd: --rebuild");
+
+      if (option_lock (&lockfile_checking))
+        return EXIT_FAILURE;
+
+      ret = manage_rebuild (log_config, database);
+      log_config_free ();
+      if (ret)
+        return EXIT_FAILURE;
+      return EXIT_SUCCESS;
+    }
+
+  if (update)
+    {
+      int ret;
+
+      proctitle_set ("gvmd: --update");
+
+      if (option_lock (&lockfile_checking))
+        return EXIT_FAILURE;
+
+      ret = manage_update (log_config, database);
       log_config_free ();
       if (ret)
         return EXIT_FAILURE;

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1637,7 +1637,6 @@ gvmd (int argc, char** argv)
   static gchar *relay_mapper = NULL;
   static gboolean rebuild = FALSE;
   static gchar *role = NULL;
-  static gboolean update = FALSE;
   static gchar *disable = NULL;
   static gchar *value = NULL;
   GError *error = NULL;
@@ -1880,10 +1879,6 @@ gvmd (int argc, char** argv)
           &manager_address_string_unix,
           "Listen on UNIX socket at <filename>.",
           "<filename>" },
-        { "update", 'm', 0, G_OPTION_ARG_NONE,
-          &update,
-          "Update entire NVT db from the scanner, without removing it first.",
-          NULL },
         { "user", '\0', 0, G_OPTION_ARG_STRING,
           &user,
           "User for --new-password.",
@@ -2254,22 +2249,6 @@ gvmd (int argc, char** argv)
         return EXIT_FAILURE;
 
       ret = manage_rebuild (log_config, database);
-      log_config_free ();
-      if (ret)
-        return EXIT_FAILURE;
-      return EXIT_SUCCESS;
-    }
-
-  if (update)
-    {
-      int ret;
-
-      proctitle_set ("gvmd: --update");
-
-      if (option_lock (&lockfile_checking))
-        return EXIT_FAILURE;
-
-      ret = manage_update (log_config, database);
       log_config_free ();
       if (ret)
         return EXIT_FAILURE;

--- a/src/manage.h
+++ b/src/manage.h
@@ -3680,6 +3680,12 @@ gvm_get_sync_script_feed_version (const gchar *, gchar **);
 int
 manage_update_nvts_osp (const gchar *);
 
+int
+manage_rebuild (GSList *, const gchar *);
+
+int
+manage_update (GSList *, const gchar *);
+
 
 /* Wizards. */
 

--- a/src/manage.h
+++ b/src/manage.h
@@ -3683,9 +3683,6 @@ manage_update_nvts_osp (const gchar *);
 int
 manage_rebuild (GSList *, const gchar *);
 
-int
-manage_update (GSList *, const gchar *);
-
 
 /* Wizards. */
 

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1816,9 +1816,12 @@ update_or_rebuild (int update)
 
   osp_connection_close (connection);
 
+  if (update == 0)
+    sql ("TRUNCATE nvts;");
+
   if (update_nvt_cache_osp (osp_update_socket, NULL, scanner_feed_version))
     {
-      printf ("Failed to update NVT cache.\n");
+      printf ("Failed to %s NVT cache.\n", update ? "update" : "rebuild);
       return -1;
     }
 
@@ -1845,9 +1848,7 @@ manage_rebuild (GSList *log_config, const gchar *database)
   if (ret)
     return ret;
 
-  // FIX
-
-  current_credentials.uuid = NULL;
+  ret = update_or_rebuild (0);
 
   manage_option_cleanup ();
 

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1888,5 +1888,5 @@ manage_update (GSList *log_config, const gchar *database)
 
   manage_option_cleanup ();
 
-  return 0;
+  return ret;
 }

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1817,11 +1817,14 @@ update_or_rebuild (int update)
   osp_connection_close (connection);
 
   if (update == 0)
-    sql ("TRUNCATE nvts;");
+    {
+      sql ("TRUNCATE nvts;");
+      set_nvts_feed_version ("0");
+    }
 
   if (update_nvt_cache_osp (osp_update_socket, NULL, scanner_feed_version))
     {
-      printf ("Failed to %s NVT cache.\n", update ? "update" : "rebuild);
+      printf ("Failed to %s NVT cache.\n", update ? "update" : "rebuild");
       return -1;
     }
 
@@ -1848,7 +1851,12 @@ manage_rebuild (GSList *log_config, const gchar *database)
   if (ret)
     return ret;
 
+  sql_begin_immediate ();
   ret = update_or_rebuild (0);
+  if (ret)
+    sql_rollback ();
+  else
+    sql_commit ();
 
   manage_option_cleanup ();
 

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1862,31 +1862,3 @@ manage_rebuild (GSList *log_config, const gchar *database)
 
   return ret;
 }
-
-/**
- * @brief Update NVT db.
- *
- * @param[in]  log_config  Log configuration.
- * @param[in]  database    Location of manage database.
- *
- * @return 0 success, -1 error, -2 database is wrong version,
- *         -3 database needs to be initialised from server,
- *         -4 no osp update socket.
- */
-int
-manage_update (GSList *log_config, const gchar *database)
-{
-  int ret;
-
-  g_info ("   Updating NVTs.");
-
-  ret = manage_option_setup (log_config, database);
-  if (ret)
-    return ret;
-
-  ret = update_or_rebuild (1);
-
-  manage_option_cleanup ();
-
-  return ret;
-}

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1534,6 +1534,148 @@ check_preference_names (int trash, time_t modification_time)
 /**
  * @brief Update VTs via OSP.
  *
+ * @param[in]  update_socket         Socket to use to contact scanner.
+ * @param[in]  db_feed_version       Feed version from meta table.
+ * @param[in]  scanner_feed_version  Feed version from scanner.
+ *
+ * @return 0 success, -1 error.
+ */
+static int
+update_nvt_cache_osp (const gchar *update_socket, gchar *db_feed_version,
+                      gchar *scanner_feed_version)
+{
+  osp_connection_t *connection;
+  GSList *scanner_prefs;
+  entity_t vts;
+  osp_get_vts_opts_t get_vts_opts;
+  time_t old_nvts_last_modified;
+
+  if (db_feed_version == NULL
+      || strcmp (db_feed_version, "") == 0
+      || strcmp (db_feed_version, "0") == 0)
+    old_nvts_last_modified = 0;
+  else
+    old_nvts_last_modified
+      = (time_t) sql_int64_0 ("SELECT max(modification_time) FROM nvts");
+
+  connection = osp_connection_new (update_socket, 0, NULL, NULL, NULL);
+  if (!connection)
+    {
+      g_warning ("%s: failed to connect to %s (2)", __func__,
+                 update_socket);
+      return -1;
+    }
+
+  if (db_feed_version)
+    get_vts_opts.filter = g_strdup_printf ("modification_time>%s", db_feed_version);
+  else
+    get_vts_opts.filter = NULL;
+  if (osp_get_vts_ext (connection, get_vts_opts, &vts))
+    {
+      g_warning ("%s: failed to get VTs", __func__);
+      g_free (get_vts_opts.filter);
+      return -1;
+    }
+  g_free (get_vts_opts.filter);
+
+  osp_connection_close (connection);
+
+  update_nvts_from_vts (&vts, scanner_feed_version);
+  free_entity (vts);
+
+  /* Update scanner preferences */
+  connection = osp_connection_new (update_socket, 0, NULL, NULL, NULL);
+  if (!connection)
+    {
+      g_warning ("%s: failed to connect to %s (3)",
+                __func__, update_socket);
+      return -1;
+    }
+
+  scanner_prefs = NULL;
+  if (osp_get_scanner_details (connection, NULL, &scanner_prefs))
+    {
+      g_warning ("%s: failed to get scanner preferences", __func__);
+      osp_connection_close (connection);
+      return -1;
+    }
+  else
+    {
+      GString *prefs_sql;
+      GSList *point;
+      int first;
+
+      point = scanner_prefs;
+      first = 1;
+
+      osp_connection_close (connection);
+      prefs_sql = g_string_new ("INSERT INTO nvt_preferences (name, value)"
+                                " VALUES");
+      while (point)
+        {
+          osp_param_t *param;
+          gchar *quoted_name, *quoted_value;
+
+          param = point->data;
+          quoted_name = sql_quote (osp_param_id (param));
+          quoted_value = sql_quote (osp_param_default (param));
+
+          g_string_append_printf (prefs_sql,
+                                  "%s ('%s', '%s')",
+                                  first ? "" : ",",
+                                  quoted_name,
+                                  quoted_value);
+          first = 0;
+          point = g_slist_next (point);
+          g_free (quoted_name);
+          g_free (quoted_value);
+        }
+      g_string_append (prefs_sql,
+                       " ON CONFLICT (name)"
+                       " DO UPDATE SET value = EXCLUDED.value;");
+
+      if (first == 0)
+        {
+          sql ("%s", prefs_sql->str);
+        }
+
+      g_string_free (prefs_sql, TRUE);
+    }
+
+  /* Tell the main process to update its NVTi cache. */
+  sql ("UPDATE %s.meta SET value = 1 WHERE name = 'update_nvti_cache';",
+       sql_schema ());
+
+  g_info ("Updating VTs in database ... done (%i VTs).",
+          sql_int ("SELECT count (*) FROM nvts;"));
+
+  if (sql_int ("SELECT coalesce ((SELECT CAST (value AS INTEGER)"
+               "                  FROM meta"
+               "                  WHERE name = 'checked_preferences'),"
+               "                 0);")
+      == 0)
+    {
+      check_old_preference_names ("config_preferences");
+      check_old_preference_names ("config_preferences_trash");
+
+      /* Force update of names in new format in case hard-coded names
+       * used by migrators are outdated */
+      old_nvts_last_modified = 0;
+
+      sql ("INSERT INTO meta (name, value)"
+           " VALUES ('checked_preferences', 1)"
+           " ON CONFLICT (name) DO UPDATE SET value = EXCLUDED.value;");
+    }
+
+  check_preference_names (0, old_nvts_last_modified);
+  check_preference_names (1, old_nvts_last_modified);
+
+  return 0;
+}
+
+/**
+ * @brief Update VTs via OSP.
+ *
  * Expect to be called in the child after a fork.
  *
  * @param[in]  update_socket  Socket to use to contact ospd-openvas scanner.
@@ -1575,133 +1717,12 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
   if ((db_feed_version == NULL)
       || strcmp (scanner_feed_version, db_feed_version))
     {
-      GSList *scanner_prefs;
-      entity_t vts;
-      osp_get_vts_opts_t get_vts_opts;
-      time_t old_nvts_last_modified;
-
       g_info ("OSP service has newer VT status (version %s) than in database (version %s, %i VTs). Starting update ...",
               scanner_feed_version, db_feed_version, sql_int ("SELECT count (*) FROM nvts;"));
 
-      if (db_feed_version == NULL
-          || strcmp (db_feed_version, "") == 0
-          || strcmp (db_feed_version, "0") == 0)
-        old_nvts_last_modified = 0;
-      else
-        old_nvts_last_modified
-          = (time_t) sql_int64_0 ("SELECT max(modification_time) FROM nvts");
-
-      connection = osp_connection_new (update_socket, 0, NULL, NULL, NULL);
-      if (!connection)
-        {
-          g_warning ("%s: failed to connect to %s (2)", __func__,
-                     update_socket);
-          return -1;
-        }
-
-      if (db_feed_version)
-        get_vts_opts.filter = g_strdup_printf ("modification_time>%s", db_feed_version);
-      else
-        get_vts_opts.filter = NULL;
-      if (osp_get_vts_ext (connection, get_vts_opts, &vts))
-        {
-          g_warning ("%s: failed to get VTs", __func__);
-          g_free (get_vts_opts.filter);
-          return -1;
-        }
-      g_free (get_vts_opts.filter);
-
-      osp_connection_close (connection);
-
-      update_nvts_from_vts (&vts, scanner_feed_version);
-      free_entity (vts);
-
-      /* Update scanner preferences */
-      connection = osp_connection_new (update_socket, 0, NULL, NULL, NULL);
-      if (!connection)
-        {
-          g_warning ("%s: failed to connect to %s (3)",
-                    __func__, update_socket);
-          return -1;
-        }
-
-      scanner_prefs = NULL;
-      if (osp_get_scanner_details (connection, NULL, &scanner_prefs))
-        {
-          g_warning ("%s: failed to get scanner preferences", __func__);
-          osp_connection_close (connection);
-          return -1;
-        }
-      else
-        {
-          GString *prefs_sql;
-          GSList *point;
-          int first;
-
-          point = scanner_prefs;
-          first = 1;
-
-          osp_connection_close (connection);
-          prefs_sql = g_string_new ("INSERT INTO nvt_preferences (name, value)"
-                                    " VALUES");
-          while (point)
-            {
-              osp_param_t *param;
-              gchar *quoted_name, *quoted_value;
-
-              param = point->data;
-              quoted_name = sql_quote (osp_param_id (param));
-              quoted_value = sql_quote (osp_param_default (param));
-
-              g_string_append_printf (prefs_sql,
-                                      "%s ('%s', '%s')",
-                                      first ? "" : ",",
-                                      quoted_name,
-                                      quoted_value);
-              first = 0;
-              point = g_slist_next (point);
-              g_free (quoted_name);
-              g_free (quoted_value);
-            }
-          g_string_append (prefs_sql,
-                           " ON CONFLICT (name)"
-                           " DO UPDATE SET value = EXCLUDED.value;");
-
-          if (first == 0)
-            {
-              sql ("%s", prefs_sql->str);
-            }
-
-          g_string_free (prefs_sql, TRUE);
-        }
-
-      /* Tell the main process to update its NVTi cache. */
-      sql ("UPDATE %s.meta SET value = 1 WHERE name = 'update_nvti_cache';",
-           sql_schema ());
-
-      g_info ("Updating VTs in database ... done (%i VTs).",
-              sql_int ("SELECT count (*) FROM nvts;"));
-
-      if (sql_int ("SELECT coalesce ((SELECT CAST (value AS INTEGER)"
-                   "                  FROM meta"
-                   "                  WHERE name = 'checked_preferences'),"
-                   "                 0);")
-          == 0)
-        {
-          check_old_preference_names ("config_preferences");
-          check_old_preference_names ("config_preferences_trash");
-
-          /* Force update of names in new format in case hard-coded names
-           * used by migrators are outdated */
-          old_nvts_last_modified = 0;
-
-          sql ("INSERT INTO meta (name, value)"
-               " VALUES ('checked_preferences', 1)"
-               " ON CONFLICT (name) DO UPDATE SET value = EXCLUDED.value;");
-        }
-
-      check_preference_names (0, old_nvts_last_modified);
-      check_preference_names (1, old_nvts_last_modified);
+      if (update_nvt_cache_osp (update_socket, db_feed_version,
+                                scanner_feed_version))
+        return -1;
     }
 
   return 0;

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1738,3 +1738,61 @@ manage_sync_nvts (int (*fork_update_nvt_cache) ())
 {
   fork_update_nvt_cache ();
 }
+
+/**
+ * @brief Rebuild NVT db.
+ *
+ * @param[in]  log_config  Log configuration.
+ * @param[in]  database    Location of manage database.
+ *
+ * @return 0 success, -1 error, -2 database is wrong version,
+ *         -3 database needs to be initialised from server.
+ */
+int
+manage_rebuild (GSList *log_config, const gchar *database)
+{
+  int ret;
+
+  g_info ("   Rebuilding NVTs.");
+
+  ret = manage_option_setup (log_config, database);
+  if (ret)
+    return ret;
+
+  // FIX
+
+  current_credentials.uuid = NULL;
+
+  manage_option_cleanup ();
+
+  return ret;
+}
+
+/**
+ * @brief Update NVT db.
+ *
+ * @param[in]  log_config  Log configuration.
+ * @param[in]  database    Location of manage database.
+ *
+ * @return 0 success, -1 error, -2 database is wrong version,
+ *         -3 database needs to be initialised from server.
+ */
+int
+manage_update (GSList *log_config, const gchar *database)
+{
+  int ret;
+
+  g_info ("   Updating NVTs.");
+
+  ret = manage_option_setup (log_config, database);
+  if (ret)
+    return ret;
+
+  // FIX
+
+  current_credentials.uuid = NULL;
+
+  manage_option_cleanup ();
+
+  return ret;
+}

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1769,6 +1769,63 @@ manage_sync_nvts (int (*fork_update_nvt_cache) ())
 }
 
 /**
+ * @brief Update or rebuild NVT db.
+ *
+ * @param[in]  update  0 rebuild, else update.
+ *
+ * @return 0 success, -1 error, -4 no osp update socket.
+ */
+static int
+update_or_rebuild (int update)
+{
+  const char *osp_update_socket;
+  gchar *db_feed_version, *scanner_feed_version;
+  osp_connection_t *connection;
+
+  if (check_osp_vt_update_socket ())
+    {
+      printf ("No OSP VT update socket found."
+              " Use --osp-vt-update or change the 'OpenVAS Default'"
+              " scanner to use the main ospd-openvas socket.\n");
+      return -4;
+    }
+
+  osp_update_socket = get_osp_vt_update_socket ();
+  if (osp_update_socket == NULL)
+    {
+      printf ("No OSP VT update socket set.\n");
+      return -4;
+    }
+
+  db_feed_version = nvts_feed_version ();
+  g_debug ("%s: db_feed_version: %s", __func__, db_feed_version);
+
+  connection = osp_connection_new (osp_update_socket, 0, NULL, NULL, NULL);
+  if (!connection)
+    {
+      printf ("Failed to connect to %s.\n", osp_update_socket);
+      return -1;
+    }
+
+  if (osp_get_vts_version (connection, &scanner_feed_version))
+    {
+      printf ("Failed to get scanner_version.\n");
+      return -1;
+    }
+  g_debug ("%s: scanner_feed_version: %s", __func__, scanner_feed_version);
+
+  osp_connection_close (connection);
+
+  if (update_nvt_cache_osp (osp_update_socket, NULL, scanner_feed_version))
+    {
+      printf ("Failed to update NVT cache.\n");
+      return -1;
+    }
+
+  return 0;
+}
+
+/**
  * @brief Rebuild NVT db.
  *
  * @param[in]  log_config  Log configuration.
@@ -1811,9 +1868,6 @@ int
 manage_update (GSList *log_config, const gchar *database)
 {
   int ret;
-  const char *osp_update_socket;
-  gchar *db_feed_version, *scanner_feed_version;
-  osp_connection_t *connection;
 
   g_info ("   Updating NVTs.");
 
@@ -1821,48 +1875,7 @@ manage_update (GSList *log_config, const gchar *database)
   if (ret)
     return ret;
 
-  if (check_osp_vt_update_socket ())
-    {
-      printf ("No OSP VT update socket found."
-              " Use --osp-vt-update or change the 'OpenVAS Default'"
-              " scanner to use the main ospd-openvas socket.\n");
-      manage_option_cleanup ();
-      return -4;
-    }
-
-  osp_update_socket = get_osp_vt_update_socket ();
-  if (osp_update_socket == NULL)
-    {
-      printf ("No OSP VT update socket set.\n");
-      manage_option_cleanup ();
-      return -4;
-    }
-
-  db_feed_version = nvts_feed_version ();
-  g_debug ("%s: db_feed_version: %s", __func__, db_feed_version);
-
-  connection = osp_connection_new (osp_update_socket, 0, NULL, NULL, NULL);
-  if (!connection)
-    {
-      g_warning ("%s: failed to connect to %s", __func__, osp_update_socket);
-      return -1;
-    }
-
-  if (osp_get_vts_version (connection, &scanner_feed_version))
-    {
-      g_warning ("%s: failed to get scanner_version", __func__);
-      return -1;
-    }
-  g_debug ("%s: scanner_feed_version: %s", __func__, scanner_feed_version);
-
-  osp_connection_close (connection);
-
-  if (update_nvt_cache_osp (osp_update_socket, NULL, scanner_feed_version))
-    {
-      printf ("Failed to update NVT cache.\n");
-      manage_option_cleanup ();
-      return -1;
-    }
+  ret = update_or_rebuild (1);
 
   manage_option_cleanup ();
 

--- a/src/manage_sql_nvts.h
+++ b/src/manage_sql_nvts.h
@@ -103,6 +103,9 @@ get_osp_vt_update_socket ();
 void
 set_osp_vt_update_socket (const char *new_socket);
 
+int
+check_osp_vt_update_socket ();
+
 void
 check_db_nvts ();
 


### PR DESCRIPTION
This adds back the --rebuild and --update options.

These should not be required in normal operation, and are added only to force an update/rebuild when errors have resulted in mismatches between the gvmd and ospd-openvas NVTs.

--update will get all NVTs from the scanner, and update them.

--rebuild will do the same, but will remove all the gvmd NVTs first.

Note that these are different from gvmd's automatic sync of NVTs, which will only consider NVTs that have been created/modified since the last sync.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
