### PR TITLE
Add user limits on hosts and ifaces to OSP prefs (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix SCP alert authentication and logging [#972](https://github.com/greenbone/gvmd/pull/972)
 - Accept expanded scheme OIDs in parse_osp_report [#983](https://github.com/greenbone/gvmd/pull/983)
 - Fix SCAP update not finishing when CPEs are older [#985](https://github.com/greenbone/gvmd/pull/985)
+- Add user limits on hosts and ifaces to OSP prefs [#1032](https://github.com/greenbone/gvmd/pull/1032)
 
 ### Removed
 - Remove 1.3.6.1.4.1.25623.1.0.90011 from Discovery config (9.0) [#847](https://github.com/greenbone/gvmd/pull/847)

--- a/src/manage.c
+++ b/src/manage.c
@@ -4062,6 +4062,50 @@ prepare_osp_scan_for_resume (task_t task, const char *scan_id, char **error)
 }
 
 /**
+ * @brief Add OSP preferences for limiting ifaces and hosts for users.
+ *
+ * @param[in]  scanner_options  The scanner preferences table to add to.
+ */
+static void
+add_user_scan_preferences (GHashTable *scanner_options)
+{
+  gchar *hosts, *ifaces, *name;
+  int hosts_allow, ifaces_allow;
+
+  // Limit access to hosts
+  hosts = user_hosts (current_credentials.uuid);
+  hosts_allow = user_hosts_allow (current_credentials.uuid);
+
+  if (hosts_allow == 1)
+    name = g_strdup ("hosts_allow");
+  else if (hosts_allow == 0)
+    name = g_strdup ("hosts_deny");
+  else
+    name = NULL;
+
+  if (name)
+    g_hash_table_replace (scanner_options, name, hosts);
+  else
+    g_free (hosts);
+
+  // Limit access to ifaces
+  ifaces = user_ifaces (current_credentials.uuid);
+  ifaces_allow = user_ifaces_allow (current_credentials.uuid);
+
+  if (ifaces_allow == 1)
+    name = g_strdup ("ifaces_allow");
+  else if (ifaces_allow == 0)
+    name = g_strdup ("ifaces_deny");
+  else
+    name = NULL;
+
+  if (name)
+    g_hash_table_replace (scanner_options, name, ifaces);
+  else
+    g_free (ifaces);
+}
+
+/**
  * @brief Launch an OpenVAS via OSP task.
  *
  * @param[in]   task        The task.
@@ -4177,6 +4221,9 @@ launch_osp_openvas_task (task_t task, target_t target, const char *scan_id,
                                 g_strdup (osp_value));
         }
     }
+
+  /* Setup user-specific scanner preference */
+  add_user_scan_preferences (scanner_options);
 
   /* Setup general task preferences */
   max_checks = task_preference_value (task, "max_checks");


### PR DESCRIPTION
When starting an OSPd-OpenVAS scan, the hosts_allow / hosts_deny
and ifaces_allow / ifaces_deny scanner preferences are now added
according to the current user's hosts and ifaces configuration.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
