### PR TITLE
[9.0] Additional tweaks to the docs / manpages:

### DIFF
--- a/doc/greenbone-certdata-sync.8
+++ b/doc/greenbone-certdata-sync.8
@@ -39,22 +39,22 @@ Check whether feed is current.
 The name of the database. For Posgres backend only. Default is tasks.
 .SH SEE ALSO
 \fBgvmd(8)\f1, \fBgreenbone-scapdata-sync(8)\f1
-.SH MORE INFORMATION ABOUT Greenbone Vulnerability Management
+.SH MORE INFORMATION
 
 The canonical places where you will find more information
-about Greenbone Vulnerability Management are:
+about the Greenbone Vulnerability Management are:
 
 .RS
 .UR https://community.greenbone.net
-Community site
+Community Portal
 .UE
 .br
 .UR https://github.com/greenbone
-Development site
+Development Platform
 .UE
 .br
-.UR https://www.openvas.org
-Traditional home site
+.UR https://www.greenbone.net
+Greenbone Website
 .UE
 .RE
 

--- a/doc/greenbone-certdata-sync.8.xml
+++ b/doc/greenbone-certdata-sync.8.xml
@@ -99,19 +99,19 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </p>
   </section>
 
-  <section name="MORE INFORMATION ABOUT Greenbone Vulnerability Management">
+  <section name="MORE INFORMATION">
     <p>
       The canonical places where you will find more information
-      about Greenbone Vulnerability Management are:
+      about the Greenbone Vulnerability Management are:
 
       <url href="https://community.greenbone.net"/>
-        (Community site)
+        (Community Portal)
 
       <url href="https://github.com/greenbone"/>
-        (Development site)
+        (Development Platform)
 
-      <url href="https://www.openvas.org"/>
-        (Traditional home site)
+      <url href="https://www.greenbone.net"/>
+        (Greenbone Website)
     </p>
   </section>
 

--- a/doc/greenbone-scapdata-sync.8
+++ b/doc/greenbone-scapdata-sync.8
@@ -42,22 +42,22 @@ Perform self-test and exit.
 Check whether feed is current.
 .SH SEE ALSO
 \fBgvmd(8)\f1, \fBgreenbone-certdata-sync(8)\f1
-.SH MORE INFORMATION ABOUT Greenbone Vulnerability Management
+.SH MORE INFORMATION
 
 The canonical places where you will find more information
-about Greenbone Vulnerability Management are:
+about the Greenbone Vulnerability Management are:
 
 .RS
 .UR https://community.greenbone.net
-Community site
+Community Portal
 .UE
 .br
 .UR https://github.com/greenbone
-Development site
+Development Platform
 .UE
 .br
-.UR https://www.openvas.org
-Traditional home site
+.UR https://www.greenbone.net
+Greenbone Website
 .UE
 .RE
 

--- a/doc/greenbone-scapdata-sync.8.xml
+++ b/doc/greenbone-scapdata-sync.8.xml
@@ -104,19 +104,19 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </p>
   </section>
 
-  <section name="MORE INFORMATION ABOUT Greenbone Vulnerability Management">
+  <section name="MORE INFORMATION">
     <p>
       The canonical places where you will find more information
-      about Greenbone Vulnerability Management are:
+      about the Greenbone Vulnerability Management are:
 
       <url href="https://community.greenbone.net"/>
-        (Community site)
+        (Community Portal)
 
       <url href="https://github.com/greenbone"/>
-        (Development site)
+        (Development Platform)
 
-      <url href="https://www.openvas.org"/>
-        (Traditional home site)
+      <url href="https://www.greenbone.net"/>
+        (Greenbone Website)
     </p>
   </section>
 

--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -194,14 +194,23 @@ gvmd --port 1241
 
 Serve GMP clients on port 1241 and connect to an OpenVAS scanner via the default OTP file socket.
 .SH SEE ALSO
-\fBopenvassd(8)\f1, \fBgsad(8)\f1, \fBgvm-cli(8)\f1, 
-.SH MORE INFORMATION ABOUT GREENBONE VULNERABILITY MANAGEMENT
+\fBopenvas(8)\f1, \fBgsad(8)\f1, \fBospd-openvas(8)\f1, \fBgreenbone-certdata-sync(8)\f1, \fBgreenbone-scapdata-sync(8)\f1,
+.SH MORE INFORMATION
 The canonical places where you will find more information about the Greenbone Vulnerability Manager are: 
 
-\fBhttps://community.greenbone.net\f1 (Community portal) 
+.RS
+.UR https://community.greenbone.net
+Community Portal
+.UE
+.br
+.UR https://github.com/greenbone
+Development Platform
+.UE
+.br
+.UR https://www.greenbone.net
+Greenbone Website
+.UE
+.RE
 
-\fBhttps://github.com/greenbone\f1 (Development Platform) 
-
-\fBhttps://greenbone.net\f1 (Greenbone website) 
 .SH COPYRIGHT
 The Greenbone Vulnerability Manager is released under the GNU GPL, version 2, or, at your option, any later version. 

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -433,26 +433,28 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <p>
       <manref name="openvassd" section="8"/>,
       <manref name="gsad" section="8"/>,
-      <manref name="gvm-cli" section="8"/>,
+      <manref name="ospd-openvas" section="8"/>,
+      <manref name="greenbone-certdata-sync" section="8"/>,
+      <manref name="greenbone-scapdata-sync" section="8"/>,
     </p>
   </section>
 
-  <section name="MORE INFORMATION ABOUT Greenbone Vulnerability Management">
+  <section name="MORE INFORMATION">
     <p>
       The canonical places where you will find more information
       about the Greenbone Vulnerability Manager are:
     </p>
     <p>
       <url href="https://community.greenbone.net"/>
-        (Community portal)
+        (Community Portal)
     </p>
     <p>
       <url href="https://github.com/greenbone"/>
         (Development Platform)
     </p>
     <p>
-      <url href="https://greenbone.net"/>
-        (Greenbone website)
+      <url href="https://www.greenbone.net"/>
+        (Greenbone Website)
     </p>
   </section>
 

--- a/doc/gvmd.html
+++ b/doc/gvmd.html
@@ -421,12 +421,14 @@
     <p>
       <b>openvassd (8)</b>,
       <b>gsad (8)</b>,
-      <b>gvm-cli (8)</b>,
+      <b>ospd-openvas (8)</b>,
+      <b>greenbone-certdata-sync (8)</b>,
+      <b>greenbone-scapdata-sync (8)</b>,
     </p>
   
 
 
-  <h2>MORE INFORMATION ABOUT Greenbone Vulnerability Management</h2>
+  <h2>MORE INFORMATION</h2>
 
     <p>
       The canonical places where you will find more information
@@ -434,15 +436,15 @@
     </p>
     <p>
       <a href = "https://community.greenbone.net">https://community.greenbone.net</a>
-        (Community portal)
+        (Community Portal)
     </p>
     <p>
       <a href = "https://github.com/greenbone">https://github.com/greenbone</a>
         (Development Platform)
     </p>
     <p>
-      <a href = "https://greenbone.net">https://greenbone.net</a>
-        (Greenbone website)
+      <a href = "https://www.greenbone.net">https://www.greenbone.net</a>
+        (Greenbone Website)
     </p>
   
 


### PR DESCRIPTION
- Update references to newer / renamed / deprecated manpages
- Updated links and texts in URLs
- Use a consistent header for the MORE INFORMATION part.

Backport of #1232 to the gvmd-9.0 branch.