### PR TITLE
GVMD_FEED_DIR default under "gvm" not "openvas"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,7 @@ if (NOT GVM_NVT_DIR)
 endif (NOT GVM_NVT_DIR)
 
 if (NOT GVMD_FEED_DIR)
-  set (GVMD_FEED_DIR "${LOCALSTATEDIR}/lib/openvas/gvmd/${GMP_VERSION}")
+  set (GVMD_FEED_DIR "${LOCALSTATEDIR}/lib/gvm/gvmd/${GMP_VERSION}")
 endif (NOT GVMD_FEED_DIR)
 
 if (NOT GVM_ACCESS_KEY_DIR)


### PR DESCRIPTION
The data handled in that directory have no relationship
to the actual scanner "openvas". The data belong to GVM.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
