### PR TITLE
Drop notes threat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove remaining use of "Severity Class" in where_levels_auto [#1311](https://github.com/greenbone/gvmd/pull/1311)
 - Remove the functionality "autofp" (Auto False Positives) [#1300](https://github.com/greenbone/gvmd/pull/1300)
 - Remove severity type "debug" [#1316](https://github.com/greenbone/gvmd/pull/1316)
+- Remove element "threat" of element "notes" [#1324](https://github.com/greenbone/gvmd/pull/1324)
 
 [21.4]: https://github.com/greenbone/gvmd/compare/gvmd-20.08...master
 

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -8237,7 +8237,6 @@ buffer_notes_xml (GString *buffer, iterator_t *notes, int include_notes_details,
             "<hosts>%s</hosts>"
             "<port>%s</port>"
             "<severity>%s</severity>"
-            "<threat>%s</threat>"
             "<task id=\"%s\"><name>%s</name><trash>%i</trash></task>"
             "<orphan>%i</orphan>",
             get_iterator_owner_name (notes)
@@ -8257,8 +8256,6 @@ buffer_notes_xml (GString *buffer, iterator_t *notes, int include_notes_details,
              ? note_iterator_port (notes) : "",
             note_iterator_severity (notes)
              ? note_iterator_severity (notes) : "",
-            note_iterator_threat (notes)
-             ? note_iterator_threat (notes) : "",
             uuid_task ? uuid_task : "",
             name_task ? name_task : "",
             trash_task,

--- a/src/manage.c
+++ b/src/manage.c
@@ -812,33 +812,6 @@ threat_message_type (const char *threat)
 }
 
 /**
- * @brief Get the threat of a message type.
- *
- * @param  type  Message type.
- *
- * @return Static threat name if type names a message type, else NULL.
- */
-const char *
-message_type_threat (const char *type)
-{
-  if (strcasecmp (type, "Alarm") == 0)
-    return "Alarm";
-  if (strcasecmp (type, "Security Hole") == 0)
-    return "High";
-  if (strcasecmp (type, "Security Warning") == 0)
-    return "Medium";
-  if (strcasecmp (type, "Security Note") == 0)
-    return "Low";
-  if (strcasecmp (type, "Log Message") == 0)
-    return "Log";
-  if (strcasecmp (type, "Error Message") == 0)
-    return "Error";
-  if (strcasecmp (type, "False Positive") == 0)
-    return "False Positive";
-  return NULL;
-}
-
-/**
  * @brief Check whether a severity falls within a threat level.
  *
  * @param[in]  severity  Severity.

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -35903,9 +35903,6 @@ modify_note (const gchar *note_id, const char *active, const char *nvt,
    { "notes.text", "text", KEYWORD_TYPE_STRING },                          \
    { "notes.hosts", "hosts", KEYWORD_TYPE_STRING },                        \
    { "notes.port", "port", KEYWORD_TYPE_STRING },                          \
-   { "severity_to_level (notes.severity, 1)",                              \
-     "threat",                                                             \
-     KEYWORD_TYPE_STRING },                                                \
    { "notes.task", NULL, KEYWORD_TYPE_INTEGER },                           \
    { "notes.result", "result", KEYWORD_TYPE_INTEGER },                     \
    { "notes.end_time", "end_time", KEYWORD_TYPE_INTEGER },                 \
@@ -36309,7 +36306,7 @@ task_t
 note_iterator_task (iterator_t* iterator)
 {
   if (iterator->done) return 0;
-  return (task_t) iterator_int64 (iterator, GET_ITERATOR_COLUMN_COUNT + 5);
+  return (task_t) iterator_int64 (iterator, GET_ITERATOR_COLUMN_COUNT + 4);
 }
 
 /**
@@ -36323,7 +36320,7 @@ result_t
 note_iterator_result (iterator_t* iterator)
 {
   if (iterator->done) return 0;
-  return (result_t) iterator_int64 (iterator, GET_ITERATOR_COLUMN_COUNT + 6);
+  return (result_t) iterator_int64 (iterator, GET_ITERATOR_COLUMN_COUNT + 5);
 }
 
 /**
@@ -36339,7 +36336,7 @@ note_iterator_end_time (iterator_t* iterator)
 {
   int ret;
   if (iterator->done) return -1;
-  ret = (time_t) iterator_int (iterator, GET_ITERATOR_COLUMN_COUNT + 7);
+  ret = (time_t) iterator_int (iterator, GET_ITERATOR_COLUMN_COUNT + 6);
   return ret;
 }
 
@@ -36355,7 +36352,7 @@ note_iterator_active (iterator_t* iterator)
 {
   int ret;
   if (iterator->done) return -1;
-  ret = iterator_int (iterator, GET_ITERATOR_COLUMN_COUNT + 8);
+  ret = iterator_int (iterator, GET_ITERATOR_COLUMN_COUNT + 7);
   return ret;
 }
 
@@ -36367,7 +36364,7 @@ note_iterator_active (iterator_t* iterator)
  * @return NVT name, or NULL if iteration is complete.  Freed by
  *         cleanup_iterator.
  */
-DEF_ACCESS (note_iterator_nvt_name, GET_ITERATOR_COLUMN_COUNT + 9);
+DEF_ACCESS (note_iterator_nvt_name, GET_ITERATOR_COLUMN_COUNT + 8);
 
 /**
  * @brief Get the NVT type from a note iterator.
@@ -36402,7 +36399,7 @@ note_iterator_nvt_type (iterator_t *iterator)
  * @return The severity to apply the note to, or NULL if iteration is complete.
  *         Freed by cleanup_iterator.
  */
-DEF_ACCESS (note_iterator_severity, GET_ITERATOR_COLUMN_COUNT + 13);
+DEF_ACCESS (note_iterator_severity, GET_ITERATOR_COLUMN_COUNT + 12);
 
 
 /* Overrides. */

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -150,8 +150,6 @@ extern int authenticate_allow_all;
 
 const char *threat_message_type (const char *);
 
-const char *message_type_threat (const char *);
-
 int delete_reports (task_t);
 
 int

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -19158,7 +19158,8 @@ nvt_severity (const char *nvt_id, const char *type)
  * @param[in]  hostname     Hostname.
  * @param[in]  port         The port the result refers to.
  * @param[in]  nvt          The OID of the NVT that produced the result.
- * @param[in]  type         Type of result.  "Security Hole", etc.
+ * @param[in]  type         Type of result: "Alarm", "Error Message" or
+ *                          "Log Message".
  * @param[in]  description  Description of the result.
  * @param[in]  path         Result path, e.g. file location of a product.
  *

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -36301,23 +36301,6 @@ DEF_ACCESS (note_iterator_hosts, GET_ITERATOR_COLUMN_COUNT + 2);
 DEF_ACCESS (note_iterator_port, GET_ITERATOR_COLUMN_COUNT + 3);
 
 /**
- * @brief Get the threat from a note iterator.
- *
- * @param[in]  iterator  Iterator.
- *
- * @return Threat.
- */
-const char *
-note_iterator_threat (iterator_t *iterator)
-{
-  const char *ret;
-  if (iterator->done) return NULL;
-  ret = iterator_string (iterator, GET_ITERATOR_COLUMN_COUNT + 4);
-  if (ret == NULL) return NULL;
-  return message_type_threat (ret);
-}
-
-/**
  * @brief Get the task from a note iterator.
  *
  * @param[in]  iterator  Iterator.

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -678,7 +678,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <e>hosts</e>
           <e>port</e>
           <e>severity</e>
-          <e>threat</e>
           <e>task</e>
           <o><e>end_time</e></o>
           <o><e>result</e></o>
@@ -842,13 +841,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <summary>Severity to which note applies</summary>
       <pattern>
         <t>severity</t>
-      </pattern>
-    </ele>
-    <ele>
-      <name>threat</name>
-      <summary>Threat level to which note applies</summary>
-      <pattern>
-        <t>threat</t>
       </pattern>
     </ele>
     <ele>
@@ -12776,7 +12768,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <text>note fixed to result</text>
             <hosts>127.0.0.1</hosts>
             <port>general/tcp</port>
-            <threat>Medium</threat>
             <task id="40b236a9-2b0f-4813-b8c7-bc2b98d9d7e4">
               <name>test</name>
             </task>
@@ -23845,7 +23836,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <o><e>severity</e></o>
       <o><e>task</e></o>
       <e>text</e>
-      <o><e>threat</e></o>
     </pattern>
     <ele>
       <name>active</name>
@@ -23889,13 +23879,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <summary>The text of the note</summary>
       <pattern>
         text
-      </pattern>
-    </ele>
-    <ele>
-      <name>threat</name>
-      <summary>Threat level to which note applies</summary>
-      <pattern>
-        <t>threat</t>
       </pattern>
     </ele>
     <ele>
@@ -25949,6 +25932,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </description>
     <version>21.4</version>
   </change>
+  <change>
+    <command>GET_NOTES</command>
+    <summary>Element THREAT has been removed</summary>
+    <description>
+      <p>
+        The element "THREAT" of element "NOTE" is removed.
+      </p>
+      <p>
+        This information is redundant with the element "SEVERITY".
+      </p>
+    </description>
+    <version>21.4</version>
+  </change>
+
   <change>
     <command>CREATE_TARGET, RUN_WIZARD</command>
     <summary>Default port list removed from CREATE_TARGET</summary>


### PR DESCRIPTION
**What**:

Remove element "threat" of element "note" in GMP.

**Why**:

It isn't used anywhere on the UI and it is redundant because there is also
element "severity".

This is also removing the very last occurrances of "Security Hole", "Security Warning"
and "Security Note", a long deprecated message type.

**How**:

The element wasn't used anyway.
The XML output was compared before and after the patch to proof a clean
removal of the element.

**Checklist**:

- [ ] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
