### PR TITLE
Ignore min_qod when getting single results by UUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix delta sorting for unusual filter sort terms [#1249](https://github.com/greenbone/gvmd/pull/1249)
 - Fix SCP alert authentication and logging [#1264](https://github.com/greenbone/gvmd/pull/1264)
 - Set file mode creation mask for feed lock handling [#1265](https://github.com/greenbone/gvmd/pull/1265)
+- Ignore min_qod when getting single results by UUID [#1276](http://github.com/greenbone/gvmd/pull/1276)
 
 ### Removed
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -22166,8 +22166,8 @@ init_result_get_iterator_severity (iterator_t* iterator, const get_data_t *get,
   int ret;
   gchar *filter;
   int autofp, apply_overrides, dynamic_severity;
-  gchar *extra_tables, *extra_where, *owned_clause, *with_clause;
-  gchar *with_clauses;
+  gchar *extra_tables, *extra_where, *extra_where_single;
+  gchar *owned_clause, *with_clause, *with_clauses;
   char *user_id;
 
   assert (report);
@@ -22316,6 +22316,11 @@ init_result_get_iterator_severity (iterator_t* iterator, const get_data_t *get,
                                      autofp, apply_overrides, dynamic_severity,
                                      filter ? filter : get->filter);
 
+  extra_where_single = results_extra_where (get->trash, report, host,
+                                            autofp, apply_overrides,
+                                            dynamic_severity,
+                                            "min_qod=0");
+
   free (filter);
 
   user_id = sql_string ("SELECT id FROM users WHERE uuid = '%s';",
@@ -22369,7 +22374,7 @@ init_result_get_iterator_severity (iterator_t* iterator, const get_data_t *get,
                                  0,
                                  extra_tables,
                                  extra_where,
-                                 NULL,
+                                 extra_where_single,
                                  TRUE,
                                  report ? TRUE : FALSE,
                                  extra_order,
@@ -22380,6 +22385,7 @@ init_result_get_iterator_severity (iterator_t* iterator, const get_data_t *get,
   g_free (with_clauses);
   g_free (extra_tables);
   g_free (extra_where);
+  g_free (extra_where_single);
   return ret;
 }
 
@@ -22404,7 +22410,7 @@ init_result_get_iterator (iterator_t* iterator, const get_data_t *get,
   static column_t columns[] = RESULT_ITERATOR_COLUMNS;
   static column_t columns_no_cert[] = RESULT_ITERATOR_COLUMNS_NO_CERT;
   int ret;
-  gchar *filter, *extra_tables, *extra_where, *opts_tables;
+  gchar *filter, *extra_tables, *extra_where, *extra_where_single, *opts_tables;
   int autofp, apply_overrides, dynamic_severity;
 
   if (report == -1)
@@ -22438,6 +22444,11 @@ init_result_get_iterator (iterator_t* iterator, const get_data_t *get,
                                      autofp, apply_overrides, dynamic_severity,
                                      filter ? filter : get->filter);
 
+  extra_where_single = results_extra_where (get->trash, report, host,
+                                            autofp, apply_overrides,
+                                            dynamic_severity,
+                                            "min_qod=0");
+
   free (filter);
 
   ret = init_get_iterator2 (iterator,
@@ -22453,12 +22464,13 @@ init_result_get_iterator (iterator_t* iterator, const get_data_t *get,
                             0,
                             extra_tables,
                             extra_where,
-                            extra_where,
+                            extra_where_single,
                             TRUE,
                             report ? TRUE : FALSE,
                             extra_order);
   g_free (extra_tables);
   g_free (extra_where);
+  g_free (extra_where_single);
   return ret;
 }
 


### PR DESCRIPTION
**What**:

Prevents results being hidden by implicit or explicit min_qod filters when selecting results by UUID.

This is an alternative solution to the issue in #1275 that also allows using other filter options like `apply_overrides=1`.

**Why**:

This error making get_results return no result at all was introduced in c9dc67a01ed0f9b381172634d4514ccd2bd83ef2.
Before this special filter options like min_qod were simply ignored by
init_get_iterator2_with when getting single results, ensuring the result
would be visible.

**How**:
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->
Response from GMP commands like these should include the result, even if result has min_qod < 70:
 - `<get_results result_id="e89920a5-9af3-47af-975c-cb38cccdea69" filter="min_qod=70"/>`
 - `<get_results result_id="e89920a5-9af3-47af-975c-cb38cccdea69" filter="min_qod=0"/>`
 - `<get_results result_id="e89920a5-9af3-47af-975c-cb38cccdea69"/>`

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
