### PR TITLE
Fix order of tar options in gvm-lsc-deb-creator.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use nvti_qod instead of the old nvti_get_tag() [#1022](https://github.com/greenbone/gvmd/pull/1022)
 - Remove active clause when filtering resources by tag [#1025](https://github.com/greenbone/gvmd/pull/1025)
 - Add user limits on hosts and ifaces to OSP prefs [#1033](https://github.com/greenbone/gvmd/pull/1033)
+- Fix order of tar options in gvm-lsc-deb-creator.sh [#1034](https://github.com/greenbone/gvmd/pull/1034)
 
 ### Removed
 - Remove support for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)

--- a/tools/gvm-lsc-deb-creator.sh
+++ b/tools/gvm-lsc-deb-creator.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2018 Greenbone Networks GmbH
+# Copyright (C) 2018-2020 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
@@ -155,13 +155,13 @@ COPYRIGHT_FILE="${DOC_DATA_DIR}/copyright"
   echo "Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/"
   echo ""
   echo "Files: *"
-  echo "Copyright: 2018 Greenbone Networks GmbH"
+  echo "Copyright: 2018-2020 Greenbone Networks GmbH"
   echo "License: GPL-2+ (/usr/share/common-licenses/GPL-2)"
 } > "${COPYRIGHT_FILE}"
 
 # Create data archive
 cd "${DATA_DIR}"
-tar -acf "../data.tar.xz" "${HOME_SUBDIR}" "${DOC_SUBDIR}" -C "${DATA_DIR}"
+tar -C "${DATA_DIR}" -acf "../data.tar.xz" "${HOME_SUBDIR}" "${DOC_SUBDIR}"
 
 
 #


### PR DESCRIPTION
In the tar command creating the data archive, the -C option for setting
the current directory has to be set before the positional arguments
with the subdirectories to add.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
