### PR TITLE
Fix and simplify SecInfo migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use GMP version with leading zero for feed dirs [#1287](https://github.com/greenbone/gvmd/pull/1287)
 - Check db version before creating SQL functions [#1304](https://github.com/greenbone/gvmd/pull/1304)
 - Fix severity_in_level SQL function [#1312](https://github.com/greenbone/gvmd/pull/1312)
+- Fix and simplify SecInfo migration [#1331](https://github.com/greenbone/gvmd/pull/1331)
 
 ### Removed
 - Remove solution element from VT tags [#886](https://github.com/greenbone/gvmd/pull/886)

--- a/src/manage.c
+++ b/src/manage.c
@@ -6199,7 +6199,7 @@ gvm_migrate_secinfo (int feed_type)
   lockfile_t lockfile;
   int ret;
 
-  if (feed_type != SCAP_FEED || feed_type != CERT_FEED)
+  if (feed_type != SCAP_FEED && feed_type != CERT_FEED)
     {
       g_warning ("%s: unsupported feed_type", __func__);
       return -1;


### PR DESCRIPTION
**What**:
This fixes the feed type check in `gvm_migrate_secinfo` and simplifies the migration by always re-initializing and re-syncing the SCAP and CERT databases to get them to a new version.

**Why**:
To ensure the migration works and to keep future SCAP and CERT migrations simple.

**How**:
Tested by modifying the value for `database_version` in the SCAP and/or CERT schema meta table to versions larger or smaller than the supported versions and running `gvmd` and `gvmd --migrate`.
Larger version numbers should be rejected while smaller ones will make gvmd rebuild the database.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
