### PR TITLE
Change the daemon name to lowercase in greenbone-feed-sync.

### DIFF
--- a/tools/greenbone-feed-sync.in
+++ b/tools/greenbone-feed-sync.in
@@ -214,7 +214,7 @@ init_feed_type () {
   then
     [ -r "@GVM_SYSCONF_DIR@/greenbone-data-objects-sync.conf" ] && . "@GVM_SYSCONF_DIR@/greenbone-data-objects-sync.conf"
 
-    FEED_TYPE_LONG="GVMd Data"
+    FEED_TYPE_LONG="gvmd Data"
     FEED_DIR="@GVMD_FEED_DIR@"
     TIMESTAMP="$FEED_DIR/timestamp"
     SCRIPT_ID="GVMD_DATA_SYNC"
@@ -231,11 +231,11 @@ init_feed_type () {
 
     if [ -e $ACCESSKEY ] ; then
       if [ -z "$FEED_NAME" ] ; then
-        FEED_NAME="Greenbone GVMd Data Feed"
+        FEED_NAME="Greenbone gvmd Data Feed"
       fi
     else
       if [ -z "$FEED_NAME" ] ; then
-        FEED_NAME="Greenbone Community GVMd Data Feed"
+        FEED_NAME="Greenbone Community gvmd Data Feed"
       fi
     fi
   else


### PR DESCRIPTION
As stated by @bjoernricks in https://github.com/greenbone/gsa/pull/2371#pullrequestreview-463214813:

> All deamon and command names should be in lower case (openvas, gvmd, gsad, gvm-cli, ...).

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
