### PR TITLE
Change the default OSPD socket path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Sync SCAP using a second schema [#1111](https://github.com/greenbone/gvmd/pull/1111)
 - Use error variable in osp_get_vts_version(). [#1159](https://github.com/greenbone/gvmd/pull/1159)
 - Include unknown preferences when uploading or syncing configs [#1005](https://github.com/greenbone/gvmd/pull/1005)
+- Set the default OSPD unix socket path to /var/run/ospd/ospd.sock [#1238](https://github.com/greenbone/gvmd/pull/1238)
 
 ### Fixed
 - Add NULL check in nvts_feed_version_epoch [#768](https://github.com/greenbone/gvmd/pull/768)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -274,7 +274,7 @@ and should be called after syncing the latter.
 
 By default, Manager tries to connect to the default OSPD scanner via the following path:
 
-    /tmp/ospd.sock
+    /var/run/ospd/ospd.sock
 
 If this path doesn't match your setup you need to change the socket path accordingly.
 
@@ -284,7 +284,7 @@ Get the UUID of the `OpenVAS Default` scanner:
 
 Update the path (example, path needs to be adapted accordingly):
 
-    gvmd --modify-scanner=<uuid of OpenVAS Default scanner> --scanner-host=<install-prefix>/var/run/ospd.sock
+    gvmd --modify-scanner=<uuid of OpenVAS Default scanner> --scanner-host=<install-prefix>/var/run/ospd/ospd-openvas.sock
 
 
 ## Logging Configuration

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -87,7 +87,7 @@
 /**
  * @brief Socket of default scanner.
  */
-#define OPENVAS_DEFAULT_SOCKET "/tmp/ospd.sock"
+#define OPENVAS_DEFAULT_SOCKET "/var/run/ospd/ospd.sock"
 
 #ifdef DEBUG_FUNCTION_NAMES
 #include <dlfcn.h>


### PR DESCRIPTION
https://github.com/greenbone/ospd/pull/140 had changed the default OSPD socket path from /tmp/ospd.sock to this new location.

I have also updated the example new path for --modify-scanners to support the changes in https://github.com/greenbone/ospd-openvas/pull/311

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
