### PR TITLE
Improve SCP username and destination path handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix SQL errors in SCAP and CERT update [#1343](https://github.com/greenbone/gvmd/pull/1343)
 - Check private key when modifying credential [#1351](https://github.com/greenbone/gvmd/pull/1351)
 - Clean up hosts strings before using them [#1352](https://github.com/greenbone/gvmd/pull/1352)
+- Improve SCP username and destination path handling [#1350](https://github.com/greenbone/gvmd/pull/1350)
 
 
 ### Removed

--- a/src/alert_methods/SCP/alert
+++ b/src/alert_methods/SCP/alert
@@ -43,9 +43,8 @@ shell_esc() {
   printf "%q" "$1"
 }
 
-# Escape destination twice because it is also expanded on the remote end.
+# Escape destination because it is also expanded on the remote end.
 DEST_ESC=`shell_esc "$DEST"`
-DEST_ESC=`shell_esc "$DEST_ESC"`
 
 if [ -z "$PRIVATE_KEY_FILE" ]
 then

--- a/src/alert_methods/SCP/alert
+++ b/src/alert_methods/SCP/alert
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright (C) 2016-2018 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
@@ -39,12 +39,19 @@ log_error() {
   echo "$MESSAGE" >&2
 }
 
+shell_esc() {
+  printf "%q" "$1"
+}
+
 # Escape destination twice because it is also expanded on the remote end.
+DEST_ESC=`shell_esc "$DEST"`
+DEST_ESC=`shell_esc "$DEST_ESC"`
+
 if [ -z "$PRIVATE_KEY_FILE" ]
 then
-  sshpass -f ${PASSWORD_FILE} scp -o HashKnownHosts=no -o UserKnownHostsFile="${KNOWN_HOSTS_FILE} ~/.ssh/known_hosts ~/.ssh/known_hosts2 /etc/ssh/ssh_known_hosts" "${REPORT_FILE}" "${USERNAME}@${HOST}:'${DEST}'" 2>$ERROR_FILE
+  sshpass -f ${PASSWORD_FILE} scp -o HashKnownHosts=no -o UserKnownHostsFile="${KNOWN_HOSTS_FILE} ~/.ssh/known_hosts ~/.ssh/known_hosts2 /etc/ssh/ssh_known_hosts" "${REPORT_FILE}" "${USERNAME}@${HOST}:${DEST_ESC}" 2>$ERROR_FILE
 else
-  sshpass -f ${PASSWORD_FILE} -P "passphrase" scp -i "$PRIVATE_KEY_FILE" -o PasswordAuthentication=no -o HashKnownHosts=no -o UserKnownHostsFile="${KNOWN_HOSTS_FILE} ~/.ssh/known_hosts ~/.ssh/known_hosts2 /etc/ssh/ssh_known_hosts" "${REPORT_FILE}" "${USERNAME}@${HOST}:'${DEST}'" 2>$ERROR_FILE
+  sshpass -f ${PASSWORD_FILE} -P "passphrase" scp -i "$PRIVATE_KEY_FILE" -o PasswordAuthentication=no -o HashKnownHosts=no -o UserKnownHostsFile="${KNOWN_HOSTS_FILE} ~/.ssh/known_hosts ~/.ssh/known_hosts2 /etc/ssh/ssh_known_hosts" "${REPORT_FILE}" "${USERNAME}@${HOST}:${DEST_ESC}" 2>$ERROR_FILE
 fi
 
 EXIT_CODE=$?

--- a/src/alert_methods/SCP/alert
+++ b/src/alert_methods/SCP/alert
@@ -43,14 +43,21 @@ shell_esc() {
   printf "%q" "$1"
 }
 
+if [ -z "$GVMD_SCP_ALERT_TIMEOUT" ]
+then
+  TIMEOUT="15m"
+ else
+  TIMEOUT="$GVMD_SCP_ALERT_TIMEOUT"
+fi
+
 # Escape destination because it is also expanded on the remote end.
 DEST_ESC=`shell_esc "$DEST"`
 
 if [ -z "$PRIVATE_KEY_FILE" ]
 then
-  sshpass -f ${PASSWORD_FILE} scp -o HashKnownHosts=no -o UserKnownHostsFile="${KNOWN_HOSTS_FILE} ~/.ssh/known_hosts ~/.ssh/known_hosts2 /etc/ssh/ssh_known_hosts" "${REPORT_FILE}" "${USERNAME}@${HOST}:${DEST_ESC}" 2>$ERROR_FILE
+  timeout $TIMEOUT sshpass -f ${PASSWORD_FILE} scp -o HashKnownHosts=no -o UserKnownHostsFile="${KNOWN_HOSTS_FILE} ~/.ssh/known_hosts ~/.ssh/known_hosts2 /etc/ssh/ssh_known_hosts" "${REPORT_FILE}" "${USERNAME}@${HOST}:${DEST_ESC}" 2>$ERROR_FILE
 else
-  sshpass -f ${PASSWORD_FILE} -P "passphrase" scp -i "$PRIVATE_KEY_FILE" -o PasswordAuthentication=no -o HashKnownHosts=no -o UserKnownHostsFile="${KNOWN_HOSTS_FILE} ~/.ssh/known_hosts ~/.ssh/known_hosts2 /etc/ssh/ssh_known_hosts" "${REPORT_FILE}" "${USERNAME}@${HOST}:${DEST_ESC}" 2>$ERROR_FILE
+  timeout $TIMEOUT sshpass -f ${PASSWORD_FILE} -P "passphrase" scp -i "$PRIVATE_KEY_FILE" -o PasswordAuthentication=no -o HashKnownHosts=no -o UserKnownHostsFile="${KNOWN_HOSTS_FILE} ~/.ssh/known_hosts ~/.ssh/known_hosts2 /etc/ssh/ssh_known_hosts" "${REPORT_FILE}" "${USERNAME}@${HOST}:${DEST_ESC}" 2>$ERROR_FILE
 fi
 
 EXIT_CODE=$?
@@ -75,6 +82,9 @@ then
 elif [ $EXIT_CODE -eq 6 ]
 then
   log_error "sshpass failed with exit code ${EXIT_CODE}: Host public key is unknown: $ERROR_SHORT"
+elif [ $EXIT_CODE -eq 124 ]
+then
+  log_error "sshpass failed with exit code ${EXIT_CODE}: Timeout after $TIMEOUT: $ERROR_SHORT"
 elif [ $EXIT_CODE -eq 127 ]
 then
   log_error "sshpass failed with exit code ${EXIT_CODE}: Command not found: $ERROR_SHORT"

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -6763,7 +6763,7 @@ validate_scp_data (alert_method_t method, const gchar *name, gchar **data)
               return 18;
             }
 
-          if (strchr (username, '@') || strchr (username, ':'))
+          if (strchr (username, ':'))
             {
               g_free (username);
               return 18;


### PR DESCRIPTION
**What**:
This allows the "@" symbol to be used in SCP usernames and improves the shell quoting of the destination path in the SCP alert script. It also adds a timeout in case SCP gets blocked even after establishing the target host connection.

**Why**:
This allows the alert to be used with Windows domain hosts as the destination for the report. It also avoids some situations where the alert would keep running indefinitely.

**How**:
This was tested by creating a "Username + Password" type credential for a Windows domain user with a username like "user@domain" and assigning it to an SCP alert.
When entering only the filename (e.g. "report.xml"), the report should be copied to the users home directory (e.g. "C:/Users/user") without any single quotes added to the file name.
Using a full path (like "C:\Test\report.xml") should also work and special characters like `, " or ' should not cause any problems as long as the path is valid and refers to an existing directory.

To test the timeout, the environment variable `GVMD_SCP_ALERT_TIMEOUT` was set to `10s` before starting gvmd and the alert was configured to send the report to a nonexistent directory on a Windows test system, which would have otherwise blocked the alert indefinitely.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
