### PR TITLE
Move feed object in trash checks to startup

### DIFF
--- a/src/manage_configs.c
+++ b/src/manage_configs.c
@@ -349,15 +349,6 @@ sync_config_with_feed (const gchar *path)
   if (find_trash_config_no_acl (uuid, &config) == 0
       && config)
     {
-      static int warned = 0;
-
-      if (warned == 0)
-        {
-          warned = 1;
-          g_warning ("%s: ignoring a config ('%s'), as it is in the trashcan"
-                     " (will not warn again)",
-                     __func__, uuid);
-        }
       g_free (uuid);
       return;
     }

--- a/src/manage_port_lists.c
+++ b/src/manage_port_lists.c
@@ -283,15 +283,6 @@ sync_port_list_with_feed (const gchar *path)
   if (find_trash_port_list_no_acl (uuid, &port_list) == 0
       && port_list)
     {
-      static int warned = 0;
-
-      if (warned == 0)
-        {
-          warned = 1;
-          g_warning ("%s: ignoring a port list ('%s'), as it is in the trashcan"
-                     " (will not warn again)",
-                     __func__, uuid);
-        }
       g_free (uuid);
       return;
     }

--- a/src/manage_report_formats.c
+++ b/src/manage_report_formats.c
@@ -643,15 +643,6 @@ sync_report_format_with_feed (const gchar *path)
   if (find_trash_report_format_no_acl (uuid, &report_format) == 0
       && report_format)
     {
-      static int warned = 0;
-
-      if (warned == 0)
-        {
-          warned = 1;
-          g_warning ("%s: ignoring a report format ('%s'), as it is in the trashcan"
-                     " (will not warn again)",
-                     __func__, uuid);
-        }
       g_free (uuid);
       return;
     }

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -4818,4 +4818,13 @@ check_db_configs ()
 
   if (sync_configs_with_feed ())
     g_warning ("%s: Failed to sync configs with feed", __func__);
+
+  /* Warn about feed resources in the trash. */
+  if (sql_int ("SELECT EXISTS (SELECT * FROM configs_trash"
+               "               WHERE predefined = 1);"))
+    {
+      g_warning ("%s: There are feed configs/policies in the trash."
+                 " These will be excluded from the sync.",
+                 __func__);
+    }
 }

--- a/src/manage_sql_port_lists.c
+++ b/src/manage_sql_port_lists.c
@@ -2607,4 +2607,13 @@ check_db_port_lists ()
    * This should be a migrator, but this way is easier to backport.  */
   sql ("UPDATE port_ranges SET \"end\" = 65535 WHERE \"end\" = 65536;");
   sql ("UPDATE port_ranges SET start = 65535 WHERE start = 65536;");
+
+  /* Warn about feed resources in the trash. */
+  if (sql_int ("SELECT EXISTS (SELECT * FROM port_lists_trash"
+               "               WHERE predefined = 1);"))
+    {
+      g_warning ("%s: There are feed port lists in the trash."
+                 " These will be excluded from the sync.",
+                 __func__);
+    }
 }

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -4558,6 +4558,15 @@ check_db_report_formats ()
   if (make_report_format_uuids_unique ())
     return -1;
 
+  /* Warn about feed resources in the trash. */
+  if (sql_int ("SELECT EXISTS (SELECT * FROM report_formats_trash"
+               "               WHERE predefined = 1);"))
+    {
+      g_warning ("%s: There are feed report formats in the trash."
+                 " These will be excluded from the sync.",
+                 __func__);
+    }
+
   return 0;
 }
 


### PR DESCRIPTION
**What**:

The warnings about feed objects being in the trash are now done once, in the main process, at startup.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

The warnings were spamming the logs.  There was a static variable to limit the warning, but that no longer works because the sync is now done in a fork.

<!-- Why are these changes necessary? -->

**How**:

Delete a feed config, report format and port list.  Keep them in the trashcan.
Startup gvmd.
In the logs there should be one and only one warning for each of the three types.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
