### PR TITLE
Put 'lean' back to 0 for GET_RESULTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix SCAP update not finishing when CPEs are older [#986](https://github.com/greenbone/gvmd/pull/986)
 - Move report format dirs when inheriting user [#989](https://github.com/greenbone/gvmd/pull/989)
 - Delete report format dirs when deleting user [#993](https://github.com/greenbone/gvmd/pull/993)
+- Put 'lean' back to 0 for GET_RESULTS [#1001](https://github.com/greenbone/gvmd/pull/1001)
 
 ### Removed
 - Remove support for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -15521,7 +15521,7 @@ handle_get_results (gmp_parser_t *gmp_parser, GError **error)
                                   NULL,
                                   0,
                                   -1,
-                                  1);   /* Lean. */
+                                  0);   /* Lean. */
               SEND_TO_CLIENT_OR_FAIL (buffer->str);
               g_string_free (buffer, TRUE);
               count ++;


### PR DESCRIPTION
There's no lean flag for GET_RESULTS, so it's shouldn't return the lean
version of a result.

Originally introduced in https://github.com/greenbone/gvmd/pull/745.

Fixes https://github.com/greenbone/gvmd/issues/999.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
