### PR TITLE
gvm-manage-certs: Added SAN parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [20.8.1] (unreleased)
 
 ### Added
+- Added ability to enter Subject Alternative Names (SAN) when generating a CSR [#1246](https://github.com/greenbone/gvmd/pull/1246)
 
 ### Changed
 - Extended the output of invalid / missing --feed parameter given to greenbone-feed-sync [#1255](https://github.com/greenbone/gvmd/pull/1255)

--- a/tools/gvm-manage-certs.in
+++ b/tools/gvm-manage-certs.in
@@ -79,7 +79,7 @@ set_defaults () {
   # (Organization unit)
   GVM_CERTIFICATE_ORG_UNIT=${GVM_CERTIFICATE_ORG_UNIT:-""}
   # Subject Alternative Name(s)
-  GVM_CERTIFICATE_SAN=${GVM_CERTIFICATE_SAN:-"localhost"}
+  GVM_CERTIFICATE_SAN=${GVM_CERTIFICATE_SAN:-""}
 
   # Hostname
   if [ -z "$GVM_CERTIFICATE_HOSTNAME" ]

--- a/tools/gvm-manage-certs.in
+++ b/tools/gvm-manage-certs.in
@@ -78,6 +78,8 @@ set_defaults () {
   GVM_CERTIFICATE_ORG=${GVM_CERTIFICATE_ORG:-"GVM Users"}
   # (Organization unit)
   GVM_CERTIFICATE_ORG_UNIT=${GVM_CERTIFICATE_ORG_UNIT:-""}
+  # Subject Alternative Name(s)
+  GVM_CERTIFICATE_SAN=${GVM_CERTIFICATE_SAN:-"localhost"}
 
   # Hostname
   if [ -z "$GVM_CERTIFICATE_HOSTNAME" ]
@@ -102,7 +104,8 @@ set_defaults () {
   GVM_CA_CERTIFICATE_ORG=${GVM_CA_CERTIFICATE_ORG:-"$GVM_CERTIFICATE_ORG"}
   # (Organization unit)
   GVM_CA_CERTIFICATE_ORG_UNIT=${GVM_CA_CERTIFICATE_ORG_UNIT:-"Certificate Authority for $GVM_CERTIFICATE_HOSTNAME"}
-
+  # The array with all the SANs
+  GVM_CA_CERTIFICATE_SAN=${GVM_CA_CERTIFICATE_SAN:-"$GVM_CERTIFICATE_SAN"}
   # Key size
   if [ -z "$GVM_CERTIFICATE_KEYSIZE" ]
   then
@@ -330,6 +333,29 @@ create_certificate ()
     then
       echo "cn = \"$GVM_CA_CERTIFICATE_HOSTNAME\"" >> $GVM_CERT_TEMPLATE_FILENAME
     fi
+    if [ -n "$GVM_CA_CERTIFICATE_SAN" ]
+    then
+      for i in $GVM_CA_CERTIFICATE_SAN
+      do
+        case "$i" in
+        *.*.*.*)
+          echo "ip_address = \"$i\"" >> $GVM_CERT_TEMPLATE_FILENAME
+        ;;
+        http*)
+          echo "uri = \"$i\"" >> $GVM_CERT_TEMPLATE_FILENAME
+        ;;
+        *.*)
+          echo "dns_name = \"$i\"" >> $GVM_CERT_TEMPLATE_FILENAME
+        ;;
+        localhost )
+          echo "dns_name = \"localhost\"" >> $GVM_CERT_TEMPLATE_FILENAME
+        ;;
+        *)
+          log_verbose "Invalid formatting for SAN: $i"
+        ;;
+        esac
+      done
+    fi
   else
     if [ -n "$GVM_CERTIFICATE_LIFETIME" ]
     then
@@ -358,6 +384,29 @@ create_certificate ()
     if [ -n "$GVM_CERTIFICATE_HOSTNAME" ]
     then
       echo "cn = \"$GVM_CERTIFICATE_HOSTNAME\"" >> $GVM_CERT_TEMPLATE_FILENAME
