### PR TITLE
Prevent CPE/NVD_ID from being "(null)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Check db version before creating SQL functions [#1304](https://github.com/greenbone/gvmd/pull/1304)
 - Fix severity_in_level SQL function [#1312](https://github.com/greenbone/gvmd/pull/1312)
 - Fix and simplify SecInfo migration [#1331](https://github.com/greenbone/gvmd/pull/1331)
+- Prevent CPE/NVD_ID from being "(null)" [#1369](https://github.com/greenbone/gvmd/pull/1369)
 
 ### Removed
 - Remove solution element from VT tags [#886](https://github.com/greenbone/gvmd/pull/886)

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -13259,7 +13259,9 @@ handle_get_info (gmp_parser_t *gmp_parser, GError **error)
                              "<score>%d</score>"
                              "<cve_refs>%s</cve_refs>"
                              "<status>%s</status>",
-                             cpe_info_iterator_nvd_id (&info),
+                             cpe_info_iterator_nvd_id (&info)
+                              ? cpe_info_iterator_nvd_id (&info)
+                              : "",
                              cpe_info_iterator_score (&info),
                              cpe_info_iterator_cve_refs (&info),
                              cpe_info_iterator_status (&info)

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -13262,8 +13262,9 @@ handle_get_info (gmp_parser_t *gmp_parser, GError **error)
                              cpe_info_iterator_nvd_id (&info),
                              cpe_info_iterator_score (&info),
                              cpe_info_iterator_cve_refs (&info),
-                             cpe_info_iterator_status (&info) ?
-                             cpe_info_iterator_status (&info) : "");
+                             cpe_info_iterator_status (&info)
+                              ? cpe_info_iterator_status (&info)
+                              : "");
 
           if (get_info_data->details == 1)
             {


### PR DESCRIPTION
**What**:

Prevent CPE/NVD_ID in GET_INFO from being "(null)".

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

Neater.

<!-- Why are these changes necessary? -->

**How did you test it**:

Filter GSA > SecInfo > CVEs for 'name="cpe:/a:apache:roller:5.2.1"' and check NVD ID field.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
