### PR TITLE
Fix alternative options for radio type preferences when exporting a scan config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix SCP alert authentication and logging [#1264](https://github.com/greenbone/gvmd/pull/1264)
 - Set file mode creation mask for feed lock handling [#1265](https://github.com/greenbone/gvmd/pull/1265)
 - Ignore min_qod when getting single results by UUID [#1276](http://github.com/greenbone/gvmd/pull/1276)
+- Fix alternative options for radio type preferences when exporting a scan_config [#1278](http://github.com/greenbone/gvmd/pull/1278)
 
 ### Removed
 

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -8674,13 +8674,6 @@ buffer_config_preference_xml (GString *buffer, iterator_t *prefs,
       char *pos = strchr (value, ';');
       if (pos) *pos = '\0';
       buffer_xml_append_printf (buffer, "<value>%s</value>", value);
-      while (pos)
-        {
-          char *pos2 = strchr (++pos, ';');
-          if (pos2) *pos2 = '\0';
-          buffer_xml_append_printf (buffer, "<alt>%s</alt>", pos);
-          pos = pos2;
-        }
     }
   else if (value
            && type
@@ -8698,6 +8691,13 @@ buffer_config_preference_xml (GString *buffer, iterator_t *prefs,
       char *pos = strchr (default_value, ';');
       if (pos) *pos = '\0';
       buffer_xml_append_printf (buffer, "<default>%s</default>", default_value);
+      while (pos)
+        {
+          char *pos2 = strchr (++pos, ';');
+          if (pos2) *pos2 = '\0';
+          buffer_xml_append_printf (buffer, "<alt>%s</alt>", pos);
+          pos = pos2;
+        }
     }
   else if (default_value
            && type


### PR DESCRIPTION
**What**:
Add alternative option for radio type nvt's preferences

**Why**:
When exporting, the alternative options were not added to the xml file.

**How**:
Importing a scan config and checking the NVT's preferences, search for an radio type pref. Only the default value was shown. Now the alternative values are shown as well.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
