### PR TITLE
[9.0] Fix gvm-manage-certs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix table check in gvm-migrate-to-postgres [#1118](https://github.com/greenbone/gvmd/pull/1118)
 - Fix XML escaping in setting up GMP scans [#1122](https://github.com/greenbone/gvmd/pull/1123)
 - Fix and simplify parse_iso_time [#1130](https://github.com/greenbone/gvmd/pull/1130)
+- Fix gvm-manage-certs. [#1139](https://github.com/greenbone/gvmd/pull/1139)
 
 [9.0.2]: https://github.com/greenbone/gvmd/compare/v9.0.1...gvmd-9.0
 

--- a/tools/gvm-manage-certs.in
+++ b/tools/gvm-manage-certs.in
@@ -371,9 +371,10 @@ create_certificate ()
   fi
   if [ $CERTIFICATE_TYPE -eq $SERVER_CERTIFICATE ]
   then
-    # This certificate will be used to encrypt data.
+    # This certificate will be used to encrypt data and sign data.
     # This is the keyEncipherment flag in RFC5280 terminology.
     echo "encryption_key" >> $GVM_CERT_TEMPLATE_FILENAME
+    echo "signing_key" >> $GVM_CERT_TEMPLATE_FILENAME
     echo "tls_www_server" >> $GVM_CERT_TEMPLATE_FILENAME
   fi
   if [ $CERTIFICATE_TYPE -eq $CLIENT_CERTIFICATE ]


### PR DESCRIPTION
Add the signing_key key usage flag for creation of the server cert/key
This is requiered for newer gnutls libraries which are more strict
regarding certifcate being used for what the were not be created for.
