### PR TITLE
[9.0] Hide deprecation section in GMP doc

### DIFF
--- a/src/schema_formats/HTML/HTML.xsl
+++ b/src/schema_formats/HTML/HTML.xsl
@@ -717,11 +717,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   </xsl:template>
 
   <xsl:template name="deprecations">
-    <h2 id="deprecations">
-      9 Deprecation Warnings for Version
-      <xsl:value-of select="/protocol/version"/>
-    </h2>
-    <xsl:apply-templates select="deprecation[version=/protocol/version]"/>
+    <xsl:if test="deprecation[version=/protocol/version]">
+      <h2 id="deprecations">
+        9 Deprecation Warnings for Version
+        <xsl:value-of select="/protocol/version"/>
+      </h2>
+      <xsl:apply-templates select="deprecation[version=/protocol/version]"/>
+    </xsl:if>
   </xsl:template>
 
   <!-- Root. -->
@@ -778,12 +780,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
                       <xsl:value-of select="/protocol/version"/>
                     </a>
                   </li>
-                  <li>
-                    <a href="#deprecations">
-                      Deprecation Warnings for Version
-                      <xsl:value-of select="/protocol/version"/>
-                    </a>
-                  </li>
+                  <xsl:if test="deprecation[version=/protocol/version]">
+                    <li>
+                      <a href="#deprecations">
+                        Deprecation Warnings for Version
+                        <xsl:value-of select="/protocol/version"/>
+                      </a>
+                    </li>
+                  </xsl:if>
                 </ol>
 
                 <xsl:call-template name="type-summary"/>


### PR DESCRIPTION
**What**:

Only show deprecation section if the GMP doc contains deprecations for
the current version.

**Why**:

The docs of GMP 9 and 20.08 don't contain any deprecations. Therefore the empty section should not be displayed.

**How**:

build gvmd and open built GMP doc in browser

`cd build/doc && firefox gmp.html`

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests (n/a)
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry (n/a)
