### PR TITLE
Make VT update message more accurate

### DIFF
--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1836,7 +1836,7 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
     {
       int ret;
 
-      g_info ("OSP service has newer VT status (version %s) than in database (version %s, %i VTs). Starting update ...",
+      g_info ("OSP service has different VT status (version %s) from database (version %s, %i VTs). Starting update ...",
               scanner_feed_version, db_feed_version, sql_int ("SELECT count (*) FROM nvts;"));
 
       ret = update_nvt_cache_osp (update_socket, db_feed_version,


### PR DESCRIPTION
The wording now includes the case when the feed version is older than the
db feed version.  This can happen for example if an NVT developer switches
to the NVT source code as feed.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
