### PR TITLE
Add dummy functions to allow restoring old dumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [20.8.1] (unreleased)
+
+### Fixed
+- Add dummy functions to allow restoring old dumps [#1251](https://github.com/greenbone/gvmd/pull/1251)
+
+[20.8.1]: https://github.com/greenbone/gvmd/compare/v20.8.0...gvmd-20.08
+
 ## [20.8.0] (2020-08-11)
 
 ### Added

--- a/src/manage_pg_server.c
+++ b/src/manage_pg_server.c
@@ -131,6 +131,66 @@ sql_hosts_contains (PG_FUNCTION_ARGS)
 /**
  * @brief Define function for Postgres.
  */
+PG_FUNCTION_INFO_V1 (sql_level_max_severity);
+
+/**
+ * @brief Dummy function to allow restoring gvmd-9.0 dumps.
+ *
+ * @deprecated This function will be removed once direct migration
+ *             compatibility with gvmd 9.0 is no longer required
+ *
+ * @return Postgres NULL Datum.
+ */
+ __attribute__((deprecated))
+Datum
+sql_level_max_severity (PG_FUNCTION_ARGS)
+{
+  PG_RETURN_NULL ();
+}
+
+/**
+ * @brief Define function for Postgres.
+ */
+PG_FUNCTION_INFO_V1 (sql_level_min_severity);
+
+/**
+ * @brief Dummy function to allow restoring gvmd-9.0 dumps.
+ *
+ * @deprecated This function will be removed once direct migration
+ *             compatibility with gvmd 9.0 is no longer required
+ *
+ * @return Postgres NULL Datum.
+ */
+ __attribute__((deprecated))
+Datum
+sql_level_min_severity (PG_FUNCTION_ARGS)
+{
+  PG_RETURN_NULL ();
+}
+
+/**
+ * @brief Define function for Postgres.
+ */
+PG_FUNCTION_INFO_V1 (sql_next_time);
+
+/**
+ * @brief Dummy function to allow restoring gvmd-9.0 dumps.
+ *
+ * @deprecated This function will be removed once direct migration
+ *             compatibility with gvmd 9.0 is no longer required
+ *
+ * @return Postgres NULL Datum.
+ */
+ __attribute__((deprecated))
+Datum
+sql_next_time (PG_FUNCTION_ARGS)
+{
+  PG_RETURN_NULL ();
+}
+
+/**
+ * @brief Define function for Postgres.
+ */
 PG_FUNCTION_INFO_V1 (sql_next_time_ical);
 
 /**
@@ -297,4 +357,24 @@ sql_regexp (PG_FUNCTION_ARGS)
       pfree (regexp);
       PG_RETURN_BOOL (ret);
     }
+}
+
+/**
+ * @brief Define function for Postgres.
+ */
+PG_FUNCTION_INFO_V1 (sql_valid_db_resource_type);
+
+/**
+ * @brief Dummy function to allow restoring gvmd-9.0 dumps.
+ *
+ * @deprecated This function will be removed once direct migration
+ *             compatibility with gvmd 9.0 is no longer required
+ *
+ * @return Postgres NULL Datum.
+ */
+ __attribute__((deprecated))
+Datum
+sql_valid_db_resource_type (PG_FUNCTION_ARGS)
+{
+  PG_RETURN_NULL ();
 }


### PR DESCRIPTION
Old database dumps can still contain references to SQL extension
functions that were changed from using the C library to PL/pgSQL.

Adding dummy functions to the library allows these to be restored
without error so they can be replaced by gvmd with the correct functions
later.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
