### PR TITLE
Ensure parent exists when moving report format dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Delete report format dirs when deleting user [#993](https://github.com/greenbone/gvmd/pull/993)
 - Put 'lean' back to 0 for GET_RESULTS [#1001](https://github.com/greenbone/gvmd/pull/1001)
 - Improve handling of removed NVT prefs [#1003](https://github.com/greenbone/gvmd/pull/1003)
+- Ensure parent exists when moving report format dir [#1019](https://github.com/greenbone/gvmd/pull/1019)
 
 ### Removed
 - Remove support for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -34,6 +34,7 @@
 #include <glib.h>
 #include <glib/gstdio.h>
 #include <grp.h>
+#include <libgen.h>
 #include <limits.h>
 #include <locale.h>
 #include <pwd.h>
@@ -1591,7 +1592,20 @@ move_report_format_dir (const char *dir, const char *new_dir)
   if (g_file_test (dir, G_FILE_TEST_EXISTS)
       && gvm_file_check_is_dir (dir))
     {
+      gchar *new_dir_parent;
+
       g_warning ("%s: rename %s to %s", __func__, dir, new_dir);
+
+      /* Ensure parent of new_dir exists. */
+      new_dir_parent = g_path_get_dirname (new_dir);
+      if (g_mkdir_with_parents (new_dir_parent, 0755 /* "rwxr-xr-x" */))
+        {
+          g_warning ("%s: failed to create parent %s", __func__,
+                     new_dir_parent);
+          g_free (new_dir_parent);
+          return -1;
+        }
+      g_free (new_dir_parent);
 
       if (rename (dir, new_dir))
         {

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -3960,8 +3960,8 @@ inherit_report_format_dir (const gchar *report_format_id, user_t user,
 
   if (move_report_format_dir (old_dir, new_dir))
     g_warning ("%s: failed to move %s dir, but will try the rest",
-               report_format_id,
-               __func__);
+               __func__,
+               report_format_id);
 
   g_free (old_dir);
   g_free (new_dir);


### PR DESCRIPTION
This solves a broken situation that would result when deleting a user with an inheritor when the inheritor did not have any of their own report formats (and hence had no report format dir).

Probably this solves a similar problem when such a user is the Feed Import Owner.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
