### PR TITLE
Clean up NVTs set to name in cleanup-result-nvts (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use temp tables to speed up migrate_213_to_214 [#911](https://github.com/greenbone/gvmd/pull/911)
 - Add a delay for re-requesting scan information via osp [#1009](https://github.com/greenbone/gvmd/pull/1009)
 - Count only best OS matches for OS asset hosts [#1028](https://github.com/greenbone/gvmd/pull/1028)
+- Clean up NVTs set to name in cleanup-result-nvts [#1038](https://github.com/greenbone/gvmd/pull/1038)
 
 ### Fixed
 - Consider results_trash when deleting users [#799](https://github.com/greenbone/gvmd/pull/799)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -25182,6 +25182,17 @@ cleanup_result_nvts ()
   GArray *affected;
   int index;
 
+  g_debug ("%s: Cleaning up results with wrong nvt ids", __func__);
+  sql ("UPDATE results"
+       " SET nvt = (SELECT oid FROM nvts WHERE name = nvt),"
+       "     result_nvt = NULL"
+       " WHERE nvt IN (SELECT name FROM nvts WHERE name != oid);");
+
+  g_debug ("%s: Cleaning up result_nvts entries with wrong nvt ids",
+           __func__);
+  sql ("DELETE FROM result_nvts"
+       " WHERE nvt IN (SELECT name FROM nvts WHERE name != oid);");
+
   g_debug ("%s: Creating missing result_nvts entries", __func__);
   sql ("INSERT INTO result_nvts (nvt)"
        " SELECT DISTINCT nvt FROM results ON CONFLICT (nvt) DO NOTHING;");


### PR DESCRIPTION
The --optimize option will now also clean up results where the nvt
is set to the name instead of the OID.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
