### PR TITLE
Fix QoD handling in NVTi cache and sensor scans (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix SCAP update not finishing when CPEs are older [#985](https://github.com/greenbone/gvmd/pull/985)
 - Add user limits on hosts and ifaces to OSP prefs [#1032](https://github.com/greenbone/gvmd/pull/1032)
 - Fix scanner_options not inserted correctly when starting ospd task [#1056](https://github.com/greenbone/gvmd/pull/1056)
+- Fix QoD handling in NVTi cache and sensor scans [#1060](https://github.com/greenbone/gvmd/pull/1060)
 
 ### Removed
 - Remove 1.3.6.1.4.1.25623.1.0.90011 from Discovery config (9.0) [#847](https://github.com/greenbone/gvmd/pull/847)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -15789,7 +15789,7 @@ update_nvti_cache ()
   init_iterator (&nvts,
                  "SELECT oid, name, family, cvss_base, tag,"
                  "       solution, solution_type, summary, insight, affected,"
-                 "       impact, detection"
+                 "       impact, detection, qod_type"
                  " FROM nvts;");
   while (next (&nvts))
     {
@@ -15808,6 +15808,7 @@ update_nvti_cache ()
       nvti_set_affected (nvti, iterator_string (&nvts, 9));
       nvti_set_impact (nvti, iterator_string (&nvts, 10));
       nvti_set_detection (nvti, iterator_string (&nvts, 11));
+      nvti_set_qod_type (nvti, iterator_string (&nvts, 12));
 
       init_iterator (&refs,
                      "SELECT type, ref_id, ref_text"
@@ -49426,7 +49427,9 @@ buffer_insert (GString *results_buffer, GString *result_nvts_buffer,
         {
           gchar *qod_str, *qod_type;
           qod_str = tag_value (nvti_tag (nvti), "qod");
-          qod_type = tag_value (nvti_tag (nvti), "qod_type");
+          qod_type = g_strdup (nvti_qod_type (nvti));
+          if (qod_type == NULL)
+            qod_type = tag_value (nvti_tag (nvti), "qod_type");
 
           if (qod_str == NULL || sscanf (qod_str, "%d", &qod) != 1)
             qod = qod_from_type (qod_type);


### PR DESCRIPTION
The update_nvti_cache function now adds the qod_type to the nvti
items. Also, buffer_insert now also tries to use it before trying to
get it from the NVT tags.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
