### PR TITLE
Fix feed lock in sync script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Improve refs and error handling in NVTs update [#1067](https://github.com/greenbone/gvmd/pull/1067)
 - Fix failure detection for xml_split command [#1074](https://github.com/greenbone/gvmd/pull/1074)
 - Fix deletion of OVAL definition data [#1079](https://github.com/greenbone/gvmd/pull/1079)
+- Fix feed lock in sync script [#1088](https://github.com/greenbone/gvmd/pull/1088)
 
 ### Removed
 - Remove support for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)

--- a/tools/greenbone-scapdata-sync.in
+++ b/tools/greenbone-scapdata-sync.in
@@ -519,11 +519,11 @@ then
 fi
 (
   flock -n 9
-  date > $LOCK_FILE
   if [ $? -eq 1 ] ; then
     log_notice "Sync in progress, exiting."
     exit 1
   fi
+  date > $LOCK_FILE
   sync_scapdata
   echo -n > $LOCK_FILE
 ) 9>$LOCK_FILE


### PR DESCRIPTION
Even if the script did not get the file lock, the date was
still written in the file and the output error $? is 0.
