### PR TITLE
Add documentation on how to update the default OSPD socket path.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -257,6 +257,23 @@ The UUIDs of all created users can be found using
     gvmd --get-users --verbose
 
 
+## Configure the default OSPD scanner socket path
+
+By default, Manager tries to connect to the default OSPD scanner via the following path:
+
+    /tmp/ospd.sock
+
+If this path doesn't match your setup you need to change the socket path accordingly.
+
+Get the UUID of the `OpenVAS Default` scanner:
+
+    gvmd --get-scanners
+
+Update the path (example, path needs to be adapted accordingly):
+
+    gvmd --modify-scanner=<uuid of OpenVAS Default scanner> --scanner-host=<install-prefix>/var/run/ospd.sock
+
+
 ## Logging Configuration
 
 By default, Manager writes logs to the file


### PR DESCRIPTION
Manager is looking at the following path by default which is not correct in most cases:

```
src/manage_sql.c:#define OPENVAS_DEFAULT_SOCKET "/tmp/ospd.sock"
```

Fixes #1132 because i have seen those messages only if the path wasn't updated / configured correctly.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
