### PR TITLE
Include all source in utils-test build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -180,7 +180,24 @@ add_test (gmp-tickets-test gmp-tickets-test)
 
 add_executable (utils-test
                 EXCLUDE_FROM_ALL
-                utils_tests.c)
+                utils_tests.c
+
+                gvmd.c gmpd.c
+                manage_utils.c manage.c sql.c
+                manage_acl.c manage_configs.c manage_get.c
+                manage_port_lists.c manage_preferences.c
+                manage_report_formats.c
+                manage_sql.c manage_sql_nvts.c manage_sql_secinfo.c
+                manage_sql_port_lists.c manage_sql_configs.c
+                manage_sql_report_formats.c
+                manage_sql_tickets.c manage_sql_tls_certificates.c
+                manage_tls_certificates.c
+                manage_migrators.c
+                sql_pg.c manage_pg.c
+                lsc_user.c lsc_crypt.c
+                gmp.c gmp_base.c gmp_configs.c gmp_delete.c gmp_get.c
+                gmp_port_lists.c gmp_report_formats.c gmp_tickets.c
+                gmp_tls_certificates.c)
 
 add_test (utils-test utils-test)
 


### PR DESCRIPTION
This solves a linker error on newer systems.  Probably due to utils.h
now including xmlutils.h, and the way gvm-libs is built.  Easier
to just include everything like the other tests, than to figure out
the details.

The build fail doesn't show up in CI, presumably because it's an older system.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
