### PR TITLE
Add user limits on hosts and ifaces to OSP prefs (master)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Ensure parent exists when moving report format dir [#1019](https://github.com/greenbone/gvmd/pull/1019)
 - Use nvti_qod instead of the old nvti_get_tag() [#1022](https://github.com/greenbone/gvmd/pull/1022)
 - Remove active clause when filtering resources by tag [#1025](https://github.com/greenbone/gvmd/pull/1025)
+- Add user limits on hosts and ifaces to OSP prefs [#1033](https://github.com/greenbone/gvmd/pull/1033)
 
 ### Removed
 - Remove support for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)


### PR DESCRIPTION
When starting an OSPd-OpenVAS scan, the hosts_allow / hosts_deny
and ifaces_allow / ifaces_deny scanner preferences are now added
according to the current user's hosts and ifaces configuration.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry