### PR TITLE
Clean up NVTs set to name in cleanup-result-nvts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Change setting UUID to correct length [#1018](https://github.com/greenbone/gvmd/pull/1018)
 - Change licence to AGPL-3.0-or-later [#1026](https://github.com/greenbone/gvmd/pull/1026)
 - Count only best OS matches for OS asset hosts [#1029](https://github.com/greenbone/gvmd/pull/1029)
+- Clean up NVTs set to name in cleanup-result-nvts [#1039](https://github.com/greenbone/gvmd/pull/1039)
 
 ### Fixed
 - Add NULL check in nvts_feed_version_epoch [#768](https://github.com/greenbone/gvmd/pull/768)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -23336,6 +23336,17 @@ cleanup_result_nvts ()
   GArray *affected;
   int index;
 
+  g_debug ("%s: Cleaning up results with wrong nvt ids", __func__);
+  sql ("UPDATE results"
+       " SET nvt = (SELECT oid FROM nvts WHERE name = nvt),"
+       "     result_nvt = NULL"
+       " WHERE nvt IN (SELECT name FROM nvts WHERE name != oid);");
+
+  g_debug ("%s: Cleaning up result_nvts entries with wrong nvt ids",
+           __func__);
+  sql ("DELETE FROM result_nvts"
+       " WHERE nvt IN (SELECT name FROM nvts WHERE name != oid);");
+
   g_debug ("%s: Creating missing result_nvts entries", __func__);
   sql ("INSERT INTO result_nvts (nvt)"
        " SELECT DISTINCT nvt FROM results ON CONFLICT (nvt) DO NOTHING;");


### PR DESCRIPTION
The --optimize option will now also clean up results where the nvt
is set to the name instead of the OID.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
