### PR TITLE
Remove remaining use of "Severity Class" in where_levels_auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Drop GMP scanners [#1269](https://github.com/greenbone/gvmd/pull/1269)
 - Reduce Severity Classes [#1285](https://github.com/greenbone/gvmd/pull/1285)
 - Removed Severity Classes [#1288](https://github.com/greenbone/gvmd/pull/1288)
+- Remove remaining use of "Severity Class" in where_levels_auto [#1311](https://github.com/greenbone/gvmd/pull/1311)
 
 [21.4]: https://github.com/greenbone/gvmd/compare/gvmd-20.08...master
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -21182,7 +21182,6 @@ where_levels_auto (const char *levels, const char *new_severity_sql,
 {
   int count;
   GString *levels_sql;
-  char *class;
 
   /* Generate SQL for constraints on message type, according to levels. */
 
@@ -21198,15 +21197,6 @@ where_levels_auto (const char *levels, const char *new_severity_sql,
   levels_sql = NULL;
   count = 0;
 
-  class = sql_string ("SELECT value FROM settings"
-                      " WHERE name = 'Severity Class'"
-                      " AND ((owner IS NULL)"
-                      "      OR (owner"
-                      "          = (SELECT id FROM users"
-                      "             WHERE users.uuid = '%s')))"
-                      " ORDER BY coalesce (owner, 0) DESC LIMIT 1;",
-                      current_credentials.uuid ? current_credentials.uuid : "");
-
   /* High. */
   if (strchr (levels, 'h'))
     {
@@ -21214,10 +21204,9 @@ where_levels_auto (const char *levels, const char *new_severity_sql,
       // FIX handles dynamic "severity" in caller?
       levels_sql = g_string_new ("");
       g_string_append_printf (levels_sql,
-                              " AND (((%s IS NULL) AND (severity_in_level (%s, 'high', '%s')",
+                              " AND (((%s IS NULL) AND (severity_in_level (%s, 'high')",
                               auto_type_sql,
-                              new_severity_sql,
-                              class);
+                              new_severity_sql);
     }
 
   /* Medium. */
@@ -21227,16 +21216,14 @@ where_levels_auto (const char *levels, const char *new_severity_sql,
         {
           levels_sql = g_string_new ("");
           g_string_append_printf (levels_sql,
-                                  " AND (((%s IS NULL) AND (severity_in_level (%s, 'medium', '%s')",
+                                  " AND (((%s IS NULL) AND (severity_in_level (%s, 'medium')",
                                   auto_type_sql,
-                                  new_severity_sql,
-                                  class);
+                                  new_severity_sql);
         }
       else
         g_string_append_printf (levels_sql,
-                                " OR severity_in_level (%s, 'medium', '%s')",
-                                new_severity_sql,
-                                class);
+                                " OR severity_in_level (%s, 'medium')",
+                                new_severity_sql);
       count++;
     }
 
@@ -21247,16 +21234,14 @@ where_levels_auto (const char *levels, const char *new_severity_sql,
         {
           levels_sql = g_string_new ("");
           g_string_append_printf (levels_sql,
-                                  " AND (((%s IS NULL) AND (severity_in_level (%s, 'low', '%s')",
+                                  " AND (((%s IS NULL) AND (severity_in_level (%s, 'low')",
                                   auto_type_sql,
-                                  new_severity_sql,
-                                  class);
+                                  new_severity_sql);
         }
       else
         g_string_append_printf (levels_sql,
-                                " OR severity_in_level (%s, 'low', '%s')",
-                                new_severity_sql,
-                                class);
+                                " OR severity_in_level (%s, 'low')",
+                                new_severity_sql);
       count++;
     }
 
@@ -21267,16 +21252,14 @@ where_levels_auto (const char *levels, const char *new_severity_sql,
         {
           levels_sql = g_string_new ("");
           g_string_append_printf (levels_sql,
-                                  " AND (((%s IS NULL) AND (severity_in_level (%s, 'log', '%s')",
+                                  " AND (((%s IS NULL) AND (severity_in_level (%s, 'log')",
                                   auto_type_sql,
-                                  new_severity_sql,
-                                  class);
+                                  new_severity_sql);
         }
       else
         g_string_append_printf (levels_sql,
-                                " OR severity_in_level (%s, 'log', '%s')",
-                                new_severity_sql,
-                                class);
+                                " OR severity_in_level (%s, 'log')",
+                                new_severity_sql);
       count++;
     }
 
@@ -21344,8 +21327,6 @@ where_levels_auto (const char *levels, const char *new_severity_sql,
       g_string_append_printf (levels_sql,
                               " AND severity != " G_STRINGIFY (SEVERITY_ERROR));
     }
-
-  free (class);
 
   return levels_sql;
 }


### PR DESCRIPTION
**What**:
A remaining use of "Severity Class" in where_levels_auto has been
removed.

**Why**:

The function generating SQL for the special "levels" keyword was still
using the setting and the old version of severity_in_level with three
parameters, which have been removed.

**How**:
With a new gvmd database, getting a report caused an error because of the now removed version of the SQL function `severity_in_level` with three parameters. With the changes applied this should work again.

**Checklist**:

- [ ] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
