### PR TITLE
Fix version field of OVAL definitions (8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Init comment for MODIFY_USER/COMMENT, in case it's empty [#894](https://github.com/greenbone/gvmd/pull/894)
 - Init comment for MODIFY_PERMISSION, in case it's empty [#919](https://github.com/greenbone/gvmd/pull/919)
 - Fix Verinice ISM report format and update version [#963](https://github.com/greenbone/gvmd/pull/963)
+- Fix version field of OVAL definitions [#1048](https://github.com/greenbone/gvmd/pull/1048)
 
 ### Removed
 

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -2976,7 +2976,8 @@ update_ovaldef_xml (gchar **file_and_date,
                   entity_t metadata, title, description, repository, reference;
                   entity_t status;
                   entities_t references;
-                  const char *deprecated, *version;
+                  const char *deprecated, *version_str;
+                  int version;
                   gchar *id, *quoted_title, *quoted_class, *quoted_description;
                   gchar *quoted_status;
                   int cve_count;
@@ -3043,15 +3044,18 @@ update_ovaldef_xml (gchar **file_and_date,
                   quoted_oval_id =
                     sql_quote (entity_attribute (definition, "id"));
 
-                  version = entity_attribute (definition, "version");
-                  if (g_regex_match_simple ("^[0-9]+$", (gchar *) version, 0, 0)
+                  version_str = entity_attribute (definition, "version");
+                  if (g_regex_match_simple ("^[0-9]+$",
+                                            (gchar *) version_str, 0, 0)
                       == 0)
                     {
                       g_warning (
-                        "%s: invalid version: %s", __FUNCTION__, version);
+                        "%s: invalid version: %s", __FUNCTION__, version_str);
                       free_entity (entity);
                       goto fail;
                     }
+                  else
+                    version = atoi (version_str);
 
                   quoted_class =
                     sql_quote (entity_attribute (definition, "class"));


### PR DESCRIPTION
The update_ovaldef_xml function now adds the actual version number to
the SQL where it mistakenly added the address of the version string.

**Checklist**:
- [ ] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
