### PR TITLE
Fix GMP doc text of `active` elem for notes and overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Correct arg to alert_uuid [#1313](https://github.com/greenbone/gvmd/pull/1313)
 - Switch result filter column 'task' from task ID to name task name [#1317](https://github.com/greenbone/gvmd/pull/1317)
 - Correct check of get_certificate_info return [#1318](https://github.com/greenbone/gvmd/pull/1318)
+- Fix GMP doc text of `active` elem for notes and overrides [#1323](https://github.com/greenbone/gvmd/pull/1323)
 
 ### Removed
 - Remove DROP from vulns creation [#1281](http://github.com/greenbone/gvmd/pull/1281)

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -4120,7 +4120,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </ele>
     <ele>
       <name>active</name>
-      <summary>Seconds note will be active.  -1 on always, 0 off</summary>
+      <summary>Days note will be active. -1 on always, 0 off</summary>
       <pattern><t>integer</t></pattern>
     </ele>
     <ele>
@@ -4249,7 +4249,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </ele>
     <ele>
       <name>active</name>
-      <summary>Seconds override will be active.  -1 on always, 0 off</summary>
+      <summary>Days override will be active. -1 on always, 0 off</summary>
       <pattern><t>integer</t></pattern>
     </ele>
     <ele>
@@ -24010,7 +24010,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </pattern>
     <ele>
       <name>active</name>
-      <summary>Seconds note will be active.  -1 on always, 0 off</summary>
+      <summary>Days note will be active. -1 on always, 0 off</summary>
       <pattern><t>integer</t></pattern>
     </ele>
     <ele>
@@ -24143,7 +24143,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </pattern>
     <ele>
       <name>active</name>
-      <summary>Seconds override will be active.  -1 on always, 0 off</summary>
+      <summary>Days override will be active. -1 on always, 0 off</summary>
       <pattern><t>integer</t></pattern>
     </ele>
     <ele>


### PR DESCRIPTION
**What**:

The description text of the `active` element in `create_note`, `create_override`,
`modify_note` and `modify_override` has been changed to say "Days" instead of
"Seconds".

**Why**:
The number actually specifies the number of active days, not seconds.

**How**:
Build the GMP documentation and check the `active` response element in the sections for the  aforementioned commands.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
