### PR TITLE
[9.0] Updated outdated links and project name in docs.

### DIFF
--- a/doc/greenbone-certdata-sync.8
+++ b/doc/greenbone-certdata-sync.8
@@ -39,7 +39,24 @@ Check whether feed is current.
 The name of the database. For Posgres backend only. Default is tasks.
 .SH SEE ALSO
 \fBgvmd(8)\f1, \fBgreenbone-scapdata-sync(8)\f1
-.SH MORE INFORMATION ABOUT THE OPENVAS PROJECT
-The canonical places where you will find more information about the OpenVAS project are: \fBhttp://www.openvas.org/\f1 (Official site) \fBhttp://wald.intevation.org/projects/openvas/\f1 (Development Platform) 
+.SH MORE INFORMATION ABOUT Greenbone Vulnerability Management
+
+The canonical places where you will find more information
+about Greenbone Vulnerability Management are:
+
+.RS
+.UR https://community.greenbone.net
+Community site
+.UE
+.br
+.UR https://github.com/greenbone
+Development site
+.UE
+.br
+.UR https://www.openvas.org
+Traditional home site
+.UE
+.RE
+
 .SH COPYRIGHT
 The Greenbone Vulnerability Manager is released under the GNU GPL, version 2, or, at your option, any later version. 

--- a/doc/greenbone-certdata-sync.8.xml
+++ b/doc/greenbone-certdata-sync.8.xml
@@ -99,16 +99,19 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </p>
   </section>
 
-  <section name="MORE INFORMATION ABOUT THE OpenVAS PROJECT">
+  <section name="MORE INFORMATION ABOUT Greenbone Vulnerability Management">
     <p>
       The canonical places where you will find more information
-      about the OpenVAS project are:
+      about Greenbone Vulnerability Management are:
 
-      <url href="http://www.openvas.org/"/>
-        (Official site)
+      <url href="https://community.greenbone.net"/>
+        (Community site)
 
-      <url href="http://wald.intevation.org/projects/openvas/"/>
-        (Development Platform)
+      <url href="https://github.com/greenbone"/>
+        (Development site)
+
+      <url href="https://www.openvas.org"/>
+        (Traditional home site)
     </p>
   </section>
 

--- a/doc/greenbone-scapdata-sync.8
+++ b/doc/greenbone-scapdata-sync.8
@@ -42,7 +42,24 @@ Perform self-test and exit.
 Check whether feed is current.
 .SH SEE ALSO
 \fBgvmd(8)\f1, \fBgreenbone-certdata-sync(8)\f1
-.SH MORE INFORMATION ABOUT THE OPENVAS PROJECT
-The canonical places where you will find more information about the OpenVAS project are: \fBhttp://www.openvas.org/\f1 (Official site) \fBhttp://wald.intevation.org/projects/openvas/\f1 (Development Platform) 
+.SH MORE INFORMATION ABOUT Greenbone Vulnerability Management
+
+The canonical places where you will find more information
+about Greenbone Vulnerability Management are:
+
+.RS
+.UR https://community.greenbone.net
+Community site
+.UE
+.br
+.UR https://github.com/greenbone
+Development site
+.UE
+.br
+.UR https://www.openvas.org
+Traditional home site
+.UE
+.RE
+
 .SH COPYRIGHT
 The Greenbone Vulnerability Manager is released under the GNU GPL, version 2, or, at your option, any later version. 

--- a/doc/greenbone-scapdata-sync.8.xml
+++ b/doc/greenbone-scapdata-sync.8.xml
@@ -104,16 +104,19 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </p>
   </section>
 
-  <section name="MORE INFORMATION ABOUT THE OpenVAS PROJECT">
+  <section name="MORE INFORMATION ABOUT Greenbone Vulnerability Management">
     <p>
       The canonical places where you will find more information
-      about the OpenVAS project are:
+      about Greenbone Vulnerability Management are:
 
-      <url href="http://www.openvas.org/"/>
-        (Official site)
+      <url href="https://community.greenbone.net"/>
+        (Community site)
 
-      <url href="http://wald.intevation.org/projects/openvas/"/>
-        (Development Platform)
+      <url href="https://github.com/greenbone"/>
+        (Development site)
+
+      <url href="https://www.openvas.org"/>
+        (Traditional home site)
     </p>
   </section>
 


### PR DESCRIPTION
Backport of #1229 to the gvmd-9.0 branch.

Related: #1231