### PR TITLE
Remove out of date NVT selector checks

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -53017,10 +53017,7 @@ delete_user (const char *user_id_arg, const char *name_arg, int ultimate,
     }
   sql ("DELETE FROM nvt_selectors"
        " WHERE name IN (SELECT nvt_selector FROM configs WHERE owner = %llu)"
-       " AND name != '" MANAGE_NVT_SELECTOR_UUID_ALL "'"
-       " AND name != '" MANAGE_NVT_SELECTOR_UUID_DISCOVERY "'"
-       " AND name != '" MANAGE_NVT_SELECTOR_UUID_HOST_DISCOVERY "'"
-       " AND name != '" MANAGE_NVT_SELECTOR_UUID_SYSTEM_DISCOVERY "';",
+       " AND name != '" MANAGE_NVT_SELECTOR_UUID_ALL "';",
        user);
   sql ("DELETE FROM config_preferences"
        " WHERE config IN (SELECT id FROM configs WHERE owner = %llu);",

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -49,28 +49,6 @@
 #define MANAGE_NVT_SELECTOR_UUID_ALL "54b45713-d4f4-4435-b20d-304c175ed8c5"
 
 /**
- * @brief UUID of 'Base' NVT selector.
- */
-#define MANAGE_NVT_SELECTOR_UUID_BASE "dd4a4170-0b5e-43fb-9bae-6ce93c19e893"
-
-/**
- * @brief UUID of 'Discovery' NVT selector.
- */
-#define MANAGE_NVT_SELECTOR_UUID_DISCOVERY "0d9a2738-8fe2-4e22-8f26-bb886179e759"
-
-/**
- * @brief UUID of 'Host Discovery' NVT selector.
- */
-#define MANAGE_NVT_SELECTOR_UUID_HOST_DISCOVERY \
- "f5f80744-55c7-11e3-8dc6-406186ea4fc5"
-
-/**
- * @brief UUID of 'System Discovery' NVT selector.
- */
-#define MANAGE_NVT_SELECTOR_UUID_SYSTEM_DISCOVERY \
- "07045d1c-a951-11e3-8da7-406186ea4fc5"
-
-/**
  * @brief Predefined role UUID.
  */
 #define PERMISSION_UUID_ADMIN_EVERYTHING "b3b56a8c-c2fd-11e2-a135-406186ea4fc5"

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -4780,22 +4780,4 @@ check_db_configs ()
 
   if (sync_configs_with_feed ())
     g_warning ("%s: Failed to sync configs with feed", __func__);
-
-  /* In the Service Detection family, NVTs sometimes move to Product
-   * Detection, and once an NVT was removed.  So remove those NVTs
-   * from Service Detection in the NVT selector. */
-
-  sql ("DELETE FROM nvt_selectors"
-       " WHERE name = '" MANAGE_NVT_SELECTOR_UUID_DISCOVERY "'"
-       " AND family = 'Service detection'"
-       " AND (SELECT family FROM nvts"
-       "      WHERE oid = nvt_selectors.family_or_nvt)"
-       "     = 'Product detection';");
-
-  if (sql_int ("SELECT EXISTS (SELECT * FROM nvts);"))
-    sql ("DELETE FROM nvt_selectors"
-         " WHERE name = '" MANAGE_NVT_SELECTOR_UUID_DISCOVERY "'"
-         " AND family = 'Service detection'"
-         " AND NOT EXISTS (SELECT * FROM nvts"
-         "                 WHERE oid = nvt_selectors.family_or_nvt);");
 }


### PR DESCRIPTION
NVT selectors are no longer specially defined except for the "All" selector.

In migrated db's the previously defined special selectors will remain in the db linked to the associated config, but there's no need to treat them specially anymore.  They will be removed if the associated config is ever deleted by the owner.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
