### PR TITLE
For radio prefs in GMP exclude value and include default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix alternative options for radio type preferences when exporting a scan_config [#1278](http://github.com/greenbone/gvmd/pull/1278)
 - Replace deprecated sys_siglist with strsignal [#1280](https://github.com/greenbone/gvmd/pull/1280)
 - Copy instead of moving when migrating predefined report formats [#1286](https://github.com/greenbone/gvmd/pull/1286)
+- For radio prefs in GMP exclude value and include default [#1296](https://github.com/greenbone/gvmd/pull/1296)
 
 ### Removed
 - Remove DROP from vulns creation [#1281](http://github.com/greenbone/gvmd/pull/1281)

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -8687,8 +8687,11 @@ buffer_config_preference_xml (GString *buffer, iterator_t *prefs,
       && type
       && (strcmp (type, "radio") == 0))
     {
+      char *pos;
+
       /* Handle the other possible values. */
-      char *pos = strchr (default_value, ';');
+
+      pos = strchr (default_value, ';');
       if (pos) *pos = '\0';
       buffer_xml_append_printf (buffer, "<default>%s</default>", default_value);
       while (pos)

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -8703,7 +8703,8 @@ buffer_config_preference_xml (GString *buffer, iterator_t *prefs,
         {
           char *pos2 = strchr (pos, ';');
           if (pos2) *pos2 = '\0';
-          buffer_xml_append_printf (buffer, "<alt>%s</alt>", pos);
+          if (value == NULL || strcmp (pos, value))
+            buffer_xml_append_printf (buffer, "<alt>%s</alt>", pos);
           if (pos2 == NULL)
             break;
           pos = pos2 + 1;

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -8688,19 +8688,27 @@ buffer_config_preference_xml (GString *buffer, iterator_t *prefs,
       && (strcmp (type, "radio") == 0))
     {
       char *pos;
+      gchar *alts;
 
       /* Handle the other possible values. */
+
+      alts = g_strdup (default_value);
 
       pos = strchr (default_value, ';');
       if (pos) *pos = '\0';
       buffer_xml_append_printf (buffer, "<default>%s</default>", default_value);
-      while (pos)
+
+      pos = alts;
+      while (1)
         {
-          char *pos2 = strchr (++pos, ';');
+          char *pos2 = strchr (pos, ';');
           if (pos2) *pos2 = '\0';
           buffer_xml_append_printf (buffer, "<alt>%s</alt>", pos);
-          pos = pos2;
+          if (pos2 == NULL)
+            break;
+          pos = pos2 + 1;
         }
+      g_free (alts);
     }
   else if (default_value
            && type


### PR DESCRIPTION
**What**:

For radio preferences in GMP, as returned by GET_NVTS:
 - include the option that is in DEFAULT_VALUE in the possible ALTs
 - never include an ALT for the option that is in VALUE.

Related recent PR: https://github.com/greenbone/gvmd/pull/1278

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

This is the expected behaviour.

<!-- Why are these changes necessary? -->

**How**:

Create Base config
Edit "Timing policy :" of "Nmap (NASL wrapper)" to "Insane", "Polite" or "Aggressive".
Open the edit dialog for "Nmap (NASL wrapper)"
The list for "Timing policy :" should include "Insane" and "Aggressive" (and "Polite" but it always did).

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
