### PR TITLE
Do not set beta version implicitly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,6 @@ cmake_minimum_required (VERSION 3.0)
 
 message ("-- Configuring Greenbone Vulnerability Manager...")
 
-# VERSION: Set patch version for stable releases, e.g. "9.0.0",
-#          unset patch version for prereleases, e.g. "9.0"
 project (gvm
          VERSION 20.8.0
          LANGUAGES C)
@@ -53,22 +51,21 @@ if (NOT CMAKE_BUILD_TYPE MATCHES "Release")
   endif (EXISTS "${CMAKE_SOURCE_DIR}/.git/")
 endif (NOT CMAKE_BUILD_TYPE MATCHES "Release")
 
-# Add padding zero for minor version
-string(LENGTH ${PROJECT_VERSION_MINOR} PROJECT_VERSION_MINOR_LENGTH)
-if (${PROJECT_VERSION_MINOR_LENGTH} GREATER 1)
-  set (PROJECT_VERSION_MINOR_STRING "${PROJECT_VERSION_MINOR}")
-else (${PROJECT_VERSION_MINOR_LENGTH} GREATER 1)
-  set (PROJECT_VERSION_MINOR_STRING "0${PROJECT_VERSION_MINOR}")
-endif (${PROJECT_VERSION_MINOR_LENGTH} GREATER 1)
+# Set beta version if this is a beta release series,
+# unset if this is a stable release series.
+set (PROJECT_BETA_RELEASE 0)
 
-# If a patch version is not defined, assume a pre-release
-if (DEFINED PROJECT_VERSION_PATCH AND NOT PROJECT_VERSION_PATCH STREQUAL "")
+# If PROJECT_BETA_RELEASE is set, the version string will be set to:
+#   "major.minor+beta${PROJECT_BETA_RELEASE}${GIT_REVISION}"
+# If PROJECT_BETA_RELEASE is NOT set, the version string will be set to:
+#   "major.minor.patch${GIT_REVISION}"
+if (PROJECT_BETA_RELEASE)
+  set (PROJECT_VERSION_SUFFIX "+beta${PROJECT_BETA_RELEASE}")
+else (PROJECT_BETA_RELEASE)
   set (PROJECT_VERSION_SUFFIX ".${PROJECT_VERSION_PATCH}")
-else (DEFINED PROJECT_VERSION_PATCH AND NOT PROJECT_VERSION_PATCH STREQUAL "")
-  set (PROJECT_VERSION_SUFFIX "+beta1")
-endif (DEFINED PROJECT_VERSION_PATCH AND NOT PROJECT_VERSION_PATCH STREQUAL "")
+endif (PROJECT_BETA_RELEASE)
 
-set (PROJECT_VERSION_STRING "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR_STRING}${PROJECT_VERSION_SUFFIX}${GIT_REVISION}")
+set (PROJECT_VERSION_STRING "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}${PROJECT_VERSION_SUFFIX}${GIT_REVISION}")
 
 ## CPack configuration
 


### PR DESCRIPTION
Use PROJECT_BETA_RELEASE variable instead of
setting the beta release implicitly when no patch
version is provided.

Do not add padding zeroes for minor versions.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
