### PR TITLE
Always check for 'All' when deleting selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Correct check of get_certificate_info return [#1318](https://github.com/greenbone/gvmd/pull/1318)
 - Fix GMP doc text of `active` elem for notes and overrides [#1323](https://github.com/greenbone/gvmd/pull/1323)
 - Move feed object in trash checks to startup [#1325](https://github.com/greenbone/gvmd/pull/1325)
+- Always check for 'All' when deleting selectors [#1342](https://github.com/greenbone/gvmd/pull/1342)
 
 ### Removed
 - Remove DROP from vulns creation [#1281](http://github.com/greenbone/gvmd/pull/1281)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -47513,10 +47513,11 @@ manage_empty_trashcan ()
       return 99;
     }
 
-  sql ("DELETE FROM nvt_selectors WHERE name IN"
-       " (SELECT nvt_selector FROM configs_trash"
-       "  WHERE owner = (SELECT id FROM users"
-       "                 WHERE uuid = '%s'));",
+  sql ("DELETE FROM nvt_selectors"
+       " WHERE name != '" MANAGE_NVT_SELECTOR_UUID_ALL "'"
+       " AND name IN (SELECT nvt_selector FROM configs_trash"
+       "              WHERE owner = (SELECT id FROM users"
+       "                             WHERE uuid = '%s'));",
        current_credentials.uuid);
   sql ("DELETE FROM config_preferences_trash"
        " WHERE config IN (SELECT id FROM configs_trash"

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -596,6 +596,8 @@ nvt_selector_remove (const char* quoted_selector,
                      const char* quoted_family,
                      int type)
 {
+  if (strcmp (quoted_selector, MANAGE_NVT_SELECTOR_UUID_ALL) == 0)
+    return;
   if (type == NVT_SELECTOR_TYPE_ANY)
     sql ("DELETE FROM nvt_selectors"
          " WHERE name = '%s'"
@@ -637,6 +639,8 @@ nvt_selector_remove_selector (const char* quoted_selector,
                               const char* family_or_nvt,
                               int type)
 {
+  if (strcmp (quoted_selector, MANAGE_NVT_SELECTOR_UUID_ALL) == 0)
+    return;
   if (type == NVT_SELECTOR_TYPE_ANY)
     sql ("DELETE FROM nvt_selectors"
          " WHERE name = '%s' AND family_or_nvt = '%s');",
@@ -3087,8 +3091,10 @@ delete_config (const char *config_id, int ultimate)
       permissions_set_orphans ("config", config, LOCATION_TRASH);
       tags_remove_resource ("config", config, LOCATION_TRASH);
 
-      sql ("DELETE FROM nvt_selectors WHERE name ="
-           " (SELECT nvt_selector FROM configs_trash WHERE id = %llu);",
+      sql ("DELETE FROM nvt_selectors"
+           " WHERE name != '" MANAGE_NVT_SELECTOR_UUID_ALL "'"
+           " AND name = (SELECT nvt_selector FROM configs_trash"
+           "             WHERE id = %llu);",
            config);
       sql ("DELETE FROM config_preferences_trash WHERE config = %llu;",
            config);
@@ -3109,8 +3115,10 @@ delete_config (const char *config_id, int ultimate)
           return 1;
         }
 
-      sql ("DELETE FROM nvt_selectors WHERE name ="
-           " (SELECT nvt_selector FROM configs_trash WHERE id = %llu);",
+      sql ("DELETE FROM nvt_selectors"
+           " WHERE name != '" MANAGE_NVT_SELECTOR_UUID_ALL "'"
+           " AND name = (SELECT nvt_selector FROM configs_trash"
+           "             WHERE id = %llu);",
            config);
 
       permissions_set_orphans ("config", config, LOCATION_TABLE);
@@ -4172,12 +4180,13 @@ manage_set_config_nvts (const gchar *config_id, const char* family,
 
       /* Clear any NVT selectors for this family from the config. */
 
-      sql ("DELETE FROM nvt_selectors"
-           " WHERE name = '%s'"
-           " AND type = " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT)
-           " AND family = '%s';",
-           quoted_selector,
-           quoted_family);
+      if (strcmp (quoted_selector, MANAGE_NVT_SELECTOR_UUID_ALL))
+        sql ("DELETE FROM nvt_selectors"
+             " WHERE name = '%s'"
+             " AND type = " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT)
+             " AND family = '%s';",
+             quoted_selector,
+             quoted_family);
 
       /* Exclude all no's. */
 
@@ -4214,12 +4223,13 @@ manage_set_config_nvts (const gchar *config_id, const char* family,
 
       /* Clear any NVT selectors for this family from the config. */
 
-      sql ("DELETE FROM nvt_selectors"
-           " WHERE name = '%s'"
-           " AND type = " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT)
-           " AND family = '%s';",
-           quoted_selector,
-           quoted_family);
+      if (strcmp (quoted_selector, MANAGE_NVT_SELECTOR_UUID_ALL))
+        sql ("DELETE FROM nvt_selectors"
+             " WHERE name = '%s'"
+             " AND type = " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT)
+             " AND family = '%s';",
+             quoted_selector,
+             quoted_family);
 
       /* Include all yes's. */
 
@@ -4776,8 +4786,9 @@ update_config (config_t config, const gchar *type, const gchar *name,
         }
 
       sql ("DELETE FROM nvt_selectors"
-           " WHERE name = (SELECT nvt_selector FROM configs"
-           "               WHERE id = %llu);",
+           " WHERE name != '" MANAGE_NVT_SELECTOR_UUID_ALL "'"
+           " AND name = (SELECT nvt_selector FROM configs"
+           "             WHERE id = %llu);",
            config);
 
       sql ("UPDATE configs SET nvt_selector = '%s' WHERE id = %llu;",


### PR DESCRIPTION
**What**:

Exclude the "All" NVT selector when deleting NVT selectors.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

The all selector must always be present, and it was being deleted for example when deleting feed configs like Full and Very Deep.  This was causing newly synced feed configs that use All to be empty.

<!-- Why are these changes necessary? -->

**How**:

Delete Full and Very Deep.  Empty Trash.  Wait for sync.  Full and Very Deep should have NVTs.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
