### PR TITLE
Fix rsync errors due to IP blocking.

### DIFF
--- a/tools/greenbone-feed-sync.in
+++ b/tools/greenbone-feed-sync.in
@@ -377,6 +377,9 @@ is_feed_current () {
     fi
     remove_tmp_key
   else
+    # Sleep for five seconds (a previous feed might have been synced a few seconds before) to prevent
+    # IP blocking due to network equipment in between keeping the previous connection too long open.
+    sleep 5
     log_notice "No Greenbone Security Feed access key found, falling back to Greenbone Community Feed"
     eval "$RSYNC -ltvrP \"$COMMUNITY_RSYNC_FEED/timestamp\" \"$FEED_INFO_TEMP_DIR\""
     if [ $? -ne 0 ]
@@ -434,6 +437,9 @@ do_rsync_community_feed () {
   if [ -z "$RSYNC" ]; then
     log_err "rsync not found!"
   else
+    # Sleep for five seconds (after is_feed_current) to prevent IP blocking due to
+    # network equipment in between keeping the previous connection too long open.
+    sleep 5
     log_notice "Using rsync: $RSYNC"
     log_notice "Configured $FEED_TYPE_LONG rsync feed: $COMMUNITY_RSYNC_FEED"
     mkdir -p "$FEED_DIR"


### PR DESCRIPTION
**What**:

Replaces #326. I have also updated this PR so that:
- the sleep is only done for the GCF and not for the GSF
- a 5 seconds sleep is used according to https://community.greenbone.net/t/connection-refused-111-greenbone-nvt-sync/7457/13
- a short sleep before is_feed_current is used as well

Also see **Why** below

**Why**:

From #326:

> The synchronization scripts do two rsyncs in quick succession, this leads to frequent IP blocking by the rsync server.
>
> Fixed by adding a short sleep before the second (synchronization) rsync.

See various ongoing topics at the community portal like e.g.:

https://community.greenbone.net/t/connection-refused-111-greenbone-nvt-sync/7457

or the related PR for openvas here: greenbone/openvas/pull/335

**How did you test it**:

No testing done as it just adds an additional sleep.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
