### PR TITLE
Make feed "data objects" read-only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 232)
+set (GVMD_DATABASE_VERSION 233)
 
 set (GVMD_SCAP_DATABASE_VERSION 16)
 

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -14856,11 +14856,17 @@ handle_get_report_formats (gmp_parser_t *gmp_parser, GError **error)
            ("<extension>%s</extension>"
             "<content_type>%s</content_type>"
             "<summary>%s</summary>"
-            "<description>%s</description>",
+            "<description>%s</description>"
+            "<predefined>%i</predefined>",
             report_format_iterator_extension (&report_formats),
             report_format_iterator_content_type (&report_formats),
             report_format_iterator_summary (&report_formats),
-            report_format_iterator_description (&report_formats));
+            report_format_iterator_description (&report_formats),
+            get_report_formats_data->get.trash
+              ? trash_report_format_predefined
+                 (get_iterator_resource (&report_formats))
+              : report_format_predefined
+                 (get_iterator_resource (&report_formats)));
 
           if (get_report_formats_data->alerts)
             {

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -11779,13 +11779,15 @@ handle_get_configs (gmp_parser_t *gmp_parser, GError **error)
                                "%i<growing>%i</growing>"
                                "</nvt_count>"
                                "<type>%i</type>"
-                               "<usage_type>%s</usage_type>",
+                               "<usage_type>%s</usage_type>"
+                               "<predefined>%i</predefined>",
                                config_iterator_family_count (&configs),
                                config_families_growing,
                                config_iterator_nvt_count (&configs),
                                config_nvts_growing,
                                config_type,
-                               usage_type);
+                               usage_type,
+                               config_iterator_predefined (&configs));
 
       if (config_type == 0 && (get_configs_data->families
                                || get_configs_data->get.details))

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -14042,10 +14042,12 @@ handle_get_port_lists (gmp_parser_t *gmp_parser, GError **error)
                                "<all>%i</all>"
                                "<tcp>%i</tcp>"
                                "<udp>%i</udp>"
-                               "</port_count>",
+                               "</port_count>"
+                               "<predefined>%i</predefined>",
                                port_list_iterator_count_all (&port_lists),
                                port_list_iterator_count_tcp (&port_lists),
