### PR TITLE
fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Accept expanded scheme OIDs in parse_osp_report [#983](https://github.com/greenbone/gvmd/pull/983)
 - Fix SCAP update not finishing when CPEs are older [#985](https://github.com/greenbone/gvmd/pull/985)
 - Add user limits on hosts and ifaces to OSP prefs [#1032](https://github.com/greenbone/gvmd/pull/1032)
+- Fix scanner_options not inserted correctly when starting ospd task [#1056](https://github.com/greenbone/gvmd/pull/1056)
 
 ### Removed
 - Remove 1.3.6.1.4.1.25623.1.0.90011 from Discovery config (9.0) [#847](https://github.com/greenbone/gvmd/pull/847)

--- a/src/manage.c
+++ b/src/manage.c
@@ -4236,12 +4236,12 @@ launch_osp_openvas_task (task_t task, target_t target, const char *scan_id,
 
   source_iface = task_preference_value (task, "source_iface");
   if (source_iface)
-    g_hash_table_insert (scanner_options, g_strdup ("source_ifae"),
+    g_hash_table_insert (scanner_options, g_strdup ("source_iface"),
                         source_iface);
 
   hosts_ordering = task_hosts_ordering (task);
   if (hosts_ordering)
-    g_hash_table_insert (scanner_options, g_strdup ("host_ordering"),
+    g_hash_table_insert (scanner_options, g_strdup ("hosts_ordering"),
                          hosts_ordering);
 
   /* Setup reverse_lookup_only preference. */


### PR DESCRIPTION
Because of typos some scanner_options did not get inserted correctly
when starting an ospd task.

**Checklist**:

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
