### PR TITLE
Fix NVTs list in CVE details (8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [8.0.3] (unreleased)
+
+### Fixed
+- Fix NVTs list in CVE details [#1098](https://github.com/greenbone/gvmd/pull/1098)
+
+[8.0.3]: https://github.com/greenbone/gvmd/compare/v8.0.2...gvmd-8.0
+
 ## [8.0.2] (2020-05-12)
 
 ### Added

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -794,9 +794,12 @@ init_cve_nvt_iterator (iterator_t *iterator,
   init_iterator (iterator,
                  "SELECT %s"
                  " FROM nvts"
-                 " WHERE cve %s '%%%s%%'"
+                 " WHERE cve %s '%%%s, %%'"
+                 "    OR cve %s '%%%s'"
                  " ORDER BY %s %s;",
                  nvt_iterator_columns (),
+                 sql_ilike_op (),
+                 cve ? cve : "",
                  sql_ilike_op (),
                  cve ? cve : "",
                  sort_field ? sort_field : "name",


### PR DESCRIPTION
The CVE matching in init_cve_nvt_iterator was not strict enough to
exclude CVE-IDs where the selected one is a prefix of another one,
e.g. CVE-2019-12345 could be included when looking up CVE-2019-1234.

**Checklist**:

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
