### PR TITLE
Fix create_credential for snmpv3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Recreate vulns after sync [#1292](https://github.com/greenbone/gvmd/pull/1292)
 - For radio prefs in GMP exclude value and include default [#1296](https://github.com/greenbone/gvmd/pull/1296)
 - Auto delete at the start of scheduling so it always runs [#1302](https://github.com/greenbone/gvmd/pull/1302)
+- Fix create_credential for snmpv3. [#1305](https://github.com/greenbone/gvmd/pull/1305)
 
 ### Removed
 - Remove DROP from vulns creation [#1281](http://github.com/greenbone/gvmd/pull/1281)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -33948,6 +33948,7 @@ create_credential (const char* name, const char* comment, const char* login,
   gchar *generated_private_key;
   credential_t new_credential;
   int auto_generate, allow_insecure_int;
+  int using_snmp_v3;
   int ret;
 
   assert (name && strlen (name) > 0);
@@ -34021,6 +34022,8 @@ create_credential (const char* name, const char* comment, const char* login,
           || strcmp (quoted_type, "snmp") == 0))
     ret = 10; // Type does not support autogenerate
 
+  using_snmp_v3 = 0;
+
   if (login == NULL
       && strcmp (quoted_type, "cc")
       && strcmp (quoted_type, "pgp")
@@ -34046,7 +34049,6 @@ create_credential (const char* name, const char* comment, const char* login,
     ret = 9;
   else if (strcmp (quoted_type, "snmp") == 0)
     {
-      int using_snmp_v3 = 0;
       if (login || given_password || auth_algorithm
           || privacy_password || privacy_algorithm)
         using_snmp_v3 = 1;
@@ -34209,7 +34211,7 @@ create_credential (const char* name, const char* comment, const char* login,
     }
 
   /* SNMP passwords */
-  if (community)
+  if (community || using_snmp_v3)
     {
       lsc_crypt_ctx_t crypt_ctx;
 


### PR DESCRIPTION
**What**:
Consider the case in which a snmp credential is created for version 3 only,
where the community is not requiered.

**Why**:
The credential was not created successfully for snmp v3 if a community was not provided. 

**How**:
Create credentials for a snmp v3 target without community and check that the login is successful.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
