### PR TITLE
Do not ignore empty hosts_allow and ifaces_allow (8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update SCAP and CERT feed info in sync scripts [#808](https://github.com/greenbone/gvmd/pull/808)
 - Count only best OS matches for OS asset hosts [#1027](https://github.com/greenbone/gvmd/pull/1027)
 - New Community Feed download URL in sync tools [#1043](https://github.com/greenbone/gvmd/pull/1043)
+- Do not ignore empty hosts_allow and ifaces_allow [#1062](https://github.com/greenbone/gvmd/pull/1062)
 
 ### Fixed
 - Allow to migrate gvmd 8 sqlite3 database to postgres with gvm-migrate-to-postgres script

--- a/src/manage.c
+++ b/src/manage.c
@@ -1842,7 +1842,7 @@ send_ifaces_access_preferences (void)
   ifaces = user_ifaces (current_credentials.uuid);
   ifaces_allow = user_ifaces_allow (current_credentials.uuid);
 
-  if (ifaces && strlen (ifaces))
+  if (ifaces_allow || (ifaces && strlen (ifaces)))
     {
       char *pref;
 
@@ -1856,7 +1856,7 @@ send_ifaces_access_preferences (void)
           return 0;
         }
 
-      if (sendf_to_server ("%s <|> %s\n", pref, ifaces))
+      if (sendf_to_server ("%s <|> %s\n", pref, ifaces ? ifaces : ""))
         {
           g_free (ifaces);
           return -1;

--- a/src/manage.c
+++ b/src/manage.c
@@ -1880,7 +1880,7 @@ send_hosts_access_preferences (void)
   hosts = user_hosts (current_credentials.uuid);
   hosts_allow = user_hosts_allow (current_credentials.uuid);
 
-  if (hosts && strlen (hosts))
+  if (hosts_allow || (hosts && strlen (hosts)))
     {
       char *pref;
 
@@ -1894,7 +1894,7 @@ send_hosts_access_preferences (void)
           return 0;
         }
 
-      if (sendf_to_server ("%s <|> %s\n", pref, hosts))
+      if (sendf_to_server ("%s <|> %s\n", pref, hosts ? hosts : ""))
         {
           g_free (hosts);
           return -1;


### PR DESCRIPTION
With this it is possible to forbid users to scan any hosts or scan
using any network interfaces.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