+    fi
+    if [ -n "$GVM_CERTIFICATE_SAN" ]
+    then
+      for i in $GVM_CERTIFICATE_SAN
+      do
+        case "$i" in
+        *.*.*.*)
+          echo "ip_address = \"$i\"" >> $GVM_CERT_TEMPLATE_FILENAME
+        ;;
+        http*)
+          echo "uri = \"$i\"" >> $GVM_CERT_TEMPLATE_FILENAME
+        ;;
+        *.*)
+          echo "dns_name = \"$i\"" >> $GVM_CERT_TEMPLATE_FILENAME
+        ;;
+        localhost )
+          echo "dns_name = \"localhost\"" >> $GVM_CERT_TEMPLATE_FILENAME
+        ;;
+        *)
+          log_verbose "Invalid formatting for SAN: $i"
+        ;;
+        esac
+      done
     fi
   fi
 

--- a/tools/gvm-manage-certs.in
+++ b/tools/gvm-manage-certs.in
@@ -293,6 +293,31 @@ create_private_key ()
   log_write "Generated private key in $1."
 }
 
+# Add SAN settings
+add_san_settings ()
+{
+  for i in $1
+  do
+    case "$i" in
+    *.*.*.*)
+      echo "ip_address = \"$i\"" >> $GVM_CERT_TEMPLATE_FILENAME
+    ;;
+    http*)
+      echo "uri = \"$i\"" >> $GVM_CERT_TEMPLATE_FILENAME
+    ;;
+    *.*)
+      echo "dns_name = \"$i\"" >> $GVM_CERT_TEMPLATE_FILENAME
+    ;;
+    localhost )
+      echo "dns_name = \"localhost\"" >> $GVM_CERT_TEMPLATE_FILENAME
+    ;;
+    *)
+      log_verbose "Invalid formatting for SAN: $i"
+    ;;
+    esac
+  done
+}
+
 # Create a certificate
 create_certificate ()
 {
@@ -335,26 +360,7 @@ create_certificate ()
     fi
     if [ -n "$GVM_CA_CERTIFICATE_SAN" ]
     then
-      for i in $GVM_CA_CERTIFICATE_SAN
-      do
-        case "$i" in
-        *.*.*.*)
-          echo "ip_address = \"$i\"" >> $GVM_CERT_TEMPLATE_FILENAME
-        ;;
-        http*)
-          echo "uri = \"$i\"" >> $GVM_CERT_TEMPLATE_FILENAME
-        ;;
-        *.*)
-          echo "dns_name = \"$i\"" >> $GVM_CERT_TEMPLATE_FILENAME
-        ;;
-        localhost )
-          echo "dns_name = \"localhost\"" >> $GVM_CERT_TEMPLATE_FILENAME
-        ;;
-        *)
-          log_verbose "Invalid formatting for SAN: $i"
-        ;;
-        esac
-      done
+      add_san_settings GVM_CA_CERTIFICATE_SAN
     fi
   else
     if [ -n "$GVM_CERTIFICATE_LIFETIME" ]
@@ -387,26 +393,7 @@ create_certificate ()
     fi
     if [ -n "$GVM_CERTIFICATE_SAN" ]
     then
-      for i in $GVM_CERTIFICATE_SAN
-      do
-        case "$i" in
-        *.*.*.*)
-          echo "ip_address = \"$i\"" >> $GVM_CERT_TEMPLATE_FILENAME
-        ;;
-        http*)
-          echo "uri = \"$i\"" >> $GVM_CERT_TEMPLATE_FILENAME
-        ;;
-        *.*)
-          echo "dns_name = \"$i\"" >> $GVM_CERT_TEMPLATE_FILENAME
-        ;;
-        localhost )
-          echo "dns_name = \"localhost\"" >> $GVM_CERT_TEMPLATE_FILENAME
-        ;;
-        *)
-          log_verbose "Invalid formatting for SAN: $i"
-        ;;
-        esac
-      done
+      add_san_settings GVM_CERTIFICATE_SAN
     fi
   fi
 


### PR DESCRIPTION
Added parsing for Subject Alternative Names in the generation of CSRs.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
