### PR TITLE
Speed up GET_VULNS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Parameter `--db-user` to set a database user [#1327](https://github.com/greenbone/gvmd/pull/1327)
 - Add `allow_simult_ips_same_host` field for targets [#1346](https://github.com/greenbone/gvmd/pull/1346)
+- Speed up GET_VULNS [#1354](https://github.com/greenbone/gvmd/pull/1354)
 
 ### Changed
 - Move EXE credential generation to a Python script [#1260](https://github.com/greenbone/gvmd/pull/1260) [#1262](https://github.com/greenbone/gvmd/pull/1262)

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -17905,6 +17905,8 @@ handle_get_vulns (gmp_parser_t *gmp_parser, GError **error)
 
   while (next (&vulns))
     {
+      time_t oldest, newest;
+
       count ++;
       SENDF_TO_CLIENT_OR_FAIL ("<vuln id=\"%s\">"
                                "<name>%s</name>"
@@ -17922,13 +17924,16 @@ handle_get_vulns (gmp_parser_t *gmp_parser, GError **error)
                                vuln_iterator_qod (&vulns));
 
       // results for the vulnerability
+      oldest = vuln_iterator_oldest (&vulns);
       SENDF_TO_CLIENT_OR_FAIL ("<results>"
                                "<count>%d</count>"
-                               "<oldest>%s</oldest>"
-                               "<newest>%s</newest>",
+                               "<oldest>%s</oldest>",
                                vuln_iterator_results (&vulns),
-                               vuln_iterator_oldest (&vulns),
-                               vuln_iterator_newest (&vulns));
+                               iso_time (&oldest));
+
+      newest = vuln_iterator_newest (&vulns);
+      SENDF_TO_CLIENT_OR_FAIL ("<newest>%s</newest>",
+                               iso_time (&newest));
 
       SEND_TO_CLIENT_OR_FAIL ("</results>");
 

--- a/src/manage.h
+++ b/src/manage.h
@@ -3461,10 +3461,10 @@ init_vuln_iterator (iterator_t*, const get_data_t*);
 int
 vuln_iterator_results (iterator_t*);
 
-const char*
+time_t
 vuln_iterator_oldest (iterator_t*);
 
-const char*
+time_t
 vuln_iterator_newest (iterator_t*);
 
 const char*

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -1604,6 +1604,26 @@ manage_create_sql_functions ()
            "                                            ('gvmd.user.uuid')))"
            "           AND task = results.task)"
            "$$ LANGUAGE SQL;");
+
+      sql ("DROP FUNCTION IF EXISTS"
+           " vuln_results_exist (text, bigint, bigint, text, integer);");
+      sql ("CREATE OR REPLACE FUNCTION"
+           " vuln_results_exist (text, bigint, bigint, text)"
+           " RETURNS boolean AS $$"
+           " SELECT EXISTS"
+           "  (SELECT * FROM results"
+           "   WHERE results.nvt = $1"
+           "   AND ($2 IS NULL OR results.task = $2)"
+           "   AND ($3 IS NULL OR results.report = $3)"
+           "   AND ($4 IS NULL OR results.host = $4)"
+           "   AND (results.severity != " G_STRINGIFY (SEVERITY_ERROR) ")"
+           "   AND (SELECT has_permission FROM permissions_get_tasks"
+           "        WHERE \"user\" = (SELECT id FROM users"
+           "                          WHERE uuid"
+           "                                = (SELECT current_setting"
+           "                                           ('gvmd.user.uuid')))"
+           "        AND task = results.task))"
+           "$$ LANGUAGE SQL;");
     }
 
   return 0;

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -52717,6 +52717,20 @@ vuln_iterator_qod (iterator_t* iterator)
 }
 
 /**
+ * @brief Get the QoD from a vuln iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The QoD.
+ */
+const char*
+vuln_iterator_type (iterator_t* iterator)
+{
+  if (iterator->done) return NULL;
+  return iterator_string (iterator, GET_ITERATOR_COLUMN_COUNT + 4);
+}
+
+/**
  * @brief Get the date of the oldest result from a vuln iterator.
  *
  * @param[in]  iterator  Iterator.
@@ -52742,20 +52756,6 @@ vuln_iterator_newest (iterator_t* iterator)
 {
   if (iterator->done) return 0;
   return iterator_int64 (iterator, GET_ITERATOR_COLUMN_COUNT + 6);
-}
-
-/**
- * @brief Get the QoD from a vuln iterator.
- *
- * @param[in]  iterator  Iterator.
- *
- * @return The QoD.
- */
-const char*
-vuln_iterator_type (iterator_t* iterator)
-{
-  if (iterator->done) return NULL;
-  return iterator_string (iterator, GET_ITERATOR_COLUMN_COUNT + 4);
 }
 
 /**

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -17009,11 +17009,11 @@ resource_count (const char *type, const get_data_t *get)
     }
   else if (strcmp (type, "vuln") == 0)
     {
-      extra_where = g_strdup (" AND (vuln_results (vulns.uuid,"
-                              "                    cast (null AS integer),"
-                              "                    cast (null AS integer),"
-                              "                    cast (null AS text))"
-                              "      > 0)");
+      extra_where = g_strdup (" AND vuln_results_exist"
+                              "      (vulns.uuid,"
+                              "       cast (null AS integer),"
+                              "       cast (null AS integer),"
+                              "       cast (null AS text))");
     }
   else
     extra_where = NULL;

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -52492,18 +52492,6 @@ user_resources_in_use (user_t user,
      "qod", NULL, KEYWORD_TYPE_INTEGER                                       \
    },                                                                        \
    {                                                                         \
-     "(SELECT iso_time (min (date)) FROM results"                            \
-     VULN_RESULTS_WHERE ")",                                                 \
-     NULL,                                                                   \
-     KEYWORD_TYPE_INTEGER                                                    \
-   },                                                                        \
-   {                                                                         \
-     "(SELECT iso_time (max (date)) FROM results"                            \
-     VULN_RESULTS_WHERE ")",                                                 \
-     NULL,                                                                   \
-     KEYWORD_TYPE_INTEGER                                                    \
-   },                                                                        \
-   {                                                                         \
      "type", NULL, KEYWORD_TYPE_INTEGER                                      \
    },                                                                        \
    {                                                                         \
@@ -52739,7 +52727,7 @@ time_t
 vuln_iterator_oldest (iterator_t* iterator)
 {
   if (iterator->done) return 0;
-  return iterator_int64 (iterator, GET_ITERATOR_COLUMN_COUNT + 7);
+  return iterator_int64 (iterator, GET_ITERATOR_COLUMN_COUNT + 5);
 }
 
 /**
@@ -52753,7 +52741,7 @@ time_t
 vuln_iterator_newest (iterator_t* iterator)
 {
   if (iterator->done) return 0;
-  return iterator_int64 (iterator, GET_ITERATOR_COLUMN_COUNT + 8);
+  return iterator_int64 (iterator, GET_ITERATOR_COLUMN_COUNT + 6);
 }
 
 /**
@@ -52767,7 +52755,7 @@ const char*
 vuln_iterator_type (iterator_t* iterator)
 {
   if (iterator->done) return NULL;
-  return iterator_string (iterator, GET_ITERATOR_COLUMN_COUNT + 6);
+  return iterator_string (iterator, GET_ITERATOR_COLUMN_COUNT + 4);
 }
 
 /**

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -52735,11 +52735,11 @@ vuln_iterator_qod (iterator_t* iterator)
  *
  * @return The oldest result date.
  */
-const char*
+time_t
 vuln_iterator_oldest (iterator_t* iterator)
 {
-  if (iterator->done) return NULL;
-  return iterator_string (iterator, GET_ITERATOR_COLUMN_COUNT + 4);
+  if (iterator->done) return 0;
+  return iterator_int64 (iterator, GET_ITERATOR_COLUMN_COUNT + 7);
 }
 
 /**
@@ -52749,11 +52749,11 @@ vuln_iterator_oldest (iterator_t* iterator)
  *
  * @return The oldest result date.
  */
-const char*
+time_t
 vuln_iterator_newest (iterator_t* iterator)
 {
-  if (iterator->done) return NULL;
-  return iterator_string (iterator, GET_ITERATOR_COLUMN_COUNT + 5);
+  if (iterator->done) return 0;
+  return iterator_int64 (iterator, GET_ITERATOR_COLUMN_COUNT + 8);
 }
 
 /**

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -52813,8 +52813,8 @@ vuln_count (const get_data_t *get)
 static gchar*
 vulns_extra_where ()
 {
-  return g_strdup (" AND (vuln_results (uuid, opts.task, opts.report,"
-                   "                    opts.host) > 0)"
+  return g_strdup (" AND vuln_results_exist (uuid, opts.task, opts.report,"
+                   "                         opts.host)"
                    " AND (qod >= opts.min_qod)");
 }
 


### PR DESCRIPTION
**What**:

Speed up GET_VULNS:
1. Remove extra time columns that were just doing ISO conversion from the iterator
2. Use EXISTS instead of "count" in the WHERE clause.
3. Also use EXISTS in the counts.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

GET_VULNS is slow with many results.

With my 1.2 million result db:

After 1 the gvmd vuln query went from 25s to 20s.
After 2 the query went down to 6s.

After 1 and 2 the request in GSA that gets the vulns went down from about 60k ms to 21k ms.
After 3 the GSA request went down to 11k ms.

<!-- Why are these changes necessary? -->

**How did you test it**:

Open GSA Vulnerabilities page.  Check times in network tab and in gvmd logs.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
