### PR TITLE
Add version for NVTs and CVEs in make_osp_result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add filter term 'predefined' [#1263](https://github.com/greenbone/gvmd/pull/1263)
 - Add missing elements in get_nvts and get_preferences GMP doc [#1307](https://github.com/greenbone/gvmd/pull/1307)
 - Add command line options db-host and db-port [#1308](https://github.com/greenbone/gvmd/pull/1308)
+- Add version for NVTs and CVEs in make_osp_result [#1335](https://github.com/greenbone/gvmd/pull/1335)
 
 ### Changed
 - Extended the output of invalid / missing --feed parameter given to greenbone-feed-sync [#1255](https://github.com/greenbone/gvmd/pull/1255)


### PR DESCRIPTION
**What**:
When results are generated with NVT OIDs or CVE-IDs as the VT the
modification time of the NVT or CVE will be added as the version.

**Why**:
In older versions using OTP the OpenVAS results used the modification time as NVT version.

**How**:
This can be tested by running a scan and checking if the NVT version is set for the results of the new report.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
