### PR TITLE
Document that a socket can be passed to --scanner-host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Move EXE credential generation to a Python script [#1260](https://github.com/greenbone/gvmd/pull/1260) [#1262](https://github.com/greenbone/gvmd/pull/1262)
+- Clarify documentation for --scan-host parameter [#1277](https://github.com/greenbone/gvmd/pull/1277)
 
 [21.4]: https://github.com/greenbone/gvmd/compare/gvmd-20.08...master
 

--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -145,7 +145,7 @@ Scanner credential for --create-scanner and --modify-scanner.
 Can be blank to unset or a credential UUID. If omitted, a new credential can be created instead.
 .TP
 \fB--scanner-host=\fISCANNER-HOST\fB\f1
-Scanner host for --create-scanner and --modify-scanner.
+Scanner host or socket for --create-scanner and --modify-scanner.
 .TP
 \fB--scanner-key-priv=\fISCANNER-KEY-PRIVATE\fB\f1
 Scanner private key path for --[create|modify]-scanner if --scanner-credential is not given.

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -327,7 +327,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <option>
       <p><opt>--scanner-host=<arg>SCANNER-HOST</arg></opt></p>
       <optdesc>
-        <p>Scanner host for --create-scanner and --modify-scanner.</p>
+        <p>Scanner host or socket for --create-scanner and --modify-scanner.</p>
       </optdesc>
     </option>
     <option>

--- a/doc/gvmd.html
+++ b/doc/gvmd.html
@@ -311,7 +311,7 @@
     
       <p><b>--scanner-host=<em>SCANNER-HOST</em></b></p>
       
-        <p>Scanner host for --create-scanner and --modify-scanner.</p>
+        <p>Scanner host or socket for --create-scanner and --modify-scanner.</p>
       
     
     

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1931,7 +1931,7 @@ gvmd (int argc, char** argv)
           "<scanner-credential>" },
         { "scanner-host", '\0', 0, G_OPTION_ARG_STRING,
           &scanner_host,
-          "Scanner host for --create-scanner and --modify-scanner.",
+          "Scanner host or socket for --create-scanner and --modify-scanner.",
           "<scanner-host>" },
         { "scanner-key-priv", '\0', 0, G_OPTION_ARG_STRING,
           &scanner_key_priv,


### PR DESCRIPTION
... as exemplified in INSTALL.md.

**What**:

Clarify what values are meaningful for the --scanner-host parameter.

**Why**:

To speed up figuring out how to update the path to the default openvas scanner.

**How**:

I tested passing a socket to --scanner-host in gvmd 9.0.0. Also as noted above this use case is an example in INSTALL.md.

**Checklist**:

- [ ] Tests n/a
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
