### PR TITLE
Fix gvm-manage-certs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix handling of duplicate settings [#1106](https://github.com/greenbone/gvmd/pull/1106)
 - Fix XML escaping in setting up GMP scans [#1122](https://github.com/greenbone/gvmd/pull/1122)
 - Fix and simplify parse_iso_time and add tests [#1129](https://github.com/greenbone/gvmd/pull/1129)
+- Fix gvm-manage-certs. [#1140](https://github.com/greenbone/gvmd/pull/1140)
 
 ### Removed
 - Remove support for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)

--- a/tools/gvm-manage-certs.in
+++ b/tools/gvm-manage-certs.in
@@ -370,9 +370,10 @@ create_certificate ()
   fi
   if [ $CERTIFICATE_TYPE -eq $SERVER_CERTIFICATE ]
   then
-    # This certificate will be used to encrypt data.
+    # This certificate will be used to encrypt data and sign data.
     # This is the keyEncipherment flag in RFC5280 terminology.
     echo "encryption_key" >> $GVM_CERT_TEMPLATE_FILENAME
+    echo "signing_key" >> $GVM_CERT_TEMPLATE_FILENAME
     echo "tls_www_server" >> $GVM_CERT_TEMPLATE_FILENAME
   fi
   if [ $CERTIFICATE_TYPE -eq $CLIENT_CERTIFICATE ]


### PR DESCRIPTION
Add the signing_key key usage flag for creation of the server cert/key
This is requiered for newer gnutls libraries which are more strict
regarding certifcate being used for what the were not be created for.
