### PR TITLE
GVM_CERTIFICATE_SAN missing $

### DIFF
--- a/tools/gvm-manage-certs.in
+++ b/tools/gvm-manage-certs.in
@@ -360,7 +360,7 @@ create_certificate ()
     fi
     if [ -n "$GVM_CA_CERTIFICATE_SAN" ]
     then
-      add_san_settings GVM_CA_CERTIFICATE_SAN
+      add_san_settings $GVM_CA_CERTIFICATE_SAN
     fi
   else
     if [ -n "$GVM_CERTIFICATE_LIFETIME" ]
@@ -393,7 +393,7 @@ create_certificate ()
     fi
     if [ -n "$GVM_CERTIFICATE_SAN" ]
     then
-      add_san_settings GVM_CERTIFICATE_SAN
+      add_san_settings $GVM_CERTIFICATE_SAN
     fi
   fi
 


### PR DESCRIPTION
**What**:

**Why**:
- env var GVM_CERTIFICATE_SAN was missing leading dollar sign
- SAN settings were never put into the template file therefore creating CSRs without SAN information

**How**:
Verified/tested through creating CSR, getting it signed by CA and using it in GVM.

**Checklist**:
- [x] Tests
- [] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
