### PR TITLE
Fix table check in gvm-migrate-to-postgres (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fix NVTs list in CVE details [#1098](https://github.com/greenbone/gvmd/pull/1098)
 - Fix handling of duplicate settings [#1105](https://github.com/greenbone/gvmd/pull/1105)
+- Fix table check in gvm-migrate-to-postgres [#1118](https://github.com/greenbone/gvmd/pull/1118)
 
 [9.0.2]: https://github.com/greenbone/gvmd/compare/v9.0.1...gvmd-9.0
 

--- a/tools/gvm-migrate-to-postgres.in
+++ b/tools/gvm-migrate-to-postgres.in
@@ -1039,7 +1039,7 @@ cleanup_sqlite_db () {
   sqlite "DROP TABLE IF EXISTS escalator_condition_data_trash;"
   test_sql_exit "Failed to remove escalator_condition_data_trash"
 
-  HAVE_CACHE=`sqlite "SELECT EXISTS (SELECT FROM sqlite_master WHERE type='table' AND name='permissions_get_tasks');"`
+  HAVE_CACHE=`sqlite "SELECT EXISTS (SELECT * FROM sqlite_master WHERE type='table' AND name='permissions_get_tasks');"`
   if [ "$HAVE_CACHE" != "0" ]
   then
     sqlite "UPDATE permissions_get_tasks SET has_permission = 1 WHERE has_permission != '0';"


### PR DESCRIPTION
The check for the permissions_get_tasks table in cleanup_sqlite_db
contained a typo so it could not detect if the table was missing.

**Checklist**:

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry