### PR TITLE
Change gvm-libs version to prepare 9.0.1 release

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,10 +27,10 @@ find_package (Threads)
 ## list and throw an error, otherwise long install-cmake-install-cmake cycles
 ## might occur.
 
-pkg_check_modules (LIBGVM_BASE REQUIRED libgvm_base>=11.0.2)
-pkg_check_modules (LIBGVM_UTIL REQUIRED libgvm_util>=11.0.2)
-pkg_check_modules (LIBGVM_OSP REQUIRED libgvm_osp>=11.0.2)
-pkg_check_modules (LIBGVM_GMP REQUIRED libgvm_gmp>=11.0.2)
+pkg_check_modules (LIBGVM_BASE REQUIRED libgvm_base>=11.0.1)
+pkg_check_modules (LIBGVM_UTIL REQUIRED libgvm_util>=11.0.1)
+pkg_check_modules (LIBGVM_OSP REQUIRED libgvm_osp>=11.0.1)
+pkg_check_modules (LIBGVM_GMP REQUIRED libgvm_gmp>=11.0.1)
 pkg_check_modules (GNUTLS REQUIRED gnutls>=3.2.15)
 pkg_check_modules (GLIB REQUIRED glib-2.0>=2.42)
 pkg_check_modules (LIBICAL REQUIRED libical>=1.00)


### PR DESCRIPTION
This changes the gvm-libs version requirements back as it was incremented by mistake.
**Checklist**:

- Tests N/A
- [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
