### PR TITLE
Make the OPENVAS_DEFAULT_SOCKET configurable via cmake.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use error variable in osp_get_vts_version(). [#1159](https://github.com/greenbone/gvmd/pull/1159)
 - Include unknown preferences when uploading or syncing configs [#1005](https://github.com/greenbone/gvmd/pull/1005)
 - Set the default OSPD unix socket path to /var/run/ospd/ospd.sock [#1238](https://github.com/greenbone/gvmd/pull/1238)
+- The default OSPD unix path is now configurable [#1244](https://github.com/greenbone/gvmd/pull/1244)
 
 ### Fixed
 - Add NULL check in nvts_feed_version_epoch [#768](https://github.com/greenbone/gvmd/pull/768)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,11 @@ if (NOT GVM_FEED_LOCK_PATH)
 endif (NOT GVM_FEED_LOCK_PATH)
 add_definitions (-DGVM_FEED_LOCK_PATH="${GVM_FEED_LOCK_PATH}")
 
+if (NOT OPENVAS_DEFAULT_SOCKET)
+  set (OPENVAS_DEFAULT_SOCKET "/var/run/ospd/ospd.sock")
+endif (NOT OPENVAS_DEFAULT_SOCKET)
+add_definitions (-DOPENVAS_DEFAULT_SOCKET="${OPENVAS_DEFAULT_SOCKET}")
+
 # TODO: Once we separate the RFP signatures out of "plugins" and
 # into var/lib/gvm/rfpsigs/ (via a sync script) then we do not need
 # to know about the NVT_DIR anymore.

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -84,11 +84,6 @@
  */
 #define G_LOG_DOMAIN "md manage"
 
-/**
- * @brief Socket of default scanner.
- */
-#define OPENVAS_DEFAULT_SOCKET "/var/run/ospd/ospd.sock"
-
 #ifdef DEBUG_FUNCTION_NAMES
 #include <dlfcn.h>
 
@@ -15324,8 +15319,9 @@ check_db_scanners ()
            " (uuid, owner, name, host, port, type, ca_pub, credential,"
            "  creation_time, modification_time)"
            " VALUES ('" SCANNER_UUID_DEFAULT "', NULL, 'OpenVAS Default',"
-           " '" OPENVAS_DEFAULT_SOCKET "', 0, %d, NULL, NULL, m_now (),"
+           " '%s', 0, %d, NULL, NULL, m_now (),"
            " m_now ());",
+           OPENVAS_DEFAULT_SOCKET,
            SCANNER_TYPE_OPENVAS);
     }
 


### PR DESCRIPTION
This is a follow-up of #1238 to make the default path configurable on build time. It will be also used for #1240 to set the `OSP_VT_UPDATE` in the gvmd.default in a second step (and once #1240 was merged).

To test i have called cmake with an additional `-DOPENVAS_DEFAULT_SOCKET=/test/ospd/ospd.sock`, after setting up a fresh database i have verified that the default socket is directly configured in the database:

```
$ gvmd --get-scanners
08b69003-5fc2-4037-a479-93b440211c73  OpenVAS  /test/ospd/ospd.sock  0  OpenVAS Default
6acd0832-df90-11e4-b9d5-28d24461215b  CVE    0  CVE
```

The same was also done without the cmake config where the scanner is having the default path:


```
$ gvmd --get-scanners
08b69003-5fc2-4037-a479-93b440211c73  OpenVAS  /var/run/ospd/ospd.sock  0  OpenVAS Default
6acd0832-df90-11e4-b9d5-28d24461215b  CVE    0  CVE
```

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
