### PR TITLE
Use current row for iterator_null, instead of first row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix handling of termination signals [#1034](https://github.com/greenbone/gvmd/pull/1034)
 - Remove db init warning that no longer makes sense [#1044](https://github.com/greenbone/gvmd/pull/1044)
 - Use correct elements to get task ID in wizards [#1004](https://github.com/greenbone/gvmd/pull/1004) [#1046](https://github.com/greenbone/gvmd/pull/1046)
+- Use current row for iterator_null, instead of first row [#1047](https://github.com/greenbone/gvmd/pull/1047)
 
 ### Removed
 - Remove support for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)

--- a/src/sql_pg.c
+++ b/src/sql_pg.c
@@ -636,7 +636,7 @@ iterator_null (iterator_t* iterator, int col)
 {
   if (iterator->done) abort ();
   assert (iterator->stmt->result);
-  return PQgetisnull (iterator->stmt->result, 0, col);
+  return PQgetisnull (iterator->stmt->result, iterator->stmt->current_row, col);
 }
 
 /**


### PR DESCRIPTION
Looks like this has been broken forever, and we did not notice because
we don't use iterator_null much.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
