### PR TITLE
Get origin and date for VT severities from OSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [21.4] (unreleased)
 
 ### Added
+- Extend GMP for extended severities [#1326](https://github.com/greenbone/gvmd/pull/1326) [#1329](https://github.com/greenbone/gvmd/pull/1329) [#1359](https://github.com/greenbone/gvmd/pull/1359)
 - Parameter `--db-user` to set a database user [#1327](https://github.com/greenbone/gvmd/pull/1327)
 - Add `allow_simult_ips_same_host` field for targets [#1346](https://github.com/greenbone/gvmd/pull/1346)
 - Speed up GET_VULNS [#1354](https://github.com/greenbone/gvmd/pull/1354) [#1355](https://github.com/greenbone/gvmd/pull/1354)

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1374,16 +1374,29 @@ nvti_from_vt (entity_t vt)
             }
           else
             {
+              entity_t origin, severity_date;
               double cvss_base_dbl;
               gchar * cvss_base;
+              time_t parsed_severity_date;
 
               cvss_base_dbl
                 = get_cvss_score_from_base_metrics (entity_text (value));
 
+              origin
+                = entity_child (severity, "origin");
+              severity_date
+                = entity_child (severity, "date");
+              
+              if (severity_date)
+                parsed_severity_date = strtol (entity_text (severity_date),
+                                               NULL, 10);
+              else
+                parsed_severity_date = nvti_modification_time (nvti);
+
               nvti_add_vtseverity (nvti,
                 vtseverity_new (severity_type,
-                                NULL /* origin */,
-                                nvti_modification_time (nvti),
+                                origin ? entity_text (origin) : NULL,
+                                parsed_severity_date,
                                 round (cvss_base_dbl * 10.0),
                                 entity_text (value)));
 

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1391,7 +1391,7 @@ nvti_from_vt (entity_t vt)
                 parsed_severity_date = strtol (entity_text (severity_date),
                                                NULL, 10);
               else
-                parsed_severity_date = nvti_modification_time (nvti);
+                parsed_severity_date = nvti_creation_time (nvti);
 
               nvti_add_vtseverity (nvti,
                 vtseverity_new (severity_type,


### PR DESCRIPTION
**What**:

When getting the VTs via OSP, the origin and date elements are now also
read and stored in the database.

**Why**:

This is part of our plan to add extended severity information.

**How did you test it**:

Tested by running `gvmd --rebuild` with an up to date scanner and NVTs feed and then checking the response to a `get_info` GMP command getting the details of an NVT that has the new fields, like `1.3.6.1.4.1.25623.1.0.117034`.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
