### PR TITLE
Fix outdated refs to openvassd.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Check hosts in MODIFY_OVERRIDE, as in CREATE_OVERRIDE [#1162](https://github.com/greenbone/gvmd/pull/1162)
 - Preserve task "once" value [#1176](https://github.com/greenbone/gvmd/pull/1176)
 - Check number of args to ensure period_offsets is 0 [#1175](https://github.com/greenbone/gvmd/pull/1175)
+- Outdated references to "openvassd" have been updated to "openvas" [#1189](https://github.com/greenbone/gvmd/pull/1189)
 
 ### Removed
 - Remove support for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)

--- a/doc/gvm-manage-certs.1
+++ b/doc/gvm-manage-certs.1
@@ -127,6 +127,6 @@ Prefix for certificate filename (e.g. "server")
 For a complete list of options, please refer to the example configuration file
 included in the documentation.
 .SH "SEE ALSO"
-.BR openvassd (8),
+.BR openvas (8),
 .BR gvmd (8),
 .BR gsad (8)

--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -191,13 +191,13 @@ Verify scanner SCANNER-UUID and exit.
 \fB--version\f1
 Print version and exit.
 .SH SIGNALS
-SIGHUP causes gvmd to rebuild the database with information from the Scanner (openvassd).
+SIGHUP causes gvmd to rebuild the database with information from the Scanner (openvas).
 .SH EXAMPLES
 gvmd --port 1241
 
 Serve GMP clients on port 1241 and connect to an OpenVAS scanner via the default OTP file socket.
 .SH SEE ALSO
-\fBopenvassd(8)\f1, \fBgsad(8)\f1, \fBgvm-cli(8)\f1, 
+\fBopenvas(8)\f1, \fBgsad(8)\f1, \fBgvm-cli(8)\f1, 
 .SH MORE INFORMATION ABOUT GREENBONE VULNERABILITY MANAGEMENT
 The canonical places where you will find more information about the Greenbone Vulnerability Manager are: 
 

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -425,7 +425,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   <section name="SIGNALS">
     <p>SIGHUP causes gvmd to rebuild the database with information from
-       the Scanner (openvassd).</p>
+       the Scanner (openvas).</p>
   </section>
 
   <section name="EXAMPLES">
@@ -436,7 +436,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   <section name="SEE ALSO">
     <p>
-      <manref name="openvassd" section="8"/>,
+      <manref name="openvas" section="8"/>,
       <manref name="gsad" section="8"/>,
       <manref name="gvm-cli" section="8"/>,
     </p>

--- a/doc/gvmd.html
+++ b/doc/gvmd.html
@@ -410,7 +410,7 @@
   <h2>SIGNALS</h2>
 
     <p>SIGHUP causes gvmd to rebuild the database with information from
-       the Scanner (openvassd).</p>
+       the Scanner (openvas).</p>
   
 
 
@@ -425,7 +425,7 @@
   <h2>SEE ALSO</h2>
 
     <p>
-      <b>openvassd (8)</b>,
+      <b>openvas (8)</b>,
       <b>gsad (8)</b>,
       <b>gvm-cli (8)</b>,
     </p>


### PR DESCRIPTION
`openvassd` has been renamed to just `openvas` already in GVM-11 (gvmd-9) but the files didn't reflect this.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
