### PR TITLE
Remove active clause when filtering resources by tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Improve handling of removed NVT prefs [#1003](https://github.com/greenbone/gvmd/pull/1003)
 - Ensure parent exists when moving report format dir [#1019](https://github.com/greenbone/gvmd/pull/1019)
 - Use nvti_qod instead of the old nvti_get_tag() [#1022](https://github.com/greenbone/gvmd/pull/1022)
+- Remove active clause when filtering resources by tag [#1025](https://github.com/greenbone/gvmd/pull/1025)
 
 ### Removed
 - Remove support for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -2965,7 +2965,6 @@ filter_clause_append_tag_id (GString *clause, keyword_t *keyword,
           "(EXISTS"
           "  (SELECT * FROM tags"
           "   WHERE tags.uuid = '%s'"
-          "   AND tags.active != 0"
           "   AND EXISTS (SELECT * FROM tag_resources"
           "                WHERE tag_resources.resource_uuid"
           "                        = %ss.uuid"


### PR DESCRIPTION
It doesn't really make sense to limit the response to active tags, because
the client is providing the tag.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
