### PR TITLE
Add `allow_simult_ips_same_host` field for targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Parameter `--db-user` to set a database user [#1327](https://github.com/greenbone/gvmd/pull/1327)
+- Add `allow_simult_ips_same_host` field for targets [#1346](https://github.com/greenbone/gvmd/pull/1346)
 
 ### Changed
 - Move EXE credential generation to a Python script [#1260](https://github.com/greenbone/gvmd/pull/1260) [#1262](https://github.com/greenbone/gvmd/pull/1262)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 238)
+set (GVMD_DATABASE_VERSION 239)
 
 set (GVMD_SCAP_DATABASE_VERSION 17)
 

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -2874,6 +2874,7 @@ modify_setting_data_reset (modify_setting_data_t *data)
 typedef struct
 {
   char *alive_tests;             ///< Alive tests.
+  char *allow_simult_ips_same_host; ///< Boolean. Whether to scan multiple IPs of a host simultaneously.
   char *comment;                 ///< Comment.
   char *exclude_hosts;           ///< Hosts to exclude from set.
   char *reverse_lookup_only;     ///< Boolean. Whether to consider only hosts that reverse lookup.
@@ -2902,6 +2903,7 @@ static void
 modify_target_data_reset (modify_target_data_t *data)
 {
   free (data->alive_tests);
+  free (data->allow_simult_ips_same_host);
   free (data->exclude_hosts);
   free (data->reverse_lookup_only);
   free (data->reverse_lookup_unify);
@@ -4550,6 +4552,7 @@ typedef enum
   CLIENT_MODIFY_TAG_VALUE,
   CLIENT_MODIFY_TARGET,
   CLIENT_MODIFY_TARGET_ALIVE_TESTS,
+  CLIENT_MODIFY_TARGET_ALLOW_SIMULT_IPS_SAME_HOST,
   CLIENT_MODIFY_TARGET_COMMENT,
   CLIENT_MODIFY_TARGET_ESXI_CREDENTIAL,
   CLIENT_MODIFY_TARGET_ESXI_LSC_CREDENTIAL,
@@ -6632,6 +6635,8 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
           set_client_state (CLIENT_MODIFY_TARGET_REVERSE_LOOKUP_UNIFY);
         else if (strcasecmp ("ALIVE_TESTS", element_name) == 0)
           set_client_state (CLIENT_MODIFY_TARGET_ALIVE_TESTS);
+        else if (strcasecmp ("ALLOW_SIMULT_IPS_SAME_HOST", element_name) == 0)
+          set_client_state (CLIENT_MODIFY_TARGET_ALLOW_SIMULT_IPS_SAME_HOST);
         else if (strcasecmp ("COMMENT", element_name) == 0)
           {
             gvm_append_string (&modify_target_data->comment, "");
@@ -24509,7 +24514,8 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                          modify_target_data->snmp_credential_id,
                          modify_target_data->reverse_lookup_only,
                          modify_target_data->reverse_lookup_unify,
-                         modify_target_data->alive_tests))
+                         modify_target_data->alive_tests,
+                         modify_target_data->allow_simult_ips_same_host))
             {
               case 1:
                 SEND_TO_CLIENT_OR_FAIL
@@ -24752,6 +24758,7 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
       CLOSE (CLIENT_MODIFY_TARGET, REVERSE_LOOKUP_ONLY);
       CLOSE (CLIENT_MODIFY_TARGET, REVERSE_LOOKUP_UNIFY);
       CLOSE (CLIENT_MODIFY_TARGET, ALIVE_TESTS);
+      CLOSE (CLIENT_MODIFY_TARGET, ALLOW_SIMULT_IPS_SAME_HOST);
       CLOSE (CLIENT_MODIFY_TARGET, COMMENT);
       CLOSE (CLIENT_MODIFY_TARGET, HOSTS);
       CLOSE (CLIENT_MODIFY_TARGET, NAME);
@@ -26908,6 +26915,9 @@ gmp_xml_handle_text (/* unused */ GMarkupParseContext* context,
 
       APPEND (CLIENT_MODIFY_TARGET_ALIVE_TESTS,
               &modify_target_data->alive_tests);
+
+      APPEND (CLIENT_MODIFY_TARGET_ALLOW_SIMULT_IPS_SAME_HOST,
+              &modify_target_data->allow_simult_ips_same_host);
 
       APPEND (CLIENT_MODIFY_TARGET_COMMENT,
               &modify_target_data->comment);

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -957,6 +957,7 @@ create_schedule_data_reset (create_schedule_data_t *data)
 typedef struct
 {
   char *alive_tests;             ///< Alive tests.
+  char *allow_simult_ips_same_host; ///< Boolean. Whether to scan multiple IPs of a host simultaneously.
   char *asset_hosts_filter;      ///< Asset hosts.
   char *comment;                 ///< Comment.
   char *exclude_hosts;           ///< Hosts to exclude from set.
@@ -987,6 +988,7 @@ static void
 create_target_data_reset (create_target_data_t *data)
 {
   free (data->alive_tests);
+  free (data->allow_simult_ips_same_host);
   free (data->asset_hosts_filter);
   free (data->comment);
   free (data->exclude_hosts);
@@ -4306,6 +4308,7 @@ typedef enum
   CLIENT_CREATE_TAG_VALUE,
   CLIENT_CREATE_TARGET,
   CLIENT_CREATE_TARGET_ALIVE_TESTS,
+  CLIENT_CREATE_TARGET_ALLOW_SIMULT_IPS_SAME_HOST,
   CLIENT_CREATE_TARGET_ASSET_HOSTS,
   CLIENT_CREATE_TARGET_EXCLUDE_HOSTS,
   CLIENT_CREATE_TARGET_REVERSE_LOOKUP_ONLY,
@@ -7604,6 +7607,8 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
           set_client_state (CLIENT_CREATE_TARGET_REVERSE_LOOKUP_UNIFY);
         else if (strcasecmp ("ALIVE_TESTS", element_name) == 0)
           set_client_state (CLIENT_CREATE_TARGET_ALIVE_TESTS);
+        else if (strcasecmp ("ALLOW_SIMULT_IPS_SAME_HOST", element_name) == 0)
+          set_client_state (CLIENT_CREATE_TARGET_ALLOW_SIMULT_IPS_SAME_HOST);
         else if (strcasecmp ("COMMENT", element_name) == 0)
           set_client_state (CLIENT_CREATE_TARGET_COMMENT);
         else if (strcasecmp ("COPY", element_name) == 0)
@@ -21897,6 +21902,7 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                          create_target_data->reverse_lookup_only,
                          create_target_data->reverse_lookup_unify,
                          create_target_data->alive_tests,
+                         create_target_data->allow_simult_ips_same_host,
                          &new_target))
             {
               case 1:
@@ -22014,6 +22020,7 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
       CLOSE (CLIENT_CREATE_TARGET, REVERSE_LOOKUP_ONLY);
       CLOSE (CLIENT_CREATE_TARGET, REVERSE_LOOKUP_UNIFY);
       CLOSE (CLIENT_CREATE_TARGET, ALIVE_TESTS);
+      CLOSE (CLIENT_CREATE_TARGET, ALLOW_SIMULT_IPS_SAME_HOST);
       CLOSE (CLIENT_CREATE_TARGET, COPY);
       CLOSE (CLIENT_CREATE_TARGET, HOSTS);
       CLOSE (CLIENT_CREATE_TARGET, NAME);
@@ -26603,6 +26610,9 @@ gmp_xml_handle_text (/* unused */ GMarkupParseContext* context,
 
       APPEND (CLIENT_CREATE_TARGET_ALIVE_TESTS,
               &create_target_data->alive_tests);
+
+      APPEND (CLIENT_CREATE_TARGET_ALLOW_SIMULT_IPS_SAME_HOST,
+              &create_target_data->allow_simult_ips_same_host);
 
       APPEND (CLIENT_CREATE_TARGET_COMMENT,
               &create_target_data->comment);

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -16565,7 +16565,7 @@ handle_get_targets (gmp_parser_t *gmp_parser, GError **error)
           char *esxi_name, *esxi_uuid, *snmp_name, *snmp_uuid;
           const char *port_list_uuid, *port_list_name, *ssh_port;
           const char *hosts, *exclude_hosts, *reverse_lookup_only;
-          const char *reverse_lookup_unify;
+          const char *reverse_lookup_unify, *allow_simult_ips_same_host;
           credential_t ssh_credential, smb_credential;
           credential_t esxi_credential, snmp_credential;
           int port_list_trash, max_hosts, port_list_available;
@@ -16728,6 +16728,8 @@ handle_get_targets (gmp_parser_t *gmp_parser, GError **error)
                                   (&targets);
           reverse_lookup_unify = target_iterator_reverse_lookup_unify
                                   (&targets);
+          allow_simult_ips_same_host
+            = target_iterator_allow_simult_ips_same_host (&targets);
 
           SENDF_TO_CLIENT_OR_FAIL ("<hosts>%s</hosts>"
                                    "<exclude_hosts>%s</exclude_hosts>"
@@ -16802,10 +16804,14 @@ handle_get_targets (gmp_parser_t *gmp_parser, GError **error)
                                    "<reverse_lookup_unify>"
                                    "%s"
                                    "</reverse_lookup_unify>"
-                                   "<alive_tests>%s</alive_tests>",
+                                   "<alive_tests>%s</alive_tests>"
+                                   "<allow_simult_ips_same_host>"
+                                   "%s"
+                                   "</allow_simult_ips_same_host>",
                                    reverse_lookup_only,
                                    reverse_lookup_unify,
-                                   target_iterator_alive_tests (&targets));
+                                   target_iterator_alive_tests (&targets),
+                                   allow_simult_ips_same_host);
 
           if (get_targets_data->get.details)
             SENDF_TO_CLIENT_OR_FAIL ("<port_range>%s</port_range>",

--- a/src/manage.c
+++ b/src/manage.c
@@ -1590,6 +1590,7 @@ task_scanner_options (task_t task, target_t target)
   GHashTable *table;
   config_t config;
   iterator_t prefs;
+  char *allow_simult_ips_same_host;
 
   config = task_config (task);
   init_config_preference_iterator (&prefs, config);
@@ -1668,6 +1669,19 @@ task_scanner_options (task_t task, target_t target)
       g_hash_table_insert (table, name, value);
     }
   cleanup_iterator (&prefs);
+
+  // Target options sent as scanner preferences
+  allow_simult_ips_same_host = target_allow_simult_ips_same_host (target);
+  if (allow_simult_ips_same_host)
+    {
+      g_hash_table_replace (table,
+                            g_strdup (strcmp (allow_simult_ips_same_host, "0")
+                                        ? "yes" 
+                                        : "no"),
+                            g_strdup (allow_simult_ips_same_host));
+    }
+  free (allow_simult_ips_same_host);
+
   return table;
 }
 

--- a/src/manage.h
+++ b/src/manage.h
@@ -1578,7 +1578,8 @@ copy_target (const char*, const char*, const char *, target_t*);
 int
 modify_target (const char*, const char*, const char*, const char*, const char*,
                const char*, const char*, const char*, const char*, const char*,
-               const char*, const char *, const char*, const char*);
+               const char*, const char*, const char*, const char*,
+               const char*);
 
 int
 delete_target (const char*, int);

--- a/src/manage.h
+++ b/src/manage.h
@@ -1681,6 +1681,9 @@ char*
 target_reverse_lookup_unify (target_t);
 
 char*
+target_allow_simult_ips_same_host (target_t);
+
+char*
 target_port_range (target_t);
 
 char*

--- a/src/manage.h
+++ b/src/manage.h
@@ -1638,6 +1638,9 @@ int
 target_iterator_snmp_trash (iterator_t*);
 
 const char*
+target_iterator_allow_simult_ips_same_host (iterator_t*);
+
+const char*
 target_iterator_port_list_uuid (iterator_t*);
 
 const char*

--- a/src/manage.h
+++ b/src/manage.h
@@ -1570,7 +1570,7 @@ int
 create_target (const char*, const char*, const char*, const char*, const char*,
                const char *, const char*, credential_t, const char*,
                credential_t, credential_t, credential_t, const char *,
-               const char *, const char *, target_t*);
+               const char *, const char *, const char *, target_t*);
 
 int
 copy_target (const char*, const char*, const char *, target_t*);

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -2496,6 +2496,43 @@ migrate_237_to_238 ()
   return 0;
 }
 
+/**
+ * @brief Migrate the database from version 238 to version 239.
+ *
+ * @return 0 success, -1 error.
+ */
+int
+migrate_238_to_239 ()
+{
+  sql_begin_immediate ();
+
+  /* Ensure that the database is currently version 238. */
+
+  if (manage_db_version () != 238)
+    {
+      sql_rollback ();
+      return -1;
+    }
+
+  /* Update the database. */
+
+  /* Table results also got a score column, for extended severities. */
+
+  sql ("ALTER TABLE targets ADD COLUMN"
+       " allow_simult_ips_same_host integer DEFAULT 1;");
+
+  sql ("ALTER TABLE targets_trash ADD COLUMN"
+       " allow_simult_ips_same_host integer DEFAULT 1;");
+
+  /* Set the database version to 239. */
+
+  set_db_version (239);
+
+  sql_commit ();
+
+  return 0;
+}
+
 #undef UPDATE_DASHBOARD_SETTINGS
 
 /**
@@ -2540,6 +2577,7 @@ static migrator_t database_migrators[] = {
   {236, migrate_235_to_236},
   {237, migrate_236_to_237},
   {238, migrate_237_to_238},
+  {239, migrate_238_to_239},
   /* End marker. */
   {-1, NULL}};
 

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -2011,7 +2011,8 @@ create_tables ()
        "  port_list integer REFERENCES port_lists (id) ON DELETE RESTRICT,"
        "  alive_test integer,"
        "  creation_time integer,"
