### PR TITLE
Do not ignore empty hosts_allow and ifaces_allow (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The details attribute of GET_REPORTS now defaults to 0 [#747](https://github.com/greenbone/gvmd/pull/747)
 - Incoming VT timestamps via OSP are now assumed to be seconds since epoch [#754](https://github.com/greenbone/gvmd/pull/754)
 - Accelerate NVT feed update [#757](https://github.com/greenbone/gvmd/pull/757)
+- Do not ignore empty hosts_allow and ifaces_allow [#1063](https://github.com/greenbone/gvmd/pull/1063)
 
 ### Fixed
 - Make get_settings return only one setting when setting_id is given [#779](https://github.com/greenbone/gvmd/pull/779)

--- a/src/manage.c
+++ b/src/manage.c
@@ -4084,7 +4084,7 @@ add_user_scan_preferences (GHashTable *scanner_options)
     name = NULL;
 
   if (name
-      && (hosts_allow || (hosts && strlen (hosts)))
+      && (hosts_allow || (hosts && strlen (hosts))))
     g_hash_table_replace (scanner_options,
                           name,
                           hosts ? hosts : g_strdup (""));
@@ -4103,7 +4103,7 @@ add_user_scan_preferences (GHashTable *scanner_options)
     name = NULL;
 
   if (name
-      && (ifaces_allow || (ifaces && strlen (ifaces)))
+      && (ifaces_allow || (ifaces && strlen (ifaces))))
     g_hash_table_replace (scanner_options,
                           name,
                           ifaces ? ifaces : g_strdup (""));

--- a/src/manage.c
+++ b/src/manage.c
@@ -4083,8 +4083,11 @@ add_user_scan_preferences (GHashTable *scanner_options)
   else
     name = NULL;
 
-  if (name)
-    g_hash_table_replace (scanner_options, name, hosts);
+  if (name
+      && (hosts_allow || (hosts && strlen (hosts)))
+    g_hash_table_replace (scanner_options,
+                          name,
+                          hosts ? hosts : g_strdup (""));
   else
     g_free (hosts);
 
@@ -4099,8 +4102,11 @@ add_user_scan_preferences (GHashTable *scanner_options)
   else
     name = NULL;
 
-  if (name)
-    g_hash_table_replace (scanner_options, name, ifaces);
+  if (name
+      && (ifaces_allow || (ifaces && strlen (ifaces)))
+    g_hash_table_replace (scanner_options,
+                          name,
+                          ifaces ? ifaces : g_strdup (""));
   else
     g_free (ifaces);
 }


### PR DESCRIPTION
With this it is possible to forbid users to scan any hosts or scan
using any network interfaces.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
