### PR TITLE
Check DB versions before CERT severity updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix severity_in_level SQL function [#1312](https://github.com/greenbone/gvmd/pull/1312)
 - Fix and simplify SecInfo migration [#1331](https://github.com/greenbone/gvmd/pull/1331)
 - Prevent CPE/NVD_ID from being "(null)" [#1369](https://github.com/greenbone/gvmd/pull/1369)
+- Check DB versions before CERT severity updates [#1376](https://github.com/greenbone/gvmd/pull/1376)
 
 ### Removed
 - Remove solution element from VT tags [#886](https://github.com/greenbone/gvmd/pull/886)


### PR DESCRIPTION
**What**:

When rebuilding the SCAP or CERT database, check if the other one
has the correct version. If not, skip updating the CERT severity
scores.

**Why**:

This fixes an issue where the SCAP DB update during migration
does not work because the CERT DB is not migrated yet and therefore
incompatible.

**How did you test it**:

This was tested by running `gvmd --migrate` after the following:

- Set SCAP and CERT DB version to 1 ok
- Set SCAP DB version to 1, deleted CERT schema ok
- Deleted SCAP schema, set CERT schema to 1 ok
- Set SCAP DB version to 1, CERT DB version to 9999
- Set SCAP DB version to 9999, CERT DB version to 1

After each step, the database was fully synced/rebuilt by letting gvmd run
normally until the regular update finished. 
After setting a high version number, it was also set to 1 after the test run
and migrated.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
