### PR TITLE
Replace deprecated sys_siglist with strsignal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Set file mode creation mask for feed lock handling [#1265](https://github.com/greenbone/gvmd/pull/1265)
 - Ignore min_qod when getting single results by UUID [#1276](http://github.com/greenbone/gvmd/pull/1276)
 - Fix alternative options for radio type preferences when exporting a scan_config [#1278](http://github.com/greenbone/gvmd/pull/1278)
+- Replace deprecated sys_siglist with strsignal [#1280](https://github.com/greenbone/gvmd/pull/1280)
 
 ### Removed
 

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1334,7 +1334,7 @@ serve_and_schedule ()
       if (termination_signal)
         {
           g_debug ("Received %s signal",
-                   sys_siglist[termination_signal]);
+                   strsignal (termination_signal));
           cleanup ();
           /* Raise signal again, to exit with the correct return value. */
           setup_signal_handler (termination_signal, SIG_DFL, 0);
@@ -1423,7 +1423,7 @@ serve_and_schedule ()
       if (termination_signal)
         {
           g_debug ("Received %s signal",
-                   sys_siglist[termination_signal]);
+                   strsignal (termination_signal));
           cleanup ();
           /* Raise signal again, to exit with the correct return value. */
           setup_signal_handler (termination_signal, SIG_DFL, 0);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -16570,7 +16570,7 @@ cleanup_manage_process (gboolean cleanup)
 void
 manage_cleanup_process_error (int signal)
 {
-  g_debug ("Received %s signal", sys_siglist[signal]);
+  g_debug ("Received %s signal", strsignal (signal));
   if (sql_is_open ())
     {
       if (current_scanner_task)

--- a/src/utils.c
+++ b/src/utils.c
@@ -800,7 +800,7 @@ setup_signal_handler (int signal, void (*handler) (int), int block)
   if (sigaction (signal, &action, NULL) == -1)
     {
       g_critical ("%s: failed to register %s handler",
-                  __func__, sys_siglist[signal]);
+                  __func__, strsignal (signal));
       exit (EXIT_FAILURE);
     }
 }
@@ -831,7 +831,7 @@ setup_signal_handler_info (int signal,
   if (sigaction (signal, &action, NULL) == -1)
     {
       g_critical ("%s: failed to register %s handler",
-                  __func__, sys_siglist[signal]);
+                  __func__, strsignal (signal));
       exit (EXIT_FAILURE);
     }
 }


### PR DESCRIPTION
Required to work with glibc >= 2.32.

https://sourceware.org/pipermail/libc-announce/2020/000029.html

  The deprecated arrays sys_siglist, _sys_siglist, and sys_sigabbrev
  are no longer available to newly linked binaries, and their declarations
  have been removed from <string.h>. They are exported solely as
  compatibility symbols to support old binaries. All programs should use
  strsignal instead.

**What**: N/A

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**: https://github.com/greenbone/gvmd/issues/1279

<!-- Why are these changes necessary? -->

**How**: N/A

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
