### PR TITLE
Add filter columns for special NVT tags (20.08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Handle QUEUED osp scan status. [#1113](https://github.com/greenbone/gvmd/pull/1113)
 - Add time placeholders for SCP path [#1164](https://github.com/greenbone/gvmd/pull/1164)
 - Expand detection information of results [#1182](https://github.com/greenbone/gvmd/pull/1182)
+- Add filter columns for special NVT tags [#1199](https://github.com/greenbone/gvmd/pull/1199)
 
 ### Changed
 - Update SCAP and CERT feed info in sync scripts [#810](https://github.com/greenbone/gvmd/pull/810)

--- a/src/manage_sql_nvts.h
+++ b/src/manage_sql_nvts.h
@@ -30,7 +30,8 @@
 #define NVT_INFO_ITERATOR_FILTER_COLUMNS                                    \
  { GET_ITERATOR_FILTER_COLUMNS, "version", "cve",                           \
    "family", "cvss_base", "severity", "cvss", "script_tags", "qod",         \
-   "qod_type", "solution_type", NULL }
+   "qod_type", "solution_type", "solution", "summary", "insight",           \
+   "affected", "impact", "detection", "solution_method", NULL }
 
 /**
  * @brief NVT iterator columns.


### PR DESCRIPTION
The NVT tags solution, summary, insight, affected, impact, detection
and solution_method were moved to their own columns and were
filterable as part of the tag filter column before this change,
so the new columns are made filterable.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
