### PR TITLE
Perform integrity check of VTs after updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Lock a file around the NVT sync [#1002](https://github.com/greenbone/gvmd/pull/1002)
 - Add a delay for re-requesting scan information via osp [#1012](https://github.com/greenbone/gvmd/pull/1012)
 - Add --optimize option cleanup-result-encoding [#1013](https://github.com/greenbone/gvmd/pull/1013)
+- Perform integrity check of VTs after updates [#1024](https://github.com/greenbone/gvmd/pull/1024)
 
 ### Changed
 - Update SCAP and CERT feed info in sync scripts [#810](https://github.com/greenbone/gvmd/pull/810)

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1075,7 +1075,8 @@ handle_sigabrt_simple (int signal)
  *
  * @param[in]  update_socket  UNIX socket for contacting openvas-ospd.
  *
- * @return 0 success.
+ * @return 0 success, -1 error, 1 VT integrity check failed,
+ *         2 scanner still loading.
  */
 static int
 update_nvt_cache_osp (const gchar *update_socket)

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1075,8 +1075,7 @@ handle_sigabrt_simple (int signal)
  *
  * @param[in]  update_socket  UNIX socket for contacting openvas-ospd.
  *
- * @return 0 success, -1 error, 1 VT integrity check failed,
- *         2 scanner still loading.
+ * @return 0 success, -1 error, 1 VT integrity check failed.
  */
 static int
 update_nvt_cache_osp (const gchar *update_socket)
@@ -1123,7 +1122,7 @@ update_nvt_cache_retry ()
               int ret;
 
               ret = update_nvt_cache_osp (osp_update_socket);
-              if (ret)
+              if (ret == 1)
                 {
                   g_message ("Rebuilding NVTs because integrity check failed");
                   ret = update_or_rebuild_nvts (0);

--- a/src/manage.c
+++ b/src/manage.c
@@ -8597,8 +8597,7 @@ gvm_migrate_secinfo (int feed_type)
  *
  * @param[in]  update_socket  Socket to use to contact ospd-openvas scanner.
  *
- * @return 0 success, -1 error, 1 VT integrity check failed,
- *         2 scanner still loading.
+ * @return 0 success, -1 error, 1 VT integrity check failed.
  */
 int
 manage_update_nvts_osp (const gchar *update_socket)

--- a/src/manage.c
+++ b/src/manage.c
@@ -8597,7 +8597,8 @@ gvm_migrate_secinfo (int feed_type)
  *
  * @param[in]  update_socket  Socket to use to contact ospd-openvas scanner.
  *
- * @return 0 success, -1 error, 2 scanner still loading.
+ * @return 0 success, -1 error, 1 VT integrity check failed,
+ *         2 scanner still loading.
  */
 int
 manage_update_nvts_osp (const gchar *update_socket)

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1821,12 +1821,13 @@ manage_sync_nvts (int (*fork_update_nvt_cache) ())
  *
  * @return 0 success, -1 error, -4 no osp update socket.
  */
-static int
-update_or_rebuild (int update)
+int
+update_or_rebuild_nvts (int update)
 {
   const char *osp_update_socket;
   gchar *db_feed_version, *scanner_feed_version;
   osp_connection_t *connection;
+  int ret;
 
   if (check_osp_vt_update_socket ())
     {
@@ -1869,9 +1870,9 @@ update_or_rebuild (int update)
       set_nvts_feed_version ("0");
     }
 
-  if (update_nvt_cache_osp (osp_update_socket, NULL, scanner_feed_version))
+  ret = update_nvt_cache_osp (osp_update_socket, NULL, scanner_feed_version);
+  if (ret)
     {
-      printf ("Failed to %s NVT cache.\n", update ? "update" : "rebuild");
       return -1;
     }
 
@@ -1884,7 +1885,8 @@ update_or_rebuild (int update)
  * @param[in]  log_config  Log configuration.
  * @param[in]  database    Location of manage database.
  *
- * @return 0 success, -1 error, -2 database is wrong version,
+ * @return 0 success, 1 VT integrity check failed, -1 error,
+ *         -2 database is wrong version,
  *         -3 database needs to be initialised from server, -5 sync active.
  */
 int
@@ -1910,7 +1912,7 @@ manage_rebuild (GSList *log_config, const gchar *database)
     return ret;
 
   sql_begin_immediate ();
-  ret = update_or_rebuild (0);
+  ret = update_or_rebuild_nvts (0);
   if (ret)
     sql_rollback ();
   else

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1510,7 +1510,7 @@ update_nvts_from_vts (entity_t *get_vts_response,
         {
           g_warning ("%s: SHA-256 hash of the VTs in the database (%s)"
                      " does not match the one from the scanner (%s).",
-                     __func__, osp_vt_hash, db_vts_hash);
+                     __func__, db_vts_hash, osp_vt_hash);
 
           g_free (db_vts_hash);
           return 1;

--- a/src/manage_sql_nvts.h
+++ b/src/manage_sql_nvts.h
@@ -116,6 +116,9 @@ void
 manage_sync_nvts (int (*) ());
 
 int
+update_or_rebuild_nvts (int);
+
+int
 manage_update_nvt_cache_osp (const gchar *);
 
 int


### PR DESCRIPTION
If OSPd-OpenVAS sends a sha256_hash attribute in the vts element, the
SHA-256 hash is also calculated for the NVTs in the database and
compared after updating.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
