### PR TITLE
 Do not ignore empty hosts_allow and ifaces_allow (7.0)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,7 @@ Main changes since 7.0.3:
   updates from GMP scanners blocking the database for a long time.
 * A check whether hosts are alive and have results when adding them in slave
   scans has been added.
+* Empty hosts_allow and ifaces_allow is no longer ignored
 
 openvas-manager 7.0.3 (2018-03-29)
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -1827,7 +1827,7 @@ send_hosts_access_preferences (void)
   hosts = user_hosts (current_credentials.uuid);
   hosts_allow = user_hosts_allow (current_credentials.uuid);
 
-  if (hosts && strlen (hosts))
+  if (hosts_allow || (hosts && strlen (hosts)))
     {
       char *pref;
 
@@ -1841,7 +1841,7 @@ send_hosts_access_preferences (void)
           return 0;
         }
 
-      if (sendf_to_server ("%s <|> %s\n", pref, hosts))
+      if (sendf_to_server ("%s <|> %s\n", pref, hosts ? hosts : ""))
         {
           g_free (hosts);
           return -1;

--- a/src/manage.c
+++ b/src/manage.c
@@ -1789,7 +1789,7 @@ send_ifaces_access_preferences (void)
   ifaces = user_ifaces (current_credentials.uuid);
   ifaces_allow = user_ifaces_allow (current_credentials.uuid);
 
-  if (ifaces && strlen (ifaces))
+  if (ifaces_allow || (ifaces && strlen (ifaces)))
     {
       char *pref;
 
@@ -1803,7 +1803,7 @@ send_ifaces_access_preferences (void)
           return 0;
         }
 
-      if (sendf_to_server ("%s <|> %s\n", pref, ifaces))
+      if (sendf_to_server ("%s <|> %s\n", pref, ifaces ? ifaces : ""))
         {
           g_free (ifaces);
           return -1;


### PR DESCRIPTION
With this it is possible to forbid users to scan any hosts or scan
using any network interfaces.

**Checklist**:

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
