### PR TITLE
Fix XML escaping in setting up GMP scans (master)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Handle removed CPEs and CVEs in SCAP sync [#1097](https://github.com/greenbone/gvmd/pull/1097)
 - Fix NVTs list in CVE details [#1100](https://github.com/greenbone/gvmd/pull/1100)
 - Fix handling of duplicate settings [#1106](https://github.com/greenbone/gvmd/pull/1106)
+- Fix XML escaping in setting up GMP scans [#1122](https://github.com/greenbone/gvmd/pull/1122)
 
 ### Removed
 - Remove support for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)

--- a/src/manage.c
+++ b/src/manage.c
@@ -2689,19 +2689,19 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
         if (config == 0)
           goto fail_target;
 
-        if (gvm_server_sendf (&connection->session,
-                              "<create_config>"
-                              "<get_configs_response"
-                              " status=\"200\""
-                              " status_text=\"OK\">"
-                              "<config id=\"XXX\">"
-                              "<type>0</type>"
-                              "<name>%s</name>"
-                              "<comment>"
-                              "Slave config created by Master"
-                              "</comment>"
-                              "<preferences>",
-                              name))
+        if (gvm_server_sendf_xml (&connection->session,
+                                  "<create_config>"
+                                  "<get_configs_response"
+                                  " status=\"200\""
+                                  " status_text=\"OK\">"
+                                  "<config id=\"XXX\">"
+                                  "<type>0</type>"
+                                  "<name>%s</name>"
+                                  "<comment>"
+                                  "Slave config created by Master"
+                                  "</comment>"
+                                  "<preferences>",
+                                  name))
           goto fail_target;
 
         /* Send NVT timeout preferences where a timeout has been
@@ -2713,20 +2713,22 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
 
             timeout = config_timeout_iterator_value (&prefs);
 
-            if (timeout && strlen (timeout)
-                && gvm_server_sendf (&connection->session,
-                                     "<preference>"
-                                     "<nvt oid=\"%s\">"
-                                     "<name>%s</name>"
-                                     "</nvt>"
-                                     "<name>Timeout</name>"
-                                     "<id>0</id>"
-                                     "<type>entry</type>"
-                                     "<value>%s</value>"
-                                     "</preference>",
-                                     config_timeout_iterator_oid (&prefs),
-                                     config_timeout_iterator_nvt_name (&prefs),
-                                     timeout))
+            if (timeout
+                && strlen (timeout)
+                && gvm_server_sendf_xml
+                     (&connection->session,
+                      "<preference>"
+                      "<nvt oid=\"%s\">"
+                      "<name>%s</name>"
+                      "</nvt>"
+                      "<name>Timeout</name>"
+                      "<id>0</id>"
+                      "<type>entry</type>"
+                      "<value>%s</value>"
+                      "</preference>",
+                      config_timeout_iterator_oid (&prefs),
+                      config_timeout_iterator_nvt_name (&prefs),
+                      timeout))
               {
                 cleanup_iterator (&prefs);
                 goto fail_target;
@@ -2763,7 +2765,7 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
         while (next (&selectors))
           {
             int type = nvt_selector_iterator_type (&selectors);
-            if (gvm_server_sendf
+            if (gvm_server_sendf_xml
                  (&connection->session,
                   "<nvt_selector>"
                   "<name>%s</name>"


### PR DESCRIPTION
The create_config command is now sent using gvm_server_sendf_xml so it's
possible to use reserved characters like ampersands in the task name
which is also used to name the config on the sensor.

**Checklist**:

- Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