-                               port_list_iterator_count_udp (&port_lists));
+                               port_list_iterator_count_udp (&port_lists),
+                               port_list_iterator_predefined (&port_lists));
 
       if (get_port_lists_data->get.details)
         {

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -18250,6 +18250,9 @@ handle_modify_config (gmp_parser_t *gmp_parser, GError **error)
     SEND_TO_CLIENT_OR_FAIL
      (XML_ERROR_SYNTAX ("modify_config",
                         "A config_id attribute is required"));
+  else if (config_predefined_uuid (modify_config_data->config_id))
+    SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX ("modify_config",
+                                              "Permission denied"));
   else if ((modify_config_data->nvt_selection_family
             /* This array implies FAMILY_SELECTION. */
             && modify_config_data->families_static_all)

--- a/src/manage_configs.c
+++ b/src/manage_configs.c
@@ -42,6 +42,28 @@
 #define G_LOG_DOMAIN "md manage"
 
 
+/* Configs. */
+
+/**
+ * @brief Return whether a config is predefined.
+ *
+ * @param[in]  config_id  UUID of config.
+ *
+ * @return 1 if predefined, else 0.
+ */
+int
+config_predefined_uuid (const gchar *config_id)
+{
+  config_t config;
+
+  if (find_config_no_acl (config_id, &config)
+      || config == 0)
+    return 0;
+
+  return config_predefined (config);
+}
+
+
 /* Feed configs. */
 
 /**

--- a/src/manage_configs.h
+++ b/src/manage_configs.h
@@ -72,6 +72,9 @@ config_type (config_t);
 char *
 config_nvt_timeout (config_t, const char *);
 
+int
+config_predefined_uuid (const gchar *);
+
 void
 init_user_config_iterator (iterator_t*, config_t, int, int, const char*);
 

--- a/src/manage_configs.h
+++ b/src/manage_configs.h
@@ -105,6 +105,9 @@ config_iterator_scanner_trash (iterator_t*);
 const char*
 config_iterator_usage_type (iterator_t*);
 
+int
+config_iterator_predefined (iterator_t*);
+
 char*
 config_nvt_selector (config_t);
 

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -2190,12 +2190,13 @@ migrate_231_to_232 ()
 /**
  * @brief Set predefined.
  *
+ * @param[in]  type   Type to update.
  * @param[in]  table  Table to update.
  *
  * @return 0 success, -1 error.
  */
 int
-migrate_232_to_233_set_predefined (const gchar *table)
+migrate_232_to_233_set_predefined (const gchar *type, const gchar *table)
 {
   GError *error;
   GDir *dir;
@@ -2204,7 +2205,7 @@ migrate_232_to_233_set_predefined (const gchar *table)
 
   dir_path = g_build_filename (GVMD_FEED_DIR,
                                GMP_VERSION,
-                               table,
+                               type,
                                NULL);
 
   /* Open feed import directory. */
@@ -2286,9 +2287,13 @@ migrate_232_to_233 ()
        " WHERE id IN (SELECT resource FROM resources_predefined"
        "              WHERE resource_type = 'report_format');");
 
-  migrate_232_to_233_set_predefined ("report_formats");
-  migrate_232_to_233_set_predefined ("configs");
-  migrate_232_to_233_set_predefined ("port_lists");
+  migrate_232_to_233_set_predefined ("report_formats", "report_formats");
+  migrate_232_to_233_set_predefined ("configs", "configs");
+  migrate_232_to_233_set_predefined ("port_lists", "port_lists");
+
+  migrate_232_to_233_set_predefined ("report_formats", "report_formats_trash");
+  migrate_232_to_233_set_predefined ("configs", "configs_trash");
+  migrate_232_to_233_set_predefined ("port_lists", "port_lists_trash");
 
   sql ("DROP TABLE resources_predefined;");
 

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -1953,6 +1953,7 @@ create_tables ()
        "  owner integer REFERENCES users (id) ON DELETE RESTRICT,"
        "  name text NOT NULL,"
        "  comment text,"
+       "  predefined integer,"
        "  creation_time integer,"
        "  modification_time integer);");
 
@@ -1962,6 +1963,7 @@ create_tables ()
        "  owner integer REFERENCES users (id) ON DELETE RESTRICT,"
        "  name text NOT NULL,"
        "  comment text,"
+       "  predefined integer,"
        "  creation_time integer,"
        "  modification_time integer);");
 
@@ -2167,6 +2169,7 @@ create_tables ()
        "  nvts_growing integer,"
        "  type integer,"
        "  scanner integer REFERENCES scanners (id) ON DELETE RESTRICT,"
+       "  predefined integer,"
        "  creation_time integer,"
        "  modification_time integer,"
        "  usage_type text);");
@@ -2184,6 +2187,7 @@ create_tables ()
        "  nvts_growing integer,"
        "  type integer,"
        "  scanner integer," /* REFERENCES scanners (id) */
+       "  predefined integer,"
        "  creation_time integer,"
        "  modification_time integer,"
        "  scanner_location integer,"
@@ -2334,11 +2338,6 @@ create_tables ()
        "  end_time integer,"
        "  min_qod integer);");
 
-  sql ("CREATE TABLE IF NOT EXISTS resources_predefined"
-       " (id SERIAL PRIMARY KEY,"
-       "  resource_type text,"
-       "  resource integer);");
-
   sql ("CREATE TABLE IF NOT EXISTS results"
        " (id SERIAL PRIMARY KEY,"
        "  uuid text UNIQUE NOT NULL,"
@@ -2409,6 +2408,7 @@ create_tables ()
        "  trust integer,"
        "  trust_time integer,"
        "  flags integer,"
+       "  predefined integer,"
        "  creation_time integer,"
        "  modification_time integer);");
 
@@ -2425,6 +2425,7 @@ create_tables ()
        "  trust integer,"
        "  trust_time integer,"
        "  flags integer,"
