### PR TITLE
Fix doc of get_tasks in GMP doc (master)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use correct elements to get task ID in wizards [#1004](https://github.com/greenbone/gvmd/pull/1004) [#1046](https://github.com/greenbone/gvmd/pull/1046)
 - Use current row for iterator_null, instead of first row [#1047](https://github.com/greenbone/gvmd/pull/1047)
 - Setup general task preferences to launch an osp openvas task. [#1055](https://github.com/greenbone/gvmd/pull/1055)
+- Fix doc of get_tasks in GMP doc [#1066](https://github.com/greenbone/gvmd/pull/1066)
 
 ### Removed
 - Remove support for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -19874,8 +19874,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <summary>Optional usage type to limit the tasks to. Affects total count unlike filter</summary>
         <type>
           <alts>
+            <alt>scan</alt>
             <alt>audit</alt>
-            <alt>policy</alt>
             <alt></alt>
           </alts>
         </type>


### PR DESCRIPTION
The usage_type attribute of the should have the option "scan" instead
of "policy".

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
