### PR TITLE
Fix handling of duplicate settings (master)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix feed lock in sync script [#1088](https://github.com/greenbone/gvmd/pull/1088)
 - Handle removed CPEs and CVEs in SCAP sync [#1097](https://github.com/greenbone/gvmd/pull/1097)
 - Fix NVTs list in CVE details [#1100](https://github.com/greenbone/gvmd/pull/1100)
+- Fix handling of duplicate settings [#1106](https://github.com/greenbone/gvmd/pull/1106)
 
 ### Removed
 - Remove support for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 228)
+set (GVMD_DATABASE_VERSION 229)
 
 set (GVMD_SCAP_DATABASE_VERSION 16)
 

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -2621,7 +2621,8 @@ create_tables ()
        "  owner integer REFERENCES users (id) ON DELETE RESTRICT,"
        "  name text NOT NULL,"
        "  comment text,"
-       "  value text);");
+       "  value text,"
+       "  UNIQUE (uuid, owner));");
 
   sql ("CREATE TABLE IF NOT EXISTS tags"
        " (id SERIAL PRIMARY KEY,"

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -50254,7 +50254,7 @@ setting_auto_cache_rebuild_int ()
                   "        ((SELECT value FROM settings"
                   "          WHERE uuid = 'a09285b0-2d47-49b6-a4ef-946ee71f1d5c'"
                   "          AND " ACL_USER_OWNS () ""
-                  "          ORDER BY coalesce (owner, 0) DESC),"
+                  "          ORDER BY coalesce (owner, 0) DESC LIMIT 1),"
                   "         '1');",
                   current_credentials.uuid);
 }
@@ -56729,7 +56729,7 @@ manage_optimize (GSList *log_config, const gchar *database, const gchar *name)
           "           WHERE uuid = '7eda49c5-096c-4bef-b1ab-d080d87300df'"
           "             AND (settings.owner = results.owner"
           "                  OR settings.owner IS NULL)"
-          "          ORDER BY settings.owner DESC)"
+          "          ORDER BY settings.owner DESC LIMIT 1)"
           " WHERE severity IS NULL;");
 
       missing_severity_changes = sql_changes();


### PR DESCRIPTION
In setting_auto_cache_rebuild_int and manage_optimize getting certain
settings could cause errors if the settings are duplicated for some
reason.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
