### PR TITLE
Add --rebuild-scap option (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add --optimize option cleanup-result-encoding [#1013](https://github.com/greenbone/gvmd/pull/1013)
 - Add --rebuild [#1016](https://github.com/greenbone/gvmd/pull/1016)
 - Lock a file around the NVT sync [#1017](https://github.com/greenbone/gvmd/pull/1017)
+- Add --rebuild-scap option [#1050](https://github.com/greenbone/gvmd/pull/1050)
 
 ### Changed
 - Extend command line options for managing scanners [#815](https://github.com/greenbone/gvmd/pull/815)

--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -124,6 +124,9 @@ Use port number NUMBER.
 \fB--port2=\fINUMBER\fB\f1
 Use port number NUMBER for address 2.
 .TP
+\fB--rebuild-scap=\fITYPE\fB\f1
+Rebuild SCAP data of type \fITYPE\f1 (currently only supports 'ovaldefs'). 
+.TP
 \fB--relay-mapper=\fIFILE\fB\f1
 Executable for mapping scanner hosts to relays. Use an empty string to explicitly disable. If the option is not given, $PATH is checked for gvm-relay-mapper. 
 .TP

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -282,6 +282,15 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       </optdesc>
     </option>
     <option>
+      <p><opt>--rebuild-scap=<arg>TYPE</arg></opt></p>
+      <optdesc>
+        <p>
+          Rebuild SCAP data of type <arg>TYPE</arg>
+          (currently only supports 'ovaldefs').
+        </p>
+      </optdesc>
+    </option>
+    <option>
       <p><opt>--relay-mapper=<arg>FILE</arg></opt></p>
       <optdesc>
         <p>Executable for mapping scanner hosts to relays.

--- a/doc/gvmd.html
+++ b/doc/gvmd.html
@@ -265,6 +265,15 @@
       
     
     
+      <p><b>--rebuild-scap=<em>TYPE</em></b></p>
+      
+        <p>
+          Rebuild SCAP data of type <em>TYPE</em>
+          (currently only supports 'ovaldefs').
+        </p>
+      
+    
+    
       <p><b>--relay-mapper=<em>FILE</em></b></p>
       
         <p>Executable for mapping scanner hosts to relays.

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1635,6 +1635,7 @@ gvmd (int argc, char** argv)
   static gchar *rc_name = NULL;
   static gchar *relay_mapper = NULL;
   static gboolean rebuild = FALSE;
+  static gchar *rebuild_scap = NULL;
   static gchar *role = NULL;
   static gchar *disable = NULL;
   static gchar *value = NULL;
@@ -1804,6 +1805,11 @@ gvmd (int argc, char** argv)
           &rebuild,
           "Remove NVT db, and rebuild it from the scanner.",
           NULL },
+        { "rebuild-scap", '\0', 0, G_OPTION_ARG_STRING,
+          &rebuild_scap,
+          "Rebuild SCAP data of type <type>"
+          " (currently only supports 'ovaldefs').",
+          "<type>" },
         { "relay-mapper", '\0', 0, G_OPTION_ARG_FILENAME,
           &relay_mapper,
           "Executable for mapping scanner hosts to relays."
@@ -2247,6 +2253,25 @@ gvmd (int argc, char** argv)
       log_config_free ();
       if (ret)
         return EXIT_FAILURE;
+      return EXIT_SUCCESS;
+    }
+
+  if (rebuild_scap)
+    {
+      int ret;
+
+      proctitle_set ("gvmd: --rebuild-scap");
+
+      if (option_lock (&lockfile_checking))
+        return EXIT_FAILURE;
+
+      ret = manage_rebuild_scap (log_config, database, rebuild_scap);
+      log_config_free ();
+      if (ret)
+        {
+          printf ("Failed to rebuild SCAP data.\n");
+          return EXIT_FAILURE;
+        }
       return EXIT_SUCCESS;
     }
 

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -5201,6 +5201,10 @@ rebuild_scap (const char *type)
   int lockfile;
 
   ret = open_secinfo_lockfile ("gvm-sync-scap", &lockfile);
+  if (ret == 1)
+    return 2;
+  else if (ret)
+    return -1;
 
   if (strcasecmp (type, "ovaldefs") == 0
       || strcasecmp (type, "ovaldef") == 0)
@@ -5238,9 +5242,7 @@ rebuild_scap (const char *type)
  * @param[in]  database    Location of manage database.
  * @param[in]  type        The type of SCAP info to rebuild.
 
- * @return 0 success, -1 error, -2 main database is wrong version,
- *         -3 main database needs to be initialised from server,
- *         -5 sync currently running.
+ * @return 0 success, -1 error.
  */
 int
 manage_rebuild_scap (GSList *log_config, const gchar *database,
@@ -5252,7 +5254,7 @@ manage_rebuild_scap (GSList *log_config, const gchar *database,
 
   ret = manage_option_setup (log_config, database);
   if (ret)
-    return ret;
+    return -1;
 
   if (manage_update_scap_db_init ())
     goto fail;
@@ -5277,6 +5279,11 @@ manage_rebuild_scap (GSList *log_config, const gchar *database,
   if (ret == 1)
     {
       printf ("Type must be 'ovaldefs'.\n");
+      goto fail;
+    }
+  else if (ret == 2)
+    {
+      printf ("SCAP sync is currently running.\n");
       goto fail;
     }
   else if (ret)

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -5135,7 +5135,7 @@ rebuild_scap (const char *type)
 {
   int updated_scap_ovaldefs, updated_scap_cpes, updated_scap_cves;
 
-  updated_scap_ovaldefs = 0;
+  // updated_scap_ovaldefs = 0; // initial value currently unused
   updated_scap_cpes = 0;
   updated_scap_cves = 0;
 

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -4973,7 +4973,7 @@ update_scap_placeholders (int updated_cves)
  * @param[in]  ignore_last_scap_update  Whether to ignore the last update time.
  * @param[in]  update_cpes              Whether to update CPEs.
  * @param[in]  update_cves              Whether to update CVEs.
- * @param[in]  ignore_ovaldefs          Whether to update OVAL definitions.
+ * @param[in]  update_ovaldefs          Whether to update OVAL definitions.
  *
  * @return 0 success, -1 error.
  */

--- a/src/manage_sql_secinfo.h
+++ b/src/manage_sql_secinfo.h
@@ -22,6 +22,7 @@
  * @brief Manager Manage library: SQL backend headers.
  */
 
+#include <glib.h>
 #ifndef _GVMD_MANAGE_SQL_SECINFO_H
 #define _GVMD_MANAGE_SQL_SECINFO_H
 
@@ -327,6 +328,9 @@
 
 void
 manage_sync_scap (sigset_t *);
+
+int
+manage_rebuild_scap (GSList *, const gchar *, const char *);
 
 void
 manage_sync_cert (sigset_t *);


### PR DESCRIPTION
This option allows rebuilding SCAP data of a given type.
Currently only OVAL definitions are supported.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
