### PR TITLE
Give feed lock a gvmd specific name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The internal list of current Local Security Checks for the Auto-FP feature was updated [#1054](https://github.com/greenbone/gvmd/pull/1054)
 - Simplify sync lockfile handling [#1059](https://github.com/greenbone/gvmd/pull/1059)
 - Do not ignore empty hosts_allow and ifaces_allow [#1064](https://github.com/greenbone/gvmd/pull/1064)
+- Rename feed lock file to feed-update-gvmd.lock [#1073](https://github.com/greenbone/gvmd/pull/1073)
 
 ### Fixed
 - Add NULL check in nvts_feed_version_epoch [#768](https://github.com/greenbone/gvmd/pull/768)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,7 +200,7 @@ if (NOT GVM_RUN_DIR)
 endif (NOT GVM_RUN_DIR)
 
 if (NOT GVM_FEED_LOCK_PATH)
-  set (GVM_FEED_LOCK_PATH "${GVM_RUN_DIR}/feed-update.lock")
+  set (GVM_FEED_LOCK_PATH "${GVM_RUN_DIR}/feed-update-gvmd.lock")
 endif (NOT GVM_FEED_LOCK_PATH)
 add_definitions (-DGVM_FEED_LOCK_PATH="${GVM_FEED_LOCK_PATH}")
 


### PR DESCRIPTION
This is to prevent clashes with ospd-openvas which
uses the very same name. In cases where both use the same
directory for lock files, ospd-openvas will be blocked
and not serve OSP.

**Checklist**:

- [ ] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
