### PR TITLE
Account for 'all' selector when syncing configs

### DIFF
--- a/src/gmp_configs.c
+++ b/src/gmp_configs.c
@@ -188,6 +188,7 @@ attr_or_null (entity_t entity, const gchar *name)
  * @param[out] comment               Address for comment.
  * @param[out] type                  Address for type.
  * @param[out] usage_type            Address for usage type.
+ * @param[out] all_selector          True if ALL_SELECTOR was present.
  * @param[out] import_nvt_selectors  Address for selectors.
  * @param[out] import_preferences    Address for preferences.
  *
@@ -197,12 +198,14 @@ int
 parse_config_entity (entity_t config, int require_preferences,
                      const char **config_id, char **name,
                      char **comment, char **type, char **usage_type,
+                     int *all_selector,
                      array_t **import_nvt_selectors,
                      array_t **import_preferences)
 {
   entity_t entity, preferences, nvt_selectors;
 
   *name = *comment = *type = NULL;
+  *all_selector = 0;
 
   if (config_id)
     *config_id = entity_attribute (config, "id");
@@ -244,6 +247,14 @@ parse_config_entity (entity_t config, int require_preferences,
           entity_t include, selector_name, selector_type, selector_fam;
           int import_include;
 
+          if (strcmp (entity_name (nvt_selector), "all_selector") == 0)
+            {
+              array_free (*import_nvt_selectors);
+              *import_nvt_selectors = NULL;
+              *all_selector = 1;
+              break;
+            }
+
           include = entity_child (nvt_selector, "include");
           if (include && strcmp (entity_text (include), "0") == 0)
             import_include = 0;
@@ -263,7 +274,8 @@ parse_config_entity (entity_t config, int require_preferences,
           children = next_entities (children);
         }
 
-      array_terminate (*import_nvt_selectors);
+      if (*import_nvt_selectors)
+        array_terminate (*import_nvt_selectors);
     }
 
   /* Collect NVT preferences. */
@@ -420,6 +432,7 @@ create_config_run (gmp_parser_t *gmp_parser, GError **error)
       char *created_name, *comment, *type, *import_name;
       entity_t usage_type;
       array_t *import_nvt_selectors, *import_preferences;
+      int all_selector;
 
       /* Allow user to overwrite usage type. */
       usage_type = entity_child (entity, "usage_type");
@@ -437,7 +450,7 @@ create_config_run (gmp_parser_t *gmp_parser, GError **error)
       /* Get the config data from the XML. */
 
       if (parse_config_entity (config, 0, NULL, &import_name, &comment, &type,
-                               NULL, &import_nvt_selectors,
+                               NULL, &all_selector, &import_nvt_selectors,
                                &import_preferences))
         {
           SEND_TO_CLIENT_OR_FAIL
@@ -457,6 +470,7 @@ create_config_run (gmp_parser_t *gmp_parser, GError **error)
                              import_name,
                              1,                     /* Make name unique. */
                              comment,
+                             all_selector,
                              import_nvt_selectors,
                              import_preferences,
                              type,

--- a/src/gmp_configs.h
+++ b/src/gmp_configs.h
@@ -46,6 +46,6 @@ create_config_element_text (const gchar *, gsize);
 
 int
 parse_config_entity (entity_t, int, const char **, char **, char **, char **,
-                     char **, array_t **, array_t **);
+                     char **, int *, array_t **, array_t **);
 
 #endif /* not _GVMD_GMP_CONFIGS_H */

--- a/src/manage_configs.c
+++ b/src/manage_configs.c
@@ -120,6 +120,7 @@ update_config_from_file (config_t config, const gchar *path)
   array_t *nvt_selectors, *preferences;
   char *comment, *name, *type, *usage_type;
   const char *config_id;
+  int all_selector;
 
   g_debug ("%s: updating %s", __func__, path);
 
@@ -131,7 +132,8 @@ update_config_from_file (config_t config, const gchar *path)
   /* Parse the data out of the entity. */
 
   switch (parse_config_entity (entity, 1, &config_id, &name, &comment, &type,
-                               &usage_type, &nvt_selectors, &preferences))
+                               &usage_type, &all_selector, &nvt_selectors,
+                               &preferences))
     {
       case 0:
         break;
@@ -148,8 +150,8 @@ update_config_from_file (config_t config, const gchar *path)
 
   /* Update the config. */
 
-  update_config (config, type, name, comment, usage_type, nvt_selectors,
-                 preferences);
+  update_config (config, type, name, comment, usage_type, all_selector,
+                 nvt_selectors, preferences);
 
   /* Cleanup. */
 
@@ -175,6 +177,7 @@ create_config_from_file (const gchar *path)
   char *created_name, *comment, *name, *type, *usage_type;
   const char *config_id;
   config_t new_config;
+  int all_selector;
 
   g_debug ("%s: creating %s", __func__, path);
 
@@ -186,7 +189,8 @@ create_config_from_file (const gchar *path)
   /* Parse the data out of the entity. */
 
   switch (parse_config_entity (config, 1, &config_id, &name, &comment, &type,
-                               &usage_type, &nvt_selectors, &preferences))
+                               &usage_type, &all_selector, &nvt_selectors,
+                               &preferences))
     {
       case 0:
         break;
@@ -207,6 +211,7 @@ create_config_from_file (const gchar *path)
                                 name,
                                 0,              /* Use name exactly as given. */
                                 comment,
+                                all_selector,
                                 nvt_selectors,
                                 preferences,
                                 type,

--- a/src/manage_configs.h
+++ b/src/manage_configs.h
@@ -51,7 +51,7 @@ typedef struct
 } nvt_selector_t;
 
 int
-create_config (const char*, const char*, int, const char*, const array_t*,
+create_config (const char*, const char*, int, const char*, int, const array_t*,
                const array_t*, const char*, const char*, config_t*, char**);
 
 int

--- a/src/manage_sql_configs.h
+++ b/src/manage_sql_configs.h
@@ -77,7 +77,7 @@ configs_extra_where (const char *);
 
 int
 create_config_no_acl (const char *, const char *, int, const char *,
-                      const array_t *, const array_t *, const char *,
+                      int, const array_t *, const array_t *, const char *,
                       const char *, config_t *, char **);
 
 gboolean
@@ -94,7 +94,7 @@ config_updated_in_feed (config_t, const gchar *);
 
 void
 update_config (config_t, const gchar *, const gchar *, const gchar *,
-               const gchar *, const array_t*, const array_t*);
+               const gchar *, int, const array_t*, const array_t*);
 
 void
 check_db_configs ();


### PR DESCRIPTION
Some configs like 'Full and Fast Ultimate' use the special hardcoded "all" NVT selector.  This PR allows the "all" selector to be specified in the feed XML files. 

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
