### PR TITLE
Fix doc of get_tasks in GMP doc (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add user limits on hosts and ifaces to OSP prefs [#1032](https://github.com/greenbone/gvmd/pull/1032)
 - Fix scanner_options not inserted correctly when starting ospd task [#1056](https://github.com/greenbone/gvmd/pull/1056)
 - Fix QoD handling in NVTi cache and sensor scans [#1060](https://github.com/greenbone/gvmd/pull/1060)
+- Fix doc of get_tasks in GMP doc [#1065](https://github.com/greenbone/gvmd/pull/1065)
 
 ### Removed
 - Remove 1.3.6.1.4.1.25623.1.0.90011 from Discovery config (9.0) [#847](https://github.com/greenbone/gvmd/pull/847)

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -20691,8 +20691,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         <summary>Optional usage type to limit the tasks to. Affects total count unlike filter</summary>
         <type>
           <alts>
+            <alt>scan</alt>
             <alt>audit</alt>
-            <alt>policy</alt>
             <alt></alt>
           </alts>
         </type>


### PR DESCRIPTION
The usage_type attribute of the should have the option "scan" instead
of "policy".

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
