### PR TITLE
Set ignore_pagination in stop_active_tasks (8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix XML escaping in setting up GMP scans [#1124](https://github.com/greenbone/gvmd/pull/1124)
 - Fix name handling when creating host assets [#1185](https://github.com/greenbone/gvmd/pull/1185)
 - Quote identifiers in SQL functions using EXECUTE [#1194](https://github.com/greenbone/gvmd/pull/1194)
+- Set ignore_pagination in stop_active_tasks [#1209](https://github.com/greenbone/gvmd/pull/1209)
 
 [8.0.3]: https://github.com/greenbone/gvmd/compare/v8.0.2...gvmd-8.0
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -17947,6 +17947,7 @@ stop_active_tasks ()
 
   assert (current_credentials.uuid == NULL);
   memset (&get, '\0', sizeof (get));
+  get.ignore_pagination = 1;
   init_task_iterator (&tasks, &get);
   while (next (&tasks))
     {


### PR DESCRIPTION
This ensures all tasks get checked whether they should be interrupted,
not just the first 10.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
