### PR TITLE
Fix documentation for get_configs GMP

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -7288,7 +7288,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </attrib>
       <attrib>
         <name>details</name>
-        <summary>Whether to get config families, preferences, nvt selectors and tasks</summary>
+        <summary>Whether to get config families, preferences and nvt selectors</summary>
         <type>boolean</type>
       </attrib>
       <attrib>


### PR DESCRIPTION
Tasks are actually not included if details=1.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

The tasks are actually not included when details=1 are set.

**Why**:

<!-- Why are these changes necessary? -->

Make documentation consistent with implementation.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

get_configs with details=1 of a config which is used by some task. No tasks element is returned.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
