### PR TITLE
Send NULL as extra_where_single in init_result_get_iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix delta sorting for unusual filter sort terms [#1249](https://github.com/greenbone/gvmd/pull/1249)
 - Fix SCP alert authentication and logging [#1264](https://github.com/greenbone/gvmd/pull/1264)
 - Set file mode creation mask for feed lock handling [#1265](https://github.com/greenbone/gvmd/pull/1265)
+- Send NULL as extra_where_single in init_result_get_iterator [#1275](https://github.com/greenbone/gvmd/pull/1265)
 
 ### Removed
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -22453,7 +22453,7 @@ init_result_get_iterator (iterator_t* iterator, const get_data_t *get,
                             0,
                             extra_tables,
                             extra_where,
-                            extra_where,
+                            NULL,                   /* extra_where_single */
                             TRUE,
                             report ? TRUE : FALSE,
                             extra_order);


### PR DESCRIPTION
**What**:

Prevents filters from having an effect when specifying a result_id in
GET_RESULTS.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

This error was introduced in c9dc67a01ed0f9b381172634d4514ccd2bd83ef2 (from https://github.com/greenbone/gvmd/pull/1076) which
introduced the extra_where_single arg.  Before that there was no way to
send extra args to init_get_iterator2_with when getting a single specified
resource, which is equivalent to sending NULL now.

<!-- Why are these changes necessary? -->

**How**:

Response from each of these should include result, even if result has min_qod < 70:
 - `2o m m '<get_results result_id="e89920a5-9af3-47af-975c-cb38cccdea69" filter="min_qod=70"/>'`
 - `2o m m '<get_results result_id="e89920a5-9af3-47af-975c-cb38cccdea69" filter="min_qod=0"/>'`
 - `2o m m '<get_results result_id="e89920a5-9af3-47af-975c-cb38cccdea69"/>'`

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
