### PR TITLE
[9.0] Update gvm-portnames-update, openvassd to openvas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix and simplify parse_iso_time [#1130](https://github.com/greenbone/gvmd/pull/1130)
 - Fix gvm-manage-certs. [#1139](https://github.com/greenbone/gvmd/pull/1139)
 - Fix CVE scanner and results handling [#1142](https://github.com/greenbone/gvmd/pull/1142)
+- Update to gvm-portnames-update to use new nomenclature [#1166](https://github.com/greenbone/gvmd/pull/1166)
 
 [9.0.2]: https://github.com/greenbone/gvmd/compare/v9.0.1...gvmd-9.0
 

--- a/tools/gvm-portnames-update.in
+++ b/tools/gvm-portnames-update.in
@@ -49,12 +49,12 @@ fi
 
 # Configure DB_DIR where our DB is located.
 if [ -z "$DB_DIR" ]; then
-  OPENVASSD=`which openvassd`
-  if [ -z "$OPENVASSD" ] ; then
-    echo "[e] Error: openvassd is not in the path, could not determine the Manager directory."
+  OPENVAS=`which openvas`
+  if [ -z "$OPENVAS" ] ; then
+    echo "[e] Error: openvas is not in the path, could not determine the Manager directory."
     exit 1
   else
-    OV_DIR=`openvassd -s | awk -F" = " '/^plugins_folder/ { print $2 }' | sed -s 's/\(^.*\)\/plugins/\1/'`
+    OV_DIR=`openvas -s | awk -F" = " '/^plugins_folder/ { print $2 }' | sed -s 's/\(^.*\)\/plugins/\1/'`
   fi
   DB_DIR="$OV_DIR/gvmd"
 fi


### PR DESCRIPTION
Backport of #802 to the gvm-9.0 branch. Seems this was never backported back then and we're still shipping outdated code.