### PR TITLE
Updated the list of current Local Security Checks for the Auto-FP feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Count only best OS matches for OS asset hosts [#1029](https://github.com/greenbone/gvmd/pull/1029)
 - Clean up NVTs set to name in cleanup-result-nvts [#1039](https://github.com/greenbone/gvmd/pull/1039)
 - Improve validation of note and override ports [#1045](https://github.com/greenbone/gvmd/pull/1045)
+- The internal list of current Local Security Checks for the Auto-FP feature was updated [#1054](https://github.com/greenbone/gvmd/pull/1054)
 
 ### Fixed
 - Add NULL check in nvts_feed_version_epoch [#768](https://github.com/greenbone/gvmd/pull/768)

--- a/src/manage.h
+++ b/src/manage.h
@@ -1056,22 +1056,32 @@ user_has_super (const char *, user_t);
 /**
  * @brief SQL list of LSC families.
  */
-#define LSC_FAMILY_LIST                  \
-  "'AIX Local Security Checks',"         \
-  " 'CentOS Local Security Checks',"     \
-  " 'Debian Local Security Checks',"     \
-  " 'Fedora Local Security Checks',"     \
-  " 'FreeBSD Local Security Checks',"    \
-  " 'Gentoo Local Security Checks',"     \
-  " 'HP-UX Local Security Checks',"      \
-  " 'Mac OS X Local Security Checks',"   \
-  " 'Mandrake Local Security Checks',"   \
-  " 'Red Hat Local Security Checks',"    \
-  " 'Solaris Local Security Checks',"    \
-  " 'SuSE Local Security Checks',"       \
-  " 'Ubuntu Local Security Checks',"     \
-  " 'Windows : Microsoft Bulletins',"    \
-  " 'Privilege escalation'"
+#define LSC_FAMILY_LIST                            \
+  "'AIX Local Security Checks',"                   \
+  " 'Amazon Linux Local Security Checks',"         \
+  " 'CentOS Local Security Checks',"               \
+  " 'Citrix Xenserver Local Security Checks',"     \
+  " 'Debian Local Security Checks',"               \
+  " 'F5 Local Security Checks',"                   \
+  " 'Fedora Local Security Checks',"               \
+  " 'FortiOS Local Security Checks',"              \
+  " 'FreeBSD Local Security Checks',"              \
+  " 'Gentoo Local Security Checks',"               \
+  " 'HP-UX Local Security Checks',"                \
+  " 'Huawei EulerOS Local Security Checks',"       \
+  " 'JunOS Local Security Checks',"                \
+  " 'Mac OS X Local Security Checks',"             \
+  " 'Mageia Linux Local Security Checks',"         \
+  " 'Mandrake Local Security Checks',"             \
+  " 'Oracle Linux Local Security Checks',"         \
+  " 'Palo Alto PAN-OS Local Security Checks',"     \
+  " 'Red Hat Local Security Checks',"              \
+  " 'Slackware Local Security Checks',"            \
+  " 'Solaris Local Security Checks',"              \
+  " 'SuSE Local Security Checks',"                 \
+  " 'VMware Local Security Checks',"               \
+  " 'Ubuntu Local Security Checks',"               \
+  " 'Windows : Microsoft Bulletins'"
 
 gboolean
 find_result_with_permission (const char*, result_t*, const char *);


### PR DESCRIPTION
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

This updates the hard-coded list of Local Security Checks used by the Auto-FP to the current used Local Security Checks families. The "Privilege escalation" family was misplaces in the list and was removed as well.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
