### PR TITLE
Adding --extra-host-identifiers command line argument to fix register_host_detail function

### DIFF
--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1716,6 +1716,7 @@ main (int argc, char **argv)
   static gchar *role = NULL;
   static gchar *disable = NULL;
   static gchar *value = NULL;
+  static gchar *extra_host_idents = "";
   GError *error = NULL;
   lockfile_t lockfile_checking, lockfile_serving;
   GOptionContext *option_context;
@@ -1954,6 +1955,10 @@ main (int argc, char **argv)
       &print_version,
       "Print version and exit.",
       NULL },
+    { "extra-host-idents", '\0', 0, G_OPTION_ARG_STRING,
+      &extra_host_idents,
+     "comma-separated list of extra host identifier names",
+     "<id_1,id_2>" },
     { NULL }};
 
   /* Set locale based on environment variables. */
@@ -2609,6 +2614,12 @@ main (int argc, char **argv)
           exit (EXIT_SUCCESS);
           break;
         }
+    }
+
+    /* Setup list of extra host identifiers*/
+    if(extra_host_idents)
+    {
+       manage_set_extra_host_idents(extra_host_idents);
     }
 
   /* Initialise GMP daemon. */

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1716,7 +1716,7 @@ main (int argc, char **argv)
   static gchar *role = NULL;
   static gchar *disable = NULL;
   static gchar *value = NULL;
-  static gchar *extra_host_idents = "";
+  static gchar *extra_host_identifiers = "";
   GError *error = NULL;
   lockfile_t lockfile_checking, lockfile_serving;
   GOptionContext *option_context;
@@ -1955,10 +1955,10 @@ main (int argc, char **argv)
       &print_version,
       "Print version and exit.",
       NULL },
-    { "extra-host-idents", '\0', 0, G_OPTION_ARG_STRING,
-      &extra_host_idents,
-     "comma-separated list of extra host identifier names",
-     "<id_1,id_2>" },
+    { "extra-host-identifiers", '\0', 0, G_OPTION_ARG_STRING,
+      &extra_host_identifiers,
+      "Comma-separated list of extra host identifier names",
+      "<id_1,id_2>" },
     { NULL }};
 
   /* Set locale based on environment variables. */
@@ -2616,10 +2616,9 @@ main (int argc, char **argv)
         }
     }
 
-    /* Setup list of extra host identifiers*/
-    if(extra_host_idents)
+  if (extra_host_identifiers)
     {
-       manage_set_extra_host_idents(extra_host_idents);
+      manage_set_extra_host_identifiers (extra_host_identifiers);
     }
 
   /* Initialise GMP daemon. */

--- a/src/manage.h
+++ b/src/manage.h
@@ -4394,4 +4394,7 @@ get_termination_signal ();
 int
 sql_cancel ();
 
+void
+manage_set_extra_host_idents(const gchar *);
+
 #endif /* not _GVMD_MANAGE_H */

--- a/src/manage.h
+++ b/src/manage.h
@@ -4395,6 +4395,6 @@ int
 sql_cancel ();
 
 void
-manage_set_extra_host_idents(const gchar *);
+manage_set_extra_host_identifiers (const gchar *);
 
 #endif /* not _GVMD_MANAGE_H */

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -560,7 +560,7 @@ static struct timeval last_msg;
  * @brief String array to store name of permitted extra host identifiers 
  *passed via command line argument
  */
-gchar extra_host_idents[EXTRA_HOST_IDENT_SIZE][MAX_HOST_IDENT_LEN+1];
+gchar extra_host_identifiers[EXTRA_HOST_IDENTIFIERS_SIZE][MAX_HOST_IDENTIFIER_LEN+1];
 
 
 
@@ -1431,17 +1431,19 @@ column_array_set (column_t *columns, const gchar *filter, gchar *select)
  * @return TRUE if identifier name is permitted else FALSE
  */
 gboolean
-is_extra_host_identifier(char *name)
+is_extra_host_identifier (const char *name)
 {
   gboolean result = FALSE;
-  for(int i =0; i < sizeof(extra_host_idents); i++)
-  {
-    if(extra_host_idents[i] != NULL && extra_host_idents[i][0] != '\0' && g_strcmp0(name, extra_host_idents[i]) == 0)
-    {
-      result = TRUE;
-      break;
-    }
-  }
+  for (int i =0; i < sizeof (extra_host_identifiers); i++)
+   {
+    if (extra_host_identifiers[i] != NULL &&
+        extra_host_identifiers[i][0] != '\0' &&
+        g_strcmp0 (name, extra_host_identifiers[i]) == 0)
+     {
+       result = TRUE;
+       break;
+     }
+   }
   return result;
 }
 
