### PR TITLE
Allow config to sync even if NVT family is not available (20.08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Clean up hosts strings before using them [#1352](https://github.com/greenbone/gvmd/pull/1352)
 - Improve SCP username and destination path handling [#1350](https://github.com/greenbone/gvmd/pull/1350)
 - Fix response memory handling in handle_osp_scan [#1364](https://github.com/greenbone/gvmd/pull/1364)
-
+- Allow config to sync even if NVT family is not available [#1366](https://github.com/greenbone/gvmd/pull/1366)
 
 ### Removed
 - Remove DROP from vulns creation [#1281](http://github.com/greenbone/gvmd/pull/1281)

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -1189,19 +1189,13 @@ insert_nvt_selectors (const char *quoted_name,
 
           family = nvt_family (selector->family_or_nvt);
           if (family == NULL)
-            {
-              g_warning ("%s: skipping NVT '%s' from import of config '%s'"
-                         " because the NVT does not have a family",
-                         __func__,
-                         selector->family_or_nvt,
-                         quoted_name);
-              if (allow_errors)
-                continue;
-              return -1;
-            }
+            g_debug ("%s: NVT '%s' in config '%s' does not have a family",
+                     __func__,
+                     selector->family_or_nvt,
+                     quoted_name);
 
           quoted_family_or_nvt = sql_quote (selector->family_or_nvt);
-          quoted_family = sql_quote (family);
+          quoted_family = sql_quote (family ? family : "");
           sql ("INSERT into nvt_selectors (name, exclude, type, family_or_nvt,"
                " family)"
                " VALUES ('%s', %i, %i, '%s', '%s');",


### PR DESCRIPTION
Backport of https://github.com/greenbone/gvmd/pull/1347.

**What**:

When syncing a config from the feed and the NVTs do not yet exist, then sync the config anyway with "" as family.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

Configs sync should succeed even if the NVTs aren't synced.

<!-- Why are these changes necessary? -->

**How**:

`DELETE FROM nvts;`
Delete feed config Discovery.
Empty trash.
Discovery should auto sync.
`select * from nvt_selectors where name = '74b247ae-d1fc-4105-99e2-01125889b4eb';`
    Should be no families.
`delete from meta where name = 'nvts_feed_version' or name = 'nvts_check_time';`
Wait for NVTs to sync.
`select * from nvt_selectors where name = '74b247ae-d1fc-4105-99e2-01125889b4eb';`
    Should now have families.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
