### PR TITLE
Rename sync script to greenbone-feed-sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,7 +195,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The details attribute of GET_REPORTS now defaults to 0 [#747](https://github.com/greenbone/gvmd/pull/747)
 - Incoming VT timestamps via OSP are now assumed to be seconds since epoch [#754](https://github.com/greenbone/gvmd/pull/754)
 - Accelerate NVT feed update [#757](https://github.com/greenbone/gvmd/pull/757)
-- Combine sync scripts and add GVMd data sync [#1155](https://github.com/greenbone/gvmd/pull/1155)
+- Combine sync scripts and add GVMd data sync [#1155](https://github.com/greenbone/gvmd/pull/1155) [#1201](https://github.com/greenbone/gvmd/pull/1201)
 
 ### Fixed
 - A PostgreSQL statement order issue [#611](https://github.com/greenbone/gvmd/issues/611) has been addressed [#642](https://github.com/greenbone/gvmd/pull/642)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,7 +237,7 @@ configure_file (doc/example-gvm-manage-certs.conf.in doc/example-gvm-manage-cert
 configure_file (VERSION.in VERSION)
 configure_file (src/gvmd_log_conf.cmake_in src/gvmd_log.conf)
 configure_file (src/schema_formats/XML/GMP.xml.in src/schema_formats/XML/GMP.xml @ONLY)
-configure_file (tools/greenbone-gvmd-feed-sync.in tools/greenbone-gvmd-feed-sync @ONLY)
+configure_file (tools/greenbone-feed-sync.in tools/greenbone-feed-sync @ONLY)
 configure_file (tools/greenbone-scapdata-sync.in tools/greenbone-scapdata-sync @ONLY)
 configure_file (tools/greenbone-certdata-sync.in tools/greenbone-certdata-sync @ONLY)
 configure_file (tools/gvm-manage-certs.in tools/gvm-manage-certs @ONLY)
@@ -384,7 +384,7 @@ install (FILES tools/cert_bund_getbyname.xsl tools/dfn_cert_getbyname.xsl
          DESTINATION ${GVM_CERT_RES_DIR}
          PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
 
-install (FILES ${CMAKE_BINARY_DIR}/tools/greenbone-gvmd-feed-sync
+install (FILES ${CMAKE_BINARY_DIR}/tools/greenbone-feed-sync
          DESTINATION ${SBINDIR}
          PERMISSIONS OWNER_EXECUTE OWNER_READ OWNER_WRITE
                      GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)

--- a/tools/greenbone-certdata-sync.in
+++ b/tools/greenbone-certdata-sync.in
@@ -21,4 +21,4 @@
 # case a GSF access key is present) or else from the Greenbone
 # Community Feed.
 
-greenbone-gvmd-feed-sync --type "cert" "$@"
+greenbone-feed-sync --type "cert" "$@"

--- a/tools/greenbone-feed-sync.in
+++ b/tools/greenbone-feed-sync.in
@@ -59,7 +59,7 @@ PORT=24
 
 # SCRIPT_NAME is the name the scripts will use to identify itself and to mark
 # log messages.
-SCRIPT_NAME="greenbone-gvmd-feed-sync"
+SCRIPT_NAME="greenbone-feed-sync"
 
 # LOG_CMD defines the command to use for logging. To have logger log to stderr
 # as well as syslog, add "-s" here.

--- a/tools/greenbone-scapdata-sync.in
+++ b/tools/greenbone-scapdata-sync.in
@@ -21,4 +21,4 @@
 # case a GSF access key is present) or else from the Greenbone
 # Community Feed.
 
-greenbone-gvmd-feed-sync --type "scap" "$@"
+greenbone-feed-sync --type "scap" "$@"


### PR DESCRIPTION
To make the name shorter, greenbone-gvmd-feed-sync is renamed to
greenbone-feed-sync and scripts using it are updated accordingly.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
