### PR TITLE
Remove extra spaces when parsing report format param type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - For radio prefs in GMP exclude value and include default [#1296](https://github.com/greenbone/gvmd/pull/1296)
 - Auto delete at the start of scheduling so it always runs [#1302](https://github.com/greenbone/gvmd/pull/1302)
 - Fix create_credential for snmpv3. [#1305](https://github.com/greenbone/gvmd/pull/1305)
+- Remove extra spaces when parsing report format param type [#1309](https://github.com/greenbone/gvmd/pull/1309)
 
 ### Removed
 - Remove DROP from vulns creation [#1281](http://github.com/greenbone/gvmd/pull/1281)

--- a/src/gmp_report_formats.c
+++ b/src/gmp_report_formats.c
@@ -235,7 +235,7 @@ parse_report_format_entity (entity_t report_format,
           type = entity_child (param_entity, "type");
           if (type)
             {
-              param->type = g_strdup (entity_text (type));
+              param->type = g_strstrip (g_strdup (entity_text (type)));
               if (entity_child (type, "max"))
                 param->type_max = g_strdup (entity_text (entity_child (type,
                                                                        "max")));


### PR DESCRIPTION


**What**:
Leading and trailing spaces are removed when parsing the report format XML for importing.

**Why**:
Pretty-printing the report format XML to be imported can add whitespaces that cause
problems in the param type element where text and elements are mixed.

**How**:
Generate a feed import file for a report format like "Topology SVG" with a python script that also uses the minidom pretty-print option, then move it to the data-objects feed directory. (The crititcal part is having a `integer` type parameter that also has `min` and `max` subelements in the `<type>` element.)
Alternatively, extra leading and trailing whitespaces can also be inserted into the `<type>` subelements of `<param>` as an existing import file.
Without the patch it will fail repeatedly with the error message `create_report_format_from_file: Bogus PARAM type`, while the report format is imported correctly with the patch.

**Checklist**:
- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
