### PR TITLE
Fix severity rounding and add severity details to GMP commands

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -9172,6 +9172,7 @@ results_xml_append_nvt (iterator_t *results, GString *buffer, int cert_loaded)
           const char *cvss_base = result_iterator_nvt_cvss_base (results);
           GString *tags = g_string_new (result_iterator_nvt_tag (results));
           int first;
+          iterator_t severities;
 
           if (!cvss_base && !strcmp (oid, "0"))
             cvss_base = "0.0";
@@ -9250,14 +9251,35 @@ results_xml_append_nvt (iterator_t *results, GString *buffer, int cert_loaded)
                                     "<name>%s</name>"
                                     "<family>%s</family>"
                                     "<cvss_base>%s</cvss_base>"
-                                    "<severities score=\"%i\">"
-                                    "</severities>"
-                                    "<tags>%s</tags>",
+                                    "<severities score=\"%i\">",
                                     oid,
                                     result_iterator_nvt_name (results) ?: oid,
                                     result_iterator_nvt_family (results) ?: "",
                                     cvss_base ?: "",
-                                    result_iterator_nvt_score (results),
+                                    result_iterator_nvt_score (results));
+
+          init_nvt_severity_iterator (&severities, oid);
+          while (next (&severities))
+            {
+              buffer_xml_append_printf
+                  (buffer,
+                   "<severity type=\"%s\">"
+                   "<origin>%s</origin>"
+                   "<date>%s</date>"
+                   "<score>%i</score>"
+                   "<value>%s</value>"
+                   "</severity>",
+                   nvt_severity_iterator_type (&severities),
+                   nvt_severity_iterator_origin (&severities),
+                   nvt_severity_iterator_date (&severities),
+                   nvt_severity_iterator_score (&severities),
+                   nvt_severity_iterator_value (&severities));
+            }
+          cleanup_iterator (&severities);
+
+          buffer_xml_append_printf (buffer,
+                                    "</severities>"
+                                    "<tags>%s</tags>",
                                     tags->str ?: "");
 
           if (result_iterator_nvt_solution (results)

--- a/src/manage.c
+++ b/src/manage.c
@@ -5294,7 +5294,7 @@ get_nvt_xml (iterator_t *nvts, int details, int pref_count,
     {
       int tag_count;
       GString *refs_str, *tags_str, *buffer, *nvt_tags;
-      iterator_t cert_refs_iterator, tags;
+      iterator_t cert_refs_iterator, tags, severities;
       gchar *tag_name_esc, *tag_value_esc, *tag_comment_esc;
       char *default_timeout = nvt_default_timeout (oid);
 
@@ -5444,17 +5444,7 @@ get_nvt_xml (iterator_t *nvts, int details, int pref_count,
                               "<category>%d</category>"
                               "<family>%s</family>"
                               "<cvss_base>%s</cvss_base>"
-                              "<severities score=\"%i\">"
-                              "</severities>"
-                              "<qod>"
-                              "<value>%s</value>"
-                              "<type>%s</type>"
-                              "</qod>"
-                              "<refs>%s</refs>"
-                              "<tags>%s</tags>"
-                              "<preference_count>%i</preference_count>"
-                              "<timeout>%s</timeout>"
-                              "<default_timeout>%s</default_timeout>",
+                              "<severities score=\"%i\">",
                               oid,
                               name_text,
                               get_iterator_creation_time (nvts)
@@ -5469,7 +5459,38 @@ get_nvt_xml (iterator_t *nvts, int details, int pref_count,
                               nvt_iterator_cvss_base (nvts)
                                ? nvt_iterator_cvss_base (nvts)
                                : "",
-                              nvt_iterator_score (nvts),
+                              nvt_iterator_score (nvts));
+
+      init_nvt_severity_iterator (&severities, oid);
+      while (next (&severities))
+        {
+          buffer_xml_append_printf
+              (buffer,
+               "<severity type=\"%s\">"
+               "<origin>%s</origin>"
+               "<date>%s</date>"
+               "<score>%i</score>"
+               "<value>%s</value>"
+               "</severity>",
+               nvt_severity_iterator_type (&severities),
+               nvt_severity_iterator_origin (&severities),
+               nvt_severity_iterator_date (&severities),
+               nvt_severity_iterator_score (&severities),
+               nvt_severity_iterator_value (&severities));
+        }
+      cleanup_iterator (&severities);
+
+      g_string_append_printf (buffer,
+                              "</severities>"
+                              "<qod>"
+                              "<value>%s</value>"
+                              "<type>%s</type>"
+                              "</qod>"
+                              "<refs>%s</refs>"
+                              "<tags>%s</tags>"
+                              "<preference_count>%i</preference_count>"
+                              "<timeout>%s</timeout>"
+                              "<default_timeout>%s</default_timeout>",
                               nvt_iterator_qod (nvts),
                               nvt_iterator_qod_type (nvts),
                               refs_str->str,

--- a/src/manage.h
+++ b/src/manage.h
@@ -1945,6 +1945,25 @@ task_role_iterator_name (iterator_t*);
 const char*
 task_role_iterator_uuid (iterator_t*);
 
+/* NVT severities */
+void
+init_nvt_severity_iterator (iterator_t *, const char *);
+
+const char *
+nvt_severity_iterator_type (iterator_t *);
+
+const char *
+nvt_severity_iterator_origin (iterator_t *);
+
+const char *
+nvt_severity_iterator_date (iterator_t *);
+
+int
+nvt_severity_iterator_score (iterator_t *);
+
+const char *
+nvt_severity_iterator_value (iterator_t *);
+
 
 /* Credentials. */
 

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1729,6 +1729,76 @@ check_preference_names (int trash, time_t modification_time)
 }
 
 /**
+ * @brief Initialise an NVT severity iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ * @param[in]  oid       OID of NVT.
+ */
+void
+init_nvt_severity_iterator (iterator_t* iterator, const char *oid)
+{
+  gchar *quoted_oid;
+  quoted_oid = sql_quote (oid ? oid : "");
+
+  init_iterator (iterator,
+                 "SELECT type, origin, iso_time(date), score, value"
+                 " FROM vt_severities"
+                 " WHERE vt_oid = '%s'",
+                 quoted_oid);
+
+  g_free (quoted_oid);
+}
+
+/**
+ * @brief Gets the type from an NVT severity iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ * 
+ * @return The type of the severity.
+ */
+DEF_ACCESS (nvt_severity_iterator_type, 0)
+
+/**
+ * @brief Gets the origin from an NVT severity iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ * 
+ * @return The origin of the severity.
+ */
+DEF_ACCESS (nvt_severity_iterator_origin, 1)
+
+/**
+ * @brief Gets the date from an NVT severity iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ * 
+ * @return The date of the severity in ISO time format.
+ */
+DEF_ACCESS (nvt_severity_iterator_date, 2)
+
+/**
+ * @brief Gets the score from an NVT severity iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ * 
+ * @return The score of the severity.
+ */
+int
+nvt_severity_iterator_score (iterator_t *iterator)
+{
+  return iterator_int (iterator, 3);
+}
+
+/**
+ * @brief Gets the value from an NVT severity iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ * 
+ * @return The value of the severity in ISO time format.
+ */
+DEF_ACCESS (nvt_severity_iterator_value, 4)
+
+/**
  * @brief Update VTs via OSP.
  *
  * @param[in]  update_socket         Socket to use to contact scanner.

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -30,6 +30,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -1373,13 +1374,17 @@ nvti_from_vt (entity_t vt)
             }
           else
             {
+              double cvss_base_dbl;
               gchar * cvss_base;
+
+              cvss_base_dbl
+                = get_cvss_score_from_base_metrics (entity_text (value));
 
               nvti_add_vtseverity (nvti,
                 vtseverity_new (severity_type,
                                 NULL /* origin */,
                                 nvti_modification_time (nvti),
-                                get_cvss_score_from_base_metrics (entity_text (value)) * 10,
+                                round (cvss_base_dbl * 10.0),
                                 entity_text (value)));
 
               nvti_add_tag (nvti, "cvss_base_vector", entity_text (value));

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1765,7 +1765,7 @@ DEF_ACCESS (nvt_severity_iterator_type, 0)
  * 
  * @return The origin of the severity.
  */
-DEF_ACCESS (nvt_severity_iterator_origin, 1)
+DEF_ACCESS (nvt_severity_iterator_origin, 1);
 
 /**
  * @brief Gets the date from an NVT severity iterator.
@@ -1774,7 +1774,7 @@ DEF_ACCESS (nvt_severity_iterator_origin, 1)
  * 
  * @return The date of the severity in ISO time format.
  */
-DEF_ACCESS (nvt_severity_iterator_date, 2)
+DEF_ACCESS (nvt_severity_iterator_date, 2);
 
 /**
  * @brief Gets the score from an NVT severity iterator.
@@ -1796,7 +1796,7 @@ nvt_severity_iterator_score (iterator_t *iterator)
  * 
  * @return The value of the severity in ISO time format.
  */
-DEF_ACCESS (nvt_severity_iterator_value, 4)
+DEF_ACCESS (nvt_severity_iterator_value, 4);
 
 /**
  * @brief Update VTs via OSP.

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -547,6 +547,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <e>category</e>
       <e>family</e>
       <e>cvss_base</e>
+      <e>severities</e>
       <e>qod</e>
       <e>refs</e>
       <e>tags</e>
@@ -585,6 +586,55 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <name>cvss_base</name>
       <summary>CVSS base score of the vulnerability test</summary>
       <pattern><t>text</t></pattern>
+    </ele>
+    <ele>
+      <name>severities</name>
+      <summary>Severity information of the NVT</summary>
+      <pattern>
+        <attrib>
+          <name>score</name>
+          <type>integer</type>
+          <required>1</required>
+          <summary>Maximum severity score</summary>
+        </attrib>
+        <any><e>severity</e></any>
+      </pattern>
+      <ele>
+        <name>severity</name>
+        <summary>A single severity rating</summary>
+        <pattern>
+          <attrib>
+            <name>type</name>
+            <type>text</type>
+            <required>1</required>
+            <summary>Type of severity rating, e.g. cvss_base_v2</summary>
+          </attrib>
+          <e>origin</e>
+          <e>date</e>
+          <e>score</e>
+          <e>value</e>
+        </pattern>
+        <ele>
+          <name>origin</name>
+          <summary>Origin of severity rating</summary>
+          <pattern>text</pattern>
+        </ele>
+        <ele>
+          <name>date</name>
+          <summary>Date the severity was defined</summary>
+          <pattern><t>iso_time</t></pattern>
+        </ele>
+        <ele>
+          <name>score</name>
+          <summary>Numeric score ranging from 0 to 100</summary>
+          <pattern><t>integer</t></pattern>
+        </ele>
+        <ele>
+          <name>value</name>
+          <summary>Detailed rating value, e.g. a CVSS vector</summary>
+          <pattern>text</pattern>
+        </ele>
+      </ele>
     </ele>
     <ele>
       <name>qod</name>
@@ -12912,6 +12962,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <e>summary</e>
               <e>family</e>
               <e>cvss_base</e>
+              <e>severities</e>
               <e>qod</e>
               <e>refs</e>
               <e>tags</e>
@@ -13003,6 +13054,55 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <name>cvss_base</name>
           <summary>CVSS base score of the NVT</summary>
           <pattern>text</pattern>
+        </ele>
+        <ele>
+          <name>severities</name>
+          <summary>Severity information of the NVT</summary>
+          <pattern>
+            <attrib>
+              <name>score</name>
+              <type>integer</type>
+              <required>1</required>
+              <summary>Maximum severity score</summary>
+            </attrib>
+            <any><e>severity</e></any>
+          </pattern>
+          <ele>
+            <name>severity</name>
+            <summary>A single severity rating</summary>
+            <pattern>
+              <attrib>
+                <name>type</name>
+                <type>text</type>
+                <required>1</required>
+                <summary>Type of severity rating, e.g. cvss_base_v2</summary>
+              </attrib>
+              <e>origin</e>
+              <e>date</e>
+              <e>score</e>
+              <e>value</e>
+            </pattern>
+            <ele>
+              <name>origin</name>
+              <summary>Origin of severity rating</summary>
+              <pattern>text</pattern>
+            </ele>
+            <ele>
+              <name>date</name>
+              <summary>Date the severity was defined</summary>
+              <pattern><t>iso_time</t></pattern>
+            </ele>
+            <ele>
+              <name>score</name>
+              <summary>Numeric score ranging from 0 to 100</summary>
+              <pattern><t>integer</t></pattern>
+            </ele>
+            <ele>
+              <name>value</name>
+              <summary>Detailed rating value, e.g. a CVSS vector</summary>
+              <pattern>text</pattern>
+            </ele>
+          </ele>
         </ele>
         <ele>
           <name>qod</name>


### PR DESCRIPTION
**What**:
This fixes a rounding error when getting the severity info from the scanner and adds subelements with severity details to the GMP commands with a `severities` element.

**Why**:
This is part of our plan to add extended severity information to results.

**How**:
For the rounding fix: Run ´gvmd --rebuild` and check the vt_severities table if the scores are 10 times the expected CVSS score.

For the GMP commands, check the responses of the `get_results` and `get_nvts` commands for a single result or NVT with details enabled.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
