### PR TITLE
Improve EXE installer NSIS script generation (8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix XML escaping in setting up GMP scans [#1124](https://github.com/greenbone/gvmd/pull/1124)
 - Fix name handling when creating host assets [#1185](https://github.com/greenbone/gvmd/pull/1185)
 - Quote identifiers in SQL functions using EXECUTE [#1194](https://github.com/greenbone/gvmd/pull/1194)
+- Improve EXE installer NSIS script generation [#1254](https://github.com/greenbone/gvmd/pull/1254)
 
 [8.0.3]: https://github.com/greenbone/gvmd/compare/v8.0.2...gvmd-8.0
 

--- a/src/lsc_user.c
+++ b/src/lsc_user.c
@@ -611,6 +611,12 @@ create_nsis_script (const gchar *script_name,
   fprintf (fd, "#\n# Default (installer) section.\n#\n");
   fprintf (fd, "section\n\n");
 
+  fprintf (fd, "# Declare variables\n");
+  fprintf (fd, "Var /GLOBAL TEMPVBSFILE\n");
+  fprintf (fd, "Var /GLOBAL TEMPADMINGROUPFILE\n");
+  fprintf (fd, "Var /GLOBAL FH\n");
+  fprintf (fd, "Var /GLOBAL ADMINGROUPNAME\n");
+
   fprintf (fd, "# Define output path\n");
   fprintf (fd, "setOutPath $INSTDIR\n\n");
 
@@ -620,54 +626,41 @@ create_nsis_script (const gchar *script_name,
 
   // Need to find localized Administrators group name, create a
   // GetAdminGroupName - vb script (Thanks to Thomas Rotter)
-  fprintf (fd, "# Create Thomas Rotters GetAdminGroupName.vb script\n");
-  fprintf (fd,
-           "ExecWait \"cmd /C Echo Set objWMIService = "
-           "GetObject($\\\"winmgmts:\\\\.\\root\\cimv2$\\\") > "
-           "$\\\"%%temp%%\\GetAdminGroupName.vbs$\\\" \"\n");
-  fprintf (fd,
-           "ExecWait \"cmd /C Echo Set colAccounts = objWMIService.ExecQuery "
-           "($\\\"Select * From Win32_Group Where SID = 'S-1-5-32-544'$\\\")  "
-           ">> $\\\"%%temp%%\\GetAdminGroupName.vbs$\\\"\"\n");
-  fprintf (fd,
-           "ExecWait \"cmd /C Echo For Each objAccount in colAccounts >> "
-           "$\\\"%%temp%%\\GetAdminGroupName.vbs$\\\"\"\n");
-  fprintf (fd,
-           "ExecWait \"cmd /C Echo Wscript.Echo objAccount.Name >> "
-           "$\\\"%%temp%%\\GetAdminGroupName.vbs$\\\"\"\n");
-  fprintf (fd,
-           "ExecWait \"cmd /C Echo Next >> "
-           "$\\\"%%temp%%\\GetAdminGroupName.vbs$\\\"\"\n");
-  fprintf (fd,
-           "ExecWait \"cmd /C cscript //nologo "
-           "$\\\"%%temp%%\\GetAdminGroupName.vbs$\\\" > "
-           "$\\\"%%temp%%\\AdminGroupName.txt$\\\"\"\n\n");
+  fprintf (fd, "# Create and run Thomas Rotter's GetAdminGroupName VB script\n");
+  fprintf (fd, "GetTempFileName $TEMPVBSFILE\n");
+  fprintf (fd, "GetTempFileName $TEMPADMINGROUPFILE\n");
+  fprintf (fd, "DetailPrint `Creating GetAdminGroupName script $TEMPVBSFILE`\n");
+  fprintf (fd, "FileOpen $FH $TEMPVBSFILE w\n");
+  fprintf (fd, "FileWrite $FH `Set objWMIService = GetObject(\"winmgmts:\\\\.\\root\\cimv2\")$\\n`\n");
+  fprintf (fd, "FileWrite $FH `Set colAccounts = objWMIService.ExecQuery (\"Select * From Win32_Group Where SID = 'S-1-5-32-544'\")$\\n`\n");
+  fprintf (fd, "FileWrite $FH `For Each objAccount in colAccounts$\\n`\n");
+  fprintf (fd, "FileWrite $FH ` Wscript.Echo objAccount.Name$\\n`\n");
+  fprintf (fd, "FileWrite $FH `Next$\\n`\n");
+  fprintf (fd, "FileClose $FH\n");
+  fprintf (fd, "ExecWait `cmd /C cscript /e:vbscript /nologo $TEMPVBSFILE > $TEMPADMINGROUPFILE`\n");
+  fprintf (fd, "# Read admin group name, remove trailing line break\n");
+  fprintf (fd, "FileOpen $FH $TEMPADMINGROUPFILE r\n");
+  fprintf (fd, "FileRead $FH $ADMINGROUPNAME\n");
+  fprintf (fd, "FileClose $FH\n");
+  fprintf (fd, "StrCpy $ADMINGROUPNAME `$ADMINGROUPNAME` -2\n");
+  fprintf (fd, "\n");
 
   /** @todo provide /comment:"GVM User" /fullname:"GVM Testuser" */
-  fprintf (fd, "# Create batch script that installs the user\n");
-  fprintf (fd,
-           "ExecWait \"cmd /C Echo Set /P AdminGroupName= "
-           "^<$\\\"%%temp%%\\AdminGroupName.txt$\\\" > "
-           "$\\\"%%temp%%\\AddUser.bat$\\\"\" \n");
-  fprintf (fd,
-           "ExecWait \"cmd /C Echo net user %s %s /add /active:yes >> "
-           "$\\\"%%temp%%\\AddUser.bat$\\\"\"\n",
+  fprintf (fd, "# Create the user and add it to the admin group\n");
+  fprintf (fd, "DetailPrint `Creating user %s`\n",
+           user_name);
+  fprintf (fd, "SetDetailsPrint none\n");
+  fprintf (fd, "ExecWait `cmd /C net user %s \"%s\" /add /active:yes`\n",
            user_name,
            password);
-  fprintf (fd,
-           "ExecWait \"cmd /C Echo net localgroup %%AdminGroupName%% "
-           "%%COMPUTERNAME%%\\%s /add >> $\\\"%%temp%%\\AddUser.bat$\\\"\"\n\n",
+  fprintf (fd, "SetDetailsPrint both\n");
+  fprintf (fd, "ExecWait `cmd /C net localgroup $ADMINGROUPNAME %%COMPUTERNAME%%\\%s /add`",
            user_name);
-
-  fprintf (fd, "# Execute AddUser script\n");
-  fprintf (fd, "ExecWait \"cmd /C $\\\"%%temp%%\\AddUser.bat$\\\"\"\n\n");
 
   // Remove up temporary files for localized Administrators group names
   fprintf (fd, "# Remove temporary files for localized admin group names\n");
-  fprintf (fd, "ExecWait \"del $\\\"%%temp%%\\AdminGroupName.txt$\\\"\"\n");
-  fprintf (fd,
-           "ExecWait \"del $\\\"%%temp%%\\GetAdminGroupName.vbs$\\\"\"\n\n");
-  fprintf (fd, "ExecWait \"del $\\\"%%temp%%\\AddUser.bat$\\\"\"\n\n");
+  fprintf (fd, "Delete $TEMPVBSFILE\n");
+  fprintf (fd, "Delete $TEMPADMINGROUPFILE\n");
 
   /** @todo Display note about NTLM and SMB signing and encryption, 'Easy
    * Filesharing' in WIN XP */


### PR DESCRIPTION
The temporary VB script and output file for getting the admin group name
are now created with random filenames.
Also, the user is now created and added to the group directly in the
installer instead of generating and running a batch script and the
command containing the password is hidden.
Temporary files are also written and read by the installer instead of
using echo commands for better readability.

This is a backport of #1226.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
