### PR TITLE
Added a new entry to the list of current Local Security Checks for the Closed CVEs feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Clarify documentation for --scan-host parameter [#1277](https://github.com/greenbone/gvmd/pull/1277)
 - In result iterator access severity directly if possible [#1321](https://github.com/greenbone/gvmd/pull/1321)
 - Change SCAP and CERT data to use new severity scoring [#1333](https://github.com/greenbone/gvmd/pull/1333) [#1357](https://github.com/greenbone/gvmd/pull/1357) [#1365](https://github.com/greenbone/gvmd/pull/1365)
+- The internal list of current Local Security Checks for the Auto-FP feature was updated [#1381](https://github.com/greenbone/gvmd/pull/1381)
 
 ### Fixed
 - Use GMP version with leading zero for feed dirs [#1287](https://github.com/greenbone/gvmd/pull/1287)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Clarify documentation for --scan-host parameter [#1277](https://github.com/greenbone/gvmd/pull/1277)
 - In result iterator access severity directly if possible [#1321](https://github.com/greenbone/gvmd/pull/1321)
 - Change SCAP and CERT data to use new severity scoring [#1333](https://github.com/greenbone/gvmd/pull/1333) [#1357](https://github.com/greenbone/gvmd/pull/1357) [#1365](https://github.com/greenbone/gvmd/pull/1365)
-- The internal list of current Local Security Checks for the 'Auto-FP' and 'Closed CVEs' features was updated [#1381](https://github.com/greenbone/gvmd/pull/1381)
+- The internal list of current Local Security Checks for the 'Closed CVEs' feature was updated [#1381](https://github.com/greenbone/gvmd/pull/1381)
 
 ### Fixed
 - Use GMP version with leading zero for feed dirs [#1287](https://github.com/greenbone/gvmd/pull/1287)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Clarify documentation for --scan-host parameter [#1277](https://github.com/greenbone/gvmd/pull/1277)
 - In result iterator access severity directly if possible [#1321](https://github.com/greenbone/gvmd/pull/1321)
 - Change SCAP and CERT data to use new severity scoring [#1333](https://github.com/greenbone/gvmd/pull/1333) [#1357](https://github.com/greenbone/gvmd/pull/1357) [#1365](https://github.com/greenbone/gvmd/pull/1365)
-- The internal list of current Local Security Checks for the Auto-FP feature was updated [#1381](https://github.com/greenbone/gvmd/pull/1381)
+- The internal list of current Local Security Checks for the 'Auto-FP' and 'Closed CVEs' features was updated [#1381](https://github.com/greenbone/gvmd/pull/1381)
 
 ### Fixed
 - Use GMP version with leading zero for feed dirs [#1287](https://github.com/greenbone/gvmd/pull/1287)

--- a/src/manage.h
+++ b/src/manage.h
@@ -1085,6 +1085,7 @@ user_has_super (const char *, user_t);
   " 'HP-UX Local Security Checks',"                \
   " 'Huawei EulerOS Local Security Checks',"       \
   " 'JunOS Local Security Checks',"                \
+  " 'Local Security Checks: EulerOS',"             \
   " 'Mac OS X Local Security Checks',"             \
   " 'Mageia Linux Local Security Checks',"         \
   " 'Mandrake Local Security Checks',"             \


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

This PR updates the hard-coded list of Local Security Checks used by the Closed CVEs to the current used Local Security Checks families.

Refer to https://github.com/greenbone/gvmd/pull/1054

**Why**:

<!-- Why are these changes necessary? -->
To support the new `Local Security Checks: EulerOS` script family.

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->
The changes have not been tested yet.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
