### PR TITLE
Allow group access to lockfile and fix growing or empty timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Outdated references to "openvassd" have been updated to "openvas" [#1189](https://github.com/greenbone/gvmd/pull/1189)
 - Quote identifiers in SQL functions using EXECUTE [#1192](https://github.com/greenbone/gvmd/pull/1192)
 - Fix handling of interrupted tasks [#1207](https://github.com/greenbone/gvmd/pull/1207)
+- Allow group access to lockfile and do not append to timestamp file [#1213](https://github.com/greenbone/gvmd/pull/1213)
 
 ### Removed
 - Remove support for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,7 +138,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Outdated references to "openvassd" have been updated to "openvas" [#1189](https://github.com/greenbone/gvmd/pull/1189)
 - Quote identifiers in SQL functions using EXECUTE [#1192](https://github.com/greenbone/gvmd/pull/1192)
 - Fix handling of interrupted tasks [#1207](https://github.com/greenbone/gvmd/pull/1207)
-- Allow group access to lockfile and do not append to timestamp file [#1213](https://github.com/greenbone/gvmd/pull/1213)
+- Allow group access to lockfile and fix growing or empty timestamp [#1213](https://github.com/greenbone/gvmd/pull/1213)
 
 ### Removed
 - Remove support for "All SecInfo": removal of "allinfo" for type in get_info [#790](https://github.com/greenbone/gvmd/pull/790)

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -12368,9 +12368,9 @@ get_feed_lock_status (const char *lockfile_name, gchar **timestamp)
   ret = 0;
 
   lockfile = open (lockfile_name,
-                   O_RDWR | O_CREAT | O_APPEND,
-                   /* "-rw-r--r--" */
-                   S_IWUSR | S_IRUSR | S_IROTH | S_IRGRP);
+                   O_RDWR | O_CREAT,
+                   /* "-rw-rw-r--" */
+                   S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
   if (lockfile == -1)
     g_warning ("%s: failed to open lock file '%s': %s", __func__,
                lockfile_name, strerror (errno));

--- a/src/utils.c
+++ b/src/utils.c
@@ -551,9 +551,9 @@ lock_internal (lockfile_t *lockfile, const gchar *lockfile_name,
   else
     full_name = g_build_filename (GVM_RUN_DIR, lockfile_name, NULL);
 
-  fd = open (full_name, O_RDWR | O_CREAT | O_APPEND,
-             /* "-rw-r--r--" */
-             S_IWUSR | S_IRUSR | S_IROTH | S_IRGRP);
+  fd = open (full_name, O_RDWR | O_CREAT,
+             /* "-rw-rw-r--" */
+             S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
   if (fd == -1)
     {
       g_warning ("Failed to open lock file '%s': %s", full_name,

--- a/tools/greenbone-feed-sync.in
+++ b/tools/greenbone-feed-sync.in
@@ -605,6 +605,6 @@ fi
   date > $LOCK_FILE
   sync_feed_data
   echo -n > $LOCK_FILE
-) 9>$LOCK_FILE
+) 9<$LOCK_FILE
 
 exit 0

--- a/tools/greenbone-feed-sync.in
+++ b/tools/greenbone-feed-sync.in
@@ -605,6 +605,6 @@ fi
   date > $LOCK_FILE
   sync_feed_data
   echo -n > $LOCK_FILE
-) 9<$LOCK_FILE
+) 9>>$LOCK_FILE
 
 exit 0

--- a/tools/greenbone-feed-sync.in
+++ b/tools/greenbone-feed-sync.in
@@ -596,6 +596,7 @@ then
   exit 0
 fi
 (
+  chmod +660 $LOCK_FILE
   flock -n 9
   if [ $? -eq 1 ] ; then
     log_notice "Sync in progress, exiting."


### PR DESCRIPTION
This allows gvmd and ospd-openvas to be run as different users in the same group and stops the timestamp in the lockfile from growing or being cleared when it is already locked.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
