### PR TITLE
Fix name handling when creating host assets (20.08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Check hosts in MODIFY_OVERRIDE, as in CREATE_OVERRIDE [#1162](https://github.com/greenbone/gvmd/pull/1162)
 - Preserve task "once" value [#1176](https://github.com/greenbone/gvmd/pull/1176)
 - Check number of args to ensure period_offsets is 0 [#1175](https://github.com/greenbone/gvmd/pull/1175)
+- Fix name handling when creating host assets [#1183](https://github.com/greenbone/gvmd/pull/1183)
 
 ### Removed
 - Remove support for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -19343,8 +19343,7 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                   case 2:
                     SEND_TO_CLIENT_OR_FAIL
                        (XML_ERROR_SYNTAX ("create_asset",
-                                          "Name may only contain alphanumeric"
-                                          " characters"));
+                                          "Name must be an IP address"));
                     log_event_fail ("asset", "Asset", NULL, "created");
                     break;
                   case 99:

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -49076,7 +49076,6 @@ create_asset_host (const char *host_name, const char *comment,
        current_credentials.uuid,
        quoted_host_name,
        quoted_comment);
-  g_free (quoted_host_name);
   g_free (quoted_comment);
 
   host = sql_last_insert_id ();
@@ -49089,8 +49088,10 @@ create_asset_host (const char *host_name, const char *comment,
        "  '', '%s', 'User', '%s', '', m_now (), m_now ());",
        host,
        current_credentials.uuid,
-       host_name,
+       quoted_host_name,
        current_credentials.uuid);
+
+  g_free (quoted_host_name);
 
   if (host_return)
     *host_return = host;

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -49046,12 +49046,14 @@ identifier_name (const char *name)
  * @param[in]  comment      Comment.
  * @param[out] host_return  Created asset.
  *
- * @return 0 success, 1 failed to find report, 99 permission denied, -1 error.
+ * @return 0 success, 1 failed to find report, 2 host not an IP address,
+ *         99 permission denied, -1 error.
  */
 int
 create_asset_host (const char *host_name, const char *comment,
                    resource_t* host_return)
 {
+  int host_type;
   resource_t host;
   gchar *quoted_host_name, *quoted_comment;
 
@@ -49064,6 +49066,13 @@ create_asset_host (const char *host_name, const char *comment,
     {
       sql_rollback ();
       return 99;
+    }
+
+  host_type = gvm_get_host_type (host_name);
+  if (host_type != HOST_TYPE_IPV4 && host_type != HOST_TYPE_IPV6)
+    {
+      sql_rollback ();
+      return 2;
     }
 
   quoted_host_name = sql_quote (host_name);


### PR DESCRIPTION
This fixes missing quoting of the name in the host case of the `create_asset` command and makes it require an IP address.

**Checklist**:

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
