### PR TITLE
Add missing elements in get_nvts and get_preferences GMP doc (20.08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Added ability to enter Subject Alternative Names (SAN) when generating a CSR [#1246](https://github.com/greenbone/gvmd/pull/1246)
 - Add filter term 'predefined' [#1263](https://github.com/greenbone/gvmd/pull/1263)
-- Add missing elements in get_nvts GMP doc [#1307](https://github.com/greenbone/gvmd/pull/1307)
+- Add missing elements in get_nvts and get_preferences GMP doc [#1307](https://github.com/greenbone/gvmd/pull/1307)
 
 ### Changed
 - Extended the output of invalid / missing --feed parameter given to greenbone-feed-sync [#1255](https://github.com/greenbone/gvmd/pull/1255)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Added ability to enter Subject Alternative Names (SAN) when generating a CSR [#1246](https://github.com/greenbone/gvmd/pull/1246)
 - Add filter term 'predefined' [#1263](https://github.com/greenbone/gvmd/pull/1263)
+- Add missing elements in get_nvts GMP doc [#1307](https://github.com/greenbone/gvmd/pull/1307)
 
 ### Changed
 - Extended the output of invalid / missing --feed parameter given to greenbone-feed-sync [#1255](https://github.com/greenbone/gvmd/pull/1255)

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -14787,6 +14787,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <name>preference</name>
         <pattern>
           <e>nvt</e>
+          <e>hr_name</e>
           <e>name</e>
           <e>id</e>
           <e>type</e>
@@ -14810,6 +14811,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <summary>The name of the NVT</summary>
             <pattern><t>name</t></pattern>
           </ele>
+        </ele>
+        <ele>
+          <name>hr_name</name>
+          <summary>The full, more "human readable" name of the preference</summary>
+          <pattern><t>name</t></pattern>
         </ele>
         <ele>
           <name>name</name>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -13235,6 +13235,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <e>nvt</e>
               <e>name</e>
               <e>hr_name</e>
+              <e>id</e>
               <e>type</e>
               <e>value</e>
               <any><e>alt</e></any>
@@ -13265,6 +13266,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <ele>
               <name>hr_name</name>
               <summary>The full, more "human readable" name of the preference</summary>
+              <pattern>text</pattern>
+            </ele>
+            <ele>
+              <name>id</name>
+              <summary>The ID of the preference</summary>
               <pattern>text</pattern>
             </ele>
             <ele>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -13038,6 +13038,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <o><e>preference_count</e></o>
               <o><e>timeout</e></o>
               <o><e>default_timeout</e></o>
+              <e>solution</e>
               <o><e>preferences</e></o>
             </g>
           </o>
@@ -13193,6 +13194,23 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <pattern>text</pattern>
         </ele>
         <ele>
+          <name>solution</name>
+          <summary>Solution for the vulnerability</summary>
+          <pattern>
+            <attrib>
+              <name>type</name>
+              <summary>The solution type, for example "VendorFix"</summary>
+              <type>text</type>
+            </attrib>
+            <attrib>
+              <name>method</name>
+              <summary>The solution method, for example "DebianAPTUpgrade"</summary>
+              <type>text</type>
+            </attrib>
+            text
+          </pattern>
+        </ele>
+        <ele>
           <name>preferences</name>
           <summary>List of preferences of the NVT</summary>
           <pattern>
@@ -13216,6 +13234,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <pattern>
               <e>nvt</e>
               <e>name</e>
+              <e>hr_name</e>
               <e>type</e>
               <e>value</e>
               <any><e>alt</e></any>
@@ -13241,6 +13260,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <ele>
               <name>name</name>
               <summary>The name of the preference</summary>
+              <pattern>text</pattern>
+            </ele>
+            <ele>
+              <name>hr_name</name>
+              <summary>The full, more "human readable" name of the preference</summary>
               <pattern>text</pattern>
             </ele>
             <ele>


### PR DESCRIPTION
**What**:
This adds the `solution` element, the `hr_name` and `id` subelements for
preferences to the documentation of the `get_nvts`response and the `hr_name` element to the `get_preferences` response.

**Why**:
The elements were undocumented but should be considered part of the API.

**How**:
Build and install the documentation, then check the sections of the `get_nvts` and `get_preferences` commands in the resulting share/doc/gvm/html/gmp.html files within the install prefix.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
