### PR TITLE
Check gvmd data feed subdirectories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add command line options db-host and db-port [#1308](https://github.com/greenbone/gvmd/pull/1308)
 - Add missing config and target to modify_task GMP doc [#1310](https://github.com/greenbone/gvmd/pull/1310)
 - Add version for NVTs and CVEs in make_osp_result [#1335](https://github.com/greenbone/gvmd/pull/1335)
-- Add check if gvmd data feed dir exists [#1360](https://github.com/greenbone/gvmd/pull/1360)
+- Add check if gvmd data feed dir exists [#1360](https://github.com/greenbone/gvmd/pull/1360) [#1362](https://github.com/greenbone/gvmd/pull/1362)
 
 ### Changed
 - Extended the output of invalid / missing --feed parameter given to greenbone-feed-sync [#1255](https://github.com/greenbone/gvmd/pull/1255)

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1212,7 +1212,7 @@ fork_feed_sync ()
 {
   int pid;
   sigset_t sigmask_all, sigmask_current;
-  gboolean gvmd_data_feed_dir_exists;
+  gboolean gvmd_data_feed_dirs_exist;
   
   static gboolean disable_gvmd_data_feed_warning = FALSE;
 
@@ -1238,19 +1238,19 @@ fork_feed_sync ()
       return -1;
     }
 
-  gvmd_data_feed_dir_exists = manage_gvmd_data_feed_dir_exists ();
+  gvmd_data_feed_dirs_exist = manage_gvmd_data_feed_dirs_exist ();
 
-  if (disable_gvmd_data_feed_warning && gvmd_data_feed_dir_exists)
+  if (disable_gvmd_data_feed_warning && gvmd_data_feed_dirs_exist)
     {
       disable_gvmd_data_feed_warning = FALSE;
-      g_message ("Previously missing gvmd data feed directory %s found.",
-                 GVMD_FEED_DIR);
+      g_message ("Previously missing gvmd data feed directory found.");
     }
-  else if (gvmd_data_feed_dir_exists == FALSE
+  else if (gvmd_data_feed_dirs_exist == FALSE
            && disable_gvmd_data_feed_warning == FALSE)
     {
       disable_gvmd_data_feed_warning = TRUE;
-      g_warning ("The gvmd data feed directory %s does not exist.",
+      g_warning ("The gvmd data feed directory %s or one of its subdirectories"
+                 " does not exist.",
                  GVMD_FEED_DIR);
     }
 
@@ -1276,7 +1276,7 @@ fork_feed_sync ()
         /* Check the feed version. */
 
         manage_sync (sigmask_normal, fork_update_nvt_cache,
-                     gvmd_data_feed_dir_exists);
+                     gvmd_data_feed_dirs_exist);
 
         /* Exit. */
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -8416,14 +8416,17 @@ sort_data_free (sort_data_t *sort_data)
 /* Feeds. */
 
 /**
- * @brief Tests if the gvmd data feed directory exists.
+ * @brief Tests if the gvmd data feed directory and its subdirectories exist.
  *
  * @return TRUE if the directory exists.
  */
 gboolean
-manage_gvmd_data_feed_dir_exists ()
+manage_gvmd_data_feed_dirs_exist ()
 {
-  return g_file_test (GVMD_FEED_DIR, G_FILE_TEST_EXISTS);
+  return g_file_test (GVMD_FEED_DIR, G_FILE_TEST_EXISTS)
+         && configs_feed_dir_exists ()
+         && port_lists_feed_dir_exists ()
+         && report_formats_feed_dir_exists ();
 }
 
 /**

--- a/src/manage.h
+++ b/src/manage.h
@@ -3658,7 +3658,10 @@ aggregate_iterator_subgroup_value (iterator_t*);
 #define GVMD_DATA_FEED 4
 
 gboolean
-manage_gvmd_data_feed_dir_exists ();
+manage_gvmd_data_feed_dir_exists (const char *);
+
+gboolean
+manage_gvmd_data_feed_dirs_exist ();
 
 const gchar *
 get_feed_lock_path ();

--- a/src/manage_configs.c
+++ b/src/manage_configs.c
@@ -381,7 +381,7 @@ sync_configs_with_feed ()
 
   /* Test if base feed directory exists */
 
-  if (manage_gvmd_data_feed_dir_exists () == FALSE)
+  if (configs_feed_dir_exists () == FALSE)
     return 0;
 
   /* Only sync if NVTs are up to date. */
@@ -446,6 +446,17 @@ sync_configs_with_feed ()
   current_credentials.username = NULL;
 
   return 0;
+}
+
+/**
+ * @brief Tests if the configs feed directory exists.
+ * 
+ * @return TRUE if the directory exists.
+ */
+gboolean
+configs_feed_dir_exists ()
+{
+  return g_file_test (feed_dir_configs (), G_FILE_TEST_EXISTS);
 }
 
 /**

--- a/src/manage_configs.h
+++ b/src/manage_configs.h
@@ -183,6 +183,9 @@ void
 update_config_preference (const char *, const char *, const char *,
                           const char *, gboolean);
 
+gboolean
+configs_feed_dir_exists ();
+
 void
 manage_sync_configs ();
 

--- a/src/manage_port_lists.c
+++ b/src/manage_port_lists.c
@@ -314,7 +314,7 @@ sync_port_lists_with_feed ()
 
   /* Test if base feed directory exists */
 
-  if (manage_gvmd_data_feed_dir_exists () == FALSE)
+  if (port_lists_feed_dir_exists () == FALSE)
     return 0;
 
   /* Setup owner. */
@@ -369,6 +369,17 @@ sync_port_lists_with_feed ()
   current_credentials.username = NULL;
 
   return 0;
+}
+
+/**
+ * @brief Tests if the port lists feed directory exists.
+ * 
+ * @return TRUE if the directory exists.
+ */
+gboolean
+port_lists_feed_dir_exists ()
+{
+  return g_file_test (feed_dir_port_lists (), G_FILE_TEST_EXISTS);
 }
 
 /**

--- a/src/manage_port_lists.h
+++ b/src/manage_port_lists.h
@@ -132,6 +132,9 @@ port_list_target_iterator_name (iterator_t *);
 int
 port_list_target_iterator_readable (iterator_t *);
 
+gboolean
+port_lists_feed_dir_exists ();
+
 void
 manage_sync_port_lists ();
 

--- a/src/manage_report_formats.c
+++ b/src/manage_report_formats.c
@@ -674,7 +674,7 @@ sync_report_formats_with_feed ()
 
   /* Test if base feed directory exists */
 
-  if (manage_gvmd_data_feed_dir_exists () == FALSE)
+  if (report_formats_feed_dir_exists () == FALSE)
     return 0;
 
   /* Setup owner. */
@@ -730,6 +730,17 @@ sync_report_formats_with_feed ()
   current_credentials.username = NULL;
 
   return 0;
+}
+
+/**
+ * @brief Tests if the report formats feed directory exists.
+ * 
+ * @return TRUE if the directory exists.
+ */
+gboolean
+report_formats_feed_dir_exists ()
+{
+  return g_file_test (feed_dir_report_formats (), G_FILE_TEST_EXISTS);
 }
 
 /**

--- a/src/manage_report_formats.h
+++ b/src/manage_report_formats.h
@@ -228,6 +228,9 @@ init_param_option_iterator (iterator_t*, report_format_param_t, int,
 const char*
 param_option_iterator_value (iterator_t *);
 
+gboolean
+report_formats_feed_dir_exists ();
+
 void
 manage_sync_report_formats ();
 


### PR DESCRIPTION
**What**:
The check if the gvmd feed data directory exists now also checks the
version-specific subdirectories for configs, port lists and report
formats in case only those are missing.

**Why**:
If the parent directory is created but the subdirectory is missing, gvmd would
still generate a large number of warning messages.

**How did you test it**:
Renaming one subdirectory of the 20.08 feed (e.g. `configs` to `configs~`)
at a time and then renaming it back to the original name,
waiting for the log messages to appear after each step.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
