### PR TITLE
Check number of args to ensure period_offsets is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix gvm-manage-certs. [#1140](https://github.com/greenbone/gvmd/pull/1140)
 - Fix CVE scanner and results handling [#1141](https://github.com/greenbone/gvmd/pull/1141)
 - Handle INTERRUPTED scans [#1146](https://github.com/greenbone/gvmd/pull/1146)
+- Check number of args to ensure period_offsets is 0 [#1165](https://github.com/greenbone/gvmd/pull/1165)
 
 ### Removed
 - Remove support for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)

--- a/src/manage_pg_server.c
+++ b/src/manage_pg_server.c
@@ -136,7 +136,7 @@ PG_FUNCTION_INFO_V1 (sql_next_time_ical);
 /**
  * @brief Get the next time given schedule times.
  *
- * This is a callback for a SQL function of four to six arguments.
+ * This is a callback for a SQL function of one to three arguments.
  *
  * @return Postgres Datum.
  */
@@ -168,7 +168,10 @@ sql_next_time_ical (PG_FUNCTION_ARGS)
       zone = textndup (timezone_arg, VARSIZE (timezone_arg) - VARHDRSZ);
     }
 
-  periods_offset = PG_GETARG_INT32 (2);
+  if (PG_NARGS() < 3)
+    periods_offset = 0;
+  else
+    periods_offset = PG_GETARG_INT32 (2);
 
   ret = icalendar_next_time_from_string (ical_string, zone,
                                          periods_offset);


### PR DESCRIPTION
This was preventing schedule_next_time from being set when modifying the
schedule of a task.

Not sure why nobody noticed.  Might only happen under Postgres 12.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
