### PR TITLE
Delete TLS certificate sources when deleting users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix GMP doc text of `active` elem for notes and overrides [#1323](https://github.com/greenbone/gvmd/pull/1323)
 - Move feed object in trash checks to startup [#1325](https://github.com/greenbone/gvmd/pull/1325)
 - Do not inherit settings from deleted users [#1328](https://github.com/greenbone/gvmd/pull/1328)
+- Delete TLS certificate sources when deleting users [#1334](https://github.com/greenbone/gvmd/pull/1334)
 
 ### Removed
 - Remove DROP from vulns creation [#1281](http://github.com/greenbone/gvmd/pull/1281)

--- a/src/manage_sql_tls_certificates.c
+++ b/src/manage_sql_tls_certificates.c
@@ -940,6 +940,21 @@ delete_tls_certificates_user (user_t user)
 {
   /* Regular tls_certificate. */
 
+  sql ("DELETE FROM tls_certificate_sources"
+       " WHERE tls_certificate IN"
+       " (SELECT id FROM tls_certificates WHERE owner = %llu)",
+       user);
+
+  sql ("DELETE FROM tls_certificate_locations"
+       " WHERE NOT EXISTS"
+       "   (SELECT * FROM tls_certificate_sources"
+       "     WHERE location = tls_certificate_locations.id);");
+
+  sql ("DELETE FROM tls_certificate_origins"
+       " WHERE NOT EXISTS"
+       "   (SELECT * FROM tls_certificate_sources"
+       "     WHERE origin = tls_certificate_origins.id);");
+
   sql ("DELETE FROM tls_certificates WHERE owner = %llu;", user);
 }
 


### PR DESCRIPTION
**What**:
The delete_tls_certificates_user function now also removes the referenced
rows from tls_certificate_sources, tls_certificate_locations and
tls_certificate_origins.

**Why**:
This caused foreign key constraint violations when deleting a user owning
any TLS certificates.

**How**:
Tested this by creating a new user, importing a report with TLS certificates and then trying to delete the user without an inheritor.
With the patch this should work, whereas it caused an error like this before:
```
sql_exec_internal: PQexec failed: ERROR:  update or delete on table "tls_certificates" violates foreign key constraint "tls_certificate_sources_tls_certificate_fkey" on table "tls_certificate_sources"
DETAIL:  Key (id)=(806) is still referenced from table "tls_certificate_sources".
```

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
