### PR TITLE
Use right format specifier for merge_ovaldef version (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Init comment for MODIFY_USER/COMMENT, in case it's empty [#894](https://github.com/greenbone/gvmd/pull/894)
 - Init comment for MODIFY_PERMISSION, in case it's empty [#919](https://github.com/greenbone/gvmd/pull/919)
 - Fix Verinice ISM report format and update version [#963](https://github.com/greenbone/gvmd/pull/963)
+- Use right format specifier for merge_ovaldef version [#1053](https://github.com/greenbone/gvmd/pull/1053)
 
 ### Removed
 

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -3065,7 +3065,7 @@ update_ovaldef_xml (gchar **file_and_date,
                   else
                     quoted_status = sql_quote ("");
 
-                  sql ("SELECT merge_ovaldef ('%s', '%s', '', %i, %i, %i, %i,"
+                  sql ("SELECT merge_ovaldef ('%s', '%s', '', %i, %i, %s, %i,"
                        "                      '%s', '%s', '%s', '%s', '%s',"
                        "                      %i);",
                        quoted_id,


### PR DESCRIPTION
'version' is a string, not an int.

Backport of #874

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
