### PR TITLE
Ignore case when comparing disabled commands

### DIFF
--- a/src/manage_acl.c
+++ b/src/manage_acl.c
@@ -73,6 +73,29 @@ user_may_internal (const char *operation)
 }
 
 /**
+ * @brief Check if a string array contains a string, ignoring case.
+ *
+ * @param[in]  strv    String array.
+ * @param[in]  string  String.
+ *
+ * @return 1 if strv contains string, else 0.
+ */
+static int
+strv_strcasecmp (gchar **strv, const gchar *string)
+{
+  if (string == NULL)
+    return 0;
+
+  while (*strv)
+    if (strcasecmp (*strv, string) == 0)
+      return 1;
+    else
+      strv++;
+
+  return 0;
+}
+
+/**
  * @brief Get commands that the current user may run.
  *
  * @param[in]  disabled_commands  All disabled commands.
@@ -110,8 +133,7 @@ acl_commands (gchar **disabled_commands)
   while ((*all).name)
     {
       if ((disabled_commands == NULL
-           || g_strv_contains ((const char * const *) disabled_commands,
-                               (*all).name)
+           || strv_strcasecmp (disabled_commands, (*all).name)
               == 0)
           && (special_user
               || user_may_internal ((*all).name)))

--- a/src/manage_acl.c
+++ b/src/manage_acl.c
@@ -81,7 +81,7 @@ user_may_internal (const char *operation)
  * @return 1 if strv contains string, else 0.
  */
 static int
-strv_strcasecmp (gchar **strv, const gchar *string)
+strv_case_eq (gchar **strv, const gchar *string)
 {
   if (string == NULL)
     return 0;
@@ -133,7 +133,7 @@ acl_commands (gchar **disabled_commands)
   while ((*all).name)
     {
       if ((disabled_commands == NULL
-           || strv_strcasecmp (disabled_commands, (*all).name)
+           || strv_case_eq (disabled_commands, (*all).name)
               == 0)
           && (special_user
               || user_may_internal ((*all).name)))


### PR DESCRIPTION
This was introduced in befde8cbbd1de47a9f2350f9f7c4d7a0cef65053 in https://github.com/greenbone/gvmd/pull/807.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
