### PR TITLE
Remove OVAL case from --rebuild-scap

### DIFF
--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1632,7 +1632,7 @@ gvmd (int argc, char** argv)
   static gchar *rc_name = NULL;
   static gchar *relay_mapper = NULL;
   static gboolean rebuild = FALSE;
-  static gchar *rebuild_scap = NULL;
+  static gboolean rebuild_scap = FALSE;
   static gchar *role = NULL;
   static gchar *disable = NULL;
   static gchar *value = NULL;
@@ -1811,11 +1811,10 @@ gvmd (int argc, char** argv)
           &rebuild,
           "Remove NVT db, and rebuild it from the scanner.",
           NULL },
-        { "rebuild-scap", '\0', 0, G_OPTION_ARG_STRING,
+        { "rebuild-scap", '\0', 0, G_OPTION_ARG_NONE,
           &rebuild_scap,
-          "Rebuild SCAP data of type <type>"
-          " (currently supports 'ovaldefs' and 'all').",
-          "<type>" },
+          "Rebuild all SCAP data.",
+          NULL },
         { "relay-mapper", '\0', 0, G_OPTION_ARG_FILENAME,
           &relay_mapper,
           "Executable for mapping scanner hosts to relays."
@@ -2277,7 +2276,7 @@ gvmd (int argc, char** argv)
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
 
-      ret = manage_rebuild_scap (log_config, database, rebuild_scap);
+      ret = manage_rebuild_scap (log_config, database);
       log_config_free ();
       if (ret)
         {

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -4882,14 +4882,12 @@ manage_sync_scap (sigset_t *sigmask_current)
 }
 
 /**
- * @brief Rebuild part of the SCAP DB.
+ * @brief Rebuild the entire SCAP DB.
  *
- * @param[in]  type        The type of SCAP info to rebuild.
- *
- * @return 0 success, 1 invalid type, 2 sync running, -1 error
+ * @return 0 success, 2 sync running, -1 error
  */
 static int
-rebuild_scap (const char *type)
+rebuild_scap ()
 {
   int ret = -1;
   lockfile_t lockfile;
@@ -4900,16 +4898,9 @@ rebuild_scap (const char *type)
   else if (ret)
     return -1;
 
-  if (strcasecmp (type, "all") == 0
-      || strcasecmp (type, "ovaldefs") == 0
-      || strcasecmp (type, "ovaldef") == 0)
-    {
-      ret = update_scap (TRUE);
-      if (ret == 1)
-        ret = 2;
-    }
-  else
-    ret = 1;
+  ret = update_scap (TRUE);
+  if (ret == 1)
+    ret = 2;
 
   if (feed_lockfile_unlock (&lockfile))
     {
@@ -4926,29 +4917,22 @@ rebuild_scap (const char *type)
  *
  * @param[in]  log_config  Log configuration.
  * @param[in]  database    Location of manage database.
- * @param[in]  type        The type of SCAP info to rebuild.
-
+ *
  * @return 0 success, -1 error.
  */
 int
-manage_rebuild_scap (GSList *log_config, const gchar *database,
-                     const char *type)
+manage_rebuild_scap (GSList *log_config, const gchar *database)
 {
   int ret;
 
-  g_info ("   Rebuilding SCAP data (%s).", type);
+  g_info ("   Rebuilding SCAP data");
 
   ret = manage_option_setup (log_config, database);
   if (ret)
     return -1;
 
-  ret = rebuild_scap (type);
-  if (ret == 1)
-    {
-      printf ("Type must be 'ovaldefs' or 'all'.\n");
-      goto fail;
-    }
-  else if (ret == 2)
+  ret = rebuild_scap ();
+  if (ret == 2)
     {
       printf ("SCAP sync is currently running.\n");
       goto fail;

--- a/src/manage_sql_secinfo.h
+++ b/src/manage_sql_secinfo.h
@@ -212,7 +212,7 @@ void
 manage_sync_scap (sigset_t *);
 
 int
-manage_rebuild_scap (GSList *, const gchar *, const char *);
+manage_rebuild_scap (GSList *, const gchar *);
 
 void
 manage_sync_cert (sigset_t *);


### PR DESCRIPTION
With the new [background schema sync](https://github.com/greenbone/gvmd/pull/1111) the entire SCAP is always rebuilt.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
