### PR TITLE
Fix handling of duplicate settings (8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Fix NVTs list in CVE details [#1098](https://github.com/greenbone/gvmd/pull/1098)
+- Fix handling of duplicate settings [#1104](https://github.com/greenbone/gvmd/pull/1104)
 
 [8.0.3]: https://github.com/greenbone/gvmd/compare/v8.0.2...gvmd-8.0
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -64100,7 +64100,7 @@ setting_auto_cache_rebuild_int ()
                   "        ((SELECT value FROM settings"
                   "          WHERE uuid = 'a09285b0-2d47-49b6-a4ef-946ee71f1d5c'"
                   "          AND " ACL_USER_OWNS () ""
-                  "          ORDER BY coalesce (owner, 0) DESC),"
+                  "          ORDER BY coalesce (owner, 0) DESC LIMIT 1),"
                   "         '1');",
                   current_credentials.uuid);
 }
@@ -70422,7 +70422,7 @@ manage_optimize (GSList *log_config, const gchar *database, const gchar *name)
             "           WHERE uuid = '7eda49c5-096c-4bef-b1ab-d080d87300df'"
             "             AND (settings.owner = results.owner"
             "                  OR settings.owner IS NULL)"
-            "          ORDER BY settings.owner DESC)"
+            "          ORDER BY settings.owner DESC LIMIT 1)"
             " WHERE severity IS NULL"
             "    OR severity = '';");
       else
@@ -70432,7 +70432,7 @@ manage_optimize (GSList *log_config, const gchar *database, const gchar *name)
             "           WHERE uuid = '7eda49c5-096c-4bef-b1ab-d080d87300df'"
             "             AND (settings.owner = results.owner"
             "                  OR settings.owner IS NULL)"
-            "          ORDER BY settings.owner DESC)"
+            "          ORDER BY settings.owner DESC LIMIT 1)"
             " WHERE severity IS NULL;");
 
       missing_severity_changes = sql_changes();


### PR DESCRIPTION
In setting_auto_cache_rebuild_int and manage_optimize getting certain
settings could cause errors if the settings are duplicated for some
reason.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
