### PR TITLE
Do not ignore empty hosts_allow and ifaces_allow (master)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Clean up NVTs set to name in cleanup-result-nvts [#1039](https://github.com/greenbone/gvmd/pull/1039)
 - Improve validation of note and override ports [#1045](https://github.com/greenbone/gvmd/pull/1045)
 - The internal list of current Local Security Checks for the Auto-FP feature was updated [#1054](https://github.com/greenbone/gvmd/pull/1054)
+- Do not ignore empty hosts_allow and ifaces_allow [#1064](https://github.com/greenbone/gvmd/pull/1064)
 
 ### Fixed
 - Add NULL check in nvts_feed_version_epoch [#768](https://github.com/greenbone/gvmd/pull/768)

--- a/src/manage.c
+++ b/src/manage.c
@@ -4063,8 +4063,11 @@ add_user_scan_preferences (GHashTable *scanner_options)
   else
     name = NULL;
 
-  if (name)
-    g_hash_table_replace (scanner_options, name, hosts);
+  if (name
+      && (hosts_allow || (hosts && strlen (hosts)))
+    g_hash_table_replace (scanner_options,
+                          name,
+                          hosts ? hosts : g_strdup (""));
   else
     g_free (hosts);
 
@@ -4079,8 +4082,11 @@ add_user_scan_preferences (GHashTable *scanner_options)
   else
     name = NULL;
 
-  if (name)
-    g_hash_table_replace (scanner_options, name, ifaces);
+  if (name
+      && (ifaces_allow || (ifaces && strlen (ifaces)))
+    g_hash_table_replace (scanner_options,
+                          name,
+                          ifaces ? ifaces : g_strdup (""));
   else
     g_free (ifaces);
 }

--- a/src/manage.c
+++ b/src/manage.c
@@ -4064,7 +4064,7 @@ add_user_scan_preferences (GHashTable *scanner_options)
     name = NULL;
 
   if (name
-      && (hosts_allow || (hosts && strlen (hosts)))
+      && (hosts_allow || (hosts && strlen (hosts))))
     g_hash_table_replace (scanner_options,
                           name,
                           hosts ? hosts : g_strdup (""));
@@ -4083,7 +4083,7 @@ add_user_scan_preferences (GHashTable *scanner_options)
     name = NULL;
 
   if (name
-      && (ifaces_allow || (ifaces && strlen (ifaces)))
+      && (ifaces_allow || (ifaces && strlen (ifaces))))
     g_hash_table_replace (scanner_options,
                           name,
                           ifaces ? ifaces : g_strdup (""));


### PR DESCRIPTION
With this it is possible to forbid users to scan any hosts or scan
using any network interfaces.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
