### PR TITLE
Fix sorting in get_aggregates and its documentation (20.08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix response memory handling in handle_osp_scan [#1364](https://github.com/greenbone/gvmd/pull/1364)
 - Allow config to sync even if NVT family is not available [#1366](https://github.com/greenbone/gvmd/pull/1366)
 - Delete report format dirs last when deleting a user [#1368](https://github.com/greenbone/gvmd/pull/1368)
+- Fix sorting in get_aggregates and its documentation [#1375](https://github.com/greenbone/gvmd/pull/1375)
 
 ### Removed
 - Remove DROP from vulns creation [#1281](http://github.com/greenbone/gvmd/pull/1281)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -5334,7 +5334,8 @@ init_aggregate_iterator (iterator_t* iterator, const char *type,
                       order_column = g_strdup_printf ("max (aggregate_max_%d)",
                                                       index);
                     else if (strcmp (sort_stat, "mean") == 0)
-                      order_column = g_strdup_printf ("sum (aggregate_avg_%d)",
+                      order_column = g_strdup_printf ("sum (aggregate_sum_%d)"
+                                                      " / sum(aggregate_count)",
                                                       index);
                     else
                       order_column = g_strdup_printf ("%s (aggregate_%s_%d)",

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -8098,13 +8098,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <summary>Optional tuples of sort criteria</summary>
       <pattern>
         <attrib>
-          <name>sort_field</name>
+          <name>field</name>
           <summary>The column to sort the aggregated rows by.
-          With a subgroup column, groups will be sorted by the group_column first.</summary>
+          With a subgroup column, groups will be sorted by the group_column first</summary>
           <type>text</type>
         </attrib>
         <attrib>
-          <name>sort_order</name>
+          <name>order</name>
           <summary>The order to sort by</summary>
           <type>
             <alts>
@@ -8114,7 +8114,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </type>
         </attrib>
         <attrib>
-          <name>sort_stat</name>
+          <name>stat</name>
           <summary>The statistic to sort the aggregated rows by</summary>
           <type>
             <alts>


### PR DESCRIPTION
**What**:
This fixes the sorting by the mean / average of a column and the GMP documentation for the sort element.

**Why**:
The sorting by mean returned data in the wrong order and the GMP documentation had the wrong attribute names for the sort elements.

**How did you test it**:
To test the sorting by average, run the following GMP command with gvm-cli:
```xml
<get_aggregates type="nvt" group_column="family">
    <data_column>severity</data_column>
    <sort field="severity" stat="mean" order="descending"/>
</get_aggregates>

```
The documentation was tested by building it and checking the HTML document.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
