### PR TITLE
Cache report counts when Dynamic Severity is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Speed up result counting iterator [#1358](https://github.com/greenbone/gvmd/pull/1358) [#1361](https://github.com/greenbone/gvmd/pull/1361)
 - Speed up result iterator [#1370](https://github.com/greenbone/gvmd/pull/1358) [#1361](https://github.com/greenbone/gvmd/pull/1370)
 - Improve GMP docs around users [#1363](https://github.com/greenbone/gvmd/pull/1363)
+- Cache report counts when Dynamic Severity is enabled [#1389](https://github.com/greenbone/gvmd/pull/1389)
 
 ### Changed
 - Move EXE credential generation to a Python script [#1260](https://github.com/greenbone/gvmd/pull/1260) [#1262](https://github.com/greenbone/gvmd/pull/1262)

--- a/src/manage.h
+++ b/src/manage.h
@@ -1131,9 +1131,6 @@ result_detection_reference (result_t, report_t, const char *, const char *,
 #define MIN_QOD_DEFAULT 70
 
 void
-reports_clear_count_cache (int);
-
-void
 reports_clear_count_cache_for_override (override_t, int);
 
 void

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -19718,12 +19718,21 @@ reports_hashtable ()
 }
 
 /**
- * @brief Clear the report count cache for all reports and users.
+ * @brief Clear the report count cache for all reports of a user.
+ *
+ * @param[in]  uuid  UUID of user.
  */
 static void
-reports_clear_count_cache ()
+reports_clear_count_cache (const gchar *uuid)
 {
-  sql ("DELETE FROM report_counts;");
+  gchar *quoted_uuid;
+
+  quoted_uuid = sql_quote (uuid);
+  sql ("DELETE FROM report_counts"
+       " WHERE report_counts.user = (SELECT id FROM users"
+       "                             WHERE uuid = '%s');",
+       quoted_uuid);
+  g_free (quoted_uuid);
 }
 
 /**
@@ -49366,7 +49375,7 @@ modify_setting (const gchar *uuid, const gchar *name,
         {
           /* Dynamic Severity */
           current_credentials.dynamic_severity = atoi (value);
-          reports_clear_count_cache ();
+          reports_clear_count_cache (current_credentials.uuid);
         }
 
       if (strcmp (uuid, "7eda49c5-096c-4bef-b1ab-d080d87300df") == 0)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -23765,17 +23765,14 @@ report_counts (const char* report_id, int* holes, int* infos,
 static int
 report_counts_cache_exists (report_t report, int override, int min_qod)
 {
-  if (setting_dynamic_severity_int ())
-    return 0;
-  else
-    return sql_int ("SELECT EXISTS (SELECT * FROM report_counts"
-                    " WHERE report = %llu"
-                    "   AND override = %d"
-                    "   AND \"user\" = (SELECT id FROM users"
-                    "                   WHERE users.uuid = '%s')"
-                    "   AND min_qod = %d"
-                    "   AND (end_time = 0 OR end_time >= m_now ()));",
-                    report, override, current_credentials.uuid, min_qod);
+  return sql_int ("SELECT EXISTS (SELECT * FROM report_counts"
+                  " WHERE report = %llu"
+                  "   AND override = %d"
+                  "   AND \"user\" = (SELECT id FROM users"
+                  "                   WHERE users.uuid = '%s')"
+                  "   AND min_qod = %d"
+                  "   AND (end_time = 0 OR end_time >= m_now ()));",
+                  report, override, current_credentials.uuid, min_qod);
 }
 
 /**
@@ -23826,11 +23823,6 @@ cache_report_counts (report_t report, int override, int min_qod,
   int i, ret;
   double severity;
   int end_time;
-
-  /* Do not cache results when using dynamic severity. */
-
-  if (setting_dynamic_severity_int ())
-    return 0;
 
   /* Try cache results. */
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -19727,6 +19727,18 @@ reports_clear_count_cache ()
 }
 
 /**
+ * @brief Clear all report counts for all dynamic severity users.
+ */
+void
+reports_clear_count_cache_dynamic ()
+{
+  sql ("DELETE FROM report_counts"
+       " WHERE report_counts.user IN (SELECT owner FROM settings"
+       "                              WHERE name = 'Dynamic Severity'"
+       "                              AND value = '1');");
+}
+
+/**
  * @brief Rebuild the report count cache for all reports and users.
  *
  * @param[in]  clear        Whether to clear the cache before rebuilding.

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -19718,6 +19718,15 @@ reports_hashtable ()
 }
 
 /**
+ * @brief Clear the report count cache for all reports and users.
+ */
+static void
+reports_clear_count_cache ()
+{
+  sql ("DELETE FROM report_counts;");
+}
+
+/**
  * @brief Rebuild the report count cache for all reports and users.
  *
  * @param[in]  clear        Whether to clear the cache before rebuilding.
@@ -49345,6 +49354,7 @@ modify_setting (const gchar *uuid, const gchar *name,
         {
           /* Dynamic Severity */
           current_credentials.dynamic_severity = atoi (value);
+          reports_clear_count_cache ();
         }
 
       if (strcmp (uuid, "7eda49c5-096c-4bef-b1ab-d080d87300df") == 0)

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -476,4 +476,7 @@ create_view_vulns ();
 int
 config_family_entire_and_growing (config_t, const char*);
 
+void
+reports_clear_count_cache_dynamic ();
+
 #endif /* not _GVMD_MANAGE_SQL_H */

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1926,6 +1926,10 @@ update_nvt_cache_osp (const gchar *update_socket, gchar *db_feed_version,
       g_string_free (prefs_sql, TRUE);
     }
 
+  /* Update the cache of report counts. */
+
+  reports_clear_count_cache_dynamic ();
+
   /* Tell the main process to update its NVTi cache. */
   sql ("UPDATE %s.meta SET value = 1 WHERE name = 'update_nvti_cache';",
        sql_schema ());


### PR DESCRIPTION
**What**:

Add caching of report counts for users who have Dynamic Severity enabled.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

Improves the speed of GET_REPORTS when Dynamic Severity is enabled.

Most noticeable on GSA Reports page, because other pages only need to count single reports (which is usually fast even without the cache).

This also prepares for switching to Dynamic Severity only.

<!-- Why are these changes necessary? -->

**How did you test it**:

1. with user1, switch to dynamic severity
2. `delete from report_counts;`
3. with user1, go to GSA > Reports
4. `select * from report_counts;`  <= should return rows
5. with user2, go to GSA > Reports
6. `select report_counts.user, count(*) from report_counts group by report_counts.user;` <= should return 2 rows
7. with user1, switch off dynamic severity
9. 6 should show 1 row
10. with user1 got to GSA > Reports
11. with user1, switch on dynamic severity
12. 6 should show 1 row
13. with user1 go to GSA > Reports
14. 6 should show 2 rows
14. do a --rebuild
15. 6 should show 1 row

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