+       "  predefined integer,"
        /* The UUID that the report format had before it was deleted.
         *
         * Regular report formats are given a new UUID when they are moved to

--- a/src/manage_port_lists.h
+++ b/src/manage_port_lists.h
@@ -73,6 +73,9 @@ port_list_iterator_count_tcp (iterator_t *);
 int
 port_list_iterator_count_udp (iterator_t *);
 
+int
+port_list_iterator_predefined (iterator_t *);
+
 char*
 port_list_uuid (port_list_t);
 

--- a/src/manage_port_lists.h
+++ b/src/manage_port_lists.h
@@ -33,6 +33,12 @@ gboolean
 find_port_range (const char*, port_list_t*);
 
 int
+trash_port_list_predefined (port_list_t);
+
+int
+port_list_predefined (port_list_t);
+
+int
 create_port_list (const char *, const char *, const char *, const char *,
                   array_t *, port_list_t *);
 

--- a/src/manage_report_formats.c
+++ b/src/manage_report_formats.c
@@ -90,19 +90,6 @@ trash_report_format_writable (report_format_t report_format)
 }
 
 /**
- * @brief Return whether a report format is predefined.
- *
- * @param[in]  report_format  Report format.
- *
- * @return 1 if predefined, else 0.
- */
-int
-report_format_predefined (report_format_t report_format)
-{
-  return resource_predefined ("report_format", report_format);
-}
-
-/**
  * @brief Get the name of a report format param type.
  *
  * @param[in]  type  Param type.

--- a/src/manage_report_formats.c
+++ b/src/manage_report_formats.c
@@ -524,13 +524,12 @@ create_report_format_from_file (const gchar *path)
                                        params,
                                        params_options,
                                        signature,
+                                       1,
                                        &new_report_format))
     {
       case 0:
         {
           gchar *uuid;
-
-          resource_set_predefined ("report_format", new_report_format, 1);
 
           uuid = report_format_uuid (new_report_format);
           log_event ("report_format", "Report format", uuid, "created");

--- a/src/manage_report_formats.h
+++ b/src/manage_report_formats.h
@@ -86,6 +86,9 @@ int
 report_format_predefined (report_format_t);
 
 int
+trash_report_format_predefined (report_format_t);
+
+int
 report_format_active (report_format_t);
 
 int

--- a/src/manage_report_formats.h
+++ b/src/manage_report_formats.h
@@ -23,9 +23,6 @@
 
 #include <glib.h>
 
-void
-resource_set_predefined (const gchar *, resource_t, int);
-
 gboolean
 find_report_format_with_permission (const char*, report_format_t*,
                                     const char *);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -46409,10 +46409,10 @@ manage_restore (const char *id)
       sql ("INSERT INTO configs"
            " (uuid, owner, name, nvt_selector, comment, family_count,"
            "  nvt_count, families_growing, nvts_growing, type, scanner,"
-           "  creation_time, modification_time, usage_type)"
+           "  predefined, creation_time, modification_time, usage_type)"
            " SELECT uuid, owner, name, nvt_selector, comment, family_count,"
            "        nvt_count, families_growing, nvts_growing, type, scanner,"
-           "        creation_time, modification_time, usage_type"
+           "        predefined, creation_time, modification_time, usage_type"
            " FROM configs_trash WHERE id = %llu;",
            resource);
 

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -2752,7 +2752,7 @@ config_scanner (config_t config)
 int
 config_predefined (config_t config)
 {
-  return sql_int ("SELECT predefined FROM report_formats"
+  return sql_int ("SELECT predefined FROM configs"
                   " WHERE id = %llu;",
                   config);
 }

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -2743,6 +2743,36 @@ config_scanner (config_t config)
 }
 
 /**
+ * @brief Return whether a config is predefined.
+ *
+ * @param[in]  config  Config.
+ *
+ * @return 1 if predefined, else 0.
+ */
+int
+config_predefined (config_t config)
+{
+  return sql_int ("SELECT predefined FROM report_formats"
+                  " WHERE id = %llu;",
+                  config);
+}
+
+/**
+ * @brief Return whether a trash config is predefined.
+ *
+ * @param[in]  config  Config.
+ *
+ * @return 1 if predefined, else 0.
+ */
+int
+trash_config_predefined (config_t config)
+{
+  return sql_int ("SELECT predefined FROM configs_trash"
+                  " WHERE id = %llu;",
+                  config);
+}
+
+/**
  * @brief Get the timeout value for an NVT in a config.
  *
  * @param[in]  config  Config.

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -4724,7 +4724,7 @@ update_config (config_t config, const gchar *type, const gchar *name,
   quoted_type = sql_quote (type);
   sql ("UPDATE configs"
        " SET name = '%s', comment = '%s', type = '%s', usage_type = '%s',"
-       " modification_time = m_now ()"
+       " predefined = 1, modification_time = m_now ()"
        " WHERE id = %llu;",
        quoted_name,
        quoted_comment,

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -3114,11 +3114,11 @@ delete_config (const char *config_id, int ultimate)
       sql ("INSERT INTO configs_trash"
            " (uuid, owner, name, nvt_selector, comment, family_count,"
            "  nvt_count, families_growing, nvts_growing, type, scanner,"
-           "  creation_time, modification_time,"
+           "  predefined, creation_time, modification_time,"
            "  scanner_location, usage_type)"
            " SELECT uuid, owner, name, nvt_selector, comment, family_count,"
            "        nvt_count, families_growing, nvts_growing, type, scanner,"
-           "        creation_time, modification_time,"
+           "        predefined, creation_time, modification_time,"
            "        " G_STRINGIFY (LOCATION_TABLE) ", usage_type"
            " FROM configs WHERE id = %llu;",
            config);

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -2949,6 +2949,8 @@ copy_config (const char* name, const char* comment, const char *config_id,
       return ret;
     }
 
+  sql ("UPDATE configs SET predefined = 0 WHERE id = %llu;", new);
+
   sql ("INSERT INTO config_preferences (config, type, name, value,"
        "                                default_value, hr_name)"
        " SELECT %llu, type, name, value, default_value, hr_name"

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -3532,6 +3532,22 @@ config_iterator_scanner_trash (iterator_t* iterator)
 DEF_ACCESS (config_iterator_usage_type, GET_ITERATOR_COLUMN_COUNT + 8);
 
 /**
+ * @brief Get predefined status from a config iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return 1 if predefined, else 0.
+ */
+int
+config_iterator_predefined (iterator_t* iterator)
+{
+  int ret = 0;
+  if (iterator->done) return 0;
+  ret = iterator_int (iterator, GET_ITERATOR_COLUMN_COUNT + 9);
+  return ret;
+}
+
+/**
  * @brief Return whether a config is referenced by a task.
  *
  * @param[in]  config  Config.

--- a/src/manage_sql_configs.h
+++ b/src/manage_sql_configs.h
@@ -79,6 +79,12 @@ find_config_no_acl (const char *, config_t *);
 gboolean
 find_trash_config_no_acl (const char *, config_t *);
 
+int
+config_predefined (config_t config);
+
+int
+trash_config_predefined (config_t);
+
 void
 migrate_predefined_configs ();
 

--- a/src/manage_sql_configs.h
+++ b/src/manage_sql_configs.h
@@ -44,6 +44,7 @@
    { "scanner", NULL, KEYWORD_TYPE_INTEGER },                                 \
    { "0", NULL, KEYWORD_TYPE_INTEGER },                                       \
    { "usage_type", NULL, KEYWORD_TYPE_STRING },                               \
+   { "predefined", NULL, KEYWORD_TYPE_INTEGER },                              \
    { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                                       \
  }
 
@@ -62,6 +63,7 @@
    { "scanner", NULL, KEYWORD_TYPE_INTEGER },                                 \
    { "scanner_location", NULL, KEYWORD_TYPE_INTEGER },                        \
    { "usage_type", NULL, KEYWORD_TYPE_STRING },                               \
+   { "predefined", NULL, KEYWORD_TYPE_INTEGER },                              \
    { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                                       \
  }
 

--- a/src/manage_sql_port_lists.c
+++ b/src/manage_sql_port_lists.c
@@ -2564,7 +2564,7 @@ update_port_list (port_list_t port_list, const gchar *name,
   quoted_comment = sql_quote (comment ? comment : "");
   sql ("UPDATE port_lists"
        " SET name = '%s', comment = '%s',"
-       " modification_time = m_now ()"
+       " predefined = 1, modification_time = m_now ()"
        " WHERE id = %llu;",
        quoted_name,
        quoted_comment,

--- a/src/manage_sql_port_lists.c
+++ b/src/manage_sql_port_lists.c
@@ -1396,6 +1396,8 @@ copy_port_list (const char* name, const char* comment,
       return ret;
     }
 
+  sql ("UPDATE port_lists SET predefined = 0 WHERE id = %llu;", new);
+
   /* Copy port ranges. */
 
   sql ("INSERT INTO port_ranges "

--- a/src/manage_sql_port_lists.c
+++ b/src/manage_sql_port_lists.c
@@ -1707,8 +1707,9 @@ delete_port_list (const char *port_list_id, int ultimate)
       port_list_t trash_port_list;
 
       sql ("INSERT INTO port_lists_trash"
-           " (uuid, owner, name, comment, creation_time, modification_time)"
-           " SELECT uuid, owner, name, comment, creation_time,"
+           " (uuid, owner, name, comment, predefined, creation_time,"
+           "  modification_time)"
+           " SELECT uuid, owner, name, comment, predefined, creation_time,"
            "        modification_time"
            " FROM port_lists WHERE id = %llu;",
            port_list);
@@ -2406,8 +2407,10 @@ restore_port_list (const char *port_list_id)
     }
 
   sql ("INSERT INTO port_lists"
-       " (uuid, owner, name, comment, creation_time, modification_time)"
-       " SELECT uuid, owner, name, comment, creation_time, modification_time"
+       " (uuid, owner, name, comment, predefined, creation_time,"
+       "  modification_time)"
+       " SELECT uuid, owner, name, comment, predefined, creation_time,"
+       "        modification_time"
        " FROM port_lists_trash WHERE id = %llu;",
        port_list);
 

