### PR TITLE
Fix CVE scanner and results handling (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix XML escaping in setting up GMP scans [#1122](https://github.com/greenbone/gvmd/pull/1123)
 - Fix and simplify parse_iso_time [#1130](https://github.com/greenbone/gvmd/pull/1130)
 - Fix gvm-manage-certs. [#1139](https://github.com/greenbone/gvmd/pull/1139)
+- Fix CVE scanner and results handling [#1142](https://github.com/greenbone/gvmd/pull/1142)
 
 [9.0.2]: https://github.com/greenbone/gvmd/compare/v9.0.1...gvmd-9.0
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -4717,7 +4717,9 @@ cve_scan_host (task_t task, report_t report, gvm_host_t *gvm_host)
             {
               const char *app, *cve;
               double severity;
-              gchar *desc, *location;
+              gchar *desc;
+              iterator_t locations_iter;
+              GString *locations;
               result_t result;
 
               if (prognosis_report_host == 0)
@@ -4730,7 +4732,30 @@ cve_scan_host (task_t task, report_t report, gvm_host_t *gvm_host)
 
               app = prognosis_iterator_cpe (&prognosis);
               cve = prognosis_iterator_cve (&prognosis);
-              location = app_location (report_host, app);
+              locations = g_string_new("");
+              init_app_locations_iterator (&locations_iter, report_host, app);
+
+              while (next (&locations_iter))
+                {
+                  const char *location;
+                  location = app_locations_iterator_location (&locations_iter);
+
+                  if (locations->len)
+                    g_string_append (locations, ", ");
+                  g_string_append (locations, location);
+
+                  insert_report_host_detail (report, ip, "cve", cve,
+                                             "CVE Scanner", app, location);
+
+                  insert_report_host_detail (report, ip, "cve", cve,
+                                             "CVE Scanner", "detected_at",
+                                             location);
+
+                  insert_report_host_detail (report, ip, "cve", cve,
+                                             "CVE Scanner", "detected_by",
+                                             /* Detected by itself. */
+                                             cve);
+                }
 
               desc = g_strdup_printf ("The host carries the product: %s\n"
                                       "It is vulnerable according to: %s.\n"
@@ -4739,11 +4764,11 @@ cve_scan_host (task_t task, report_t report, gvm_host_t *gvm_host)
                                       "%s",
                                       app,
                                       cve,
-                                      location
+                                      locations->len
                                        ? "The product was found at: "
                                        : "",
-                                      location ? location : "",
-                                      location ? ".\n" : "",
+                                      locations->len ? locations->str : "",
+                                      locations->len ? ".\n" : "",
                                       prognosis_iterator_description
                                        (&prognosis));
 
@@ -4755,20 +4780,7 @@ cve_scan_host (task_t task, report_t report, gvm_host_t *gvm_host)
 
               report_add_result (report, result);
 
-              if (location)
-                {
-                  insert_report_host_detail (report, ip, "cve", cve,
-                                              "CVE Scanner", app, location);
-
-                  insert_report_host_detail (report, ip, "cve", cve,
-                                              "CVE Scanner", "detected_at",
-                                              location);
-                  insert_report_host_detail (report, ip, "cve", cve,
-                                              "CVE Scanner", "detected_by",
-                                              /* Detected by itself. */
-                                              cve);
-                }
-              g_free (location);
+              g_string_free (locations, TRUE);
             }
           cleanup_iterator (&prognosis);
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -4663,15 +4663,19 @@ run_osp_task (task_t task, int from, char **report_id)
  * @brief Perform a CVE "scan" on a host.
  *
  * @param[in]  task      Task.
+ * @param[in]  report    The report to add the host, results and details to.
  * @param[in]  gvm_host  Host.
  *
  * @return 0 success, 1 failed to get nthlast report for a host.
  */
 static int
-cve_scan_host (task_t task, gvm_host_t *gvm_host)
+cve_scan_host (task_t task, report_t report, gvm_host_t *gvm_host)
 {
   report_host_t report_host;
   gchar *ip, *host;
+
+  assert (task);
+  assert (report);
 
   host = gvm_host_value_str (gvm_host);
 
@@ -4681,7 +4685,7 @@ cve_scan_host (task_t task, gvm_host_t *gvm_host)
 
   g_debug ("%s: ip: %s", __FUNCTION__, ip);
 
-  /* Get the last report that applies to the host. */
+  /* Get the last report host that applies to the host IP address. */
 
   if (host_nthlast_report_host (ip, &report_host, 1))
     {
@@ -4716,8 +4720,8 @@ cve_scan_host (task_t task, gvm_host_t *gvm_host)
               gchar *desc, *location;
               result_t result;
 
-              if (global_current_report && (prognosis_report_host == 0))
-                prognosis_report_host = manage_report_host_add (global_current_report,
+              if (prognosis_report_host == 0)
+                prognosis_report_host = manage_report_host_add (report,
                                                                 ip,
                                                                 start_time,
                                                                 0);
@@ -4748,26 +4752,21 @@ cve_scan_host (task_t task, gvm_host_t *gvm_host)
 
               result = make_cve_result (task, ip, cve, severity, desc);
               g_free (desc);
-              if (global_current_report)
+
+              report_add_result (report, result);
+
+              if (location)
                 {
-                  report_add_result (global_current_report, result);
+                  insert_report_host_detail (report, ip, "cve", cve,
+                                              "CVE Scanner", app, location);
 
-                  insert_report_host_detail (global_current_report, ip, "cve", cve,
-                                             "CVE Scanner", "App", app);
-
-                  if (location)
-                    {
-                      insert_report_host_detail (global_current_report, ip, "cve", cve,
-                                                 "CVE Scanner", app, location);
-
-                      insert_report_host_detail (global_current_report, ip, "cve", cve,
-                                                 "CVE Scanner", "detected_at",
-                                                 location);
-                      insert_report_host_detail (global_current_report, ip, "cve", cve,
-                                                 "CVE Scanner", "detected_by",
-                                                 /* Detected by itself. */
-                                                 cve);
-                    }
+                  insert_report_host_detail (report, ip, "cve", cve,
+                                              "CVE Scanner", "detected_at",
+                                              location);
+                  insert_report_host_detail (report, ip, "cve", cve,
+                                              "CVE Scanner", "detected_by",
+                                              /* Detected by itself. */
+                                              cve);
                 }
               g_free (location);
             }
@@ -4778,7 +4777,7 @@ cve_scan_host (task_t task, gvm_host_t *gvm_host)
               /* Complete the report_host. */
 
               report_host_set_end_time (prognosis_report_host, time (NULL));
-              insert_report_host_detail (global_current_report, ip, "cve", "",
+              insert_report_host_detail (report, ip, "cve", "",
                                          "CVE Scanner", "CVE Scan", "1");
             }
         }
@@ -4875,7 +4874,7 @@ fork_cve_scan_handler (task_t task, target_t target)
   gvm_hosts = gvm_hosts_new (hosts);
   free (hosts);
   while ((gvm_host = gvm_hosts_next (gvm_hosts)))
-    if (cve_scan_host (task, gvm_host))
+    if (cve_scan_host (task, global_current_report, gvm_host))
       {
         set_task_interrupted (task,
                               "Failed to get nthlast report."

--- a/src/manage.c
+++ b/src/manage.c
@@ -4733,6 +4733,10 @@ cve_scan_host (task_t task, report_t report, gvm_host_t *gvm_host)
               app = prognosis_iterator_cpe (&prognosis);
               cve = prognosis_iterator_cve (&prognosis);
               locations = g_string_new("");
+
+              insert_report_host_detail (global_current_report, ip, "cve", cve,
+                                         "CVE Scanner", "App", app);
+
               init_app_locations_iterator (&locations_iter, report_host, app);
 
               while (next (&locations_iter))

--- a/src/manage.h
+++ b/src/manage.h
@@ -1561,8 +1561,11 @@ manage_send_report (report_t, report_t, report_format_t, const get_data_t *,
 
 /* Reports. */
 
-gchar *
-app_location (report_host_t, const gchar *);
+void
+init_app_locations_iterator (iterator_t*, report_host_t, const gchar *);
+
+const char *
+app_locations_iterator_location (iterator_t *);
 
 void
 init_host_prognosis_iterator (iterator_t*, report_host_t);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -21557,8 +21557,8 @@ init_host_prognosis_iterator (iterator_t* iterator, report_host_t report_host)
 {
   init_iterator (iterator,
                  "SELECT cves.name AS vulnerability,"
-                 "       CAST (cves.cvss AS NUMERIC) AS severity,"
-                 "       cves.description,"
+                 "       max(CAST (cves.cvss AS NUMERIC)) AS severity,"
+                 "       max(cves.description) AS description,"
                  "       cpes.name AS location,"
                  "       (SELECT host FROM report_hosts"
                  "        WHERE id = %llu) AS host"
@@ -21569,6 +21569,7 @@ init_host_prognosis_iterator (iterator_t* iterator, report_host_t report_host)
                  " AND report_host_details.name = 'App'"
                  " AND cpes.id=affected_products.cpe"
                  " AND cves.id=affected_products.cve"
+                 " GROUP BY cves.id, vulnerability, location, host"
                  " ORDER BY cves.id ASC"
                  " LIMIT %s OFFSET 0;",
                  report_host,

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -21495,40 +21495,54 @@ detect_cleanup:
 /* Prognostics. */
 
 /**
- * @brief Get the location of an App for a report's host.
+ * @brief Initialize an iterator of locations of an App for a report's host.
  *
+ * @param[in]  iterator     Iterator.
  * @param[in]  report_host  Report host.
  * @param[in]  app          CPE.
- *
- * @return Location if there is one, else NULL.
  */
-gchar *
-app_location (report_host_t report_host, const gchar *app)
+void
+init_app_locations_iterator (iterator_t *iterator,
+                             report_host_t report_host,
+                             const gchar *app)
 {
-  gchar *quoted_app, *ret;
+  gchar *quoted_app;
 
   assert (app);
 
   quoted_app = sql_quote (app);
 
-  ret = sql_string ("SELECT value FROM report_host_details"
-                    " WHERE report_host = %llu"
-                    " AND name = '%s'"
-                    " AND source_type = 'nvt'"
-                    " AND source_name"
-                    "     = (SELECT source_name FROM report_host_details"
-                    "        WHERE report_host = %llu"
-                    "        AND source_type = 'nvt'"
-                    "        AND name = 'App'"
-                    "        AND value = '%s');",
-                    report_host,
-                    quoted_app,
-                    report_host,
-                    quoted_app);
+  init_iterator (iterator,
+                 "SELECT string_agg(DISTINCT value, ', ')"
+                 " FROM report_host_details"
+                 " WHERE report_host = %llu"
+                 " AND name = '%s'"
+                 " AND source_type = 'nvt'"
+                 " AND source_name"
+                 "     IN (SELECT source_name FROM report_host_details"
+                 "         WHERE report_host = %llu"
+                 "         AND source_type = 'nvt'"
+                 "         AND name = 'App'"
+                 "         AND value = '%s');",
+                 report_host,
+                 quoted_app,
+                 report_host,
+                 quoted_app);
 
   g_free (quoted_app);
+}
 
-  return ret;
+/**
+ * @brief Get a location from an app locations iterator.
+ *
+ * @param[in]  iterator   Iterator.
+ *
+ * @return  The location.
+ */
+const char *
+app_locations_iterator_location (iterator_t *iterator)
+{
+  return iterator_string (iterator, 0);
 }
 
 /**


### PR DESCRIPTION
Multiple App location host details per report host could cause SQL errors (#1133) and generate duplicated results.

**Checklist**:

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
