### PR TITLE
Limit "whole-only" config families to "growing" and "every nvt"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Expect report format scripts to exit with code 0 [#1383](https://github.com/greenbone/gvmd/pull/1383)
 - Send entire families to ospd-openvas using VT_GROUP [#1384](https://github.com/greenbone/gvmd/pull/1384)
 - The internal list of current Local Security Checks for the 'Closed CVEs' feature was updated [#1381](https://github.com/greenbone/gvmd/pull/1381)
+- Limit "whole-only" config families to "growing" and "every nvt" [#1386](https://github.com/greenbone/gvmd/pull/1386)
 
 ### Fixed
 - Use GMP version with leading zero for feed dirs [#1287](https://github.com/greenbone/gvmd/pull/1287)

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -18415,6 +18415,14 @@ handle_modify_config (gmp_parser_t *gmp_parser, GError **error)
             log_event_fail ("config", "Scan Config",
                             modify_config_data->config_id, "modified");
             goto modify_config_leave;
+          case 3:
+            SEND_TO_CLIENT_OR_FAIL
+             (XML_ERROR_SYNTAX ("modify_config",
+                                "Whole-only families must include entire"
+                                " family and be growing"));
+            log_event_fail ("config", "Scan Config",
+                            modify_config_data->config_id, "modified");
+            goto modify_config_leave;
           case -1:
             SEND_TO_CLIENT_OR_FAIL
              (XML_ERROR_SYNTAX ("modify_config",

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -18358,6 +18358,13 @@ handle_modify_config (gmp_parser_t *gmp_parser, GError **error)
             log_event_fail ("config", "Scan Config",
                             modify_config_data->config_id, "modified");
             goto modify_config_leave;
+          case 3:
+            SEND_TO_CLIENT_OR_FAIL
+             (XML_ERROR_SYNTAX ("modify_config",
+                                "Attempt to modify NVT in whole-only family"));
+            log_event_fail ("config", "Scan Config",
+                            modify_config_data->config_id, "modified");
+            goto modify_config_leave;
           case -1:
             SEND_TO_CLIENT_OR_FAIL
              (XML_ERROR_SYNTAX ("modify_config",

--- a/src/manage.h
+++ b/src/manage.h
@@ -1099,6 +1099,20 @@ user_has_super (const char *, user_t);
   " 'Ubuntu Local Security Checks',"               \
   " 'Windows : Microsoft Bulletins'"
 
+/**
+ * @brief Whole only families.
+ */
+#define FAMILIES_WHOLE_ONLY                        \
+  { "CentOS Local Security Checks",                \
+    "Debian Local Security Checks",                \
+    "Fedora Local Security Checks",                \
+    "Huawei EulerOS Local Security Checks",        \
+    "Oracle Linux Local Security Checks",          \
+    "Red Hat Local Security Checks",               \
+    "SuSE Local Security Checks",                  \
+    "Ubuntu Local Security Checks",                \
+    NULL }
+
 gboolean
 find_result_with_permission (const char*, result_t*, const char *);
 

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -790,7 +790,8 @@ nvt_selector_has (const char* quoted_selector, const char* family_or_nvt,
  * @param[in]  growing_families      The rest of the growing families.
  * @param[in]  grow_families         1 if families should grow, else 0.
  *
- * @return 0 success, 1 config in use, 2 failed to find config, -1 error.
+ * @return 0 success, 1 config in use, 2 failed to find config, 3 whole-only
+ *         families must be growing and include entire family, -1 error.
  */
 int
 manage_set_config_families (const gchar *config_id,
@@ -799,11 +800,21 @@ manage_set_config_families (const gchar *config_id,
                             GPtrArray* growing_families,
                             int grow_families)
 {
+  static const gchar *wholes[] = FAMILIES_WHOLE_ONLY;
   config_t config;
   iterator_t families;
   gchar *quoted_selector;
   int constraining;
   char *selector;
+
+  /* Ensure that whole-only families include all NVTs and are growing. */
+
+  for (const gchar **whole = wholes; *whole; whole++)
+    if (member (growing_all_families, *whole)
+        || member (static_all_families, *whole))
+      return 3;
+
+  /* Check the args. */
 
   sql_begin_immediate ();
 

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -4996,3 +4996,28 @@ check_db_configs ()
                  __func__);
     }
 }
+
+/**
+ * @brief Check whole-only families.
+ *
+ * Called after NVT sync.
+ */
+void
+check_whole_only_in_configs ()
+{
+  static const gchar *wholes[] = FAMILIES_WHOLE_ONLY;
+
+  for (const gchar **whole = wholes; *whole; whole++)
+    {
+      gchar *quoted_family;
+
+      quoted_family = sql_quote (*whole);
+      sql ("DELETE FROM nvt_selectors"
+           " WHERE type = " G_STRINGIFY (NVT_SELECTOR_TYPE_NVT)
+           " AND EXISTS (SELECT * FROM nvts"
+           "             WHERE oid = family_or_nvt"
+           "             AND family = '%s');",
+           quoted_family);
+      g_free (quoted_family);
+    }
+}

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -4103,13 +4103,32 @@ manage_set_config (const gchar *config_id, const char*name, const char *comment,
 }
 
 /**
+ * @brief Check whether a family is "whole-only".
+ *
+ * @param[in]  family         Family name.
+ *
+ * @return 1 if whole-only, else 0.
+ */
+int
+family_whole_only (const gchar *family)
+{
+  static const gchar *wholes[] = FAMILIES_WHOLE_ONLY;
+
+  for (const gchar **whole = wholes; *whole; whole++)
+    if (strcmp (*whole, family) == 0)
+      return 1;
+  return 0;
+}
+
+/**
  * @brief Set the NVT's selected for a single family of a config.
  *
  * @param[in]  config_id      Config.
  * @param[in]  family         Family name.
  * @param[in]  selected_nvts  NVT's.
  *
- * @return 0 success, 1 config in use, 2 failed to find config, -1 error.
+ * @return 0 success, 1 config in use, 2 failed to find config, 3 whole-only
+ *         family, -1 error.
  */
 int
 manage_set_config_nvts (const gchar *config_id, const char* family,
@@ -4119,6 +4138,9 @@ manage_set_config_nvts (const gchar *config_id, const char* family,
   char *selector;
   gchar *quoted_family, *quoted_selector;
   int new_nvt_count = 0, old_nvt_count;
+
+  if (family_whole_only (family))
+    return 3;
 
   sql_begin_immediate ();
 

--- a/src/manage_sql_configs.h
+++ b/src/manage_sql_configs.h
@@ -100,4 +100,7 @@ update_config (config_t, const gchar *, const gchar *, const gchar *,
 void
 check_db_configs ();
 
+void
+check_whole_only_in_configs ();
+
 #endif /* not _GVMD_MANAGE_SQL_CONFIGS_H */

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -40,6 +40,7 @@
 #include "manage_sql_nvts.h"
 #include "manage_preferences.h"
 #include "manage_sql.h"
+#include "manage_sql_configs.h"
 #include "sql.h"
 #include "utils.h"
 
@@ -1953,6 +1954,8 @@ update_nvt_cache_osp (const gchar *update_socket, gchar *db_feed_version,
 
   check_preference_names (0, old_nvts_last_modified);
   check_preference_names (1, old_nvts_last_modified);
+
+  check_whole_only_in_configs ();
 
   return 0;
 }


### PR DESCRIPTION
**What**:

This brings gvmd in line with the interface change from https://github.com/greenbone/gsa/pull/2222:

- prevent selection/exclusion of single NVTs with certain LSC families
- prevent static selection of certain LSC families
- after every NVT sync ensure that certain LSC families stay "entire family, growing"

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

For certain LSC families GSA only allows selection of the entire family in configs.  gvmd should match this
 - for consistency
 - to avoid confusion and errors resulting from gvmd offering different capabilities from GSA via GMP
 - to make it easy for openvas-ospd to select the driver NVT for these families (if the only case is selecting entire growing family, then ospd-openvas only needs to match the vt_group for the family).

<!-- Why are these changes necessary? -->

**How did you test it**:

GMP that should fail:
-  `<modify_config config_id="49b2cb3b-79ea-4093-bee3-8bce68797484"><nvt_selection><family>CentOS Local Security Checks</family><nvt oid="1.3.6.1.4.1.25623.1.0.880021"/></nvt_selection></modify_config>`
- `<modify_config config_id="dea76e26-0fca-4628-9476-af8e521a475c"><family_selection><growing>1</growing><family><name>Debian Local Security Checks</name><all>1</all></family></family_selection></modify_config>`
- `<modify_config config_id="49b2cb3b-79ea-4093-bee3-8bce68797484"><nvt_selection><family>CentOS Local Security Checks</family><nvt oid="1.3.6.1.4.1.25623.1.0.880021"/></nvt_selection></modify_config>`

GMP that should pass:
- `<modify_config config_id="dea76e26-0fca-4628-9476-af8e521a475c"><family_selection><growing>1</growing><family><name>Debian Local Security Checks</name><all>0</all></family></family_selection></modify_config>`
- `<modify_config config_id="dea76e26-0fca-4628-9476-af8e521a475c"><nvt_selection><family>Port scanners</family><nvt oid="1.3.6.1.4.1.25623.1.0.14259"/></nvt_selection></modify_config>`

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
