### PR TITLE
Recreate vulns after sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix alternative options for radio type preferences when exporting a scan_config [#1278](http://github.com/greenbone/gvmd/pull/1278)
 - Replace deprecated sys_siglist with strsignal [#1280](https://github.com/greenbone/gvmd/pull/1280)
 - Copy instead of moving when migrating predefined report formats [#1286](https://github.com/greenbone/gvmd/pull/1286)
+- Recreate vulns after sync [#1292](https://github.com/greenbone/gvmd/pull/1292)
 
 ### Removed
 - Remove DROP from vulns creation [#1281](http://github.com/greenbone/gvmd/pull/1281)

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -481,4 +481,7 @@ void
 add_role_permission_resource (const gchar *, const gchar *, const gchar *,
                               const gchar *);
 
+void
+create_view_vulns ();
+
 #endif /* not _GVMD_MANAGE_SQL_H */

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -4711,6 +4711,9 @@ update_scap_end ()
       sql ("ALTER SCHEMA scap RENAME TO scap3;");
       sql ("ALTER SCHEMA scap2 RENAME TO scap;");
       sql ("DROP SCHEMA scap3 CASCADE;");
+      /* View 'vulns' contains references into the SCAP schema, so it is
+       * removed by the CASCADE. */
+      create_view_vulns ();
     }
   else
     sql ("ALTER SCHEMA scap2 RENAME TO scap;");


### PR DESCRIPTION
**What**:

Recreate vulns view after removing old SCAP schema.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

The vulns view references the scap schema.  When the scap schema is renamed and removed, the vulns view is removed with it automatically (due to CASCADE).

<!-- Why are these changes necessary? -->

**How**:

1 Go to GSA Scans > Vulnerabilities.  See list.
2 Initiate a SCAP rebuild: update scap.meta set value = 0 where name = 'last_update';
3 When build is done refresh GSA page.  See list.  Without patch this will show an error.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
