### PR TITLE
Auto delete at the start of scheduling so it always runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Skip DB check in helpers when main process is running [#1291](https://github.com/greenbone/gvmd/pull/1291)
 - Recreate vulns after sync [#1292](https://github.com/greenbone/gvmd/pull/1292)
 - For radio prefs in GMP exclude value and include default [#1296](https://github.com/greenbone/gvmd/pull/1296)
+- Auto delete at the start of scheduling so it always runs [#1302](https://github.com/greenbone/gvmd/pull/1302)
 
 ### Removed
 - Remove DROP from vulns creation [#1281](http://github.com/greenbone/gvmd/pull/1281)

--- a/src/manage.c
+++ b/src/manage.c
@@ -7387,6 +7387,8 @@ manage_schedule (manage_connection_forker_t fork_connection,
   previous_start_task = 0;
   previous_stop_task = 0;
 
+  auto_delete_reports ();
+
   ret = manage_update_nvti_cache ();
   if (ret)
     {
@@ -7540,8 +7542,6 @@ manage_schedule (manage_connection_forker_t fork_connection,
 
   clear_duration_schedules (0);
   update_duration_schedule_periods (0);
-
-  auto_delete_reports ();
 
   return 0;
 }


### PR DESCRIPTION
**What**:

Move the report auto deletion up in manage_schedule so that it runs even if --disable-scheduling is present.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

We want the auto delete to always work.

<!-- Why are these changes necessary? -->

**How**:

Start gvmd with --disable-scheduling.  Create a task, setting auto delete to 2.  Run task 3 times to completion.  Should only be 2 reports.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
