### PR TITLE
Speed up regular result iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add `allow_simult_ips_same_host` field for targets [#1346](https://github.com/greenbone/gvmd/pull/1346)
 - Speed up GET_VULNS [#1354](https://github.com/greenbone/gvmd/pull/1354) [#1355](https://github.com/greenbone/gvmd/pull/1354)
 - Speed up result counting iterator [#1358](https://github.com/greenbone/gvmd/pull/1358) [#1361](https://github.com/greenbone/gvmd/pull/1361)
+- Speed up result iterator [#1370](https://github.com/greenbone/gvmd/pull/1358) [#1361](https://github.com/greenbone/gvmd/pull/1370)
 - Improve GMP docs around users [#1363](https://github.com/greenbone/gvmd/pull/1363)
 
 ### Changed

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -22163,13 +22163,19 @@ init_result_get_iterator (iterator_t* iterator, const get_data_t *get,
         actual_columns = columns_no_cert;
     }
 
-  if (apply_overrides)
-    /* Overrides, maybe dynamic. */
+  if (apply_overrides && dynamic_severity)
+    /* Overrides, dynamic. */
     lateral = "(SELECT new_severity"
-              " FROM result_new_severities"
-              " WHERE result_new_severities.result = results.id"
-              " AND result_new_severities.user = opts.user_id"
-              " AND result_new_severities.dynamic = opts.dynamic"
+              " FROM result_new_severities_dynamic"
+              " WHERE result_new_severities_dynamic.result = results.id"
+              " AND result_new_severities_dynamic.user = opts.user_id"
+              " LIMIT 1)";
+  else if (apply_overrides)
+    /* Overrides, no dynamic. */
+    lateral = "(SELECT new_severity"
+              " FROM result_new_severities_static"
+              " WHERE result_new_severities_static.result = results.id"
+              " AND result_new_severities_static.user = opts.user_id"
               " LIMIT 1)";
   else if (dynamic_severity)
     /* No overrides, dynamic. */

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -54715,11 +54715,19 @@ type_build_select (const char *type, const char *columns_str,
   if (strcasecmp (type, "RESULT") == 0)
     {
       gchar *original;
+      int overrides, dynamic;
+
+      overrides = filter_term_apply_overrides (filter ? filter : get->filter);
+      dynamic = setting_dynamic_severity_int ();
 
       original = opts_table;
+
       opts_table = g_strdup_printf (" LEFT OUTER JOIN nvts"
-                                    " ON results.nvt = nvts.oid %s",
-                                    original);
+                                    " ON results.nvt = nvts.oid %s,"
+                                    " LATERAL %s AS lateral_new_severity",
+                                    original,
+                                    result_iterator_lateral (overrides,
+                                                             dynamic));
       g_free (original);
     }
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -22173,7 +22173,13 @@ init_result_get_iterator (iterator_t* iterator, const get_data_t *get,
               " LIMIT 1)";
   else if (dynamic_severity)
     /* No overrides, dynamic. */
-    lateral = "(SELECT current_severity (results.severity, results.nvt)"
+    lateral = "(SELECT coalesce ((CASE WHEN results.severity"
+              "                             > " G_STRINGIFY (SEVERITY_LOG)
+              "                   THEN CAST (nvts.cvss_base"
+              "                              AS double precision)"
+              "                   ELSE results.severity"
+              "                   END),"
+              "                  results.severity)"
               " AS new_severity)";
   else
     /* No overrides, no dynamic.

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -21994,7 +21994,7 @@ init_result_get_iterator_severity (iterator_t* iterator, const get_data_t *get,
           = "coalesce (results.severity, results.severity)";
     }
 
-  columns[0].select = "lateralSeverity";
+  columns[0].select = "lateral_severity";
   columns[0].filter = "severity";
   columns[0].type = KEYWORD_TYPE_DOUBLE;
 
@@ -22004,20 +22004,20 @@ init_result_get_iterator_severity (iterator_t* iterator, const get_data_t *get,
 
   opts = result_iterator_opts_table (apply_overrides,
                                      dynamic_severity);
-  extra_tables = g_strdup_printf (", LATERAL %s AS lateralSeverity%s",
+  extra_tables = g_strdup_printf (", LATERAL %s AS lateral_severity%s",
                                   lateral, opts);
   g_free (opts);
 
   extra_where = results_extra_where (get->trash, report, host,
                                      apply_overrides, dynamic_severity,
                                      filter ? filter : get->filter,
-                                     "lateralSeverity");
+                                     "lateral_severity");
 
   extra_where_single = results_extra_where (get->trash, report, host,
                                             apply_overrides,
                                             dynamic_severity,
                                             "min_qod=0",
-                                            "lateralSeverity");
+                                            "lateral_severity");
 
   free (filter);
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -22022,6 +22022,16 @@ init_result_get_iterator_severity (iterator_t* iterator, const get_data_t *get,
 }
 
 /**
+ * @brief SQL for getting current severity.
+ */
+#define CURRENT_SEVERITY_SQL                                            \
+  "coalesce ((CASE WHEN results.severity > " G_STRINGIFY (SEVERITY_LOG) \
+  "           THEN CAST (nvts.cvss_base AS double precision)"           \
+  "           ELSE results.severity"                                    \
+  "           END),"                                                    \
+  "          results.severity)"
+
+/**
  * @brief Initialise a result iterator.
  *
  * @param[in]  iterator    Iterator.
@@ -22071,16 +22081,6 @@ init_result_get_iterator (iterator_t* iterator, const get_data_t *get,
     actual_columns = columns;
   else
     actual_columns = columns_no_cert;
-
-/**
- * @brief SQL for getting current severity.
- */
-#define CURRENT_SEVERITY_SQL                                            \
-  "coalesce ((CASE WHEN results.severity > " G_STRINGIFY (SEVERITY_LOG) \
-  "           THEN CAST (nvts.cvss_base AS double precision)"           \
-  "           ELSE results.severity"                                    \
-  "           END),"                                                    \
-  "          results.severity)"
 
   if (apply_overrides && dynamic_severity)
     /* Overrides, dynamic. */

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -21426,7 +21426,9 @@ where_qod (int min_qod)
     /* ^ 10 = 0 */                                                            \
     { "port", "location", KEYWORD_TYPE_STRING },                              \
     { "nvt", NULL, KEYWORD_TYPE_STRING },                                     \
-    { "severity_to_type (severity)", "original_type", KEYWORD_TYPE_STRING },  \
+    { "severity_to_type (results.severity)",                                  \
+      "original_type",                                                        \
+      KEYWORD_TYPE_STRING },                                                  \
     { "severity_to_type (" new_severity_sql ")",                              \
       "type",                                                                 \
       KEYWORD_TYPE_STRING },                                                  \
@@ -21437,7 +21439,7 @@ where_qod (int min_qod)
       "cvss_base",                                                            \
       KEYWORD_TYPE_DOUBLE },                                                  \
     { "nvt_version", NULL, KEYWORD_TYPE_STRING },                             \
-    { "severity", "original_severity", KEYWORD_TYPE_DOUBLE },                 \
+    { "results.severity", "original_severity", KEYWORD_TYPE_DOUBLE },         \
     /* ^ 20 = 10 */                                                           \
     { new_severity_sql,                                                       \
       "severity",                                                             \
@@ -22174,8 +22176,10 @@ init_result_get_iterator (iterator_t* iterator, const get_data_t *get,
     /* No overrides, dynamic. */
     lateral = "current_severity (results.severity, results.nvt)";
   else
-    /* No overrides, no dynamic. */
-    lateral = "results.severity";
+    /* No overrides, no dynamic.
+     *
+     * SELECT because results.severity gives syntax error. */
+    lateral = "(SELECT results.severity AS new_severity)";
 
   opts_tables = result_iterator_opts_table (apply_overrides, dynamic_severity);
   extra_tables = g_strdup_printf (" LEFT OUTER JOIN nvts"

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -22072,6 +22072,9 @@ init_result_get_iterator (iterator_t* iterator, const get_data_t *get,
   else
     actual_columns = columns_no_cert;
 
+/**
+ * @brief SQL for getting current severity.
+ */
 #define CURRENT_SEVERITY_SQL                                            \
   "coalesce ((CASE WHEN results.severity > " G_STRINGIFY (SEVERITY_LOG) \
   "           THEN CAST (nvts.cvss_base AS double precision)"           \

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -22172,10 +22172,10 @@ init_result_get_iterator (iterator_t* iterator, const get_data_t *get,
               " LIMIT 1)";
   else if (dynamic_severity)
     /* No overrides, dynamic. */
-    lateral = "results.severity";
+    lateral = "current_severity (results.severity, results.nvt)";
   else
     /* No overrides, no dynamic. */
-    lateral = "current_severity (results.severity, results.nvt)";
+    lateral = "results.severity";
 
   opts_tables = result_iterator_opts_table (apply_overrides, dynamic_severity);
   extra_tables = g_strdup_printf (" LEFT OUTER JOIN nvts"

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -21555,7 +21555,7 @@ where_qod (int min_qod)
  * @brief Result iterator columns.
  */
 #define BASE_RESULT_ITERATOR_COLUMNS                                          \
-  PRE_BASE_RESULT_ITERATOR_COLUMNS("results.severity")
+  PRE_BASE_RESULT_ITERATOR_COLUMNS("lateral_new_severity.new_severity")
 
 /**
  * @brief Result iterator columns.

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -21560,51 +21560,9 @@ where_qod (int min_qod)
 /**
  * @brief Result iterator columns.
  */
-#define BASE_RESULT_ITERATOR_COLUMNS_D                                        \
-  PRE_BASE_RESULT_ITERATOR_COLUMNS("lateral_new_severity.new_severity")
-
-/**
- * @brief Result iterator columns.
- */
-#define BASE_RESULT_ITERATOR_COLUMNS_OD                                       \
-  PRE_BASE_RESULT_ITERATOR_COLUMNS("lateral_new_severity.new_severity")
-
-/**
- * @brief Result iterator columns.
- */
 #define RESULT_ITERATOR_COLUMNS                                               \
   {                                                                           \
     BASE_RESULT_ITERATOR_COLUMNS                                              \
-    { SECINFO_SQL_RESULT_CERT_BUNDS,                                          \
-      NULL,                                                                   \
-      KEYWORD_TYPE_INTEGER },                                                 \
-    { SECINFO_SQL_RESULT_DFN_CERTS,                                           \
-      NULL,                                                                   \
-      KEYWORD_TYPE_INTEGER },                                                 \
-    { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                                      \
-  }
-
-/**
- * @brief Result iterator columns.
- */
-#define RESULT_ITERATOR_COLUMNS_D                                             \
-  {                                                                           \
-    BASE_RESULT_ITERATOR_COLUMNS_D                                            \
-    { SECINFO_SQL_RESULT_CERT_BUNDS,                                          \
-      NULL,                                                                   \
-      KEYWORD_TYPE_INTEGER },                                                 \
-    { SECINFO_SQL_RESULT_DFN_CERTS,                                           \
-      NULL,                                                                   \
-      KEYWORD_TYPE_INTEGER },                                                 \
-    { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                                      \
-  }
-
-/**
- * @brief Result iterator columns.
- */
-#define RESULT_ITERATOR_COLUMNS_OD                                            \
-  {                                                                           \
-    BASE_RESULT_ITERATOR_COLUMNS_OD                                           \
     { SECINFO_SQL_RESULT_CERT_BUNDS,                                          \
       NULL,                                                                   \
       KEYWORD_TYPE_INTEGER },                                                 \
@@ -21620,36 +21578,6 @@ where_qod (int min_qod)
 #define RESULT_ITERATOR_COLUMNS_NO_CERT                                       \
   {                                                                           \
     BASE_RESULT_ITERATOR_COLUMNS                                              \
-    { "0",                                                                    \
-      NULL,                                                                   \
-      KEYWORD_TYPE_INTEGER },                                                 \
-    { "0",                                                                    \
-      NULL,                                                                   \
-      KEYWORD_TYPE_INTEGER },                                                 \
-    { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                                      \
-  }
-
-/**
- * @brief Result iterator columns, when CERT db is not loaded.
- */
-#define RESULT_ITERATOR_COLUMNS_D_NO_CERT                                     \
-  {                                                                           \
-    BASE_RESULT_ITERATOR_COLUMNS_D                                            \
-    { "0",                                                                    \
-      NULL,                                                                   \
-      KEYWORD_TYPE_INTEGER },                                                 \
-    { "0",                                                                    \
-      NULL,                                                                   \
-      KEYWORD_TYPE_INTEGER },                                                 \
-    { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                                      \
-  }
-
-/**
- * @brief Result iterator columns, when CERT db is not loaded.
- */
-#define RESULT_ITERATOR_COLUMNS_OD_NO_CERT                                    \
-  {                                                                           \
-    BASE_RESULT_ITERATOR_COLUMNS_OD                                           \
     { "0",                                                                    \
       NULL,                                                                   \
       KEYWORD_TYPE_INTEGER },                                                 \
@@ -22107,11 +22035,7 @@ init_result_get_iterator (iterator_t* iterator, const get_data_t *get,
 {
   static const char *filter_columns[] = RESULT_ITERATOR_FILTER_COLUMNS;
   static column_t columns[] = RESULT_ITERATOR_COLUMNS;
-  static column_t columns_dynamic[] = RESULT_ITERATOR_COLUMNS_D;
-  static column_t columns_overrides_dynamic[] = RESULT_ITERATOR_COLUMNS_OD;
   static column_t columns_no_cert[] = RESULT_ITERATOR_COLUMNS_NO_CERT;
-  static column_t columns_dynamic_no_cert[] = RESULT_ITERATOR_COLUMNS_D_NO_CERT;
-  static column_t columns_overrides_dynamic_no_cert[] = RESULT_ITERATOR_COLUMNS_OD_NO_CERT;
   int ret;
   gchar *filter, *extra_tables, *extra_where, *extra_where_single, *opts_tables, *lateral;
   int apply_overrides, dynamic_severity;
@@ -22139,29 +22063,9 @@ init_result_get_iterator (iterator_t* iterator, const get_data_t *get,
   dynamic_severity = setting_dynamic_severity_int ();
 
   if (manage_cert_loaded ())
-    {
-      if (apply_overrides)
-        /* Overrides, maybe dynamic. */
-        actual_columns = columns_overrides_dynamic;
-      else if (dynamic_severity)
-        /* No overrides, dynamic. */
-        actual_columns = columns_dynamic;
-      else
-        /* No overrides, no dynamic. */
-        actual_columns = columns;
-    }
+    actual_columns = columns;
   else
-    {
-      if (apply_overrides)
-        /* Overrides, maybe dynamic. */
-        actual_columns = columns_overrides_dynamic_no_cert;
-      else if (dynamic_severity)
-        /* No overrides, dynamic. */
-        actual_columns = columns_dynamic_no_cert;
-      else
-        /* No overrides, no dynamic. */
-        actual_columns = columns_no_cert;
-    }
+    actual_columns = columns_no_cert;
 
   if (apply_overrides && dynamic_severity)
     /* Overrides, dynamic. */

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -22142,30 +22142,24 @@ init_result_get_iterator (iterator_t* iterator, const get_data_t *get,
       if (apply_overrides)
         /* Overrides, maybe dynamic. */
         actual_columns = columns_overrides_dynamic;
+      else if (dynamic_severity)
+        /* No overrides, dynamic. */
+        actual_columns = columns_dynamic;
       else
-        {
-          if (dynamic_severity)
-            /* Dynamic, no overrides. */
-            actual_columns = columns_dynamic;
-          else
-            /* No dynamic, no overrides. */
-            actual_columns = columns;
-        }
+        /* No overrides, no dynamic. */
+        actual_columns = columns;
     }
   else
     {
       if (apply_overrides)
         /* Overrides, maybe dynamic. */
         actual_columns = columns_overrides_dynamic_no_cert;
+      else if (dynamic_severity)
+        /* No overrides, dynamic. */
+        actual_columns = columns_dynamic_no_cert;
       else
-        {
-          if (dynamic_severity)
-            /* Dynamic, no overrides. */
-            actual_columns = columns_dynamic_no_cert;
-          else
-            /* No dynamic, no overrides. */
-            actual_columns = columns_no_cert;
-        }
+        /* No overrides, no dynamic. */
+        actual_columns = columns_no_cert;
     }
 
   if (apply_overrides)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -22081,14 +22081,15 @@ init_result_get_iterator (iterator_t* iterator, const get_data_t *get,
 
   if (apply_overrides && dynamic_severity)
     /* Overrides, dynamic. */
-    lateral = "(SELECT coalesce ((SELECT ov_new_severity FROM result_overrides"
+    lateral = "(WITH curr AS (SELECT " CURRENT_SEVERITY_SQL " AS curr_severity)"
+              " SELECT coalesce ((SELECT ov_new_severity FROM result_overrides"
               "                   WHERE result = results.id"
               "                   AND result_overrides.user = opts.user_id"
               "                   AND severity_matches_ov"
-              "                        (" CURRENT_SEVERITY_SQL ","
+              "                        ((SELECT curr_severity FROM curr LIMIT 1),"
               "                         ov_old_severity)"
               "                   LIMIT 1),"
-              "                  " CURRENT_SEVERITY_SQL ")"
+              "                  (SELECT curr_severity FROM curr LIMIT 1))"
               " AS new_severity)";
   else if (apply_overrides)
     /* Overrides, no dynamic. */

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -21213,7 +21213,7 @@ where_levels_auto (const char *levels, const char *new_severity_sql)
 
   g_string_append (levels_sql, ")");
 
-  if (count == 6)
+  if (count == 5)
     {
       /* All levels. */
       g_string_free (levels_sql, TRUE);
@@ -22121,6 +22121,8 @@ init_result_get_iterator (iterator_t* iterator, const get_data_t *get,
   int apply_overrides, dynamic_severity;
   column_t *actual_columns;
 
+  g_debug ("%s", __FUNCTION__);
+
   if (report == -1)
     {
       init_iterator (iterator, "SELECT NULL WHERE false;");
@@ -22210,6 +22212,9 @@ init_result_get_iterator (iterator_t* iterator, const get_data_t *get,
   g_free (extra_tables);
   g_free (extra_where);
   g_free (extra_where_single);
+
+  g_debug ("%s: done", __FUNCTION__);
+
   return ret;
 }
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -22173,7 +22173,7 @@ result_count (const get_data_t *get, report_t report, const char* host)
   static column_t columns[] = RESULT_ITERATOR_COLUMNS;
   static column_t columns_no_cert[] = RESULT_ITERATOR_COLUMNS_NO_CERT;
   int ret;
-  gchar *filter, *extra_tables, *extra_where, *opts_tables;
+  gchar *filter, *extra_tables, *extra_where, *opts_tables, *lateral;
   int apply_overrides, dynamic_severity;
 
   if (report == -1)
@@ -22192,10 +22192,40 @@ result_count (const get_data_t *get, report_t report, const char* host)
     = filter_term_apply_overrides (filter ? filter : get->filter);
   dynamic_severity = setting_dynamic_severity_int ();
 
+  if (apply_overrides && dynamic_severity)
+    /* Overrides, dynamic. */
+    lateral = "(WITH curr AS (SELECT " CURRENT_SEVERITY_SQL " AS curr_severity)"
+              " SELECT coalesce ((SELECT ov_new_severity FROM result_overrides"
+              "                   WHERE result = results.id"
+              "                   AND result_overrides.user = opts.user_id"
+              "                   AND severity_matches_ov"
+              "                        ((SELECT curr_severity FROM curr LIMIT 1),"
+              "                         ov_old_severity)"
+              "                   LIMIT 1),"
+              "                  (SELECT curr_severity FROM curr LIMIT 1))"
+              " AS new_severity)";
+  else if (apply_overrides)
+    /* Overrides, no dynamic. */
+    lateral = "(SELECT new_severity"
+              " FROM result_new_severities_static"
+              " WHERE result_new_severities_static.result = results.id"
+              " AND result_new_severities_static.user = opts.user_id"
+              " LIMIT 1)";
+  else if (dynamic_severity)
+    /* No overrides, dynamic. */
+    lateral = "(SELECT " CURRENT_SEVERITY_SQL " AS new_severity)";
+  else
+    /* No overrides, no dynamic.
+     *
+     * SELECT because results.severity gives syntax error. */
+    lateral = "(SELECT results.severity AS new_severity)";
+
   opts_tables = result_iterator_opts_table (apply_overrides, dynamic_severity);
   extra_tables = g_strdup_printf (" LEFT OUTER JOIN nvts"
-                                  " ON results.nvt = nvts.oid %s",
-                                  opts_tables);
+                                  " ON results.nvt = nvts.oid %s,"
+                                  " LATERAL %s AS lateral_new_severity",
+                                  opts_tables,
+                                  lateral);
   g_free (opts_tables);
 
   extra_where = results_extra_where (get->trash, report, host,

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -21433,7 +21433,7 @@ where_qod (int min_qod)
     { "description", NULL, KEYWORD_TYPE_STRING },                             \
     { "task", NULL, KEYWORD_TYPE_INTEGER },                                   \
     { "report", "report_rowid", KEYWORD_TYPE_INTEGER },                       \
-    { "(SELECT cvss_base FROM nvts WHERE nvts.oid =  nvt)",                   \
+    { "nvts.cvss_base",                                                       \
       "cvss_base",                                                            \
       KEYWORD_TYPE_DOUBLE },                                                  \
     { "nvt_version", NULL, KEYWORD_TYPE_STRING },                             \

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -21561,8 +21561,7 @@ where_qod (int min_qod)
  * @brief Result iterator columns.
  */
 #define BASE_RESULT_ITERATOR_COLUMNS_D                                        \
-  PRE_BASE_RESULT_ITERATOR_COLUMNS("current_severity (results.severity,"      \
-                                   "                  results.nvt)")
+  PRE_BASE_RESULT_ITERATOR_COLUMNS("lateral_new_severity.new_severity")
 
 /**
  * @brief Result iterator columns.
@@ -22174,7 +22173,8 @@ init_result_get_iterator (iterator_t* iterator, const get_data_t *get,
               " LIMIT 1)";
   else if (dynamic_severity)
     /* No overrides, dynamic. */
-    lateral = "current_severity (results.severity, results.nvt)";
+    lateral = "(SELECT current_severity (results.severity, results.nvt)"
+              " AS new_severity)";
   else
     /* No overrides, no dynamic.
      *


### PR DESCRIPTION
**What**:

Speed up iterator created by init_result_get_iterator:

1. Simplify level check when checking for all levels.
2. Use LATERAL to keep the new severity SQL in a single place in the statement.
3. Inline SQL from views and functions to take advantage of the JOIN on table nvts.
4. Use WITH to isolate the current severity calculation in the "overrides on, dynamic on" case.

Improvements to my GET_RESULTS times:
````
static, overrides off      17s to 6s
static, overrides on      248s to 34s
dynamic, overrides off     45s to 6s
dynamic, overrides on     415s to 33s
````
This translates to similar jumps in the GSA Results page.

This PR is similar to the changes to the result counting iterator in https://github.com/greenbone/gvmd/pull/1358.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

Improves the speed of the GSA result pages when using bigger dbs, especially the Results page.

Making the dynamic cases fast may enable us to switch to "query-time" dynamic-only severity (https://github.com/greenbone/gvmd/pull/1337).

<!-- Why are these changes necessary? -->

**How did you test it**:

<details>
  <summary>With an 800k result db, having 3 overrides.</summary><p>

 1. `git checkout master`
 2. `make install`
 3. `gvmd`
 4. `update settings set value = 0 where owner = (select id from users where name = 'm') and uuid = '77ec2444-e7f2-4a80-a59b-f4237782d93f';`
 5. `time o m m '<get_results details="1" filter="apply_overrides=0 min_qod=70 sort-reverse=severity rows=10 first=1"/>' > /tmp/master-st` => 17s
 6. `time o m m '<get_results details="1" filter="apply_overrides=1 min_qod=70 sort-reverse=severity rows=10 first=1"/>' > /tmp/master-st-ov` => 248s
 7. `update settings set value = 1 where owner = (select id from users where name = 'm') and uuid = '77ec2444-e7f2-4a80-a59b-f4237782d93f';`
 8. `time o m m '<get_results details="1" filter="apply_overrides=0 min_qod=70 sort-reverse=severity rows=10 first=1"/>' > /tmp/master-dy` => 45s
 9. `time o m m '<get_results details="1" filter="apply_overrides=1 min_qod=70 sort-reverse=severity rows=10 first=1"/>' > /tmp/master-dy-ov` => 415s
 9. `time o m m '<get_results details="1" filter="rexec apply_overrides=1 min_qod=70 sort-reverse=severity rows=10 first=1"/>' > /tmp/master-dy-ov-filter` => 209s (with pg jit off)

 10. `git checkout lateral-results`
 11. `make install`
 12. `gvmd`
 13. `update settings set value = 1 where owner = (select id from users where name = 'm') and uuid = '77ec2444-e7f2-4a80-a59b-f4237782d93f';`
 14. `time o m m '<get_results details="1" filter="apply_overrides=0 min_qod=70 sort-reverse=severity rows=10 first=1"/>' > /tmp/lateral-st` => 6s
 15. `time o m m '<get_results details="1" filter="apply_overrides=1 min_qod=70 sort-reverse=severity rows=10 first=1"/>' > /tmp/lateral-st-ov` => 34s
 16. `update settings set value = 1 where owner = (select id from users where name = 'm') and uuid = '77ec2444-e7f2-4a80-a59b-f4237782d93f';`
 17. `time o m m '<get_results details="1" filter="apply_overrides=0 min_qod=70 sort-reverse=severity rows=10 first=1"/>' > /tmp/lateral-dy` => 5s
 18. `time o m m '<get_results details="1" filter="apply_overrides=1 min_qod=70 sort-reverse=severity rows=10 first=1"/>' > /tmp/lateral-dy-ov` => 33s
 18. `time o m m '<get_results details="1" filter="rexec apply_overrides=1 min_qod=70 sort-reverse=severity rows=10 first=1"/>' > /tmp/lateral-dy-ov-filter` => 73s (with pg jit off)


 19. `cd /tmp`
 20. `diff master-st lateral-st` => empty
 21. `diff master-st-ov lateral-st-ov`  => empty
 22. `diff master-dy lateral-dy` => empty
 23. `diff master-dy-ov lateral-dy-ov` => empty
24. `diff master-dy-ov-filter lateral-dy-ov-filter` => empty
</p>
</details>

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
