### PR TITLE
Account for -1 of orphans when deleting permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Switch result filter column 'task' from task ID to name task name [#1317](https://github.com/greenbone/gvmd/pull/1317)
 - Correct check of get_certificate_info return [#1318](https://github.com/greenbone/gvmd/pull/1318)
 - Fix GMP doc text of `active` elem for notes and overrides [#1323](https://github.com/greenbone/gvmd/pull/1323)
+- Account for -1 of orphans when deleting permission [#1345](https://github.com/greenbone/gvmd/pull/1345)
 
 ### Removed
 - Remove DROP from vulns creation [#1281](http://github.com/greenbone/gvmd/pull/1281)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -44368,7 +44368,8 @@ delete_permission (const char *permission_id, int ultimate)
     cache_permissions_for_resource (resource_type, resource, NULL);
 
   /* Update Reports cache */
-  if (resource_type && resource && strcmp (resource_type, "override") == 0)
+  if (resource_type && (resource > 0) && strcmp (resource_type, "override")
+      == 0)
     {
       reports = reports_for_override (resource);
     }
@@ -56110,7 +56111,7 @@ cache_permissions_for_resource (const char *type, resource_t resource,
 {
   int free_users;
 
-  if (type == NULL || resource == 0)
+  if (type == NULL || resource == 0 || resource == -1)
     return;
 
   if (cache_users == NULL)


### PR DESCRIPTION
**What**:

Check also for a -1 resource when deleting a permission.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

Without the check the caching code tries to do SQL on an id that is out of range.

<!-- Why are these changes necessary? -->

**How**:

Create task.
Add permission to task, note UUID.
Delete task.
Empty trash.
Delete permission using UUID.  Should succeed.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
