### PR TITLE
Handle some cases of missing CVE feed info

### DIFF
--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -2802,7 +2802,7 @@ insert_cve_from_entry (element_t entry, element_t last_modified,
         cvss_vector = element_child (base_metrics, "cvss3:vectorString");
       if (cvss_vector == NULL)
         {
-          g_warning ("%s: cvss:access-vector missing", __func__);
+          g_warning ("%s: cvss:vector-string missing (id %s)", __func__, id);
           g_free (id);
           return -1;
         }

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -2797,6 +2797,9 @@ insert_cve_from_entry (element_t entry, element_t last_modified,
       cvss_vector = element_child (base_metrics,
                                    cvss_is_v3 ? "cvss3:vector-string"
                                               : "cvss:vector-string");
+      if (cvss_is_v3 && (cvss_vector == NULL))
+        /* At least nvdcve-2.0-2004.xml uses this format. */
+        cvss_vector = element_child (base_metrics, "cvss3:vectorString");
       if (cvss_vector == NULL)
         {
           g_warning ("%s: cvss:access-vector missing", __func__);


### PR DESCRIPTION
**What**:

Handle missing scores in the feed XML and the alternate name for cvss3:vector.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

SCAP sync was failing.

<!-- Why are these changes necessary? -->

**How**:

`gvmd --rebuild-scap=all` should work.

Note that sync will also fail because some of the v2 CVSS base entries are missing vectors in the feed.  This needs to be fixed on the feed side.  Let me know if you need hack code to do it by hand.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
