### PR TITLE
Add check if gvmd data feed dir exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add command line options db-host and db-port [#1308](https://github.com/greenbone/gvmd/pull/1308)
 - Add missing config and target to modify_task GMP doc [#1310](https://github.com/greenbone/gvmd/pull/1310)
 - Add version for NVTs and CVEs in make_osp_result [#1335](https://github.com/greenbone/gvmd/pull/1335)
+- Add check if gvmd data feed dir exists [#1360](https://github.com/greenbone/gvmd/pull/1360)
 
 ### Changed
 - Extended the output of invalid / missing --feed parameter given to greenbone-feed-sync [#1255](https://github.com/greenbone/gvmd/pull/1255)

--- a/src/manage.c
+++ b/src/manage.c
@@ -7330,6 +7330,8 @@ feed_sync_required ()
   return FALSE;
 }
 
+
+
 /**
  * @brief Perform any syncing that is due.
  *
@@ -7338,10 +7340,12 @@ feed_sync_required ()
  * @param[in]  sigmask_current  Sigmask to restore in child.
  * @param[in]  fork_update_nvt_cache  Function that forks a child that syncs
  *                                    the NVTS.  Child does not return.
+ * @param[in]  try_gvmd_data_sync  Whether to try to sync gvmd data objects.
  */
 void
 manage_sync (sigset_t *sigmask_current,
-             int (*fork_update_nvt_cache) ())
+             int (*fork_update_nvt_cache) (),
+             gboolean try_gvmd_data_sync)
 {
   lockfile_t lockfile;
 
@@ -7360,9 +7364,12 @@ manage_sync (sigset_t *sigmask_current,
         }
     }
 
-  manage_sync_configs ();
-  manage_sync_port_lists ();
-  manage_sync_report_formats ();
+  if (try_gvmd_data_sync)
+    {
+      manage_sync_configs ();
+      manage_sync_port_lists ();
+      manage_sync_report_formats ();
+    }
 }
 
 /**
@@ -8407,6 +8414,17 @@ sort_data_free (sort_data_t *sort_data)
 
 
 /* Feeds. */
+
+/**
+ * @brief Tests if the gvmd data feed directory exists.
+ *
+ * @return TRUE if the directory exists.
+ */
+gboolean
+manage_gvmd_data_feed_dir_exists ()
+{
+  return g_file_test (GVMD_FEED_DIR, G_FILE_TEST_EXISTS);
+}
 
 /**
  * @brief Get the feed lock file path.

--- a/src/manage.h
+++ b/src/manage.h
@@ -2673,7 +2673,7 @@ void
 set_scheduled_user_uuid (const gchar* uuid);
 
 void
-manage_sync (sigset_t *, int (*fork_update_nvt_cache) ());
+manage_sync (sigset_t *, int (*fork_update_nvt_cache) (), gboolean);
 
 int
 manage_schedule (manage_connection_forker_t,
@@ -3656,6 +3656,9 @@ aggregate_iterator_subgroup_value (iterator_t*);
 #define SCAP_FEED 2
 #define CERT_FEED 3
 #define GVMD_DATA_FEED 4
+
+gboolean
+manage_gvmd_data_feed_dir_exists ();
 
 const gchar *
 get_feed_lock_path ();

--- a/src/manage_configs.c
+++ b/src/manage_configs.c
@@ -379,6 +379,11 @@ sync_configs_with_feed ()
   const gchar *config_path;
   gchar *nvt_feed_version;
 
+  /* Test if base feed directory exists */
+
+  if (manage_gvmd_data_feed_dir_exists () == FALSE)
+    return 0;
+
   /* Only sync if NVTs are up to date. */
 
   nvt_feed_version = nvts_feed_version ();

--- a/src/manage_port_lists.c
+++ b/src/manage_port_lists.c
@@ -312,6 +312,11 @@ sync_port_lists_with_feed ()
   GDir *dir;
   const gchar *port_list_path;
 
+  /* Test if base feed directory exists */
+
+  if (manage_gvmd_data_feed_dir_exists () == FALSE)
+    return 0;
+
   /* Setup owner. */
 
   setting_value (SETTING_UUID_FEED_IMPORT_OWNER, &current_credentials.uuid);

--- a/src/manage_report_formats.c
+++ b/src/manage_report_formats.c
@@ -672,6 +672,11 @@ sync_report_formats_with_feed ()
   GDir *dir;
   const gchar *report_format_path;
 
+  /* Test if base feed directory exists */
+
+  if (manage_gvmd_data_feed_dir_exists () == FALSE)
+    return 0;
+
   /* Setup owner. */
 
   setting_value (SETTING_UUID_FEED_IMPORT_OWNER, &current_credentials.uuid);


### PR DESCRIPTION
**What**:

gvmd now checks if the parent feed directory exists and only warns about it once per startup.

**Why**:
To avoid flooding the log if the feed directory does not exist because the sync was not run yet.

**How did you test it**:

I tested this by running gvmd and renaming the gvmd feed directory (`$PREFIX/var/lib/gvm/data-objects/`)
to a different name and back.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
