### PR TITLE
XML escape solution element in get_nvt_xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Extend command line options for managing scanners [#815](https://github.com/greenbone/gvmd/pull/815)
 - Try authentication when verifying GMP scanners [#837](https://github.com/greenbone/gvmd/pull/837)
 - Try importing private keys with libssh if GnuTLS fails [#841](https://github.com/greenbone/gvmd/pull/841)
-- Extend GMP API for nvt object to carry a explicit solution element [#849](https://github.com/greenbone/gvmd/pull/849)
+- Extend GMP API for nvt object to carry a explicit solution element [#849](https://github.com/greenbone/gvmd/pull/849) [#1143](https://github.com/greenbone/gvmd/pull/1143)
 - Allow resuming OSPd-based OpenVAS tasks [#869](https://github.com/greenbone/gvmd/pull/869)
 - Require PostgreSQL 9.6 as a minimum [#872](https://github.com/greenbone/gvmd/pull/872)
 - Speed up the SCAP sync [#875](https://github.com/greenbone/gvmd/pull/875) [#877](https://github.com/greenbone/gvmd/pull/877) [#879](https://github.com/greenbone/gvmd/pull/879) [#881](https://github.com/greenbone/gvmd/pull/881) [#883](https://github.com/greenbone/gvmd/pull/883) [#887](https://github.com/greenbone/gvmd/pull/887) [#889](https://github.com/greenbone/gvmd/pull/889) [#890](https://github.com/greenbone/gvmd/pull/890) [#891](https://github.com/greenbone/gvmd/pull/891) [#901](https://github.com/greenbone/gvmd/pull/901)

--- a/src/manage.c
+++ b/src/manage.c
@@ -46,6 +46,7 @@
  */
 #define _GNU_SOURCE
 
+#include "gmp_base.h"
 #include "manage.h"
 #include "manage_acl.h"
 #include "manage_configs.h"
@@ -8036,21 +8037,21 @@ get_nvt_xml (iterator_t *nvts, int details, int pref_count,
           nvt_iterator_solution_type (nvts) ||
           nvt_iterator_solution_method (nvts))
         {
-          g_string_append_printf (buffer, "<solution");
+          buffer_xml_append_printf (buffer, "<solution");
 
           if (nvt_iterator_solution_type (nvts))
-            g_string_append_printf (buffer, " type='%s'",
+            buffer_xml_append_printf (buffer, " type='%s'",
               nvt_iterator_solution_type (nvts));
 
           if (nvt_iterator_solution_method (nvts))
-            g_string_append_printf (buffer, " method='%s'",
+            buffer_xml_append_printf (buffer, " method='%s'",
               nvt_iterator_solution_method (nvts));
 
           if (nvt_iterator_solution (nvts))
-            g_string_append_printf (buffer, ">%s</solution>",
+            buffer_xml_append_printf (buffer, ">%s</solution>",
               nvt_iterator_solution (nvts));
           else
-            g_string_append_printf (buffer, "/>");
+            buffer_xml_append_printf (buffer, "/>");
         }
 
 


### PR DESCRIPTION
The text in the element was only escaped properly in results, but not
the get_nvts GMP command.

**Checklist**:

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
