### PR TITLE
Fix response memory handling in handle_osp_scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Check private key when modifying credential [#1351](https://github.com/greenbone/gvmd/pull/1351)
 - Clean up hosts strings before using them [#1352](https://github.com/greenbone/gvmd/pull/1352)
 - Improve SCP username and destination path handling [#1350](https://github.com/greenbone/gvmd/pull/1350)
+- Fix response memory handling in handle_osp_scan [#1364](https://github.com/greenbone/gvmd/pull/1364)
 
 
 ### Removed

--- a/src/manage.c
+++ b/src/manage.c
@@ -3569,7 +3569,6 @@ handle_osp_scan (task_t task, report_t report, const char *scan_id)
 
   while (1)
     {
-      char *report_xml = NULL;
       int run_status, progress;
       osp_scan_status_t osp_scan_status;
 
@@ -3582,7 +3581,7 @@ handle_osp_scan (task_t task, report_t report, const char *scan_id)
         }
 
       progress = get_osp_scan_report (scan_id, host, port, ca_pub, key_pub,
-                                      key_priv, 0, 0, &report_xml);
+                                      key_priv, 0, 0, NULL);
       if (progress < 0 || progress > 100)
         {
           result_t result = make_osp_result
@@ -3599,10 +3598,12 @@ handle_osp_scan (task_t task, report_t report, const char *scan_id)
       else
         {
           /* Get the full OSP report. */
+          char *report_xml = NULL;
           progress = get_osp_scan_report (scan_id, host, port, ca_pub, key_pub,
                                           key_priv, 1, 1, &report_xml);
           if (progress < 0 || progress > 100)
             {
+              g_free (report_xml);
               result_t result = make_osp_result
                                  (task, "", "", "",
                                   threat_message_type ("Error"),


### PR DESCRIPTION
**What**:
When getting only the progress, the XML string is no longer requested
and when getting the full report, the string is freed in case of an
error.

**Why**:
The XML from the progress requests was never freed until the end of the scan,
so the strings kept consuming more and more memory, which could cause
problems during longer scans.

**How did you test it**:
By observing the memory consumption of the scan handler process in `htop` and
profiling gvmd with the massif tool of Valgrind while scanning a large range of
alive hosts.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
