### PR TITLE
Delete report format dirs last when deleting a user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Clean up hosts strings before using them [#1352](https://github.com/greenbone/gvmd/pull/1352)
 - Improve SCP username and destination path handling [#1350](https://github.com/greenbone/gvmd/pull/1350)
 - Fix response memory handling in handle_osp_scan [#1364](https://github.com/greenbone/gvmd/pull/1364)
-
+- Delete report format dirs last when deleting a user [#1368](https://github.com/greenbone/gvmd/pull/1368)
 
 ### Removed
 - Remove DROP from vulns creation [#1281](http://github.com/greenbone/gvmd/pull/1281)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -52449,7 +52449,7 @@ delete_user (const char *user_id_arg, const char *name_arg, int ultimate,
 
       /* Report Formats. */
 
-      has_rows = inherit_report_formats (inheritor, user, &rows);
+      has_rows = inherit_report_formats (user, inheritor, &rows);
 
       /* Delete user. */
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -52348,7 +52348,6 @@ delete_user (const char *user_id_arg, const char *name_arg, int ultimate,
              real_inheritor_name, real_inheritor_id,
              deleted_user_name, deleted_user_id);
 
-      g_free (deleted_user_id);
       g_free (deleted_user_name);
       g_free (real_inheritor_id);
       g_free (real_inheritor_name);
@@ -52465,11 +52464,17 @@ delete_user (const char *user_id_arg, const char *name_arg, int ultimate,
 
       /* Very last: report formats dirs. */
 
-      if (has_rows)
+      if (deleted_user_id == NULL)
+        g_warning ("%s: deleted_user_id NULL, skipping dirs", __func__);
+      else if (has_rows)
         do
         {
-          inherit_report_format_dir (iterator_string (&rows, 0), user, inheritor);
+          inherit_report_format_dir (iterator_string (&rows, 0),
+                                     deleted_user_id,
+                                     inheritor);
         } while (next (&rows));
+
+      g_free (deleted_user_id);
       cleanup_iterator (&rows);
 
       sql_commit ();

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -52148,6 +52148,7 @@ delete_user (const char *user_id_arg, const char *name_arg, int ultimate,
   char *current_uuid, *feed_owner_id;
   gboolean has_rows;
   iterator_t rows;
+  gchar *deleted_user_id;
 
   assert (user_id_arg || name_arg);
 
@@ -52312,7 +52313,7 @@ delete_user (const char *user_id_arg, const char *name_arg, int ultimate,
 
   if (inheritor)
     {
-      gchar *deleted_user_id, *deleted_user_name;
+      gchar *deleted_user_name;
       gchar *real_inheritor_id, *real_inheritor_name;
 
       /* Transfer ownership of objects to the inheritor. */
@@ -52785,11 +52786,17 @@ delete_user (const char *user_id_arg, const char *name_arg, int ultimate,
 
   /* Delete user. */
 
+  deleted_user_id = user_uuid (user);
+
   sql ("DELETE FROM users WHERE id = %llu;", user);
 
   /* Delete report format dirs. */
 
-  delete_report_format_dirs_user (user, has_rows ? &rows : NULL);
+  if (deleted_user_id)
+    delete_report_format_dirs_user (deleted_user_id, has_rows ? &rows : NULL);
+  else
+    g_warning ("%s: deleted_user_id NULL, skipping removal of report formats dir",
+               __func__);
 
   sql_commit ();
   return 0;

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -3953,7 +3953,7 @@ empty_trashcan_report_formats ()
  * @brief Change ownership of report formats, for user deletion.
  *
  * @param[in]  report_format_id  UUID of report format.
- * @param[in]  user              Current owner.
+ * @param[in]  user_id           UUID of current owner.
  * @param[in]  inheritor         New owner.
  */
 void
@@ -4070,9 +4070,9 @@ delete_report_formats_user (user_t user, iterator_t *rows)
 /**
  * @brief Delete all report formats owned by a user.
  *
- * @param[in]  user  The user.
- * @param[in]  rows  Trash report format ids if any, else NULL.  Cleaned up
- *                   before returning.
+ * @param[in]  user_id  UUID of user.
+ * @param[in]  rows     Trash report format ids if any, else NULL.  Cleaned up
+ *                      before returning.
  */
 void
 delete_report_format_dirs_user (const gchar *user_id, iterator_t *rows)

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -4075,9 +4075,9 @@ delete_report_formats_user (user_t user, iterator_t *rows)
  *                   before returning.
  */
 void
-delete_report_format_dirs_user (user_t user, iterator_t *rows)
+delete_report_format_dirs_user (const gchar *user_id, iterator_t *rows)
 {
-  gchar *dir, *user_id;
+  gchar *dir;
 
   /* Remove trash report formats from trash directory. */
 
@@ -4100,16 +4100,10 @@ delete_report_format_dirs_user (user_t user, iterator_t *rows)
 
   /* Remove user's regular report formats directory. */
 
-  user_id = user_uuid (user);
-  if (user_id == NULL)
-    g_warning ("%s: user_id NULL, skipping removal of report formats dir",
-               __func__);
-
   dir = g_build_filename (GVMD_STATE_DIR,
                           "report_formats",
                           user_id,
                           NULL);
-  g_free (user_id);
 
   if (g_file_test (dir, G_FILE_TEST_EXISTS)
       && gvm_file_remove_recurse (dir))

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -3957,20 +3957,13 @@ empty_trashcan_report_formats ()
  * @param[in]  inheritor         New owner.
  */
 void
-inherit_report_format_dir (const gchar *report_format_id, user_t user,
+inherit_report_format_dir (const gchar *report_format_id, const gchar *user_id,
                            user_t inheritor)
 {
-  gchar *user_id, *inheritor_id, *old_dir, *new_dir;
+  gchar *inheritor_id, *old_dir, *new_dir;
 
-  g_debug ("%s: %s from %llu to %llu", __func__, report_format_id, user,
+  g_debug ("%s: %s from %s to %llu", __func__, report_format_id, user_id,
            inheritor);
-
-  user_id = user_uuid (user);
-  if (user_id == NULL)
-    {
-      g_warning ("%s: user_id NULL, skipping report format dir", __func__);
-      return;
-    }
 
   inheritor_id = user_uuid (inheritor);
   if (inheritor_id == NULL)
@@ -3991,7 +3984,6 @@ inherit_report_format_dir (const gchar *report_format_id, user_t user,
                               report_format_id,
                               NULL);
 
-  g_free (user_id);
   g_free (inheritor_id);
 
   if (move_report_format_dir (old_dir, new_dir))

--- a/src/manage_sql_report_formats.h
+++ b/src/manage_sql_report_formats.h
@@ -65,7 +65,7 @@ gboolean
 inherit_report_formats (user_t, user_t, iterator_t *);
 
 void
-inherit_report_format_dir (const gchar *, user_t, user_t);
+inherit_report_format_dir (const gchar *, const gchar *, user_t);
 
 void
 update_report_format (report_format_t, const gchar *, const gchar *,

--- a/src/manage_sql_report_formats.h
+++ b/src/manage_sql_report_formats.h
@@ -56,7 +56,7 @@ gboolean
 delete_report_formats_user (user_t, iterator_t *);
 
 void
-delete_report_format_dirs_user (user_t, iterator_t *);
+delete_report_format_dirs_user (const gchar *, iterator_t *);
 
 int
 empty_trashcan_report_formats ();

--- a/src/manage_sql_report_formats.h
+++ b/src/manage_sql_report_formats.h
@@ -52,8 +52,11 @@ gchar *
 apply_report_format (gchar *, gchar *, gchar *, gchar *,
                      GList **);
 
+gboolean
+delete_report_formats_user (user_t, iterator_t *);
+
 void
-delete_report_formats_user (user_t);
+delete_report_format_dirs_user (user_t, iterator_t *);
 
 int
 empty_trashcan_report_formats ();

--- a/src/manage_sql_report_formats.h
+++ b/src/manage_sql_report_formats.h
@@ -58,8 +58,11 @@ delete_report_formats_user (user_t);
 int
 empty_trashcan_report_formats ();
 
+gboolean
+inherit_report_formats (user_t, user_t, iterator_t *);
+
 void
-inherit_report_formats (user_t, user_t);
+inherit_report_format_dir (const gchar *, user_t, user_t);
 
 void
 update_report_format (report_format_t, const gchar *, const gchar *,


### PR DESCRIPTION
**What**:

When deleting a user, to avoid having to roll back the movement of the report format dirs, delete the dirs absolutely last.  That is, delete dirs after all SQL has run, in case any of that SQL fails.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

Errors in the SQL were leaving the report format dirs in an inconsistent state.

<!-- Why are these changes necessary? -->

**How did you test it**:

1. `gvmd --create-user=webadmin --password=w --role=Admin`
2. as feed owner, delete 5 report formats, empty trashcan
3. `gvmd --modify-setting 78eceaec-3385-11ea-b237-28d24461215b --value UUID_OF_webadmin` (set feed owner to webadmin)
4. `create table refs (id SERIAL PRIMARY KEY, owner integer REFERENCES users (id) ON DELETE RESTRICT);`
5. `insert into refs (owner) values ((select id from users where name = 'webadmin'));`
6. `ls var/lib/gvm/gvmd/report_formats/`  => 5 files
7. `gvmd --delete-user=webadmin --inheritor=user2` (should fail due to refs)
8. `ls var/lib/gvm/gvmd/report_formats/`  => still 5 files
9. `gvmd --delete-user=webadmin` (should fail due to refs)
10. `ls var/lib/gvm/gvmd/report_formats/`  => still 5 files
11. `delete from refs;`
12. repeat 7 or 9, should pass.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