--- a/src/manage_sql_port_lists.c
+++ b/src/manage_sql_port_lists.c
@@ -1860,6 +1860,7 @@ delete_port_range (const char *port_range_id, int dummy)
      "udp",                                                        \
      KEYWORD_TYPE_INTEGER                                          \
    },                                                              \
+   { "predefined", NULL, KEYWORD_TYPE_INTEGER },                   \
    { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                            \
  }
 
@@ -1908,6 +1909,7 @@ delete_port_range (const char *port_range_id, int dummy)
      "udp",                                                        \
      KEYWORD_TYPE_INTEGER                                          \
    },                                                              \
+   { "predefined", NULL, KEYWORD_TYPE_INTEGER },                   \
    { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                            \
  }
 
@@ -2021,6 +2023,20 @@ port_list_iterator_count_udp (iterator_t* iterator)
 {
   if (iterator->done) return -1;
   return iterator_int (iterator, GET_ITERATOR_COLUMN_COUNT + 2);
+}
+
+/**
+ * @brief Get predefined status from a port_list iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return 1 if predefined, else 0.
+ */
+int
+port_list_iterator_predefined (iterator_t* iterator)
+{
+  if (iterator->done) return 0;
+  return iterator_int (iterator, GET_ITERATOR_COLUMN_COUNT + 3);
 }
 
 /**

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -1307,6 +1307,8 @@ copy_report_format (const char* name, const char* source_uuid,
       return ret;
     }
 
+  sql ("UPDATE report_formats SET predefined = 0 WHERE id = %llu;", new);
+
   if (report_format_predefined (old))
     sql ("UPDATE report_formats SET trust = %i, trust_time = %i"
          " WHERE id = %llu;",

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -1506,6 +1506,25 @@ copy_report_format (const char* name, const char* source_uuid,
 }
 
 /**
+ * @brief Return whether a report format is predefined.
+ *
+ * @param[in]  report_format_id  UUID of report format.
+ *
+ * @return 1 if predefined, else 0.
+ */
+static int
+report_format_predefined_uuid (const gchar *report_format_id)
+{
+  report_format_t report_format;
+
+  if (find_report_format_no_acl (report_format_id, &report_format)
+      || report_format == 0)
+    return 0;
+
+  return report_format_predefined (report_format);
+}
+
+/**
  * @brief Modify a report format.
  *
  * @param[in]  report_format_id  UUID of report format.
@@ -1535,6 +1554,12 @@ modify_report_format (const char *report_format_id, const char *name,
   assert (current_credentials.uuid);
 
   if (acl_user_may ("modify_report_format") == 0)
+    {
+      sql_rollback ();
+      return 99;
+    }
+
+  if (report_format_predefined_uuid (report_format_id))
     {
       sql_rollback ();
       return 99;

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -2241,6 +2241,21 @@ trash_report_format_in_use (report_format_t report_format)
 }
 
 /**
+ * @brief Return whether a report format is predefined.
+ *
+ * @param[in]  report_format  Report format.
+ *
+ * @return 1 if predefined, else 0.
+ */
+int
+report_format_predefined (report_format_t report_format)
+{
+  return sql_int ("SELECT predefined FROM report_formats"
+                  " WHERE id = %llu;",
+                  report_format);
+}
+
+/**
  * @brief Return the extension of a report format.
  *
  * @param[in]  report_format  Report format.

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -877,6 +877,7 @@ add_report_format_params (report_format_t report_format, array_t *params,
  * @param[in]   params_options Array.  Each item is an array corresponding to
  *                             params.  Each item of an inner array is a string,
  *                             the text of an option in a selection.
+ * @param[in]   predefined     Whether report format is from the feed.
  * @param[in]   signature      Signature.
  * @param[out]  report_format  Created report format.
  *
@@ -893,6 +894,7 @@ create_report_format_internal (int check_access, int may_exist, int active,
                                const char *summary, const char *description,
                                array_t *files, array_t *params,
                                array_t *params_options, const char *signature,
+                               int predefined,
                                report_format_t *report_format)
 {
   gchar *quoted_name, *quoted_summary, *quoted_description, *quoted_extension;
@@ -1205,6 +1207,9 @@ create_report_format_internal (int check_access, int may_exist, int active,
 
   g_free (dir);
 
+  if (predefined)
+    resource_set_predefined ("report_format", report_format_rowid, 1);
+
   sql_commit ();
 
   return 0;
@@ -1249,6 +1254,7 @@ create_report_format (const char *uuid, const char *name,
                                         uuid, name, content_type, extension,
                                         summary, description, files, params,
                                         params_options, signature,
+                                        0, /* Predefined. */
                                         report_format);
 }
 
