### PR TITLE
Fix SCP alert authentication and logging (20.08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Add dummy functions to allow restoring old dumps [#1251](https://github.com/greenbone/gvmd/pull/1251)
 - Fix delta sorting for unusual filter sort terms [#1249](https://github.com/greenbone/gvmd/pull/1249)
+- Fix SCP alert authentication and logging [#1264](https://github.com/greenbone/gvmd/pull/1264)
 
 ### Removed
 

--- a/src/alert_methods/SCP/alert
+++ b/src/alert_methods/SCP/alert
@@ -32,16 +32,19 @@ echo $KNOWN_HOSTS > $KNOWN_HOSTS_FILE
 ERROR_FILE=`mktemp` || exit 1
 
 log_error() {
-  logger "SCP alert: $1"
-  echo "$1" >&2
+  # remove \r used in line feed by scp or sshpass (\r\n)
+  # which can make journalctl interpret the output as blob data
+  MESSAGE=`echo "$1" | tr -d '\r'`
+  logger "SCP alert: $MESSAGE"
+  echo "$MESSAGE" >&2
 }
 
 # Escape destination twice because it is also expanded on the remote end.
 if [ -z "$PRIVATE_KEY_FILE" ]
 then
-  sshpass -f ${PASSWORD_FILE} scp -o BatchMode=yes -o HashKnownHosts=no -o UserKnownHostsFile="${KNOWN_HOSTS_FILE} ~/.ssh/known_hosts ~/.ssh/known_hosts2 /etc/ssh/ssh_known_hosts" "${REPORT_FILE}" "${USERNAME}@${HOST}:'${DEST}'" 2>$ERROR_FILE
+  sshpass -f ${PASSWORD_FILE} scp -o HashKnownHosts=no -o UserKnownHostsFile="${KNOWN_HOSTS_FILE} ~/.ssh/known_hosts ~/.ssh/known_hosts2 /etc/ssh/ssh_known_hosts" "${REPORT_FILE}" "${USERNAME}@${HOST}:'${DEST}'" 2>$ERROR_FILE
 else
-  sshpass -f ${PASSWORD_FILE} scp -i "$PRIVATE_KEY_FILE" -o PasswordAuthentication=no -o BatchMode=yes -o HashKnownHosts=no -o UserKnownHostsFile="${KNOWN_HOSTS_FILE} ~/.ssh/known_hosts ~/.ssh/known_hosts2 /etc/ssh/ssh_known_hosts" "${REPORT_FILE}" "${USERNAME}@${HOST}:'${DEST}'" 2>$ERROR_FILE
+  sshpass -f ${PASSWORD_FILE} -P "passphrase" scp -i "$PRIVATE_KEY_FILE" -o PasswordAuthentication=no -o HashKnownHosts=no -o UserKnownHostsFile="${KNOWN_HOSTS_FILE} ~/.ssh/known_hosts ~/.ssh/known_hosts2 /etc/ssh/ssh_known_hosts" "${REPORT_FILE}" "${USERNAME}@${HOST}:'${DEST}'" 2>$ERROR_FILE
 fi
 
 EXIT_CODE=$?


### PR DESCRIPTION
The BatchMode=yes option for scp is removed to make sshpass work and the
prompt expected by sshpass is adjusted for public key auth.

Carriage return characters are removed from the log output as they
can make journalctl interpret it as blob data.

(This was originally fixed in gvmd-9.0 with #972 but not ported to the 20.08 branch)

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
