### PR TITLE
Fix XML escaping in setting up GMP scans (8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fix NVTs list in CVE details [#1098](https://github.com/greenbone/gvmd/pull/1098)
 - Fix handling of duplicate settings [#1104](https://github.com/greenbone/gvmd/pull/1104)
+- Fix XML escaping in setting up GMP scans [#1124](https://github.com/greenbone/gvmd/pull/1124)
 
 [8.0.3]: https://github.com/greenbone/gvmd/compare/v8.0.2...gvmd-8.0
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -3227,19 +3227,19 @@ slave_setup (gvm_connection_t *connection,
         if (config == 0)
           goto fail_target;
 
-        if (gvm_server_sendf (&connection->session,
-                              "<create_config>"
-                              "<get_configs_response"
-                              " status=\"200\""
-                              " status_text=\"OK\">"
-                              "<config id=\"XXX\">"
-                              "<type>0</type>"
-                              "<name>%s</name>"
-                              "<comment>"
-                              "Slave config created by Master"
-                              "</comment>"
-                              "<preferences>",
-                              name))
+        if (gvm_server_sendf_xml (&connection->session,
+                                  "<create_config>"
+                                  "<get_configs_response"
+                                  " status=\"200\""
+                                  " status_text=\"OK\">"
+                                  "<config id=\"XXX\">"
+                                  "<type>0</type>"
+                                  "<name>%s</name>"
+                                  "<comment>"
+                                  "Slave config created by Master"
+                                  "</comment>"
+                                  "<preferences>",
+                                  name))
           goto fail_target;
 
         /* Send NVT timeout preferences where a timeout has been
@@ -3251,19 +3251,21 @@ slave_setup (gvm_connection_t *connection,
 
             timeout = config_timeout_iterator_value (&prefs);
 
-            if (timeout && strlen (timeout)
-                && gvm_server_sendf (&connection->session,
-                                     "<preference>"
-                                     "<nvt oid=\"%s\">"
-                                     "<name>%s</name>"
-                                     "</nvt>"
-                                     "<name>Timeout</name>"
-                                     "<type>entry</type>"
-                                     "<value>%s</value>"
-                                     "</preference>",
-                                     config_timeout_iterator_oid (&prefs),
-                                     config_timeout_iterator_nvt_name (&prefs),
-                                     timeout))
+            if (timeout
+                && strlen (timeout)
+                && gvm_server_sendf_xml
+                     (&connection->session,
+                      "<preference>"
+                      "<nvt oid=\"%s\">"
+                      "<name>%s</name>"
+                      "</nvt>"
+                      "<name>Timeout</name>"
+                      "<type>entry</type>"
+                      "<value>%s</value>"
+                      "</preference>",
+                      config_timeout_iterator_oid (&prefs),
+                      config_timeout_iterator_nvt_name (&prefs),
+                      timeout))
               {
                 cleanup_iterator (&prefs);
                 goto fail_target;
@@ -3298,19 +3300,20 @@ slave_setup (gvm_connection_t *connection,
         while (next (&selectors))
           {
             int type = nvt_selector_iterator_type (&selectors);
-            if (gvm_server_sendf (&connection->session,
-                                  "<nvt_selector>"
-                                  "<name>%s</name>"
-                                  "<include>%i</include>"
-                                  "<type>%i</type>"
-                                  "<family_or_nvt>%s</family_or_nvt>"
-                                  "</nvt_selector>",
-                                  nvt_selector_iterator_name (&selectors),
-                                  nvt_selector_iterator_include (&selectors),
-                                  type,
-                                  (type == NVT_SELECTOR_TYPE_ALL
-                                     ? ""
-                                     : nvt_selector_iterator_nvt (&selectors))))
+            if (gvm_server_sendf_xml
+                 (&connection->session,
+                  "<nvt_selector>"
+                  "<name>%s</name>"
+                  "<include>%i</include>"
+                  "<type>%i</type>"
+                  "<family_or_nvt>%s</family_or_nvt>"
+                  "</nvt_selector>",
+                  nvt_selector_iterator_name (&selectors),
+                  nvt_selector_iterator_include (&selectors),
+                  type,
+                  (type == NVT_SELECTOR_TYPE_ALL
+                    ? ""
+                    : nvt_selector_iterator_nvt (&selectors))))
               goto fail_target;
           }
         cleanup_iterator (&selectors);


### PR DESCRIPTION
The create_config command is now sent using gvm_server_sendf_xml so it's
possible to use reserved characters like ampersands in the task name
which is also used to name the config on the sensor.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
