### PR TITLE
Check feed status without acquiring lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Extended the output of invalid / missing --feed parameter given to greenbone-feed-sync [#1255](https://github.com/greenbone/gvmd/pull/1255)
 - The xsltproc binary is now marked as mandatory [#1259](https://github.com/greenbone/gvmd/pull/1259)
+- Check feed status without acquiring lock [#1266](https://github.com/greenbone/gvmd/pull/1266)
 
 ### Fixed
 - Add dummy functions to allow restoring old dumps [#1251](https://github.com/greenbone/gvmd/pull/1251)

--- a/src/manage.c
+++ b/src/manage.c
@@ -7339,6 +7339,9 @@ manage_sync (sigset_t *sigmask_current,
 {
   lockfile_t lockfile;
 
+  reinit_manage_process ();
+  manage_session_init (current_credentials.uuid);
+
   if (feed_sync_required ())
     {
       if (feed_lockfile_lock (&lockfile) == 0)

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1790,6 +1790,81 @@ update_nvt_cache_osp (const gchar *update_socket, gchar *db_feed_version,
 }
 
 /**
+ * @brief Check VTs feed version status via OSP, optionally get versions.
+ *
+ * @param[in]  update_socket  Socket to use to contact ospd-openvas scanner.
+ * @param[out] db_feed_version_out       Output of database feed version.
+ * @param[out] scanner_feed_version_out  Output of scanner feed version.
+ *
+ * @return 0 VTs feed current, -1 error, 1 VT update needed.
+ */
+static int
+nvts_feed_version_status_internal (const gchar *update_socket,
+                                   gchar **db_feed_version_out,
+                                   gchar **scanner_feed_version_out)
+{
+  gchar *db_feed_version, *scanner_feed_version;
+  osp_connection_t *connection;
+  gchar *error;
+
+  if (db_feed_version_out)
+    *db_feed_version_out = NULL;
+  if (scanner_feed_version_out)
+    *scanner_feed_version_out = NULL;
+
+  db_feed_version = nvts_feed_version ();
+  g_debug ("%s: db_feed_version: %s", __func__, db_feed_version);
+  if (db_feed_version_out && db_feed_version)
+    *db_feed_version_out = g_strdup (db_feed_version);
+
+  connection = osp_connection_new (update_socket, 0, NULL, NULL, NULL);
+  if (!connection)
+    {
+      g_debug ("%s: failed to connect to %s", __func__, update_socket);
+      g_free (db_feed_version);
+      return -1;
+    }
+
+  error = NULL;
+  if (osp_get_vts_version (connection, &scanner_feed_version, &error))
+    {
+      g_debug ("%s: failed to get scanner_feed_version. %s",
+               __func__, error ? : "");
+      g_free (error);
+      g_free (db_feed_version);
+      return -1;
+    }
+  g_debug ("%s: scanner_feed_version: %s", __func__, scanner_feed_version);
+  if (scanner_feed_version_out && scanner_feed_version)
+    *scanner_feed_version_out = g_strdup (scanner_feed_version);
+
+  osp_connection_close (connection);
+
+  if ((db_feed_version == NULL)
+      || strcmp (scanner_feed_version, db_feed_version))
+    {
+      g_free (db_feed_version);
+      g_free (scanner_feed_version);
+      return 1;
+    }
+
+  return 0;
+}
+
+/**
+ * @brief Check VTs feed version status
+ *
+ * @return 0 VTs feed current, 1 VT update needed, -1 error.
+ */
+int
+nvts_feed_version_status ()
+{
+  return nvts_feed_version_status_internal (get_osp_vt_update_socket (),
+                                            NULL,
+                                            NULL);
+}
+
+/**
  * @brief Update VTs via OSP.
  *
  * Expect to be called in the child after a fork.
@@ -1801,9 +1876,8 @@ update_nvt_cache_osp (const gchar *update_socket, gchar *db_feed_version,
 int
 manage_update_nvt_cache_osp (const gchar *update_socket)
 {
-  osp_connection_t *connection;
   gchar *db_feed_version, *scanner_feed_version;
-  gchar *error;
+  int ret;
 
   /* Re-open DB after fork. */
 
@@ -1812,43 +1886,25 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
 
   /* Try update VTs. */
 
-  db_feed_version = nvts_feed_version ();
-  g_debug ("%s: db_feed_version: %s", __func__, db_feed_version);
-
-  connection = osp_connection_new (update_socket, 0, NULL, NULL, NULL);
-  if (!connection)
+  ret = nvts_feed_version_status_internal (update_socket,
+                                           &db_feed_version,
+                                           &scanner_feed_version);
+  if (ret == 1)
     {
-      g_debug ("%s: failed to connect to %s", __func__, update_socket);
-      return -1;
-    }
-
-  error = NULL;
-  if (osp_get_vts_version (connection, &scanner_feed_version, &error))
-    {
-      g_debug ("%s: failed to get scanner_feed_version. %s",
-               __func__, error ? : "");
-      g_free (error);
-      return -1;
-    }
-  g_debug ("%s: scanner_feed_version: %s", __func__, scanner_feed_version);
-
-  osp_connection_close (connection);
-
-  if ((db_feed_version == NULL)
-      || strcmp (scanner_feed_version, db_feed_version))
-    {
-      int ret;
-
-      g_info ("OSP service has different VT status (version %s) from database (version %s, %i VTs). Starting update ...",
-              scanner_feed_version, db_feed_version, sql_int ("SELECT count (*) FROM nvts;"));
+      g_info ("OSP service has different VT status (version %s)"
+              " from database (version %s, %i VTs). Starting update ...",
+              scanner_feed_version, db_feed_version,
+              sql_int ("SELECT count (*) FROM nvts;"));
 
       ret = update_nvt_cache_osp (update_socket, db_feed_version,
                                   scanner_feed_version);
 
+      g_free (db_feed_version);
+      g_free (scanner_feed_version);
       return ret;
     }
 
-  return 0;
+  return ret;
 }
 
 /**

--- a/src/manage_sql_nvts.h
+++ b/src/manage_sql_nvts.h
@@ -119,6 +119,9 @@ int
 update_or_rebuild_nvts (int);
 
 int
+nvts_feed_version_status ();
+
+int
 manage_update_nvt_cache_osp (const gchar *);
 
 char *

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -4240,6 +4240,8 @@ manage_feed_timestamp (const gchar *name)
 /**
  * @brief Gets the SCAP or CERT database version status.
  *
+ * @param[in]  feed_type  The feed type to check. Must be "cert" or "scap".
+ *
  * @return 0 feed current, 1 update needed, 2 database missing,
  *         3 missing "last_update", 4 inconsistent data, -1 error.
  */
@@ -4248,12 +4250,25 @@ secinfo_feed_version_status (const char *feed_type)
 {
   int last_feed_update, last_db_update;
 
+  if (strcmp (feed_type, "cert") == 0)
+    {
+      if (manage_cert_loaded () == 0)
+        return 2;
+    }
+  else if (strcmp (feed_type, "scap") == 0)
+    {
+      if (manage_scap_loaded () == 0)
+        return 2;
+    }
+  else
+    {
+      g_warning ("%s: Unexpected feed type: %s", __func__, feed_type);
+      return -1;
+    }
+
   last_feed_update = manage_feed_timestamp (feed_type);
   if (last_feed_update == -1)
     return -1;
-
-  if (manage_cert_loaded () == 0)
-    return 2;
 
   last_db_update = sql_int ("SELECT coalesce ((SELECT value FROM %s.meta"
                             "                  WHERE name = 'last_update'),"

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -4208,8 +4208,9 @@ manage_feed_timestamp (const gchar *name)
         stamp = 0;
       else
         {
-          g_warning ("%s: Failed to get timestamp: %s",
+          g_warning ("%s: Failed to get %s feed timestamp: %s",
                      __func__,
+                     name,
                      error->message);
           return -1;
         }
@@ -4218,8 +4219,9 @@ manage_feed_timestamp (const gchar *name)
     {
       if (strlen (timestamp) < 8)
         {
-          g_warning ("%s: Feed timestamp too short: %s",
+          g_warning ("%s: %s feed timestamp too short: %s",
                      __func__,
+                     name,
                      timestamp);
           g_free (timestamp);
           return -1;
@@ -4233,6 +4235,49 @@ manage_feed_timestamp (const gchar *name)
     }
 
  return stamp;
+}
+
+/**
+ * @brief Gets the SCAP or CERT database version status.
+ *
+ * @return 0 feed current, 1 update needed, 2 database missing,
+ *         3 missing "last_update", 4 inconsistent data, -1 error.
+ */
+int
+secinfo_feed_version_status (const char *feed_type)
+{
+  int last_feed_update, last_db_update;
+
+  last_feed_update = manage_feed_timestamp (feed_type);
+  if (last_feed_update == -1)
+    return -1;
+
+  if (manage_cert_loaded () == 0)
+    return 2;
+
+  last_db_update = sql_int ("SELECT coalesce ((SELECT value FROM %s.meta"
+                            "                  WHERE name = 'last_update'),"
+                            "                 '-3');",
+                            feed_type);
+  if (last_db_update == -3)
+    return 3;
+  else if (last_db_update < 0)
+    return 4;
+  else
+    {
+      if (last_db_update == last_feed_update)
+        {
+          return 0;
+        }
+
+      if (last_db_update > last_feed_update)
+        {
+          g_warning ("%s: last %s database update later than last feed update",
+                     __func__, feed_type);
+          return -1;
+        }
+    }
+  return 1;
 }
 
 

--- a/src/manage_sql_secinfo.h
+++ b/src/manage_sql_secinfo.h
@@ -208,6 +208,9 @@
  */
 #define SECINFO_COMMIT_SIZE_DEFAULT 0
 
+int
+secinfo_feed_version_status ();
+
 void
 manage_sync_scap (sigset_t *);
 


### PR DESCRIPTION
The feed versions / timestamps are now checked without acquiring the lock on the lockfile first so the check does not appear as an update in progress.
This check and handling the actual updates is also done in a forked process now so the scanner taking longer to respond with the feed version does not block the main process.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
