### PR TITLE
Stop current scheduling of task when permission denied 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Perform integrity check of VTs after updates [#1024](https://github.com/greenbone/gvmd/pull/1024) [#1035](https://github.com/greenbone/gvmd/pull/1035)
 - Ensure path of listening UNIX socket exists [#1040](https://github.com/greenbone/gvmd/pull/1040)
 - Add --rebuild-scap option [#1051](https://github.com/greenbone/gvmd/pull/1051)
+- Stop current scheduling of task when permission denied [#1058](https://github.com/greenbone/gvmd/pull/1058)
 
 ### Changed
 - Update SCAP and CERT feed info in sync scripts [#810](https://github.com/greenbone/gvmd/pull/810)

--- a/src/manage.c
+++ b/src/manage.c
@@ -7105,14 +7105,28 @@ scheduled_task_start (scheduled_task_t *scheduled_task,
                                 scheduled_task->task_uuid,
                                 NULL))
     {
-      if (gmp_start_task_report_c (&connection,
-                                   scheduled_task->task_uuid,
-                                   NULL))
+      gmp_start_task_opts_t opts;
+
+      opts = gmp_start_task_opts_defaults;
+      opts.task_id = scheduled_task->task_uuid;
+
+      switch (gmp_start_task_ext_c (&connection, opts))
         {
-          g_warning ("%s: gmp_start_task and gmp_resume_task failed", __func__);
-          scheduled_task_free (scheduled_task);
-          gvm_connection_free (&connection);
-          exit (EXIT_FAILURE);
+          case 0:
+            break;
+
+          case 99:
+            g_warning ("%s: user denied permission to start task", __func__);
+            scheduled_task_free (scheduled_task);
+            gvm_connection_free (&connection);
+            /* Return success, so that parent stops trying to start the task. */
+            exit (EXIT_SUCCESS);
+
+          default:
+            g_warning ("%s: gmp_start_task and gmp_resume_task failed", __func__);
+            scheduled_task_free (scheduled_task);
+            gvm_connection_free (&connection);
+            exit (EXIT_FAILURE);
         }
     }
 


### PR DESCRIPTION
This prevents the scheduler from failing to start the task every 10 seconds
forever, when the user does not have permission to run the task.  This can
happen, for example, if the task uses someone else's target, and permission
to access the target is revoked.

Note that this only affects the current attempt to run the task.  If the schedule
is periodic then the scheduler will try again next time the task is due.

Requires https://github.com/greenbone/gvm-libs/pull/327.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
