### PR TITLE
Add currently_syncing for NVTs in GMP get_feeds (20.08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add time placeholders for SCP path [#1164](https://github.com/greenbone/gvmd/pull/1164)
 - Expand detection information of results [#1182](https://github.com/greenbone/gvmd/pull/1182)
 - Add filter columns for special NVT tags [#1199](https://github.com/greenbone/gvmd/pull/1199)
+- Add currently_syncing for NVTs in GMP get_feeds [#1210](https://github.com/greenbone/gvmd/pull/1210)
 
 ### Changed
 - Update SCAP and CERT feed info in sync scripts [#810](https://github.com/greenbone/gvmd/pull/810)


### PR DESCRIPTION
The command only checked if a sync was running for the other feeds like
SCAP before. This is made more consistent by adding the check for
the NVT feed as well.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
