### PR TITLE
Add filter columns for special NVT tags (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [9.0.2] (unreleased)
 
+### Added
+- Add filter columns for special NVT tags [#1200](https://github.com/greenbone/gvmd/pull/1200)
+
 ### Fixed
 - Fix NVTs list in CVE details [#1098](https://github.com/greenbone/gvmd/pull/1098)
 - Fix handling of duplicate settings [#1105](https://github.com/greenbone/gvmd/pull/1105)

--- a/src/manage_sql_nvts.h
+++ b/src/manage_sql_nvts.h
@@ -31,7 +31,8 @@
 #define NVT_INFO_ITERATOR_FILTER_COLUMNS                                    \
  { GET_ITERATOR_FILTER_COLUMNS, "version", "cve",                           \
    "family", "cvss_base", "severity", "cvss", "script_tags", "qod",         \
-   "qod_type", "solution_type", NULL }
+   "qod_type", "solution_type", "solution", "summary", "insight",           \
+   "affected", "impact", "detection", "solution_method", NULL }
 
 /**
  * @brief NVT iterator columns.


### PR DESCRIPTION
The NVT tags solution, summary, insight, affected, impact, detection
and solution_method were moved to their own columns and were
filterable as part of the tag filter column before this change,
so the new columns are made filterable.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
