### PR TITLE
Lock a file around the NVT sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Print UUIDs in --get-users when --verbose given [#991](https://github.com/greenbone/gvmd/pull/991)
 - Add --get-roles [#992](https://github.com/greenbone/gvmd/pull/992)
 - Add --rebuild [#998](https://github.com/greenbone/gvmd/pull/998)
+- Lock a file around the NVT sync [#1002](https://github.com/greenbone/gvmd/pull/1002)
 
 ### Changed
 - Update SCAP and CERT feed info in sync scripts [#810](https://github.com/greenbone/gvmd/pull/810)

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1716,6 +1716,7 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
 {
   osp_connection_t *connection;
   gchar *db_feed_version, *scanner_feed_version;
+  static lockfile_t lockfile;
 
   /* Re-open DB after fork. */
 
@@ -1746,6 +1747,16 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
   if ((db_feed_version == NULL)
       || strcmp (scanner_feed_version, db_feed_version))
     {
+      switch (lockfile_lock_nb (&lockfile, "gvm-syncing-nvts"))
+        {
+          case 1:
+            g_warning ("%s: an NVT sync is already running", __func__);
+            return -1;
+          case -1:
+            g_warning ("%s: error getting sync lock", __func__);
+            return -1;
+        }
+
       g_info ("OSP service has newer VT status (version %s) than in database (version %s, %i VTs). Starting update ...",
               scanner_feed_version, db_feed_version, sql_int ("SELECT count (*) FROM nvts;"));
 
@@ -1771,9 +1782,11 @@ manage_sync_nvts (int (*fork_update_nvt_cache) ())
 /**
  * @brief Update or rebuild NVT db.
  *
+ * Caller must get the lock.
+ *
  * @param[in]  update  0 rebuild, else update.
  *
- * @return 0 success, -1 error, -4 no osp update socket.
+ * @return 0 success, -1 error, -4 no osp update socket, -5 sync active.
  */
 static int
 update_or_rebuild (int update)
@@ -1844,8 +1857,19 @@ int
 manage_rebuild (GSList *log_config, const gchar *database)
 {
   int ret;
+  static lockfile_t lockfile;
 
   g_info ("   Rebuilding NVTs.");
+
+  switch (lockfile_lock_nb (&lockfile, "gvm-syncing-nvts"))
+    {
+      case 1:
+        printf ("An NVT sync is already running.\n");
+        return -5;
+      case -1:
+        printf ("Error getting sync lock.\n");
+        return -1;
+    }
 
   ret = manage_option_setup (log_config, database);
   if (ret)

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1786,7 +1786,7 @@ manage_sync_nvts (int (*fork_update_nvt_cache) ())
  *
  * @param[in]  update  0 rebuild, else update.
  *
- * @return 0 success, -1 error, -4 no osp update socket, -5 sync active.
+ * @return 0 success, -1 error, -4 no osp update socket.
  */
 static int
 update_or_rebuild (int update)
@@ -1851,7 +1851,7 @@ update_or_rebuild (int update)
  * @param[in]  database    Location of manage database.
  *
  * @return 0 success, -1 error, -2 database is wrong version,
- *         -3 database needs to be initialised from server.
+ *         -3 database needs to be initialised from server, -5 sync active.
  */
 int
 manage_rebuild (GSList *log_config, const gchar *database)


### PR DESCRIPTION
This is required because it is now possible to start a sync outside the gvmd main process, with --rebuild.

Also, the lock file provides a way to check if the sync is running.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
