### PR TITLE
Trim malloc heap after updating cache (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add --rebuild [#1016](https://github.com/greenbone/gvmd/pull/1016)
 - Lock a file around the NVT sync [#1017](https://github.com/greenbone/gvmd/pull/1017)
 - Add --rebuild-scap option [#1050](https://github.com/greenbone/gvmd/pull/1050)
-
+- Trim malloc heap after updating cache [#1086](https://github.com/greenbone/gvmd/pull/1086)
 
 ### Changed
 - Extend command line options for managing scanners [#815](https://github.com/greenbone/gvmd/pull/815)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -48,6 +48,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <glib/gstdio.h>
+#include <malloc.h>
 #include <locale.h>
 #include <pwd.h>
 #include <stdlib.h>
@@ -15828,6 +15829,8 @@ update_nvti_cache ()
       nvtis_add (nvti_cache, nvti);
     }
   cleanup_iterator (&nvts);
+
+  malloc_trim (0);
 }
 
 /**


### PR DESCRIPTION
Backport of https://github.com/greenbone/gvmd/pull/1085

This statement uses a lot of memory, so there's a lot of free space
in malloc internally.  Free the space so that RES does not look
so bad in the main process.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
