### PR TITLE
Use correct element to get task ID in wizard

### DIFF
--- a/src/wizards/quick_first_scan.xml
+++ b/src/wizards/quick_first_scan.xml
@@ -259,7 +259,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         <xsl:template match="/">
           <xsl:choose>
             <xsl:when test="starts-with (/wizard/previous/extra_data/status, '2')">
-              <get_tasks task_id="{/wizard/previous/response/create_task_response/@id}"/>
+              <get_tasks task_id="{/wizard/previous/extra_data/task/@id}"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:if test="/wizard/previous/extra_data/task/@id != ''">


### PR DESCRIPTION
The wizard was working, but this was causing an error response when starting the wizard in GSA.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
