### PR TITLE
Add logging for ANALYZE at end of migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Expand detection information of results [#1182](https://github.com/greenbone/gvmd/pull/1182)
 - Add filter columns for special NVT tags [#1199](https://github.com/greenbone/gvmd/pull/1199)
 - Add currently_syncing for NVTs in GMP get_feeds [#1210](https://github.com/greenbone/gvmd/pull/1210)
+- Add logging for ANALYZE at end of migration [#1211](https://github.com/greenbone/gvmd/pull/1211)
 
 ### Changed
 - Update SCAP and CERT feed info in sync scripts [#810](https://github.com/greenbone/gvmd/pull/810)

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -2573,6 +2573,7 @@ manage_migrate (GSList *log_config, const gchar *database)
    * Reopen the database before the ANALYZE, in case the schema has changed. */
   cleanup_manage_process (TRUE);
   init_manage_process (database);
+  g_info ("   Analyzing the database. This may take up to several hours.");
   sql ("ANALYZE;");
 
   cleanup_manage_process (TRUE);


### PR DESCRIPTION
This step can take a long time for large databases, so it should get a
log message to distinguish it from the last version change step or
the CERT and SCAP migration.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
