### PR TITLE
Create SCAP constraints at end of CSV sync

### DIFF
--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -3145,7 +3145,7 @@ manage_db_init (const gchar *name)
 
       sql ("CREATE TABLE scap2.cves"
            " (id SERIAL PRIMARY KEY,"
-           "  uuid text UNIQUE,"
+           "  uuid text,"
            "  name text,"
            "  comment text,"
            "  description text,"
@@ -3162,7 +3162,7 @@ manage_db_init (const gchar *name)
 
       sql ("CREATE TABLE scap2.cpes"
            " (id SERIAL PRIMARY KEY,"
-           "  uuid text UNIQUE,"
+           "  uuid text,"
            "  name text,"
            "  comment text,"
            "  creation_time integer,"
@@ -3175,15 +3175,12 @@ manage_db_init (const gchar *name)
            "  nvd_id text);");
 
       sql ("CREATE TABLE scap2.affected_products"
-           " (cve INTEGER NOT NULL,"
-           "  cpe INTEGER NOT NULL,"
-           "  UNIQUE (cve, cpe),"
-           "  FOREIGN KEY(cve) REFERENCES cves(id),"
-           "  FOREIGN KEY(cpe) REFERENCES cpes(id));");
+           " (cve INTEGER,"
+           "  cpe INTEGER);");
 
       sql ("CREATE TABLE scap2.ovaldefs"
            " (id SERIAL PRIMARY KEY,"
-           "  uuid text UNIQUE,"
+           "  uuid text,"
            "  name text,"                   /* OVAL identifier. */
            "  comment text,"
            "  creation_time integer,"
@@ -3200,13 +3197,11 @@ manage_db_init (const gchar *name)
 
       sql ("CREATE TABLE scap2.ovalfiles"
            " (id SERIAL PRIMARY KEY,"
-           "  xml_file TEXT UNIQUE);");
+           "  xml_file TEXT);");
 
       sql ("CREATE TABLE scap2.affected_ovaldefs"
-           " (cve INTEGER NOT NULL,"
-           "  ovaldef INTEGER NOT NULL,"
-           "  FOREIGN KEY(cve) REFERENCES cves(id),"
-           "  FOREIGN KEY(ovaldef) REFERENCES ovaldefs(id));");
+           " (cve INTEGER,"
+           "  ovaldef INTEGER);");
 
       /* Init tables. */
 
@@ -3214,6 +3209,52 @@ manage_db_init (const gchar *name)
            " VALUES ('database_version', '16');");
       sql ("INSERT INTO scap2.meta (name, value)"
            " VALUES ('last_update', '0');");
+    }
+  else
+    {
+      assert (0);
+      return -1;
+    }
+
+  return 0;
+}
+
+/**
+ * @brief Init external database.
+ *
+ * @param[in]  name  Name.  Currently only "scap".
+ *
+ * @return 0 success, -1 error.
+ */
+int
+manage_db_add_constraints (const gchar *name)
+{
+  if (strcasecmp (name, "scap") == 0)
+    {
+      sql ("ALTER TABLE scap2.cves"
+           " ADD UNIQUE (uuid);");
+
+      sql ("ALTER TABLE scap2.cpes"
+           " ADD UNIQUE (uuid);");
+
+      sql ("ALTER TABLE scap2.affected_products"
+           " ALTER cve SET NOT NULL,"
+           " ALTER cpe SET NOT NULL,"
+           " ADD UNIQUE (cve, cpe),"
+           " ADD FOREIGN KEY(cve) REFERENCES cves(id),"
+           " ADD FOREIGN KEY(cpe) REFERENCES cpes(id);");
+
+      sql ("ALTER TABLE scap2.ovaldefs"
+           " ADD UNIQUE (uuid);");
+
+      sql ("ALTER TABLE scap2.ovalfiles"
+           " ADD UNIQUE (xml_file);");
+
+      sql ("ALTER TABLE scap2.affected_ovaldefs"
+           " ALTER cve SET NOT NULL,"
+           " ALTER ovaldef SET NOT NULL,"
+           " ADD FOREIGN KEY(cve) REFERENCES cves(id),"
+           " ADD FOREIGN KEY(ovaldef) REFERENCES ovaldefs(id);");
     }
   else
     {

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -80,6 +80,9 @@ manage_db_init (const gchar *);
 int
 manage_db_init_indexes (const gchar *);
 
+int
+manage_db_add_constraints (const gchar *);
+
 
 /* Helpers. */
 
@@ -4723,7 +4726,7 @@ try_load_csv ()
            file_affected_ovaldefs);
       g_free (file_affected_ovaldefs);
 
-      /* Add the indexes, now that the data is ready. */
+      /* Add the indexes and constraints, now that the data is ready. */
 
       g_debug ("%s: add indexes", __func__);
       proctitle_set ("gvmd: Syncing SCAP: Adding indexes");
@@ -4731,6 +4734,15 @@ try_load_csv ()
       if (manage_db_init_indexes ("scap"))
         {
           g_warning ("%s: could not initialize SCAP indexes", __func__);
+          return -1;
+        }
+
+      g_debug ("%s: add constraints", __func__);
+      proctitle_set ("gvmd: Syncing SCAP: Adding constraints");
+
+      if (manage_db_add_constraints ("scap"))
+        {
+          g_warning ("%s: could not add SCAP constraints", __func__);
           return -1;
         }
 
@@ -4805,7 +4817,7 @@ update_scap (gboolean reset_scap_db)
   if (try_load_csv () == 0)
     return 0;
 
-  /* Add the indexes, now that the data is ready. */
+  /* Add the indexes and constraints. */
 
   g_debug ("%s: add indexes", __func__);
   proctitle_set ("gvmd: Syncing SCAP: Adding indexes");
@@ -4813,6 +4825,12 @@ update_scap (gboolean reset_scap_db)
   if (manage_db_init_indexes ("scap"))
     {
       g_warning ("%s: could not initialize SCAP indexes", __func__);
+      return -1;
+    }
+
+  if (manage_db_add_constraints ("scap"))
+    {
+      g_warning ("%s: could not add SCAP constraints", __func__);
       return -1;
     }
 


### PR DESCRIPTION
This takes my CVS SCAP sync from 60s to 20s.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