-       "  modification_time integer);");
+       "  modification_time integer,"
+       "  allow_simult_ips_same_host integer DEFAULT 1);");
 
   sql ("CREATE TABLE IF NOT EXISTS targets_trash"
        " (id SERIAL PRIMARY KEY,"
@@ -2027,7 +2028,8 @@ create_tables ()
        "  port_list_location integer,"
        "  alive_test integer,"
        "  creation_time integer,"
-       "  modification_time integer);");
+       "  modification_time integer,"
+       "  allow_simult_ips_same_host integer DEFAULT 1);");
 
   sql ("CREATE TABLE IF NOT EXISTS targets_login_data"
        " (id SERIAL PRIMARY KEY,"

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -30823,7 +30823,8 @@ copy_target (const char* name, const char* comment, const char *target_id,
 
   ret = copy_resource ("target", name, comment, target_id,
                        "hosts, exclude_hosts, port_list, reverse_lookup_only,"
-                       " reverse_lookup_unify, alive_test",
+                       " reverse_lookup_unify, alive_test,"
+                       " allow_simult_ips_same_host",
                        1, new_target, &old_target);
   if (ret)
     return ret;

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -32118,6 +32118,20 @@ target_reverse_lookup_unify (target_t target)
 }
 
 /**
+ * @brief Return the allow_simult_ips_same_host value of a target.
+ *
+ * @param[in]  target  Target.
+ *
+ * @return The allow_simult_ips_same_host value if available, else NULL.
+ */
+char*
+target_allow_simult_ips_same_host (target_t target)
+{
+  return sql_string ("SELECT allow_simult_ips_same_host FROM targets"
+                     " WHERE id = %llu;", target);
+}
+
+/**
  * @brief Return the SSH LSC port of a target.
  *
  * @param[in]  target  Target.

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -30921,10 +30921,12 @@ delete_target (const char *target_id, int ultimate)
            " (uuid, owner, name, hosts, exclude_hosts, comment,"
            "  port_list, port_list_location,"
            "  reverse_lookup_only, reverse_lookup_unify, alive_test,"
+           "  allow_simult_ips_same_host,"
            "  creation_time, modification_time)"
            " SELECT uuid, owner, name, hosts, exclude_hosts, comment,"
            "        port_list, " G_STRINGIFY (LOCATION_TABLE) ","
            "        reverse_lookup_only, reverse_lookup_unify, alive_test,"
+           "        allow_simult_ips_same_host,"
            "        creation_time, modification_time"
            " FROM targets WHERE id = %llu;",
            target);
@@ -46233,10 +46235,12 @@ manage_restore (const char *id)
       sql ("INSERT INTO targets"
            " (uuid, owner, name, hosts, exclude_hosts, comment,"
            "  port_list, reverse_lookup_only, reverse_lookup_unify,"
-           "  alive_test, creation_time, modification_time)"
+           "  alive_test, allow_simult_ips_same_host,"
+           "  creation_time, modification_time)"
            " SELECT uuid, owner, name, hosts, exclude_hosts, comment,"
            "        port_list, reverse_lookup_only, reverse_lookup_unify,"
-           "        alive_test, creation_time, modification_time"
+           "        alive_test, allow_simult_ips_same_host,"
+           "        creation_time, modification_time"
            " FROM targets_trash WHERE id = %llu;",
            resource);
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -31467,6 +31467,9 @@ modify_target (const char *target_id, const char *name, const char *hosts,
      NULL,                                                  \
      KEYWORD_TYPE_INTEGER },                                \
    { "0", NULL, KEYWORD_TYPE_INTEGER },                     \
+   { "allow_simult_ips_same_host",                          \
+     NULL,                                                  \
+     KEYWORD_TYPE_INTEGER },                                \
    {                                                        \
      "(SELECT name FROM credentials"                        \
      " WHERE credentials.id"                                \
@@ -31568,6 +31571,9 @@ modify_target (const char *target_id, const char *name, const char *hosts,
      NULL,                                                          \
      KEYWORD_TYPE_INTEGER },                                        \
    { "trash_target_credential_location (id, CAST ('snmp' AS text))",\
+     NULL,                                                          \
+     KEYWORD_TYPE_INTEGER },                                        \
+   { "allow_simult_ips_same_host",                                  \
      NULL,                                                          \
      KEYWORD_TYPE_INTEGER },                                        \
    { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                             \
@@ -31888,6 +31894,16 @@ target_iterator_snmp_trash (iterator_t* iterator)
   ret = iterator_int (iterator, GET_ITERATOR_COLUMN_COUNT + 17);
   return ret;
 }
+
+/**
+ * @brief Get the allow_simult_ips_same_host value from a target iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return allow_simult_ips_same_host or NULL if iteration is complete.
+ */
+DEF_ACCESS (target_iterator_allow_simult_ips_same_host,
+            GET_ITERATOR_COLUMN_COUNT + 18);
 
 /**
  * @brief Return the UUID of a tag.

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -30547,6 +30547,7 @@ target_login_port (target_t target, const char* type)
  * @param[in]   reverse_lookup_only   Scanner preference reverse_lookup_only.
  * @param[in]   reverse_lookup_unify  Scanner preference reverse_lookup_unify.
  * @param[in]   alive_tests     Alive tests.
+ * @param[in]   allow_simult_ips_same_host  Scanner preference allow_simult_ips_same_host.
  * @param[out]  target          Created target.
  *
  * @return 0 success, 1 target exists already, 2 error in host specification,
@@ -30565,6 +30566,7 @@ create_target (const char* name, const char* asset_hosts_filter,
                credential_t esxi_credential, credential_t snmp_credential,
                const char *reverse_lookup_only,
                const char *reverse_lookup_unify, const char *alive_tests,
+               const char *allow_simult_ips_same_host,
                target_t* target)
 {
   gchar *quoted_name, *quoted_hosts, *quoted_exclude_hosts, *quoted_comment;
@@ -30701,6 +30703,11 @@ create_target (const char* name, const char* asset_hosts_filter,
     reverse_lookup_unify = "0";
   else
     reverse_lookup_unify = "1";
+  if (allow_simult_ips_same_host
+      && strcmp (allow_simult_ips_same_host, "0") == 0)
+    allow_simult_ips_same_host = "0";
+  else
+    allow_simult_ips_same_host = "1";
 
   quoted_name = sql_quote (name ?: "");
 
@@ -30712,14 +30719,17 @@ create_target (const char* name, const char* asset_hosts_filter,
   sql ("INSERT INTO targets"
        " (uuid, name, owner, hosts, exclude_hosts, comment, "
        "  port_list, reverse_lookup_only, reverse_lookup_unify, alive_test,"
+       "  allow_simult_ips_same_host,"
        "  creation_time, modification_time)"
        " VALUES (make_uuid (), '%s',"
        " (SELECT id FROM users WHERE users.uuid = '%s'),"
        " '%s', '%s', '%s', %llu, '%s', '%s', %i,"
+       " %s,"
        " m_now (), m_now ());",
         quoted_name, current_credentials.uuid,
         quoted_hosts, quoted_exclude_hosts, quoted_comment, port_list,
-        reverse_lookup_only, reverse_lookup_unify, alive_test);
+        reverse_lookup_only, reverse_lookup_unify, alive_test,
+        allow_simult_ips_same_host);
 
   new_target = sql_last_insert_id ();
   if (target)

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -19004,6 +19004,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <e>alive_tests</e>
           <e>reverse_lookup_only</e>
           <e>reverse_lookup_unify</e>
+          <e>allow_simult_ips_same_host</e>
           <o><e>tasks</e></o>
         </pattern>
         <ele>
@@ -19314,6 +19315,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <name>reverse_lookup_unify</name>
           <summary>
             Whether to scan only one IP when multiple IPs have the same name
+          </summary>
+          <pattern><t>boolean</t></pattern>
+        </ele>
+        <ele>
+          <name>allow_simult_ips_same_host</name>
+          <summary>
+            Whether to scan multiple IPs of the same host simulaneously
           </summary>
           <pattern><t>boolean</t></pattern>
         </ele>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -19321,7 +19321,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <ele>
           <name>allow_simult_ips_same_host</name>
           <summary>
-            Whether to scan multiple IPs of the same host simulaneously
+            Whether to scan multiple IPs of the same host simultaneously
           </summary>
           <pattern><t>boolean</t></pattern>
         </ele>
@@ -24773,6 +24773,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <o><e>alive_tests</e></o>
       <o><e>reverse_lookup_only</e></o>
       <o><e>reverse_lookup_unify</e></o>
+      <o><e>allow_simult_ips_same_host</e></o>
     </pattern>
     <ele>
       <name>comment</name>
@@ -24905,6 +24906,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <name>reverse_lookup_unify</name>
       <summary>
         Whether to scan only one IP when multiple IPs have the same name
+      </summary>
+      <pattern><t>boolean</t></pattern>
+    </ele>
+    <ele>
+      <name>allow_simult_ips_same_host</name>
+      <summary>
+        Whether to scan multiple IPs of the same host simultaneously
       </summary>
       <pattern><t>boolean</t></pattern>
     </ele>


### PR DESCRIPTION
**What**:
This adds the `allow_simult_ips_same_host` column to the targets and corresponding elements to the GMP commands `create_target`, `get_targets` and `modify_target`.
The value is sent to the scanner as a scanner preference.

**Why**:
This allows defining the scanner preference added in https://github.com/greenbone/openvas/pull/604 as part of the target in case scanning multiple IP addresses of a single host causes problem

**How**:
I've checked the GMP responses of the `get_targets` command by inspecting the HTTP responses for the targets list and trashcan in GSA.

For the other two GMP commands I've used gvm-cli with GMP commands like the following with the values "0", "1" and "123":
```xml
<modify_target target_id="88c4b9e5-5b1c-4a0b-8b7c-b2b098676526">
  <allow_simult_ips_same_host>0</allow_simult_ips_same_host>
</modify_target>
```
```xml
<create_target>
  <allow_simult_ips_same_host>0</allow_simult_ips_same_host>
  <name>localhost test</name>
  <hosts>localhost</hosts>
  <port_list id="c7e03b6c-3bbe-11e1-a057-406186ea4fc5"/>
</create_target>
```

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
