### PR TITLE
Fix severity_in_level SQL function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Use GMP version with leading zero for feed dirs [#1287](https://github.com/greenbone/gvmd/pull/1287)
 - Check db version before creating SQL functions [#1304](https://github.com/greenbone/gvmd/pull/1304)
+- Fix severity_in_level SQL function [#1312](https://github.com/greenbone/gvmd/pull/1312)
 
 ### Removed
 - Drop GMP scanners [#1269](https://github.com/greenbone/gvmd/pull/1269)

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -1446,7 +1446,6 @@ manage_create_sql_functions ()
            "         WHEN 'high'"
            "         THEN $1 >= 7"
            "              AND $1 <= 10"
-           "              AND $1 < 7"
            "         WHEN 'medium'"
            "         THEN $1 >= 4"
            "              AND $1 < 7"


### PR DESCRIPTION
**What**:
This fixes the conditions for "high" severity in the `severity_in_level` SQL function

**Why**:
The "high" case had a condition that should only apply for "medium", making it so "high" results are never shown.

**How**:
Check a report that should contain "high" severity results. 
Without the patch they should be hidden even when the filter is set correctly. With the patch they should appear again.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
