### PR TITLE
Improve EXE installer NSIS script generation (9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Quote identifiers in SQL functions using EXECUTE [#1193](https://github.com/greenbone/gvmd/pull/1193)
 - Improve handling of removed NVT prefs [#1204](https://github.com/greenbone/gvmd/pull/1204)
 - Set ignore_pagination in stop_active_tasks [#1208](https://github.com/greenbone/gvmd/pull/1208)
+- Improve EXE installer NSIS script generation [#1253](https://github.com/greenbone/gvmd/pull/1253)
 
 [9.0.2]: https://github.com/greenbone/gvmd/compare/v9.0.1...gvmd-9.0
 


### PR DESCRIPTION
The temporary VB script and output file for getting the admin group name
are now created with random filenames.
Also, the user is now created and added to the group directly in the
installer instead of generating and running a batch script and the
command containing the password is hidden.
Temporary files are also written and read by the installer instead of
using echo commands for better readability.

This is a backport of #1226.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
