### PR TITLE
Trim malloc heap after updating cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Ensure path of listening UNIX socket exists [#1040](https://github.com/greenbone/gvmd/pull/1040)
 - Add --rebuild-scap option [#1051](https://github.com/greenbone/gvmd/pull/1051)
 - Stop current scheduling of task when permission denied [#1058](https://github.com/greenbone/gvmd/pull/1058)
+- Trim malloc heap after updating cache [#1085](https://github.com/greenbone/gvmd/pull/1085)
 
 ### Changed
 - Update SCAP and CERT feed info in sync scripts [#810](https://github.com/greenbone/gvmd/pull/810)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -51,6 +51,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <glib/gstdio.h>
+#include <malloc.h>
 #include <pwd.h>
 #include <stdlib.h>
 #include <sys/socket.h>
@@ -15433,6 +15434,8 @@ update_nvti_cache ()
     }
 
   cleanup_iterator (&nvts);
+
+  malloc_trim (0);
 }
 
 /**


### PR DESCRIPTION
This statement uses a lot of memory, so there's a lot of free space
in malloc internally.  Free the space so that RES does not look
so bad in the main process.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
