### PR TITLE
Clean up hosts strings before using them (20.08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Delete TLS certificate sources when deleting users [#1334](https://github.com/greenbone/gvmd/pull/1334)
 - Fix SQL errors in SCAP and CERT update [#1343](https://github.com/greenbone/gvmd/pull/1343)
 - Check private key when modifying credential [#1351](https://github.com/greenbone/gvmd/pull/1351)
+- Clean up hosts strings before using them [#1352](https://github.com/greenbone/gvmd/pull/1352)
 
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix SQL errors in SCAP and CERT update [#1343](https://github.com/greenbone/gvmd/pull/1343)
 - Check private key when modifying credential [#1351](https://github.com/greenbone/gvmd/pull/1351)
 
+
 ### Removed
 - Remove DROP from vulns creation [#1281](http://github.com/greenbone/gvmd/pull/1281)
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -4152,6 +4152,7 @@ launch_osp_openvas_task (task_t task, target_t target, const char *scan_id,
 {
   osp_connection_t *connection;
   char *hosts_str, *ports_str, *exclude_hosts_str, *finished_hosts_str;
+  gchar *clean_hosts, *clean_exclude_hosts;
   int alive_test, reverse_lookup_only, reverse_lookup_unify;
   osp_target_t *osp_target;
   GSList *osp_targets, *vts;
@@ -4190,6 +4191,9 @@ launch_osp_openvas_task (task_t task, target_t target, const char *scan_id,
   hosts_str = target_hosts (target);
   ports_str = target_port_range (target);
   exclude_hosts_str = target_exclude_hosts (target);
+  
+  clean_hosts = clean_hosts_string (hosts_str);
+  clean_exclude_hosts = clean_hosts_string (exclude_hosts_str);
 
   if (target_alive_tests (target) > 0)
    alive_test = target_alive_tests (target);
@@ -4211,7 +4215,7 @@ launch_osp_openvas_task (task_t task, target_t target, const char *scan_id,
       exclude_hosts_str = new_exclude_hosts;
     }
 
-  osp_target = osp_target_new (hosts_str, ports_str, exclude_hosts_str,
+  osp_target = osp_target_new (clean_hosts, ports_str, clean_exclude_hosts,
                                alive_test, reverse_lookup_unify,
                                reverse_lookup_only);
   if (finished_hosts_str)

--- a/src/manage.c
+++ b/src/manage.c
@@ -4225,6 +4225,8 @@ launch_osp_openvas_task (task_t task, target_t target, const char *scan_id,
   free (ports_str);
   free (exclude_hosts_str);
   free (finished_hosts_str);
+  g_free (clean_hosts);
+  g_free (clean_exclude_hosts);
   osp_targets = g_slist_append (NULL, osp_target);
 
   ssh_credential = target_osp_ssh_credential (target);

--- a/src/manage_pg_server.c
+++ b/src/manage_pg_server.c
@@ -262,27 +262,33 @@ sql_max_hosts (PG_FUNCTION_ARGS)
   else
     {
       text *hosts_arg;
-      char *hosts, *exclude;
+      char *hosts, *exclude, *clean_hosts, *clean_exclude;
       int ret, max_hosts;
 
       hosts_arg = PG_GETARG_TEXT_P (0);
       hosts = textndup (hosts_arg, VARSIZE (hosts_arg) - VARHDRSZ);
+      clean_hosts = clean_hosts_string (hosts);
+
       if (PG_ARGISNULL (1))
         {
           exclude = palloc (1);
           exclude[0] = 0;
+          clean_exclude = NULL;
         }
       else
         {
           text *exclude_arg;
           exclude_arg = PG_GETARG_TEXT_P (1);
           exclude = textndup (exclude_arg, VARSIZE (exclude_arg) - VARHDRSZ);
+          clean_exclude = clean_hosts_string (exclude);
         }
 
       max_hosts = get_max_hosts ();
-      ret = manage_count_hosts_max (hosts, exclude, max_hosts);
+      ret = manage_count_hosts_max (clean_hosts, clean_exclude, max_hosts);
       pfree (hosts);
       pfree (exclude);
+      g_free (clean_hosts);
+      g_free (clean_exclude);
       PG_RETURN_INT32 (ret);
     }
 }

--- a/src/manage_utils.c
+++ b/src/manage_utils.c
@@ -156,21 +156,22 @@ manage_count_hosts_max (const char *given_hosts, const char *exclude_hosts,
 {
   int count;
   gvm_hosts_t *hosts;
-  gchar *clean_hosts, *clean_exclude_hosts;
+  gchar *clean_hosts;
   
   clean_hosts = clean_hosts_string (given_hosts);
-  clean_exclude_hosts = clean_hosts_string (exclude_hosts);
 
   hosts = gvm_hosts_new_with_max (clean_hosts, max_hosts);
   if (hosts == NULL)
     {
       g_free (clean_hosts);
-      g_free (clean_exclude_hosts);
       return -1;
     }
 
   if (exclude_hosts)
     {
+      gchar *clean_exclude_hosts;
+
+      clean_exclude_hosts = clean_hosts_string (exclude_hosts);
       if (gvm_hosts_exclude_with_max (hosts,
                                       clean_exclude_hosts,
                                       max_hosts)
@@ -180,12 +181,12 @@ manage_count_hosts_max (const char *given_hosts, const char *exclude_hosts,
           g_free (clean_exclude_hosts);
           return -1;
         }
+      g_free (clean_exclude_hosts);
     }
 
   count = gvm_hosts_count (hosts);
   gvm_hosts_free (hosts);
   g_free (clean_hosts);
-  g_free (clean_exclude_hosts);
 
   return count;
 }

--- a/src/manage_utils.c
+++ b/src/manage_utils.c
@@ -1449,9 +1449,13 @@ clean_hosts_string (const char *hosts)
   /*
    * Regular expression matching leading zeroes in groups of digits
    * separated by dots or other characters.
+   * First line matches zeroes before non-zero numbers, e.g. "000" in "000120"
+   * Second line matches groups of all zeroes except one, e.g. "00" in "000"
    */
-  ipv4_replace_regex = g_regex_new ("(0+)(?=(?:[1-9]\\d*|0)(?:\\.|\\b))",
-                                    0, 0, NULL);
+  ipv4_replace_regex 
+    = g_regex_new ("(?<=\\D|^)(0+)(?=(?:(?:[1-9]\\d*)(?:\\D|$)))"
+                   "|(?<=\\D|^)(0+)(?=0(?:\\D|$))",
+                   0, 0, NULL);
   new_hosts = g_string_new ("");
 
   hosts_split = g_strsplit (hosts, ",", -1);

--- a/src/manage_utils.c
+++ b/src/manage_utils.c
@@ -1430,9 +1430,10 @@ clean_hosts_string (const char *hosts)
   if (hosts == NULL)
     return NULL;
 
-  ipv4_match_regex = g_regex_new ("^[0-9]+(?:\\.[0-9]+){3}"
-                                  "(?:\\/[0-9]+|-[0-9]+(?:\\.[0-9]+){3})?$",
-                                  0, 0, NULL);
+  ipv4_match_regex
+    = g_regex_new ("^[0-9]+(?:\\.[0-9]+){3}"
+                   "(?:\\/[0-9]+|-[0-9]+(?:(?:\\.[0-9]+){3})?)?$",
+                   0, 0, NULL);
   ipv4_replace_regex = g_regex_new ("(0+)(?=(?:[1-9]\\d*|0)(?:\\.|\\b))",
                                     0, 0, NULL);
   new_hosts = g_string_new ("");

--- a/src/manage_utils.c
+++ b/src/manage_utils.c
@@ -1431,10 +1431,25 @@ clean_hosts_string (const char *hosts)
   if (hosts == NULL)
     return NULL;
 
+  /*
+   * Regular expression for matching candidates for IPv4 addresses
+   * (four groups of digits separated by a dot "."),
+   * with optional extensions for ranges:
+   * - Another IP address candidate, separated with a hyphen "-"
+   *   (e.g. "192.168.123.001-192.168.123.005)"
+   * - A final group of digits, separated with a hyphen "-"
+   *   (short form address range, e.g. "192.168.123.001-005)
+   * - A final group of digits, separated with a slash "-"
+   *   (CIDR notation, e.g. "192.168.123.001/027)
+   */
   ipv4_match_regex
     = g_regex_new ("^[0-9]+(?:\\.[0-9]+){3}"
                    "(?:\\/[0-9]+|-[0-9]+(?:(?:\\.[0-9]+){3})?)?$",
                    0, 0, NULL);
+  /*
+   * Regular expression matching leading zeroes in groups of digits
+   * separated by dots or other characters.
+   */
   ipv4_replace_regex = g_regex_new ("(0+)(?=(?:[1-9]\\d*|0)(?:\\.|\\b))",
                                     0, 0, NULL);
   new_hosts = g_string_new ("");
@@ -1448,6 +1463,10 @@ clean_hosts_string (const char *hosts)
         {
           // IPv4 address, address range or CIDR notation
           gchar *new_item;
+          /* Remove leading zeroes in each group of digits by replacing them
+           * with empty strings,
+           * e.g. "000.001.002.003-004" becomes "0.1.2.3-4"
+           */
           new_item = g_regex_replace (ipv4_replace_regex,
                                       *item, -1, 0, "", 0, NULL);
           g_string_append (new_hosts, new_item);

--- a/src/manage_utils.h
+++ b/src/manage_utils.h
@@ -100,4 +100,7 @@ icalendar_duration_from_vcalendar (icalcomponent *);
 time_t
 icalendar_first_time_from_vcalendar (icalcomponent *, icaltimezone *);
 
+gchar *
+clean_hosts_string (const char*);
+
 #endif /* not _GVMD_MANAGE_UTILS_H */

--- a/src/manage_utils.h
+++ b/src/manage_utils.h
@@ -101,6 +101,6 @@ time_t
 icalendar_first_time_from_vcalendar (icalcomponent *, icaltimezone *);
 
 gchar *
-clean_hosts_string (const char*);
+clean_hosts_string (const char *);
 
 #endif /* not _GVMD_MANAGE_UTILS_H */

--- a/src/manage_utils_tests.c
+++ b/src/manage_utils_tests.c
@@ -148,6 +148,46 @@ Ensure (manage_utils, icalendar_next_time_from_string_tz)
   assert_that (verify_next (next, EPOCH_2020JAN1_HAR, now, 2 * 60), is_equal_to (1));
 }
 
+/* Hosts test */
+
+Ensure (manage_utils, clean_hosts_string_zeroes)
+{
+  gchar *clean_str;
+
+  // Simple IP address
+  clean_str = clean_hosts_string ("000.001.002.003");
+  assert_that (clean_str, is_equal_to_string ("0.1.2.3"));
+  g_free (clean_str);
+
+  // Long form range
+  clean_str = clean_hosts_string ("000.001.002.003-000.001.010.100");
+  assert_that (clean_str, is_equal_to_string ("0.1.2.3-0.1.10.100"));
+  g_free (clean_str);
+
+  // Short form range
+  clean_str = clean_hosts_string ("000.001.002.003-004");
+  assert_that (clean_str, is_equal_to_string ("0.1.2.3-4"));
+  g_free (clean_str);
+
+  // CIDR notation range
+  clean_str = clean_hosts_string ("000.001.002.003/004");
+  assert_that (clean_str, is_equal_to_string ("0.1.2.3/4"));
+  g_free (clean_str);
+
+  // Hostname with multiple zeroes (should stay the same)
+  clean_str = clean_hosts_string ("server001.example.com");
+  assert_that (clean_str, is_equal_to_string ("server001.example.com"));
+  g_free (clean_str);
+
+  // List of addresses and ranges
+  clean_str = clean_hosts_string ("000.001.002.003,  040.050.060.070-80,"
+                                  " 123.012.001.001-123.012.001.010");
+  assert_that (clean_str,
+               is_equal_to_string ("0.1.2.3, 40.50.60.70-80,"
+                                   " 123.12.1.1-123.12.1.10"));
+  g_free (clean_str);
+}
+
 /* Test suite. */
 
 int
@@ -163,6 +203,8 @@ main (int argc, char **argv)
 
   add_test_with_context (suite, manage_utils, icalendar_next_time_from_string_utc);
   add_test_with_context (suite, manage_utils, icalendar_next_time_from_string_tz);
+  
+  add_test_with_context (suite, manage_utils, clean_hosts_string_zeroes);
 
   if (argc > 1)
     return run_single_test (suite, argv[1], create_text_reporter ());


### PR DESCRIPTION
**What**:
Before sending hosts strings to the OSPd-OpenVAS scanner and before
calculating the number of hosts, leading zeroes in IPv4 addresses
are removed.

**Why**:
The addresses would be considered invalid otherwise, resulting in the hosts count to be reported as -1.
Starting a scan with a target using an IPv4 address with leading zeroes would also cause the scanner to crash.

**How**:
This was tested by:
1. Calling the `max_hosts` SQL function containing IPv4 addresses with extra zeroes, e.g.
`SELECT max_hosts('192.168.123.001-192.168.123.035', '192.168.123.033');`
`SELECT max_hosts('192.168.123.000/26, host001.example.com, 127.000.000.001', '');`
which should now return a positive number of hosts instead of -1.
2. Creating a target, modifying it via SQL to use a IPv4 address with extra zeroes.
(e.g. `UPDATE targets SET hosts='192.168.123.045' WHERE name='ipv4test';`)
A scan using it should run the same as one with the same address without extra zeroes and not end in the "Interrupted" status.
3. Temporarily adding extra debug output to functions where the new `clean_hosts_string` function was added to verify IPv4 addresses are cleaned up in the cases for single addresses, simple host ranges (e.g. 192.168.123.001-192.168.123.035) and CIDR notation ranges are handled while extra zeroes in hostnames like host001.example.com are kept intact. 

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