@@ -1269,6 +1275,7 @@ create_report_format (const char *uuid, const char *name,
  *                             params.  Each item of an inner array is a string,
  *                             the text of an option in a selection.
  * @param[in]   signature      Signature.
+ * @param[in]   predefined     Whether report format is from the feed.
  * @param[out]  report_format  Created report format.
  *
  * @return 0 success, 1 report format exists, 2 empty file name, 3 param value
@@ -1283,7 +1290,7 @@ create_report_format_no_acl (const char *uuid, const char *name,
                              const char *summary, const char *description,
                              array_t *files, array_t *params,
                              array_t *params_options, const char *signature,
-                             report_format_t *report_format)
+                             int predefined, report_format_t *report_format)
 {
   return create_report_format_internal (0, /* Check permission. */
                                         0, /* Allow existing report format. */
@@ -1292,7 +1299,7 @@ create_report_format_no_acl (const char *uuid, const char *name,
                                         uuid, name, content_type, extension,
                                         summary, description, files, params,
                                         params_options, signature,
-                                        report_format);
+                                        predefined, report_format);
 }
 
 /**

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -4146,7 +4146,7 @@ update_report_format (report_format_t report_format, const gchar *report_id, con
   sql ("UPDATE report_formats"
        " SET name = '%s', content_type = '%s', extension = '%s',"
        "     summary = '%s', description = '%s', signature = '%s',"
-       "     modification_time = m_now ()"
+       "     predefined = 1, modification_time = m_now ()"
        " WHERE id = %llu;",
        quoted_name,
        quoted_content_type,

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -2256,6 +2256,21 @@ report_format_predefined (report_format_t report_format)
 }
 
 /**
+ * @brief Return whether a trash report format is predefined.
+ *
+ * @param[in]  report_format  Report format.
+ *
+ * @return 1 if predefined, else 0.
+ */
+int
+trash_report_format_predefined (report_format_t report_format)
+{
+  return sql_int ("SELECT predefined FROM report_formats_trash"
+                  " WHERE id = %llu;",
+                  report_format);
+}
+
+/**
  * @brief Return the extension of a report format.
  *
  * @param[in]  report_format  Report format.

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -1893,11 +1893,11 @@ delete_report_format (const char *report_format_id, int ultimate)
       sql ("INSERT INTO report_formats_trash"
            " (uuid, owner, name, extension, content_type, summary,"
            "  description, signature, trust, trust_time, flags, original_uuid,"
-           "  creation_time, modification_time)"
+           "  predefined, creation_time, modification_time)"
            " SELECT"
            "  %s, owner, name, extension, content_type, summary,"
            "  description, signature, trust, trust_time, flags, uuid,"
-           "  creation_time, modification_time"
+           "  predefined, creation_time, modification_time"
            " FROM report_formats"
            " WHERE id = %llu;",
            report_format_predefined (report_format) ? "uuid" : "make_uuid ()",
@@ -2019,11 +2019,11 @@ restore_report_format (const char *report_format_id)
   sql ("INSERT INTO report_formats"
        " (uuid, owner, name, extension, content_type, summary,"
        "  description, signature, trust, trust_time, flags,"
-       "  creation_time, modification_time)"
+       "  predefined, creation_time, modification_time)"
        " SELECT"
        "  original_uuid, owner, name, extension, content_type, summary,"
        "  description, signature, trust, trust_time, flags,"
-       "  creation_time, modification_time"
+       "  predefined, creation_time, modification_time"
        " FROM report_formats_trash"
        " WHERE id = %llu;",
        resource);

--- a/src/manage_sql_report_formats.h
+++ b/src/manage_sql_report_formats.h
@@ -37,7 +37,7 @@ int
 create_report_format_no_acl (const char *, const char *, const char *,
                              const char *, const char *, const char *,
                              array_t *, array_t *, array_t *, const char *,
-                             report_format_t *);
+                             int, report_format_t *);
 
 const char**
 report_format_filter_columns ();

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -7386,6 +7386,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <o><e>families</e></o>
           <o><e>preferences</e></o>
           <o><e>nvt_selectors</e></o>
+          <e>predefined</e>
         </pattern>
         <ele>
           <name>owner</name>
@@ -7769,6 +7770,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <pattern>text</pattern>
             </ele>
           </ele>
+        </ele>
+        <ele>
+          <name>predefined</name>
+          <summary>Whether the config was predefined by the feed</summary>
+          <pattern><t>boolean</t></pattern>
         </ele>
       </ele>
       <ele>
@@ -14333,6 +14339,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <e>port_count</e>
           <o><e>port_ranges</e></o>
           <o><e>targets</e></o>
+          <e>predefined</e>
         </pattern>
         <ele>
           <name>owner</name>
@@ -14531,6 +14538,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <pattern></pattern>
             </ele>
           </ele>
+        </ele>
+        <ele>
+          <name>predefined</name>
+          <summary>Whether the port list was predefined by the feed</summary>
+          <pattern><t>boolean</t></pattern>
         </ele>
       </ele>
       <ele>
@@ -15815,6 +15827,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </o>
           <e>trust</e>
           <e>active</e>
+          <e>predefined</e>
           <any><e>param</e></any>
         </pattern>
         <ele>
@@ -16090,6 +16103,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <ele>
           <name>active</name>
           <summary>Whether the report format is active</summary>
+          <pattern><t>boolean</t></pattern>
+        </ele>
+        <ele>
+          <name>predefined</name>
+          <summary>Whether the report format was predefined by the feed</summary>
           <pattern><t>boolean</t></pattern>
         </ele>
       </ele>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -26037,23 +26037,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <version>20.08</version>
   </change>
   <change>
-    <command>GET_REPORT_FORMATS</command>
-    <summary>PREDEFINED has been removed</summary>
-    <description>
-      <p>
-        The element REPORT_FORMAT/PREDEFINED has been removed from the
-        response to GET_REPORT_FORMATS.
-      </p>
-      <p>
-        Predefined report formats have been replaced with report formats
-        that are delivered in the feed.  Existing predefined report
-        formats will remain in the db, and their ownership will be
-        transferred to the Feed Import Owner.
-      </p>
-    </description>
-    <version>20.08</version>
-  </change>
-  <change>
     <command>COMMANDS</command>
     <summary>COMMANDS has been removed</summary>
     <description>


### PR DESCRIPTION
Reluctant to add these extra checks, but hopefully this avoids confusion that could happen if the admin modifies the config/port list/report format, but then the feed sync overwrites those modifications.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
