### PR TITLE
Set ignore_pagination in stop_active_tasks (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix the description of the Raw and Anonymous XML report formats [#1166](https://github.com/greenbone/gvmd/pull/1191)
 - Quote identifiers in SQL functions using EXECUTE [#1193](https://github.com/greenbone/gvmd/pull/1193)
 - Improve handling of removed NVT prefs [#1204](https://github.com/greenbone/gvmd/pull/1204)
+- Set ignore_pagination in stop_active_tasks [#1208](https://github.com/greenbone/gvmd/pull/1208)
 
 [9.0.2]: https://github.com/greenbone/gvmd/compare/v9.0.1...gvmd-9.0
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -18137,6 +18137,7 @@ stop_active_tasks ()
 
   assert (current_credentials.uuid == NULL);
   memset (&get, '\0', sizeof (get));
+  get.ignore_pagination = 1;
   init_task_iterator (&tasks, &get);
   while (next (&tasks))
     {


### PR DESCRIPTION
This ensures all tasks get checked whether they should be interrupted,
not just the first 10.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
