### PR TITLE
Add SecInfo case to alert check in MODIFY_FILTER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix alternative options for radio type preferences when exporting a scan_config [#1278](http://github.com/greenbone/gvmd/pull/1278)
 - Replace deprecated sys_siglist with strsignal [#1280](https://github.com/greenbone/gvmd/pull/1280)
 - Copy instead of moving when migrating predefined report formats [#1286](https://github.com/greenbone/gvmd/pull/1286)
+- Add SecInfo case to alert check in MODIFY_FILTER [#1293](https://github.com/greenbone/gvmd/pull/1293)
 
 ### Removed
 - Remove DROP from vulns creation [#1281](http://github.com/greenbone/gvmd/pull/1281)

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -23536,6 +23536,14 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                 log_event_fail ("filter", "Filter",
                                 modify_filter_data->filter_id, "modified");
                 break;
+              case 6:
+                SEND_TO_CLIENT_OR_FAIL
+                 (XML_ERROR_SYNTAX ("modify_filter",
+                                    "Filter is used by an alert so type must be"
+                                    " 'info' if specified"));
+                log_event_fail ("filter", "Filter",
+                                modify_filter_data->filter_id, "modified");
+                break;
               case 99:
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("modify_filter",

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -46190,8 +46190,8 @@ filter_alert_iterator_readable (iterator_t* iterator)
  *
  * @return 0 success, 1 failed to find filter, 2 filter with new name exists,
  *         3 error in type name, 4 filter_id required, 5 filter is in use so
- *         type must be "result" if specified, 99 permission denied,
- *         -1 internal error.
+ *         type must be "result", 6 filter is in use so type must be "info",
+ *         99 permission denied, -1 internal error.
  */
 int
 modify_filter (const char *filter_id, const char *name, const char *comment,
@@ -46246,7 +46246,7 @@ modify_filter (const char *filter_id, const char *name, const char *comment,
       && strcasecmp (type, "info"))
     {
       sql_rollback ();
-      return 5;
+      return 6;
     }
 
   /* Check whether a filter with the same name exists already. */


### PR DESCRIPTION
**What**:

MODIFY_FILTER was only accounting for "result" in the linked alert check.  It now accounts for SecInfo filters in the check.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

It was not possible to save filters attached to SecInfo alert conditions.

<!-- Why are these changes necessary? -->

**How**:

In GSA create an alert with a "New NVTs" event and a filter condition.  It should be possible to Edit and Save the associated filter.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
