### PR TITLE
Fix name handling when creating host assets (7.0)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -30,6 +30,7 @@ Main changes since 7.0.3:
 * A check whether hosts are alive and have results when adding them in slave
   scans has been added.
 * Empty hosts_allow and ifaces_allow is no longer ignored
+* Fix name handling when creating host assets
 
 openvas-manager 7.0.3 (2018-03-29)
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -62934,12 +62934,14 @@ identifier_name (const char *name)
  * @param[in]  comment      Comment.
  * @param[out] host_return  Created asset.
  *
- * @return 0 success, 1 failed to find report, 99 permission denied, -1 error.
+ * @return 0 success, 1 failed to find report, 2 host not an IP address,
+ *         99 permission denied, -1 error.
  */
 int
 create_asset_host (const char *host_name, const char *comment,
                    resource_t* host_return)
 {
+  int host_type;
   resource_t host;
   gchar *quoted_host_name, *quoted_comment;
 
@@ -62952,6 +62954,13 @@ create_asset_host (const char *host_name, const char *comment,
     {
       sql_rollback ();
       return 99;
+    }
+
+  host_type = openvas_get_host_type (host_name);
+  if (host_type != HOST_TYPE_IPV4 && host_type != HOST_TYPE_IPV6)
+    {
+      sql_rollback ();
+      return 2;
     }
 
   quoted_host_name = sql_quote (host_name);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -62964,7 +62964,6 @@ create_asset_host (const char *host_name, const char *comment,
        current_credentials.uuid,
        quoted_host_name,
        quoted_comment);
-  g_free (quoted_host_name);
   g_free (quoted_comment);
 
   host = sql_last_insert_id ();
@@ -62977,8 +62976,10 @@ create_asset_host (const char *host_name, const char *comment,
        "  '', '%s', 'User', '%s', '', m_now (), m_now ());",
        host,
        current_credentials.uuid,
-       host_name,
+       quoted_host_name,
        current_credentials.uuid);
+
+  g_free (quoted_host_name);
 
   if (host_return)
     *host_return = host;

--- a/src/omp.c
+++ b/src/omp.c
@@ -21609,8 +21609,7 @@ omp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
               case 2:
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("create_asset",
-                                    "Name may only contain alphanumeric"
-                                    " characters"));
+                                    "Name must be an IP address"));
                 log_event_fail ("asset", "Asset", NULL, "created");
                 break;
               case 99:


### PR DESCRIPTION
This fixes missing quoting of the name in the host case of the `create_asset` command and makes it require an IP address.

**Checklist**:

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
