### PR TITLE
Handle "interrupted" OSP status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix and simplify parse_iso_time and add tests [#1129](https://github.com/greenbone/gvmd/pull/1129)
 - Fix gvm-manage-certs. [#1140](https://github.com/greenbone/gvmd/pull/1140)
 - Fix CVE scanner and results handling [#1141](https://github.com/greenbone/gvmd/pull/1141)
+- Handle INTERRUPTED scans [#1146](https://github.com/greenbone/gvmd/pull/1146)
 
 ### Removed
 - Remove support for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)


### PR DESCRIPTION
Handle INTERRUPTED status if the scanner was unexpectedly interrupted.

Depends on greenbone/gvm-libs#356