### PR TITLE
Use error variable in osp_get_vts_version(),

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Do not ignore empty hosts_allow and ifaces_allow [#1064](https://github.com/greenbone/gvmd/pull/1064)
 - Reduce the memory cache of NVTs [#1076](https://github.com/greenbone/gvmd/pull/1076)
 - Sync SCAP using a second schema [#1111](https://github.com/greenbone/gvmd/pull/1111)
+- Use error variable in osp_get_vts_version(). [#1159](https://github.com/greenbone/gvmd/pull/1159)
 
 ### Fixed
 - Add NULL check in nvts_feed_version_epoch [#768](https://github.com/greenbone/gvmd/pull/768)

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1676,6 +1676,7 @@ update_nvt_cache_osp (const gchar *update_socket, gchar *db_feed_version,
       return -1;
     }
 
+  get_vts_opts = osp_get_vts_opts_default;
   if (db_feed_version)
     get_vts_opts.filter = g_strdup_printf ("modification_time>%s", db_feed_version);
   else
@@ -1799,6 +1800,7 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
 {
   osp_connection_t *connection;
   gchar *db_feed_version, *scanner_feed_version;
+  gchar *error;
 
   /* Re-open DB after fork. */
 
@@ -1817,9 +1819,12 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
       return -1;
     }
 
-  if (osp_get_vts_version (connection, &scanner_feed_version))
+  error = NULL;
+  if (osp_get_vts_version (connection, &scanner_feed_version, &error))
     {
-      g_debug ("%s: failed to get scanner_version", __func__);
+      g_debug ("%s: failed to get scanner_feed_version. %s",
+               __func__, error ? : "");
+      g_free (error);
       return -1;
     }
   g_debug ("%s: scanner_feed_version: %s", __func__, scanner_feed_version);
@@ -1870,6 +1875,7 @@ update_or_rebuild_nvts (int update)
   gchar *db_feed_version, *scanner_feed_version;
   osp_connection_t *connection;
   int ret;
+  gchar *error;
 
   if (check_osp_vt_update_socket ())
     {
@@ -1896,9 +1902,11 @@ update_or_rebuild_nvts (int update)
       return -1;
     }
 
-  if (osp_get_vts_version (connection, &scanner_feed_version))
+  error = NULL;
+  if (osp_get_vts_version (connection, &scanner_feed_version, &error))
     {
-      printf ("Failed to get scanner_version.\n");
+      printf ("Failed to get scanner_version. %s\n", error ? : "");
+      g_free (error);
       return -1;
     }
   g_debug ("%s: scanner_feed_version: %s", __func__, scanner_feed_version);


### PR DESCRIPTION
as the function has changed in gvm-libs.

Depends on greenbone/gvm-libs#357 and greenbone/gvm-libs#360