### PR TITLE
Only update related CERT info if CERT is loaded

### DIFF
--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -4637,8 +4637,6 @@ update_scap_placeholders ()
 static int
 update_scap_end ()
 {
-  int last_cert_update, last_scap_update;
-
   g_debug ("%s: update timestamp", __func__);
 
   if (update_scap_timestamp ())
@@ -4659,21 +4657,26 @@ update_scap_end ()
 
   /* Update CERT data that depends on SCAP. */
 
-  last_cert_update = 0;
   if (manage_cert_loaded ())
-    last_cert_update = sql_int ("SELECT coalesce ((SELECT value FROM cert.meta"
-                                "                  WHERE name = 'last_update'),"
-                                "                 '0');");
+    {
+      int last_cert_update, last_scap_update;
 
-  last_scap_update = sql_int ("SELECT coalesce ((SELECT value FROM scap.meta"
-                              "                  WHERE name = 'last_update'),"
-                              "                 '0');");
+      last_cert_update = sql_int ("SELECT"
+                                  " coalesce ((SELECT value FROM cert.meta"
+                                  "            WHERE name = 'last_update'),"
+                                  "           '0');");
 
-  g_debug ("%s: last_scap_update: %i", __func__, last_scap_update);
-  g_debug ("%s: last_cert_update: %i", __func__, last_cert_update);
+      last_scap_update = sql_int ("SELECT"
+                                  " coalesce ((SELECT value FROM scap.meta"
+                                  "            WHERE name = 'last_update'),"
+                                  "           '0');");
 
-  update_cvss_dfn_cert (1, last_cert_update, last_scap_update);
-  update_cvss_cert_bund (1, last_cert_update, last_scap_update);
+      g_debug ("%s: last_scap_update: %i", __func__, last_scap_update);
+      g_debug ("%s: last_cert_update: %i", __func__, last_cert_update);
+
+      update_cvss_dfn_cert (1, last_cert_update, last_scap_update);
+      update_cvss_cert_bund (1, last_cert_update, last_scap_update);
+    }
 
   /* Analyze. */
 


### PR DESCRIPTION
This is a small fix of https://github.com/greenbone/gvmd/pull/1180.  In some situations the CERT may not be loaded by the end of the SCAP sync, so trying to update the related CERT info would lead to an error.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
