### PR TITLE
Escape preference VALUE and DEFAULT in gvm-export-config

### DIFF
--- a/tools/gvm-export-config
+++ b/tools/gvm-export-config
@@ -62,7 +62,7 @@ echo "  <preferences>"
 
 # 1.3.6.1.4.1.25623.1.0.100315:5:checkbox:Mark unrechable Hosts as dead (not scanning)
 # 1.3.6.1.4.1.25623.1.0.100315:11:checkbox:nmap: try also with only -sP
-sql "SELECT E'    <preference>\n      <nvt oid=\"' || split_part (name, ':', 1) || E'\">\n        <name>' || (SELECT name FROM nvts WHERE oid = split_part (config_preferences.name, ':', 1)) || E'</name>\n      </nvt>\n      <name>' || regexp_replace(name, E'([^:]*:){3}(.*)', '\2') || E'</name>\n      <type>' || split_part (name, ':', 3) || E'</type>\n      <value>' || value || E'</value>\n      <default>' || (SELECT value FROM nvt_preferences WHERE nvt_preferences.name = config_preferences.name) || E'</default>\n      <id>' || split_part (name, ':', 2) || E'</id>\n    </preference>' FROM config_preferences WHERE type = 'PLUGINS_PREFS' AND config = (SELECT id FROM configs WHERE uuid='${UUID}');"
+sql "SELECT E'    <preference>\n      <nvt oid=\"' || split_part (name, ':', 1) || E'\">\n        <name>' || (SELECT name FROM nvts WHERE oid = split_part (config_preferences.name, ':', 1)) || E'</name>\n      </nvt>\n      <name>' || regexp_replace(name, E'([^:]*:){3}(.*)', '\2') || E'</name>\n      <type>' || split_part (name, ':', 3) || E'</type>\n      ' || xmlelement(name value, value) || E'\n      ' || xmlelement(name default, (SELECT value FROM nvt_preferences WHERE nvt_preferences.name = config_preferences.name)) || E'\n      <id>' || split_part (name, ':', 2) || E'</id>\n    </preference>' FROM config_preferences WHERE type = 'PLUGINS_PREFS' AND config = (SELECT id FROM configs WHERE uuid='${UUID}');"
 
 echo "  </preferences>"
 


### PR DESCRIPTION
**What**:

Escape the VALUE and PREFERENCE elements generated by gvm-export-config.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

The script was generating invalid XML.

<!-- Why are these changes necessary? -->

**How**:

Run `gvm-export-config UUID` for a config created from https://download.greenbone.net/scanconfigs/GOS_6.0/Policy_GaussDB_20200813.xml.  The angled brackets in pref "Misc information on News server" VALUE and DEFAULT should be escaped.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
