### PR TITLE
Reduce number of trashcan warnings during feed sync

### DIFF
--- a/src/manage_configs.c
+++ b/src/manage_configs.c
@@ -325,8 +325,15 @@ sync_config_with_feed (const gchar *path)
   if (find_trash_config_no_acl (uuid, &config) == 0
       && config)
     {
-      g_warning ("%s: ignoring config '%s', as it is in the trashcan",
-                 __func__, uuid);
+      static int warned = 0;
+
+      if (warned == 0)
+        {
+          warned = 1;
+          g_warning ("%s: ignoring a config ('%s'), as it is in the trashcan"
+                     " (will not warn again)",
+                     __func__, uuid);
+        }
       g_free (uuid);
       return;
     }

--- a/src/manage_port_lists.c
+++ b/src/manage_port_lists.c
@@ -281,8 +281,15 @@ sync_port_list_with_feed (const gchar *path)
   if (find_trash_port_list_no_acl (uuid, &port_list) == 0
       && port_list)
     {
-      g_warning ("%s: ignoring port list '%s', as it is in the trashcan",
-                 __func__, uuid);
+      static int warned = 0;
+
+      if (warned == 0)
+        {
+          warned = 1;
+          g_warning ("%s: ignoring a port list ('%s'), as it is in the trashcan"
+                     " (will not warn again)",
+                     __func__, uuid);
+        }
       g_free (uuid);
       return;
     }

--- a/src/manage_report_formats.c
+++ b/src/manage_report_formats.c
@@ -655,8 +655,15 @@ sync_report_format_with_feed (const gchar *path)
   if (find_trash_report_format_no_acl (uuid, &report_format) == 0
       && report_format)
     {
-      g_warning ("%s: ignoring report format '%s', as it is in the trashcan",
-                 __func__, uuid);
+      static int warned = 0;
+
+      if (warned == 0)
+        {
+          warned = 1;
+          g_warning ("%s: ignoring a report format ('%s'), as it is in the trashcan"
+                     " (will not warn again)",
+                     __func__, uuid);
+        }
       g_free (uuid);
       return;
     }

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -1698,7 +1698,7 @@ delete_report_format (const char *report_format_id, int ultimate)
    *   - the UUID of a report format is the same every time it is
    *     imported, so to prevent multiple deletes from producing
    *     duplicate UUIDs in the trashcan, each report format in the
-   *     trashcan gets a new UUID,
+   *     trashcan gets a new UUID (except feed report formats),
    *
    *   - the report format has information on disk on top of the
    *     info in the db, so the disk information has to be held
@@ -1875,11 +1875,12 @@ delete_report_format (const char *report_format_id, int ultimate)
            "  description, signature, trust, trust_time, flags, original_uuid,"
            "  creation_time, modification_time)"
            " SELECT"
-           "  make_uuid (), owner, name, extension, content_type, summary,"
+           "  %s, owner, name, extension, content_type, summary,"
            "  description, signature, trust, trust_time, flags, uuid,"
            "  creation_time, modification_time"
            " FROM report_formats"
            " WHERE id = %llu;",
+           report_format_predefined (report_format) ? "uuid" : "make_uuid ()",
            report_format);
 
       trash_report_format = sql_last_insert_id ();

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -545,7 +545,7 @@ find_trash_report_format_no_acl (const char *uuid, report_format_t *report_forma
 
   quoted_uuid = sql_quote (uuid);
   switch (sql_int64 (report_format,
-                     "SELECT id FROM report_formats WHERE uuid = '%s';",
+                     "SELECT id FROM report_formats_trash WHERE uuid = '%s';",
                      quoted_uuid))
     {
       case 0:


### PR DESCRIPTION
When syncing from the feed we do not sync a resource if it already exists in the trash, but we do warn about this because it might be confusing for the user.  However this results in a lot of warnings so this PR limits the warnings to one message per type.

Also fixes the trashcan check for report formats, which weren't getting the warnings at all.

Also changes the deletion of feed report formats to keep the UUID the same, otherwise the sync will just load a new one when a feed report format is moved to the trash.  Non-feed report formats still get a new UUID when they are moved to the trash, as before.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
