### PR TITLE
Remove DROP from vulns creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix alternative options for radio type preferences when exporting a scan_config [#1278](http://github.com/greenbone/gvmd/pull/1278)
 
 ### Removed
+- Remove DROP from vulns creation [#1281](http://github.com/greenbone/gvmd/pull/1281)
 
 [20.8.1]: https://github.com/greenbone/gvmd/compare/v20.8.0...gvmd-20.08
 

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -2862,7 +2862,6 @@ create_tables ()
        "  JOIN tls_certificate_origins AS origins"
        "    ON sources.origin = origins.id;");
 
-  sql ("DROP VIEW IF EXISTS vulns;");
   if (sql_int ("SELECT EXISTS (SELECT * FROM information_schema.tables"
                "               WHERE table_catalog = '%s'"
                "               AND table_schema = 'scap'"


### PR DESCRIPTION
This DROP was added in 01baac22a, which changed the view to a UNION with
explicit columns.  It's likely that the DROP was needed because CREATE OR
REPLACE does not support changing the columns.

But that was 2017 and the columns have not changed since, so anyone
upgrading from the last version will have the same columns.

If someone needs to change the columns they can add a migrator.

**What**:

Remove DROP from vulns creation.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

We have reports of "ERROR: relation "vulns" does not exist" that are hard to reproduce, and this may help.

**How**:

Restart gvmd.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