@@ -61847,25 +61849,25 @@ manage_empty_trashcan ()
  * @param[in]  idents  comma-separated list of identifier names
  */
 void
-manage_set_extra_host_idents(const gchar *idents)
+manage_set_extra_host_identifiers (const gchar *idents)
 {
   char *token = NULL;
   int idx = 0;
 
-  for(int i = 0; i < sizeof(extra_host_idents); i++)
-  {
-    g_strlcpy(extra_host_idents[i], "", MAX_HOST_IDENT_LEN + 1);
-  }
+  for (int i = 0; i < sizeof (extra_host_identifiers); i++)
+   {
+     g_strlcpy(extra_host_identifiers[i], "", MAX_HOST_IDENTIFIER_LEN + 1);
+   }
 
-  gchar *tmp_str = g_strdup(idents);
-  token = strtok(tmp_str, ",");
-  while(token != NULL && idx < sizeof(extra_host_idents))
-  {
-    g_strlcpy(extra_host_idents[idx], token, MAX_HOST_IDENT_LEN + 1);
-    token = strtok(NULL, ",");
-    idx++;
-  }
-  g_free(tmp_str);
+  gchar *tmp_str = g_strdup (idents);
+  token = strtok (tmp_str, ",");
+  while (token != NULL && idx < sizeof (extra_host_identifiers))
+   {
+     g_strlcpy (extra_host_identifiers[idx], token, MAX_HOST_IDENTIFIER_LEN + 1);
+     token = strtok (NULL, ",");
+     idx++;
+   }
+  g_free (tmp_str);
 }
 
 /**
@@ -62692,7 +62694,7 @@ manage_report_host_details (report_t report, const char *ip, entity_t entity)
                   array_add_new_string (identifier_hosts, g_strdup (ip));
                 }
               /* check extra permitted host identifiers passed via command line argument */
-              if (is_extra_host_identifier(entity_text (name)))
+              if (is_extra_host_identifier (entity_text (name)))
                 {
                   identifier_t *identifier;
 
@@ -63480,7 +63482,8 @@ identifier_name (const char *name)
   return (strcmp ("hostname", name) == 0)
          || (strcmp ("MAC", name) == 0)
          || (strcmp ("OS", name) == 0)
-         || (strcmp ("ssh-key", name) == 0);
+         || (strcmp ("ssh-key", name) == 0)
+         || is_extra_host_identifier (name);
 }
 
 /**

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -263,6 +263,16 @@
 #define TIMEVAL_SUBTRACT_MS(a, b) \
   ((((a).tv_sec - (b).tv_sec) * 1000) + ((a).tv_usec - (b).tv_usec) / 1000)
 
+/**
+ * @brief Number of extra host detail identifiers passed via command line argument
+ */
+#define EXTRA_HOST_IDENT_SIZE 10
+
+/**
+ * @brief Maximum length of host identifier name
+ */
+#define MAX_HOST_IDENT_LEN 31
+
 /* Macros. */
 
 /**

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -264,14 +264,14 @@
   ((((a).tv_sec - (b).tv_sec) * 1000) + ((a).tv_usec - (b).tv_usec) / 1000)
 
 /**
- * @brief Number of extra host detail identifiers passed via command line argument
+ * @brief Maximum number of extra host detail identifiers passed via command line argument
  */
-#define EXTRA_HOST_IDENT_SIZE 10
+#define EXTRA_HOST_IDENTIFIERS_SIZE 10
 
 /**
  * @brief Maximum length of host identifier name
  */
-#define MAX_HOST_IDENT_LEN 31
+#define MAX_HOST_IDENTIFIER_LEN 31
 
 /* Macros. */
 


### PR DESCRIPTION
The **manage_report_host_details** function in manage_sql.c has several if clauses that compares host identifier names to a set of hard-coded names such as "MAC", "OS" and "ip". This prevents NVT plugins which rely on register_host_detail function to set host identifier values (such as asset serial number, firmware, etc) for names other than those hard-coded ones. This PR adds a new command line parameter (--extra-host-idents) that allows the user to define a comma-separated list of identifier names to extend the hard-coded values in register_host_detail function, hence enabling NVT plugins to call register_host_detail NASL function as expected.

**Checklist**:
- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
