### PR TITLE
Improve refs and error handling in NVTs update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use current row for iterator_null, instead of first row [#1047](https://github.com/greenbone/gvmd/pull/1047)
 - Setup general task preferences to launch an osp openvas task. [#1055](https://github.com/greenbone/gvmd/pull/1055)
 - Fix doc of get_tasks in GMP doc [#1066](https://github.com/greenbone/gvmd/pull/1066)
+- Improve refs and error handling in NVTs update [#1067](https://github.com/greenbone/gvmd/pull/1067)
 
 ### Removed
 - Remove support for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1265,47 +1265,43 @@ nvti_from_vt (entity_t vt)
     }
 
   refs = entity_child (vt, "refs");
-  if (refs == NULL)
+  if (refs)
     {
-      g_warning ("%s: VT missing REFS", __func__);
-      nvti_free (nvti);
-      return NULL;
-    }
-
-  children = refs->entities;
-  while ((ref = first_entity (children)))
-    {
-      const gchar *ref_type;
-
-      ref_type = entity_attribute (ref, "type");
-      if (ref_type == NULL)
+      children = refs->entities;
+      while ((ref = first_entity (children)))
         {
-          GString *debug = g_string_new ("");
-          g_warning ("%s: REF missing type attribute", __func__);
-          print_entity_to_string (ref, debug);
-          g_warning ("%s: ref: %s", __func__, debug->str);
-          g_string_free (debug, TRUE);
-        }
-      else
-        {
-          const gchar *ref_id;
+          const gchar *ref_type;
 
-          ref_id = entity_attribute (ref, "id");
-          if (ref_id == NULL)
+          ref_type = entity_attribute (ref, "type");
+          if (ref_type == NULL)
             {
               GString *debug = g_string_new ("");
-              g_warning ("%s: REF missing id attribute", __func__);
+              g_warning ("%s: REF missing type attribute", __func__);
               print_entity_to_string (ref, debug);
               g_warning ("%s: ref: %s", __func__, debug->str);
               g_string_free (debug, TRUE);
             }
           else
             {
-              nvti_add_vtref (nvti, vtref_new (ref_type, ref_id, NULL));
-            }
-        }
+              const gchar *ref_id;
 
-      children = next_entities (children);
+              ref_id = entity_attribute (ref, "id");
+              if (ref_id == NULL)
+                {
+                  GString *debug = g_string_new ("");
+                  g_warning ("%s: REF missing id attribute", __func__);
+                  print_entity_to_string (ref, debug);
+                  g_warning ("%s: ref: %s", __func__, debug->str);
+                  g_string_free (debug, TRUE);
+                }
+              else
+                {
+                  nvti_add_vtref (nvti, vtref_new (ref_type, ref_id, NULL));
+                }
+            }
+
+          children = next_entities (children);
+        }
     }
 
   severities = entity_child (vt, "severities");
@@ -1422,6 +1418,9 @@ update_nvts_from_vts (entity_t *get_vts_response,
   while ((vt = first_entity (children)))
     {
       nvti_t *nvti = nvti_from_vt (vt);
+
+      if (nvti == NULL)
+        continue;
 
       if (nvti_creation_time (nvti) > feed_version_epoch)
         count_new_vts += 1;


### PR DESCRIPTION
If the refs element is missing, it is simply ignored so the scanner no
longer has to send an empty element.
Also, if nvti_from_vt fails, update_nvts_from_vts will skip the VT
instead of inserting a broken NVT into the table.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
