### PR TITLE
Add --rebuild-scap option (8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Document container tasks in GMP doc [#690](https://github.com/greenbone/gvmd/pull/690)
 - New columns Ports, Apps, Distance, and Auth in the CSV Hosts report format [#734](https://github.com/greenbone/gvmd/pull/734)
 - Allow use of public key auth in SCP alert [#846](https://github.com/greenbone/gvmd/pull/846)
+- Add --rebuild-scap option [#1049](https://github.com/greenbone/gvmd/pull/1049)
 
 ### Changes
 - Check and create default permissions individually [#672](https://github.com/greenbone/gvmd/pull/672)

--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -127,6 +127,9 @@ Use port number NUMBER.
 \fB--port2=\fINUMBER\fB\f1
 Use port number NUMBER for address 2.
 .TP
+\fB--rebuild-scap=\fITYPE\fB\f1
+Rebuild SCAP data of type \fITYPE\f1 (currently only supports 'ovaldefs'). 
+.TP
 \fB--role=\fIROLE\fB\f1
 Role for --create-user and --get-users.
 .TP

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -287,6 +287,15 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       </optdesc>
     </option>
     <option>
+      <p><opt>--rebuild-scap=<arg>TYPE</arg></opt></p>
+      <optdesc>
+        <p>
+          Rebuild SCAP data of type <arg>TYPE</arg>
+          (currently only supports 'ovaldefs').
+        </p>
+      </optdesc>
+    </option>
+    <option>
       <p><opt>--role=<arg>ROLE</arg></opt></p>
       <optdesc>
         <p>Role for --create-user and --get-users.</p>

--- a/doc/gvmd.html
+++ b/doc/gvmd.html
@@ -270,6 +270,15 @@
       
     
     
+      <p><b>--rebuild-scap=<em>TYPE</em></b></p>
+      
+        <p>
+          Rebuild SCAP data of type <em>TYPE</em>
+          (currently only supports 'ovaldefs').
+        </p>
+      
+    
+    
       <p><b>--role=<em>ROLE</em></b></p>
       
         <p>Role for --create-user and --get-users.</p>

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1712,6 +1712,7 @@ main (int argc, char **argv)
   static gchar *modify_setting = NULL;
   static gchar *scanner_name = NULL;
   static gchar *rc_name = NULL;
+  static gchar *rebuild_scap = NULL;
   static gchar *role = NULL;
   static gchar *disable = NULL;
   static gchar *value = NULL;
@@ -1874,6 +1875,10 @@ main (int argc, char **argv)
       &manager_port_string_2,
       "Use port number <number> for address 2.",
       "<number>" },
+    { "rebuild-scap", '\0', 0, G_OPTION_ARG_STRING,
+      &rebuild_scap,
+      "Rebuild SCAP data of type <type> (currently only supports 'ovaldefs').",
+      "<type>" },
     { "role", '\0', 0, G_OPTION_ARG_STRING,
       &role,
       "Role for --create-user and --get-users.",
@@ -2262,6 +2267,25 @@ main (int argc, char **argv)
       log_config_free ();
       if (ret)
         return EXIT_FAILURE;
+      return EXIT_SUCCESS;
+    }
+
+  if (rebuild_scap)
+    {
+      int ret;
+
+      proctitle_set ("gvmd: --rebuild-scap");
+
+      if (option_lock (&lockfile_checking))
+        return EXIT_FAILURE;
+
+      ret = manage_rebuild_scap (log_config, database, rebuild_scap);
+      log_config_free ();
+      if (ret)
+        {
+          printf ("Failed to rebuild SCAP data.\n");
+          return EXIT_FAILURE;
+        }
       return EXIT_SUCCESS;
     }
 

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -3638,6 +3638,51 @@ manage_db_reinit (const gchar *name)
 }
 
 /**
+ * @brief Opens and locks a lockfile for use in SecInfo operations
+ *
+ * @param[in]  lockfile_basename  Basename for lockfile.
+ * @param[out] lockfile           File descriptor of the lockfile or -1
+ *
+ * @return 0 success, 1 file already locked / sync in progress, -1 error
+ */
+static int
+open_secinfo_lockfile (const gchar *lockfile_basename, int *lockfile)
+{
+  gchar *lockfile_name;
+
+  lockfile_name
+    = g_build_filename (g_get_tmp_dir (), lockfile_basename, NULL);
+
+  *lockfile = open (lockfile_name,
+                    O_RDWR | O_CREAT | O_APPEND,
+                    /* "-rw-r--r--" */
+                    S_IWUSR | S_IRUSR | S_IROTH | S_IRGRP);
+
+  if (*lockfile == -1)
+    {
+      g_warning ("%s: failed to open lock file '%s': %s",
+                  __FUNCTION__,
+                  lockfile_name,
+                  strerror (errno));
+      g_free (lockfile_name);
+      return -1;
+    }
+
+  if (flock (*lockfile, LOCK_EX | LOCK_NB)) /* Exclusive, Non blocking. */
+    {
+      if (errno == EWOULDBLOCK)
+        g_debug ("%s: skipping, sync in progress", __FUNCTION__);
+      else
+        g_debug ("%s: flock: %s", __FUNCTION__, strerror (errno));
+      g_free (lockfile_name);
+      return 1;
+    }
+
+  g_free (lockfile_name);
+  return 0;
+}
+
+/**
  * @brief Sync a SecInfo DB.
  *
  * @param[in]  sigmask_current    Sigmask to restore in child.
@@ -3651,8 +3696,7 @@ sync_secinfo (sigset_t *sigmask_current,
               const gchar *process_title,
               const gchar *lockfile_basename)
 {
-  int pid, lockfile;
-  gchar *lockfile_name;
+  int pid, lockfile, ret;
 
   /* Fork a child to sync the db, so that the parent can return to the main
    * loop. */
@@ -3673,32 +3717,12 @@ sync_secinfo (sigset_t *sigmask_current,
 
       /* Open the lock file. */
 
-      lockfile_name =
-        g_build_filename (g_get_tmp_dir (), lockfile_basename, NULL);
+      ret = open_secinfo_lockfile (lockfile_basename, &lockfile);
 
-      lockfile = open (lockfile_name,
-                       O_RDWR | O_CREAT | O_APPEND,
-                       /* "-rw-r--r--" */
-                       S_IWUSR | S_IRUSR | S_IROTH | S_IRGRP);
-      if (lockfile == -1)
-        {
-          g_warning ("%s: failed to open lock file '%s': %s",
-                     __FUNCTION__,
-                     lockfile_name,
-                     strerror (errno));
-          g_free (lockfile_name);
-          exit (EXIT_FAILURE);
-        }
-
-      if (flock (lockfile, LOCK_EX | LOCK_NB)) /* Exclusive, Non blocking. */
-        {
-          if (errno == EWOULDBLOCK)
-            g_debug ("%s: skipping, sync in progress", __FUNCTION__);
-          else
-            g_debug ("%s: flock: %s", __FUNCTION__, strerror (errno));
-          g_free (lockfile_name);
-          exit (EXIT_SUCCESS);
-        }
+      if (ret == 1)
+        exit (EXIT_SUCCESS);
+      else if (ret)
+        exit (EXIT_FAILURE);
 
       /* Init. */
 
@@ -3728,13 +3752,10 @@ sync_secinfo (sigset_t *sigmask_current,
 
   if (close (lockfile))
     {
-      g_free (lockfile_name);
       g_warning (
         "%s: failed to close lock file: %s", __FUNCTION__, strerror (errno));
       exit (EXIT_FAILURE);
     }
-
-  g_free (lockfile_name);
 
   exit (EXIT_SUCCESS);
 }
@@ -4245,17 +4266,31 @@ update_scap_placeholders (int updated_cves)
 }
 
 /**
- * @brief Sync the SCAP DB.
+ * @brief Update data in the SCAP DB.
  *
- * @param[in]  lockfile  Lock file.
+ * Currently only works correctly with all data or OVAL definitions.
+ *
+ * @param[in]  lockfile                 Lock file.
+ * @param[in]  ignore_last_scap_update  Whether to ignore the last update time.
+ * @param[in]  update_cpes              Whether to update CPEs.
+ * @param[in]  update_cves              Whether to update CVEs.
+ * @param[in]  ignore_ovaldefs          Whether to update OVAL definitions.
  *
  * @return 0 success, -1 error.
  */
 static int
-sync_scap (int lockfile)
+update_scap (int lockfile,
+             gboolean ignore_last_scap_update,
+             gboolean update_cpes,
+             gboolean update_cves,
+             gboolean update_ovaldefs)
 {
   int last_feed_update, last_scap_update;
   int updated_scap_ovaldefs, updated_scap_cpes, updated_scap_cves;
+
+  updated_scap_ovaldefs = 0;
+  updated_scap_cpes = 0;
+  updated_scap_cves = 0;
 
   if (manage_scap_db_exists ())
     {
@@ -4273,8 +4308,11 @@ sync_scap (int lockfile)
         }
     }
 
-  last_scap_update = -1;
-  if (manage_scap_loaded ())
+  if (manage_scap_loaded () == 0)
+    last_scap_update = -1;
+  else if (ignore_last_scap_update)
+    last_scap_update = 0;
+  else
     last_scap_update = sql_int ("SELECT coalesce ((SELECT value FROM scap.meta"
                                 "                  WHERE name = 'last_update'),"
                                 "                 '-1');");
@@ -4319,46 +4357,55 @@ sync_scap (int lockfile)
 
   g_info ("%s: Updating data from feed", __FUNCTION__);
 
-  g_debug ("%s: update cpes", __FUNCTION__);
-
-  updated_scap_cpes = update_scap_cpes (last_scap_update);
-  if (updated_scap_cpes == -1)
+  if (update_cpes)
     {
-      manage_update_scap_db_cleanup ();
-      goto fail;
+      g_debug ("%s: update cpes", __FUNCTION__);
+
+      updated_scap_cpes = update_scap_cpes (last_scap_update);
+      if (updated_scap_cpes == -1)
+        {
+          manage_update_scap_db_cleanup ();
+          goto fail;
+        }
     }
 
-  g_debug ("%s: update cves", __FUNCTION__);
-
-  updated_scap_cves = update_scap_cves (last_scap_update);
-  if (updated_scap_cves == -1)
+  if (update_cves)
     {
-      manage_update_scap_db_cleanup ();
-      goto fail;
+      g_debug ("%s: update cves", __FUNCTION__);
+
+      updated_scap_cves = update_scap_cves (last_scap_update);
+      if (updated_scap_cves == -1)
+        {
+          manage_update_scap_db_cleanup ();
+          goto fail;
+        }
     }
 
-  g_debug ("%s: update ovaldefs", __FUNCTION__);
-
-  updated_scap_ovaldefs =
-    update_scap_ovaldefs (last_scap_update, 0 /* Feed data. */);
-  if (updated_scap_ovaldefs == -1)
+  if (update_ovaldefs)
     {
-      manage_update_scap_db_cleanup ();
-      goto fail;
-    }
+      g_debug ("%s: update ovaldefs", __FUNCTION__);
 
-  g_debug ("%s: updating user defined data", __FUNCTION__);
+      updated_scap_ovaldefs =
+        update_scap_ovaldefs (last_scap_update, 0 /* Feed data. */);
+      if (updated_scap_ovaldefs == -1)
+        {
+          manage_update_scap_db_cleanup ();
+          goto fail;
+        }
 
-  switch (update_scap_ovaldefs (last_scap_update, 1 /* Private data. */))
-    {
-    case 0:
-      break;
-    case -1:
-      manage_update_scap_db_cleanup ();
-      goto fail;
-    default:
-      updated_scap_ovaldefs = 1;
-      break;
+      g_debug ("%s: updating user defined data", __FUNCTION__);
+
+      switch (update_scap_ovaldefs (last_scap_update, 1 /* Private data. */))
+        {
+        case 0:
+          break;
+        case -1:
+          manage_update_scap_db_cleanup ();
+          goto fail;
+        default:
+          updated_scap_ovaldefs = 1;
+          break;
+        }
     }
 
   update_scap_cvss (
@@ -4398,6 +4445,23 @@ fail:
 /**
  * @brief Sync the SCAP DB.
  *
+ * @param[in]  lockfile  Lock file.
+ *
+ * @return 0 success, -1 error.
+ */
+static int
+sync_scap (int lockfile)
+{
+  return update_scap (lockfile,
+                      FALSE, /* ignore_last_scap_update */
+                      TRUE,  /* update_cpes */
+                      TRUE,  /* update_cves */
+                      TRUE   /* update_ovaldefs */);
+}
+
+/**
+ * @brief Sync the SCAP DB.
+ *
  * @param[in]  sigmask_current  Sigmask to restore in child.
  */
 void
@@ -4412,16 +4476,15 @@ manage_sync_scap (sigset_t *sigmask_current)
  *
  * @param[in]  type        The type of SCAP info to rebuild.
  *
- * @return 0 success, 1 invalid type, -1 error
+ * @return 0 success, 1 invalid type, 2 sync running, -1 error
  */
 static int
 rebuild_scap (const char *type)
 {
-  int updated_scap_ovaldefs, updated_scap_cpes, updated_scap_cves;
+  int ret = -1;
+  int lockfile;
 
-  // updated_scap_ovaldefs = 0; // initial value currently unused
-  updated_scap_cpes = 0;
-  updated_scap_cves = 0;
+  ret = open_secinfo_lockfile ("gvm-sync-scap", &lockfile);
 
   if (strcasecmp (type, "ovaldefs") == 0
       || strcasecmp (type, "ovaldef") == 0)
@@ -4431,30 +4494,25 @@ rebuild_scap (const char *type)
       sql ("DELETE FROM affected_ovaldefs");
       sql ("DELETE FROM ovaldefs");
 
-      updated_scap_ovaldefs = update_scap_ovaldefs (0, 0 /* Feed data. */);
-      if (updated_scap_ovaldefs == -1)
-        return -1;
-
-      switch (update_scap_ovaldefs (0, 1 /* Private data. */))
-        {
-          case 0:
-            break;
-          case -1:
-            return -1;
-          default:
-            updated_scap_ovaldefs = 1;
-            break;
-        }
+      ret = update_scap (lockfile,
+                         TRUE,  /* ignore_last_scap_update */
+                         FALSE, /* update_cpes */
+                         FALSE, /* update_cves */
+                         TRUE   /* update_ovaldefs */);
+      if (ret == 1)
+        ret = 2;
     }
   else
-    return 1;
+    ret = 1;
 
-  update_scap_cvss (updated_scap_cves,
-                    updated_scap_cpes,
-                    updated_scap_ovaldefs);
-  update_scap_placeholders (updated_scap_cves);
+  if (close (lockfile))
+    {
+      g_warning (
+        "%s: failed to close lock file: %s", __FUNCTION__, strerror (errno));
+      return -1;
+    }
 
-  return 0;
+  return ret;
 }
 
 /**
@@ -4472,20 +4530,9 @@ int
 manage_rebuild_scap (GSList *log_config, const gchar *database,
                      const char *type)
 {
-  lockfile_t lockfile;
   int ret;
 
   g_info ("   Rebuilding SCAP data (%s).", type);
-
-  switch (lockfile_lock_nb (&lockfile, "gvm-sync-scap"))
-    {
-      case 1:
-        printf ("A SCAP sync is already running.\n");
-        return -5;
-      case -1:
-        printf ("Error getting sync lock.\n");
-        return -1;
-    }
 
   ret = manage_option_setup (log_config, database);
   if (ret)
@@ -4520,12 +4567,10 @@ manage_rebuild_scap (GSList *log_config, const gchar *database,
     goto fail;
 
   manage_option_cleanup ();
-  lockfile_unlock (&lockfile);
   return 0;
 
 fail:
   manage_option_cleanup ();
-  lockfile_unlock (&lockfile);
   return -1;
 }
 

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -4485,6 +4485,10 @@ rebuild_scap (const char *type)
   int lockfile;
 
   ret = open_secinfo_lockfile ("gvm-sync-scap", &lockfile);
+  if (ret == 1)
+    return 2;
+  else if (ret)
+    return -1;
 
   if (strcasecmp (type, "ovaldefs") == 0
       || strcasecmp (type, "ovaldef") == 0)
@@ -4522,9 +4526,7 @@ rebuild_scap (const char *type)
  * @param[in]  database    Location of manage database.
  * @param[in]  type        The type of SCAP info to rebuild.
 
- * @return 0 success, -1 error, -2 main database is wrong version,
- *         -3 main database needs to be initialised from server,
- *         -5 sync currently running.
+ * @return 0 success, -1 error.
  */
 int
 manage_rebuild_scap (GSList *log_config, const gchar *database,
@@ -4536,7 +4538,7 @@ manage_rebuild_scap (GSList *log_config, const gchar *database,
 
   ret = manage_option_setup (log_config, database);
   if (ret)
-    return ret;
+    return -1;
 
   if (manage_update_scap_db_init ())
     goto fail;
@@ -4561,6 +4563,11 @@ manage_rebuild_scap (GSList *log_config, const gchar *database,
   if (ret == 1)
     {
       printf ("Type must be 'ovaldefs'.\n");
+      goto fail;
+    }
+  else if (ret == 2)
+    {
+      printf ("SCAP sync is currently running.\n");
       goto fail;
     }
   else if (ret)

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -4408,6 +4408,128 @@ manage_sync_scap (sigset_t *sigmask_current)
 }
 
 /**
+ * @brief Rebuild part of the SCAP DB.
+ *
+ * @param[in]  type        The type of SCAP info to rebuild.
+ *
+ * @return 0 success, 1 invalid type, -1 error
+ */
+static int
+rebuild_scap (const char *type)
+{
+  int updated_scap_ovaldefs, updated_scap_cpes, updated_scap_cves;
+
+  updated_scap_ovaldefs = 0;
+  updated_scap_cpes = 0;
+  updated_scap_cves = 0;
+
+  if (strcasecmp (type, "ovaldefs") == 0
+      || strcasecmp (type, "ovaldef") == 0)
+    {
+      g_debug ("%s: rebuilding ovaldefs", __FUNCTION__);
+      sql ("DELETE FROM ovalfiles");
+      sql ("DELETE FROM affected_ovaldefs");
+      sql ("DELETE FROM ovaldefs");
+
+      updated_scap_ovaldefs = update_scap_ovaldefs (0, 0 /* Feed data. */);
+      if (updated_scap_ovaldefs == -1)
+        return -1;
+
+      switch (update_scap_ovaldefs (0, 1 /* Private data. */))
+        {
+          case 0:
+            break;
+          case -1:
+            return -1;
+          default:
+            updated_scap_ovaldefs = 1;
+            break;
+        }
+    }
+  else
+    return 1;
+
+  update_scap_cvss (updated_scap_cves,
+                    updated_scap_cpes,
+                    updated_scap_ovaldefs);
+  update_scap_placeholders (updated_scap_cves);
+
+  return 0;
+}
+
+/**
+ * @brief Rebuild part of the SCAP DB.
+ *
+ * @param[in]  log_config  Log configuration.
+ * @param[in]  database    Location of manage database.
+ * @param[in]  type        The type of SCAP info to rebuild.
+
+ * @return 0 success, -1 error, -2 main database is wrong version,
+ *         -3 main database needs to be initialised from server,
+ *         -5 sync currently running.
+ */
+int
+manage_rebuild_scap (GSList *log_config, const gchar *database,
+                     const char *type)
+{
+  lockfile_t lockfile;
+  int ret;
+
+  g_info ("   Rebuilding SCAP data (%s).", type);
+
+  switch (lockfile_lock_nb (&lockfile, "gvm-sync-scap"))
+    {
+      case 1:
+        printf ("A SCAP sync is already running.\n");
+        return -5;
+      case -1:
+        printf ("Error getting sync lock.\n");
+        return -1;
+    }
+
+  ret = manage_option_setup (log_config, database);
+  if (ret)
+    return ret;
+
+  if (manage_update_scap_db_init ())
+    goto fail;
+
+  if (manage_scap_db_exists ())
+    {
+      if (check_scap_db_version ())
+        goto fail;
+    }
+  else
+    {
+      g_info ("%s: Initializing SCAP database", __FUNCTION__);
+
+      if (manage_db_init ("scap"))
+        {
+          g_warning ("%s: Could not initialize SCAP database", __FUNCTION__);
+          goto fail;
+        }
+    }
+
+  ret = rebuild_scap (type);
+  if (ret == 1)
+    {
+      printf ("Type must be 'ovaldefs'.\n");
+      goto fail;
+    }
+  else if (ret)
+    goto fail;
+
+  manage_option_cleanup ();
+  lockfile_unlock (&lockfile);
+  return 0;
+
+fail:
+  manage_option_cleanup ();
+  lockfile_unlock (&lockfile);
+  return -1;
+}
+
+/**
  * @brief Set the SecInfo update commit size.
  *
  * @param new_commit_size The new SecInfo update commit size.

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -4419,7 +4419,7 @@ rebuild_scap (const char *type)
 {
   int updated_scap_ovaldefs, updated_scap_cpes, updated_scap_cves;
 
-  updated_scap_ovaldefs = 0;
+  // updated_scap_ovaldefs = 0; // initial value currently unused
   updated_scap_cpes = 0;
   updated_scap_cves = 0;
 

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -4274,7 +4274,7 @@ update_scap_placeholders (int updated_cves)
  * @param[in]  ignore_last_scap_update  Whether to ignore the last update time.
  * @param[in]  update_cpes              Whether to update CPEs.
  * @param[in]  update_cves              Whether to update CVEs.
- * @param[in]  ignore_ovaldefs          Whether to update OVAL definitions.
+ * @param[in]  update_ovaldefs          Whether to update OVAL definitions.
  *
  * @return 0 success, -1 error.
  */

--- a/src/manage_sql_secinfo.h
+++ b/src/manage_sql_secinfo.h
@@ -22,6 +22,7 @@
  * @brief Manager Manage library: SQL backend headers.
  */
 
+#include <glib.h>
 #include <signal.h>
 
 #ifndef _GVMD_MANAGE_SQL_SECINFO_H
@@ -338,6 +339,9 @@
 
 void
 manage_sync_scap (sigset_t *);
+
+int
+manage_rebuild_scap (GSList *, const gchar *, const char *);
 
 void
 manage_sync_cert (sigset_t *);


### PR DESCRIPTION
This option allows rebuilding SCAP data of a given type.
Currently only OVAL definitions are supported.

**Checklist**:

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
