### PR TITLE
Expect report format scripts to exit with code 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Clarify documentation for --scan-host parameter [#1277](https://github.com/greenbone/gvmd/pull/1277)
 - In result iterator access severity directly if possible [#1321](https://github.com/greenbone/gvmd/pull/1321)
 - Change SCAP and CERT data to use new severity scoring [#1333](https://github.com/greenbone/gvmd/pull/1333) [#1357](https://github.com/greenbone/gvmd/pull/1357) [#1365](https://github.com/greenbone/gvmd/pull/1365)
+- Expect report format scripts to exit with code 0 [#1383](https://github.com/greenbone/gvmd/pull/1383)
 
 ### Fixed
 - Use GMP version with leading zero for feed dirs [#1287](https://github.com/greenbone/gvmd/pull/1287)

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -3451,9 +3451,8 @@ run_report_format_script (gchar *report_format_id,
                 }
 
               ret = system (command);
-              /* Ignore the shell command exit status, because we've not
-                * specified what it must be in the past. */
-              if (ret == -1)
+              /* Report scripts should return 0 since version 21.04 */
+              if (ret)
                 {
                   g_warning ("%s (child):"
                               " system failed with ret %i, %i, %s",
@@ -3551,9 +3550,8 @@ run_report_format_script (gchar *report_format_id,
       /* Just run the command as the current user. */
 
       ret = system (command);
-      /* Ignore the shell command exit status, because we've not
-        * specified what it must be in the past. */
-      if (ret == -1)
+      /* Report scripts should return 0 since version 21.04 */
+      if (ret)
         {
           g_warning ("%s: system failed with ret %i, %i, %s",
                       __func__,

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -3452,7 +3452,7 @@ run_report_format_script (gchar *report_format_id,
 
               ret = system (command);
               /* Report scripts should return 0 since version 21.04 */
-              if (ret)
+              if (ret == -1 || WIFEXITED(ret) == 0 || WEXITSTATUS(ret))
                 {
                   g_warning ("%s (child):"
                               " system failed with ret %i, %i, %s",
@@ -3551,7 +3551,7 @@ run_report_format_script (gchar *report_format_id,
 
       ret = system (command);
       /* Report scripts should return 0 since version 21.04 */
-      if (ret)
+      if (ret == -1 || WIFEXITED(ret) == 0 || WEXITSTATUS(ret))
         {
           g_warning ("%s: system failed with ret %i, %i, %s",
                       __func__,


### PR DESCRIPTION
**What**:
To detect more errors, run_report_format_script will handle any non-zero
exit code from the generate script as a failure.

**Why**:
Being stricter about the return codes makes it easier to detect if errors occur running the report format scripts.

**How did you test it**:
I modified a report format `generate` script to return a non-zero exit code and loaded a report in GSA using it.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
