### PR TITLE
Use timestamp in automatic sensor task names (20.08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Extended the output of invalid / missing --feed parameter given to greenbone-feed-sync [#1255](https://github.com/greenbone/gvmd/pull/1255)
 - The xsltproc binary is now marked as mandatory [#1259](https://github.com/greenbone/gvmd/pull/1259)
 - Check feed status without acquiring lock [#1266](https://github.com/greenbone/gvmd/pull/1266)
+- Use timestamp in automatic sensor task names [#1390](https://github.com/greenbone/gvmd/pull/1390)
 
 ### Fixed
 - Add dummy functions to allow restoring old dumps [#1251](https://github.com/greenbone/gvmd/pull/1251)

--- a/src/manage.c
+++ b/src/manage.c
@@ -3230,6 +3230,7 @@ handle_gmp_slave_task (task_t task, target_t target,
 {
   char *name, *uuid;
   int ret;
+  time_t now;
   gchar *slave_task_name;
 
   /* Some of the cases in here must write to the session outside an open
@@ -3261,7 +3262,11 @@ handle_gmp_slave_task (task_t task, target_t target,
       g_warning ("%s: Failed to get task name", __func__);
       return -2;
     }
-  slave_task_name = g_strdup_printf ("%s for %s", uuid, name);
+  now = time (NULL);
+  slave_task_name = g_strdup_printf ("%s (%s) %s",
+                                     name,
+                                     uuid,
+                                     iso_time (&now));
   free (name);
   free (uuid);
 


### PR DESCRIPTION
**What**:
The automatically generated task names for tasks on GMP sensors now also
contain the date and time in ISO format.

**Why**:
This is meant to avoid naming conflicts of the related targets, configs
etc. if the task is started again after an error where the resources
created by the master were not removed or if two tasks with the same
name are run on the same sensor.

**How did you test it**:
By running a task using a GMP sensor and checking the name of the
task, target etc. on the sensor.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
