### PR TITLE
Replace sql_severity_matches_ov with a plain plpgsql function.

### DIFF
--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -288,13 +288,18 @@ manage_create_sql_functions ()
        " LANGUAGE C;",
        GVM_LIB_INSTALL_DIR);
 
-  sql ("CREATE OR REPLACE FUNCTION severity_matches_ov (double precision,"
-       "                                                double precision)"
-       " RETURNS boolean"
-       " AS '%s/libgvm-pg-server', 'sql_severity_matches_ov'"
-       " LANGUAGE C"
-       " IMMUTABLE;",
-       GVM_LIB_INSTALL_DIR);
+  sql ("CREATE OR REPLACE FUNCTION severity_matches_ov (a double precision,"
+       "                                                b double precision)"
+       "RETURNS BOOLEAN AS $$"
+       "BEGIN"
+       " RETURN CASE WHEN a IS NULL THEN false"
+       "        WHEN b IS NULL THEN true"
+       " ELSE CASE WHEN a::float8 <= 0 THEN a::float8 = b::float8"
+       "      ELSE a::float8 >= b::float8"
+       "      END"
+       " END;"
+       "END;"
+       "$$ LANGUAGE plpgsql IMMUTABLE;");
 
   sql ("CREATE OR REPLACE FUNCTION regexp (text, text)"
        " RETURNS boolean"

--- a/src/manage_pg_server.c
+++ b/src/manage_pg_server.c
@@ -299,24 +299,11 @@ PG_FUNCTION_INFO_V1 (sql_severity_matches_ov);
  *
  * @return Postgres Datum.
  */
+ __attribute__((deprecated))
 Datum
 sql_severity_matches_ov (PG_FUNCTION_ARGS)
 {
-  if (PG_ARGISNULL (0))
-    PG_RETURN_BOOL (0);
-  else if (PG_ARGISNULL (1))
-    PG_RETURN_BOOL (1);
-  else
-    {
-      float8 arg_one, arg_two;
-
-      arg_one = PG_GETARG_FLOAT8 (0);
-      arg_two = PG_GETARG_FLOAT8 (1);
-      if (arg_one <= 0)
-        PG_RETURN_BOOL (arg_one == arg_two);
-      else
-        PG_RETURN_BOOL (arg_one >= arg_two);
-    }
+  PG_RETURN_NULL ();
 }
 
 /**


### PR DESCRIPTION
**What**:
The function severity_matches_ov() used in some SQL statements is currently
implemented in C. There is no need to do so as it converts pretty simple
to plpgsql.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

Reducing the level of dependency to custom C functions in the database.

**How**:

The original C function is rewritten to only use plpgsql.

**Checklist**:

N/A
