### PR TITLE
Reduce severity classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Move EXE credential generation to a Python script [#1260](https://github.com/greenbone/gvmd/pull/1260) [#1262](https://github.com/greenbone/gvmd/pull/1262)
 - Clarify documentation for --scan-host parameter [#1277](https://github.com/greenbone/gvmd/pull/1277)
 
+### Removed
+- Reduce Severity Classes [#1285](https://github.com/greenbone/gvmd/pull/1285)
+
 [21.4]: https://github.com/greenbone/gvmd/compare/gvmd-20.08...master
 
 ## [20.8.1] (unreleased)

--- a/src/manage.c
+++ b/src/manage.c
@@ -863,7 +863,7 @@ severity_in_level (double severity, const char *level)
     }
   else
     {
-      /* NIST/BSI. */
+      /* NIST */
       if (strcmp (level, "high") == 0)
         return severity >= 7 && severity <= 10;
       else if (strcmp (level, "medium") == 0)

--- a/src/manage.c
+++ b/src/manage.c
@@ -839,20 +839,7 @@ severity_in_level (double severity, const char *level)
   const char *class;
 
   class = setting_severity ();
-  if (strcmp (class, "classic") == 0)
-    {
-      if (strcmp (level, "high") == 0)
-        return severity > 5 && severity <= 10;
-      else if (strcmp (level, "medium") == 0)
-        return severity > 2 && severity <= 5;
-      else if (strcmp (level, "low") == 0)
-        return severity > 0 && severity <= 2;
-      else if (strcmp (level, "none") == 0 || strcmp (level, "log") == 0)
-        return severity == 0;
-      else
-        return 0;
-    }
-  else if (strcmp (class, "pci-dss") == 0)
+  if (strcmp (class, "pci-dss") == 0)
     {
       if (strcmp (level, "high") == 0)
         return severity >= 4.0;

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -237,7 +237,7 @@ manage_create_sql_functions ()
        "        ELSE"
        "          v := " G_STRINGIFY (SEVERITY_UNDEFINED) ";"
        "        END CASE;"
-       "    ELSE" // NIST/BSI.
+       "    ELSE" // NIST.
        "      CASE"
        "        WHEN lower (lvl) = 'high' THEN"
        "          v := 10.0;"
@@ -278,7 +278,7 @@ manage_create_sql_functions ()
        "        ELSE"
        "          v := " G_STRINGIFY (SEVERITY_UNDEFINED) ";"
        "        END CASE;"
-       "    ELSE" // NIST/BSI.
+       "    ELSE" // NIST.
        "      CASE"
        "        WHEN lower (lvl) = 'high' THEN"
        "          v := 7.0;"
@@ -1473,7 +1473,7 @@ manage_create_sql_functions ()
            "               THEN $1 >= 0.0 AND $1 < 4.0"
            "               ELSE 0::boolean"
            "               END)"
-           "         ELSE " /* NIST/BSI */
+           "         ELSE " /* NIST */
            "              (CASE lower ($2)"
            "               WHEN 'high'"
            "               THEN $1 >= 7"

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -26458,12 +26458,11 @@ severity_class_xml (const gchar *severity)
 {
   if (severity)
     {
-      if ((strcmp (severity, "nist") == 0)
-          || (strcmp (severity, "bsi") == 0))
+      if (strcmp (severity, "nist") == 0)
         return g_strdup_printf ("<severity_class"
                                 " id=\"d4c74cda-89e1-11e3-9c29-406186ea4fc5\">"
                                 "<name>nist</name>"
-                                "<full_name>%s</full_name>"
+                                "<full_name>NVD Vulnerability Severity Ratings</full_name>"
                                 "<severity_range>"
                                 "<name>None</name>"
                                 "<min>0.0</min>"
@@ -26484,10 +26483,7 @@ severity_class_xml (const gchar *severity)
                                 "<min>7.0</min>"
                                 "<max>10.0</max>"
                                 "</severity_range>"
-                                "</severity_class>",
-                                strcmp (severity, "nist") == 0
-                                 ? "NVD Vulnerability Severity Ratings"
-                                 : "BSI Schwachstellenampel (Germany)");
+                                "</severity_class>");
       else if (strcmp (severity, "pci-dss") == 0)
         return g_strdup_printf ("<severity_class"
                                 " id=\"e442e476-89e1-11e3-bfc6-406186ea4fc5\">"

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -26456,52 +26456,52 @@ report_progress (report_t report)
 static gchar *
 severity_class_xml (const gchar *severity)
 {
-  if (severity)
-    {
-      if (strcmp (severity, "nist") == 0)
-        return g_strdup_printf ("<severity_class"
-                                " id=\"d4c74cda-89e1-11e3-9c29-406186ea4fc5\">"
-                                "<name>nist</name>"
-                                "<full_name>NVD Vulnerability Severity Ratings</full_name>"
-                                "<severity_range>"
-                                "<name>None</name>"
-                                "<min>0.0</min>"
-                                "<max>0.0</max>"
-                                "</severity_range>"
-                                "<severity_range>"
-                                "<name>Low</name>"
-                                "<min>0.1</min>"
-                                "<max>3.9</max>"
-                                "</severity_range>"
-                                "<severity_range>"
-                                "<name>Medium</name>"
-                                "<min>4.0</min>"
-                                "<max>6.9</max>"
-                                "</severity_range>"
-                                "<severity_range>"
-                                "<name>High</name>"
-                                "<min>7.0</min>"
-                                "<max>10.0</max>"
-                                "</severity_range>"
-                                "</severity_class>");
-      else if (strcmp (severity, "pci-dss") == 0)
-        return g_strdup_printf ("<severity_class"
-                                " id=\"e442e476-89e1-11e3-bfc6-406186ea4fc5\">"
-                                "<name>pci-dss</name>"
-                                "<full_name>PCI-DSS</full_name>"
-                                "<severity_range>"
-                                "<name>None</name>"
-                                "<min>0.0</min>"
-                                "<max>3.9</max>"
-                                "</severity_range>"
-                                "<severity_range>"
-                                "<name>High</name>"
-                                "<min>4.0</min>"
-                                "<max>10.0</max>"
-                                "</severity_range>"
-                                "</severity_class>");
-    }
-  return NULL;
+  if (!severity)
+    return NULL;
+
+  if (strcmp (severity, "pci-dss") == 0)
+    return g_strdup_printf ("<severity_class"
+                            " id=\"e442e476-89e1-11e3-bfc6-406186ea4fc5\">"
+                            "<name>pci-dss</name>"
+                            "<full_name>PCI-DSS</full_name>"
+                            "<severity_range>"
+                            "<name>None</name>"
+                            "<min>0.0</min>"
+                            "<max>3.9</max>"
+                            "</severity_range>"
+                            "<severity_range>"
+                            "<name>High</name>"
+                            "<min>4.0</min>"
+                            "<max>10.0</max>"
+                            "</severity_range>"
+                            "</severity_class>");
+
+  /* "nist", any other class defaults to "nist" */
+  return g_strdup_printf ("<severity_class"
+                          " id=\"d4c74cda-89e1-11e3-9c29-406186ea4fc5\">"
+                          "<name>nist</name>"
+                          "<full_name>NVD Vulnerability Severity Ratings</full_name>"
+                          "<severity_range>"
+                          "<name>None</name>"
+                          "<min>0.0</min>"
+                          "<max>0.0</max>"
+                          "</severity_range>"
+                          "<severity_range>"
+                          "<name>Low</name>"
+                          "<min>0.1</min>"
+                          "<max>3.9</max>"
+                          "</severity_range>"
+                          "<severity_range>"
+                          "<name>Medium</name>"
+                          "<min>4.0</min>"
+                          "<max>6.9</max>"
+                          "</severity_range>"
+                          "<severity_range>"
+                          "<name>High</name>"
+                          "<min>7.0</min>"
+                          "<max>10.0</max>"
+                          "</severity_range>"
+                          "</severity_class>");
 }
 
 /**

--- a/src/manage_utils.c
+++ b/src/manage_utils.c
@@ -207,7 +207,7 @@ level_min_severity (const char *level, const char *class)
     }
   else
     {
-      /* NIST/BSI. */
+      /* NIST */
       if (strcasecmp (level, "high") == 0)
         return 7.0;
       else if (strcasecmp (level, "medium") == 0)
@@ -250,7 +250,7 @@ level_max_severity (const char *level, const char *class)
     }
   else
     {
-      /* NIST/BSI. */
+      /* NIST */
       if (strcasecmp (level, "high") == 0)
         return 10.0;
       else if (strcasecmp (level, "medium") == 0)


### PR DESCRIPTION
The list of supported severity classes is reduced by removing last remains
of "classic" (deprecated since v8.0) and by removing "bsi" which is actually the same as "nist".

This cleans code and UI, without removing functionality.

- [ ] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
