### PR TITLE
add user parameter for db connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [21.4] (unreleased)
 
+### Added
+- Parameter `--db-user` to set a database user [#1327](https://github.com/greenbone/gvmd/pull/1327)
+
 ### Changed
 - Move EXE credential generation to a Python script [#1260](https://github.com/greenbone/gvmd/pull/1260) [#1262](https://github.com/greenbone/gvmd/pull/1262)
 - Clarify documentation for --scan-host parameter [#1277](https://github.com/greenbone/gvmd/pull/1277)

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -219,7 +219,7 @@ static gnutls_certificate_credentials_t client_credentials;
 /**
  * @brief Database connection info.
  */
-static db_conn_info_t database = { NULL, NULL, NULL };
+static db_conn_info_t database = { NULL, NULL, NULL, NULL };
 
 /**
  * @brief Is this process parent or child?
@@ -1764,6 +1764,10 @@ gvmd (int argc, char** argv)
           &(database.port),
           "Use <port> as database port or socket extension for PostgreSQL.",
           "<port>" },
+        { "db-user", '\0', 0, G_OPTION_ARG_STRING,
+          &(database.user),
+          "Use <user> as database user.",
+          "<user>" },
         { "decrypt-all-credentials", '\0', G_OPTION_FLAG_HIDDEN,
           G_OPTION_ARG_NONE,
           &decrypt_all_credentials,

--- a/src/manage.h
+++ b/src/manage.h
@@ -48,6 +48,7 @@ typedef struct {
   gchar *name; ///< The database name
   gchar *host; ///< The database host or socket directory
   gchar *port; ///< The database port or socket file extension
+  gchar *user; ///< The database user name
 } db_conn_info_t;
 
 /**

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -16361,6 +16361,7 @@ init_manage_internal (GSList *log_config,
   gvmd_db_conn_info.name = database->name ? g_strdup (database->name) : NULL;
   gvmd_db_conn_info.host = database->host ? g_strdup (database->host) : NULL;
   gvmd_db_conn_info.port = database->port ? g_strdup (database->port) : NULL;
+  gvmd_db_conn_info.user = database->user ? g_strdup (database->user) : NULL;
 
   if (fork_connection)
     manage_fork_connection = fork_connection;

--- a/src/sql_pg.c
+++ b/src/sql_pg.c
@@ -280,12 +280,14 @@ sql_open (const db_conn_info_t *database)
   conn_info = g_strdup_printf ("dbname='%s'"
                                " host='%s'"
                                " port='%s'"
+                               " user='%s'"
                                " application_name='%s'",
                                database->name
                                 ? database->name
                                 : sql_default_database (),
                                database->host ? database->host : "",
                                database->port ? database->port : "",
+                               database->user ? database->user : "",
                                "gvmd");
   conn = PQconnectStart (conn_info);
   g_free (conn_info);


### PR DESCRIPTION

**What**:

under some circumstances the db username is not the same as the local
user. To support that usecase the parameter db-user is added.


<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

To enable socket connection into an container with `trust` instead of `peer` configuration.

<!-- Why are these changes necessary? -->

**How**:

Start a docker container with with a installed postgresql, mount `-v /tmp/test:/var/run/postgresql:z` , change peer to trust in it via:
```
 RUN sed -i 's/peer/trust/' /etc/postgresql/11/main/pg_hba.conf
```
start a migration with a postgres known username and db:
```
/usr/local/sbin/gvmd --db-host=/tmp/test/ -d gvmd --db-user gvm -m
```

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
