### PR TITLE
Add missing config and target to modify_task GMP doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added ability to enter Subject Alternative Names (SAN) when generating a CSR [#1246](https://github.com/greenbone/gvmd/pull/1246)
 - Add filter term 'predefined' [#1263](https://github.com/greenbone/gvmd/pull/1263)
 - Add missing elements in get_nvts and get_preferences GMP doc [#1307](https://github.com/greenbone/gvmd/pull/1307)
+- Add missing config and target to modify_task GMP doc [#1310](https://github.com/greenbone/gvmd/pull/1310)
 
 ### Changed
 - Extended the output of invalid / missing --feed parameter given to greenbone-feed-sync [#1255](https://github.com/greenbone/gvmd/pull/1255)

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -25112,12 +25112,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <e>comment</e>
         <!-- Actually at least one, else command is empty. -->
         <any><e>alert</e></any>
+        <e>config</e>
         <e>name</e>
         <e>observers</e>
         <e>preferences</e>
         <e>schedule</e>
         <e>schedule_periods</e>
         <e>scanner</e>
+        <e>target</e>
         <e>file</e>
       </or>
     </pattern>
@@ -25131,6 +25133,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <ele>
       <name>alert</name>
       <summary>Task alert</summary>
+      <pattern>
+        <attrib>
+          <name>id</name>
+          <type>uuid</type>
+          <required>1</required>
+        </attrib>
+      </pattern>
+    </ele>
+    <ele>
+      <name>config</name>
+      <summary>The scan configuration used by the task</summary>
       <pattern>
         <attrib>
           <name>id</name>
@@ -25194,6 +25207,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <ele>
       <name>scanner</name>
       <summary>Task scanner</summary>
+      <pattern>
+        <attrib>
+          <name>id</name>
+          <type>uuid</type>
+          <required>1</required>
+        </attrib>
+      </pattern>
+    </ele>
+    <ele>
+      <name>target</name>
+      <summary>The hosts scanned by the task</summary>
       <pattern>
         <attrib>
           <name>id</name>


### PR DESCRIPTION
**What**:
This adds the missing `config` and `target` elements to the GMP documentation of the `modify_task` command.

**Why**:
The config and task elements were present in the create_task doc but not
in the one modify_task one.
Because of this it was unclear how to set the config or target via GMP: #1305

**How**:
Build the GMP documentation and check the HTML file for the previously missing elements.

**Checklist**:

- [ ] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
