### PR TITLE
Fix SQL errors in SCAP and CERT update (20.08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Always check for 'All' when deleting selectors [#1342](https://github.com/greenbone/gvmd/pull/1342)
 - Do not inherit settings from deleted users [#1328](https://github.com/greenbone/gvmd/pull/1328)
 - Delete TLS certificate sources when deleting users [#1334](https://github.com/greenbone/gvmd/pull/1334)
+- Fix SQL errors in SCAP and CERT update [#1343](https://github.com/greenbone/gvmd/pull/1343)
 
 ### Removed
 - Remove DROP from vulns creation [#1281](http://github.com/greenbone/gvmd/pull/1281)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -32882,7 +32882,7 @@ check_for_new_scap ()
   if (manage_scap_loaded ())
     {
       if (sql_int ("SELECT EXISTS"
-                   " (SELECT * FROM cves"
+                   " (SELECT * FROM scap.cves"
                    "  WHERE creation_time"
                    "        > coalesce (CAST ((SELECT value FROM meta"
                    "                           WHERE name"
@@ -32892,7 +32892,7 @@ check_for_new_scap ()
         event (EVENT_NEW_SECINFO, "cve", 0, 0);
 
       if (sql_int ("SELECT EXISTS"
-                   " (SELECT * FROM cpes"
+                   " (SELECT * FROM scap.cpes"
                    "  WHERE creation_time"
                    "        > coalesce (CAST ((SELECT value FROM meta"
                    "                           WHERE name"
@@ -32902,7 +32902,7 @@ check_for_new_scap ()
         event (EVENT_NEW_SECINFO, "cpe", 0, 0);
 
       if (sql_int ("SELECT EXISTS"
-                   " (SELECT * FROM ovaldefs"
+                   " (SELECT * FROM scap.ovaldefs"
                    "  WHERE creation_time"
                    "        > coalesce (CAST ((SELECT value FROM meta"
                    "                           WHERE name"
@@ -32922,7 +32922,7 @@ check_for_new_cert ()
   if (manage_cert_loaded ())
     {
       if (sql_int ("SELECT EXISTS"
-                   " (SELECT * FROM cert_bund_advs"
+                   " (SELECT * FROM cert.cert_bund_advs"
                    "  WHERE creation_time"
                    "        > coalesce (CAST ((SELECT value FROM meta"
                    "                           WHERE name"
@@ -32932,7 +32932,7 @@ check_for_new_cert ()
         event (EVENT_NEW_SECINFO, "cert_bund_adv", 0, 0);
 
       if (sql_int ("SELECT EXISTS"
-                   " (SELECT * FROM dfn_cert_advs"
+                   " (SELECT * FROM cert.dfn_cert_advs"
                    "  WHERE creation_time"
                    "        > coalesce (CAST ((SELECT value FROM meta"
                    "                           WHERE name"
@@ -33642,7 +33642,7 @@ check_for_updated_scap ()
   if (manage_scap_loaded ())
     {
       if (sql_int ("SELECT EXISTS"
-                   " (SELECT * FROM cves"
+                   " (SELECT * FROM scap.cves"
                    "  WHERE modification_time"
                    "        > coalesce (CAST ((SELECT value FROM meta"
                    "                           WHERE name"
@@ -33658,7 +33658,7 @@ check_for_updated_scap ()
         event (EVENT_UPDATED_SECINFO, "cve", 0, 0);
 
       if (sql_int ("SELECT EXISTS"
-                   " (SELECT * FROM cpes"
+                   " (SELECT * FROM scap.cpes"
                    "  WHERE modification_time"
                    "        > coalesce (CAST ((SELECT value FROM meta"
                    "                           WHERE name"
@@ -33674,7 +33674,7 @@ check_for_updated_scap ()
         event (EVENT_UPDATED_SECINFO, "cpe", 0, 0);
 
       if (sql_int ("SELECT EXISTS"
-                   " (SELECT * FROM ovaldefs"
+                   " (SELECT * FROM scap.ovaldefs"
                    "  WHERE modification_time"
                    "        > coalesce (CAST ((SELECT value FROM meta"
                    "                           WHERE name"
@@ -33700,7 +33700,7 @@ check_for_updated_cert ()
   if (manage_cert_loaded ())
     {
       if (sql_int ("SELECT EXISTS"
-                   " (SELECT * FROM cert_bund_advs"
+                   " (SELECT * FROM cert.cert_bund_advs"
                    "  WHERE modification_time"
                    "        > coalesce (CAST ((SELECT value FROM meta"
                    "                           WHERE name"
@@ -33716,7 +33716,7 @@ check_for_updated_cert ()
         event (EVENT_UPDATED_SECINFO, "cert_bund_adv", 0, 0);
 
       if (sql_int ("SELECT EXISTS"
-                   " (SELECT * FROM dfn_cert_advs"
+                   " (SELECT * FROM cert.dfn_cert_advs"
                    "  WHERE modification_time"
                    "        > coalesce (CAST ((SELECT value FROM meta"
                    "                           WHERE name"

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -4510,7 +4510,6 @@ sync_cert ()
     {
       int last_scap_update;
 
-      last_scap_update = 0;
       last_scap_update
         = sql_int ("SELECT coalesce ((SELECT value FROM scap.meta"
                    "                  WHERE name = 'last_update'),"

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -4516,6 +4516,7 @@ sync_cert ()
                    "                  WHERE name = 'last_update'),"
                    "                 '0');");
       g_debug ("%s: last_scap_update: %i", __func__, last_scap_update);
+      g_debug ("%s: last_cert_update: %i", __func__, last_cert_update);
 
       update_cvss_dfn_cert (updated_dfn_cert,
                             last_cert_update,

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -4508,13 +4508,20 @@ sync_cert ()
 
   last_scap_update = 0;
   if (manage_scap_loaded ())
-    last_scap_update = sql_int ("SELECT coalesce ((SELECT value FROM scap.meta"
-                                "                  WHERE name = 'last_update'),"
-                                "                 '0');");
-  g_debug ("%s: last_scap_update: %i", __func__, last_scap_update);
+    {
+      last_scap_update
+        = sql_int ("SELECT coalesce ((SELECT value FROM scap.meta"
+                   "                  WHERE name = 'last_update'),"
+                   "                 '0');");
+      g_debug ("%s: last_scap_update: %i", __func__, last_scap_update);
 
-  update_cvss_dfn_cert (updated_dfn_cert, last_cert_update, last_scap_update);
-  update_cvss_cert_bund (updated_cert_bund, last_cert_update, last_scap_update);
+      update_cvss_dfn_cert (updated_dfn_cert,
+                            last_cert_update,
+                            last_scap_update);
+      update_cvss_cert_bund (updated_cert_bund,
+                             last_cert_update,
+                             last_scap_update);
+    }
 
   g_debug ("%s: update timestamp", __func__);
 

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -4445,7 +4445,7 @@ update_cvss_cert_bund (int updated_cert_bund, int last_cert_update,
 static int
 sync_cert ()
 {
-  int last_feed_update, last_cert_update, last_scap_update, updated_dfn_cert;
+  int last_feed_update, last_cert_update, updated_dfn_cert;
   int updated_cert_bund;
 
   if (manage_cert_db_exists ())
@@ -4506,9 +4506,11 @@ sync_cert ()
 
   g_debug ("%s: update cvss", __func__);
 
-  last_scap_update = 0;
   if (manage_scap_loaded ())
     {
+      int last_scap_update;
+
+      last_scap_update = 0;
       last_scap_update
         = sql_int ("SELECT coalesce ((SELECT value FROM scap.meta"
                    "                  WHERE name = 'last_update'),"


### PR DESCRIPTION
**What**:
* The update of the CVSS score for CERT advisories is only run when the SCAP schema also exists
* Schema prefixes for tables are added to SCAP and CERT alert checks

**Why**:
This fixes two SQL errors that could when updating the SCAP and CERT data:
* If the CERT update finishes without the SCAP schema existing, e.g. during the first update, the error would be the `scap.cves` table not existing.
* If the SCAP and CERT alert checks are run after the update, the `search_path` may only include the default schema, so tables like `cves` are not found without a prefix (`scap.`).

**How**:
Tested by stopping gvmd, dropping the schemas `cert` and `scap`, then restarting gvmd to make it rebuild both schemas.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
