### PR TITLE
Fix migrate_227_to_228_delete

### DIFF
--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -1886,6 +1886,7 @@ migrate_227_to_228_delete (const char *table)
                   "                   WHERE report_host_details.report_host"
                   "                         = report_hosts.id"
                   "                   AND report_hosts.report = %s.report"
+                  "                   AND report_hosts.host = %s.host"
                   "                   AND name = 'Host dead'"
                   "                   AND value = '1')"
                   "     RETURNING id),"
@@ -1903,6 +1904,7 @@ migrate_227_to_228_delete (const char *table)
                   "     AND resource IN (SELECT id FROM deleted))"
                   /* Return count of deleted results. */
                   " SELECT count(*) from deleted;",
+                  table,
                   table,
                   table,
                   location,


### PR DESCRIPTION
When deleting results from dead hosts, the report_host with the
"Host dead" detail must also match the IP address of the results
to delete, not just the report.

Error comes from https://github.com/greenbone/gvmd/pull/1071.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
