### PR TITLE
Add prerequisites for S/MIME suport to INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,6 +19,9 @@ Prerequisites:
 Prerequisites for certificate generation:
 * GnuTLS certtool
 
+Prerequisites for S/MIME suport (e.g. email encryption):
+* GNU privacy guard - S/MIME version
+
 Prerequisites for building documentation:
 * Doxygen
 * xsltproc (for building the GMP HTML documentation)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,9 +19,6 @@ Prerequisites:
 Prerequisites for certificate generation:
 * GnuTLS certtool
 
-Prerequisites for S/MIME suport (e.g. email encryption):
-* GNU privacy guard - S/MIME version
-
 Prerequisites for building documentation:
 * Doxygen
 * xsltproc (for building the GMP HTML documentation)
@@ -642,6 +639,8 @@ Prerequisites for Tipping Point alert:
 Prerequisites for key generation on systems with low entropy:
 * haveged (or a similar tool)
 
+Prerequisites for S/MIME suport (e.g. email encryption):
+* GNU privacy guard - S/MIME version
 
 ## Static code analysis with the Clang Static Analyzer
 


### PR DESCRIPTION
As #741 doesn't move forward we should have at least the text based prerequisite mentioned in the INSTALL.md

According to @timopollmeier gpgsm is required for S/MIME support. This might be related to the issue seen in e.g. #540.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
