### PR TITLE
Skip DB check in helpers when main process is running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix alternative options for radio type preferences when exporting a scan_config [#1278](http://github.com/greenbone/gvmd/pull/1278)
 - Replace deprecated sys_siglist with strsignal [#1280](https://github.com/greenbone/gvmd/pull/1280)
 - Copy instead of moving when migrating predefined report formats [#1286](https://github.com/greenbone/gvmd/pull/1286)
+- Skip DB check in helpers when main process is running [#1291](https://github.com/greenbone/gvmd/pull/1291)
 
 ### Removed
 - Remove DROP from vulns creation [#1281](http://github.com/greenbone/gvmd/pull/1281)


### PR DESCRIPTION
**What**:

Skip DB check in helpers (--create-user, etc) when main process is running.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

The create_tables in the db check was causing deadlock.

<!-- Why are these changes necessary? -->

**How**:

1 `tail -f gvmd.log | grep -i "deadlock detected"`
2 `while true; do gvmd --modify-setting 78eceaec-3385-11ea-b237-28d24461215b --value d1ab52ec-a88a-4ef3-99d5-57123f88a95c; done`
3 In GSA refresh the results page.
4 Without patch should see tail output after 1 or 2 refreshes.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
