### PR TITLE
Fix and clean up gvm-lsc-exe-creator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [21.4] (unreleased)
 
 ### Changed
-- Move EXE credential generation to a Python script [#1260](https://github.com/greenbone/gvmd/pull/1260)
+- Move EXE credential generation to a Python script [#1260](https://github.com/greenbone/gvmd/pull/1260) [#1262](https://github.com/greenbone/gvmd/pull/1262)
 
 [21.4]: https://github.com/greenbone/gvmd/compare/gvmd-20.08...master
 

--- a/tools/gvm-lsc-exe-creator
+++ b/tools/gvm-lsc-exe-creator
@@ -26,41 +26,45 @@ import subprocess
 import sys
 import tempfile
 
-# Parse command line arguments
-description = "Generate a Windows EXE credential installer"
-argparser = argparse.ArgumentParser(description=description)
-argparser.add_argument("username",
-                       help="Name of the user to create")
-argparser.add_argument("password_file_path",
-                       help="Path to a file containing the user's password")
-argparser.add_argument("temp_dir",
-                       help="Directory to create temporary files in")
-argparser.add_argument("output_path",
-                       help="Path for finished installer")
-argparser.add_argument("template_path",
-                       help="Path of the NSIS script template file")
-args = argparser.parse_args()
+def main():
+    # Parse command line arguments
+    description = "Generate a Windows EXE credential installer"
+    argparser = argparse.ArgumentParser(description=description)
+    argparser.add_argument("username",
+                          help="Name of the user to create")
+    argparser.add_argument("password_file_path",
+                          help="Path to a file containing the user's password")
+    argparser.add_argument("temp_dir",
+                          help="Directory to create temporary files in")
+    argparser.add_argument("output_path",
+                          help="Path for finished installer")
+    argparser.add_argument("template_path",
+                          help="Path of the NSIS script template file")
+    args = argparser.parse_args()
 
-# Read password
-with open(args.password_file_path, "r") as password_file:
-    password = password_file.read().rstrip("\n")
+    # Read password
+    with open(args.password_file_path, "r") as password_file:
+        password = password_file.read().rstrip("\n")
 
-# Read NSIS script template
-with open(args.template_path, "r") as template_file:
-    template_string = template_file.read()
+    # Read NSIS script template
+    with open(args.template_path, "r") as template_file:
+        template_string = template_file.read()
 
-template = string.Template(template_string)
+    template = string.Template(template_string)
 
-# Create NSIS script by replacing placeholders in the given template
-substitutions = {
-                  "__USERNAME__" : args.username,
-                  "__PASSWORD__" : password,
-                  "__OUTPUT_PATH__" : args.output_path,
-                }
-nsis_script = template.safe_substitute(substitutions)
-nsis_script_path = os.path.join(args.temp_dir, "script.nsis")
-with open(nsis_script_path, "w") as nsis_script_file:
-    nsis_script_file.write(nsis_script)
+    # Create NSIS script by replacing placeholders in the given template
+    substitutions = {
+                      "__USERNAME__" : args.username,
+                      "__PASSWORD__" : password,
+                      "__OUTPUT_PATH__" : args.output_path,
+                    }
+    nsis_script = template.safe_substitute(substitutions)
+    nsis_script_path = os.path.join(args.temp_dir, "script.nsis")
+    with open(nsis_script_path, "w") as nsis_script_file:
+        nsis_script_file.write(nsis_script)
 
-run = subprocess.run(["makensis", nsis_script_path])
-sys,exit(run.returncode)
+    run = subprocess.run(["makensis", nsis_script_path])
+    sys.exit(run.returncode)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This fixes a typo in the sys.exit(...) call and moves moves most of the
code into a main() function that is only run when the file is run as a
script.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
