### PR TITLE
Added systemd, logrotate and config files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add filter columns for special NVT tags [#1199](https://github.com/greenbone/gvmd/pull/1199)
 - Add currently_syncing for NVTs in GMP get_feeds [#1210](https://github.com/greenbone/gvmd/pull/1210)
 - Add logging for ANALYZE at end of migration [#1211](https://github.com/greenbone/gvmd/pull/1211)
+- Basic systemd, logrotate and config files have been added [#1240](https://github.com/greenbone/gvmd/pull/1240)
 
 ### Changed
 - Update SCAP and CERT feed info in sync scripts [#810](https://github.com/greenbone/gvmd/pull/810)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,6 +275,10 @@ if (NOT SKIP_SRC)
   add_subdirectory (src)
 endif (NOT SKIP_SRC)
 
+## Configs (e.g. systemd service file)
+
+add_subdirectory (config)
+
 ## Documentation
 
 add_subdirectory (doc)

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Copyright (C) 2020 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+if (NOT SYSTEMD_SERVICE_DIR)
+  set (SYSTEMD_SERVICE_DIR "${CMAKE_INSTALL_PREFIX}/lib/systemd/system")
+endif (NOT SYSTEMD_SERVICE_DIR)
+
+if (NOT DEFAULT_CONFIG_DIR)
+  set (DEFAULT_CONFIG_DIR "${CMAKE_INSTALL_PREFIX}/etc/default")
+endif (NOT DEFAULT_CONFIG_DIR)
+
+if (NOT LOGROTATE_DIR)
+  set (LOGROTATE_DIR "${CMAKE_INSTALL_PREFIX}/etc/logrotate.d")
+endif (NOT LOGROTATE_DIR)
+
+configure_file (gvmd.service.in gvmd.service)
+configure_file (gvmd.logrotate.in gvmd.logrotate)
+
+install (FILES ${CMAKE_CURRENT_BINARY_DIR}/gvmd.service
+         DESTINATION ${SYSTEMD_SERVICE_DIR}/)
+
+install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/gvmd.default
+         DESTINATION ${DEFAULT_CONFIG_DIR}/ RENAME gvmd)
+
+install (FILES ${CMAKE_CURRENT_BINARY_DIR}/gvmd.logrotate
+         DESTINATION ${LOGROTATE_DIR}/ RENAME gvmd)

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -30,6 +30,7 @@ endif (NOT LOGROTATE_DIR)
 
 configure_file (gvmd.service.in gvmd.service)
 configure_file (gvmd.logrotate.in gvmd.logrotate)
+configure_file (gvmd.default.in gvmd.default)
 
 install (FILES ${CMAKE_CURRENT_BINARY_DIR}/gvmd.service
          DESTINATION ${SYSTEMD_SERVICE_DIR}/)

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -35,7 +35,7 @@ configure_file (gvmd.default.in gvmd.default)
 install (FILES ${CMAKE_CURRENT_BINARY_DIR}/gvmd.service
          DESTINATION ${SYSTEMD_SERVICE_DIR}/)
 
-install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/gvmd.default
+install (FILES ${CMAKE_CURRENT_BINARY_DIR}/gvmd.default
          DESTINATION ${DEFAULT_CONFIG_DIR}/ RENAME gvmd)
 
 install (FILES ${CMAKE_CURRENT_BINARY_DIR}/gvmd.logrotate

--- a/config/gvmd.default
+++ b/config/gvmd.default
@@ -1,0 +1,19 @@
+#
+# The user for running the gvmd in the gvmd.service systemd file
+#
+GVMD_USER="gvm"
+
+#
+# The group for running the gvmd in the gvmd.service systemd file
+#
+GVMD_GROUP="gvm"
+
+#
+# Unix socket for OSP NVT update (--osp-vt-update)
+#
+OSP_VT_UPDATE="/var/run/ospd/ospd.sock"
+
+#
+# Additional options
+#
+OPTIONS=""

--- a/config/gvmd.default.in
+++ b/config/gvmd.default.in
@@ -11,7 +11,7 @@ GVMD_GROUP="gvm"
 #
 # Unix socket for OSP NVT update (--osp-vt-update)
 #
-OSP_VT_UPDATE="/var/run/ospd/ospd.sock"
+OSP_VT_UPDATE="${OPENVAS_DEFAULT_SOCKET}"
 
 #
 # Additional options

--- a/config/gvmd.logrotate.in
+++ b/config/gvmd.logrotate.in
@@ -1,0 +1,8 @@
+${GVM_LOG_DIR}/gvmd.log {
+	compress
+	missingok
+	notifempty
+	sharedscripts
+	copytruncate
+}
+

--- a/config/gvmd.service.in
+++ b/config/gvmd.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=Greenbone Vulnerability Manager (gvmd)
+Description=Greenbone Vulnerability Manager daemon (gvmd)
 After=network.target networking.service postgresql.service ospd-openvas.service
 Wants=postgresql.service ospd-openvas.service
 Documentation=man:gvmd(8)

--- a/config/gvmd.service.in
+++ b/config/gvmd.service.in
@@ -1,0 +1,20 @@
+[Unit]
+Description=Greenbone Vulnerability Manager (gvmd)
+After=network.target networking.service postgresql.service ospd-openvas.service
+Wants=postgresql.service ospd-openvas.service
+Documentation=man:gvmd(8)
+ConditionKernelCommandLine=!recovery
+
+[Service]
+Type=forking
+User=$GVMD_USER
+Group=$GVMD_GROUP
+PIDFile=${GVM_RUN_DIR}/gvmd.pid
+EnvironmentFile=-${DEFAULT_CONFIG_DIR}/gvmd
+ExecStart=${SBINDIR}/gvmd --osp-vt-update=$OSP_VT_UPDATE $OPTIONS
+Restart=always
+TimeoutStopSec=10
+
+[Install]
+WantedBy=multi-user.target
+Alias=gvmd.service

--- a/config/gvmd.service.in
+++ b/config/gvmd.service.in
@@ -17,4 +17,3 @@ TimeoutStopSec=10
 
 [Install]
 WantedBy=multi-user.target
-Alias=gvmd.service

--- a/config/gvmd.service.in
+++ b/config/gvmd.service.in
@@ -10,7 +10,7 @@ Type=forking
 User=$GVMD_USER
 Group=$GVMD_GROUP
 PIDFile=${GVM_RUN_DIR}/gvmd.pid
-EnvironmentFile=-${DEFAULT_CONFIG_DIR}/gvmd
+EnvironmentFile=${DEFAULT_CONFIG_DIR}/gvmd
 ExecStart=${SBINDIR}/gvmd --osp-vt-update=$OSP_VT_UPDATE $OPTIONS
 Restart=always
 TimeoutStopSec=10


### PR DESCRIPTION
To have at least some basic examples how the config and startup of the daemon should look like.

Also used the default socket path configurable after #1244

Replaces #142, mainly taken from https://github.com/greenbone/gsa/pull/1486, https://github.com/greenbone/gsa/pull/1514 and https://github.com/greenbone/gsa/pull/2328

Related: https://github.com/greenbone/ospd-openvas/pull/312, https://github.com/greenbone/gsa/pull/2375

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
