### PR TITLE
Replace g_file_test with gvm-libs file tests (20.08)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - run:
           working_directory: ~/gvm-libs
           name: Checkout gvm-libs
-          command: git clone --depth 1 https://github.com/greenbone/gvm-libs.git
+          command: git clone -b gvm-libs-20.08 --depth 1 https://github.com/greenbone/gvm-libs.git
       - run:
           working_directory: ~/gvm-libs
           name: Configure and compile gvm-libs (Release)
@@ -31,7 +31,7 @@ jobs:
       - run:
           working_directory: ~/gvm-libs
           name: Checkout gvm-libs
-          command: git clone --depth 1 https://github.com/greenbone/gvm-libs.git
+          command: git clone -b gvm-libs-20.08 --depth 1 https://github.com/greenbone/gvm-libs.git
       - run:
           working_directory: ~/gvm-libs
           name: Configure and compile gvm-libs (Debug)
@@ -47,7 +47,7 @@ jobs:
       - run:
           working_directory: ~/gvm-libs
           name: Checkout gvm-libs
-          command: git clone --depth 1 https://github.com/greenbone/gvm-libs.git
+          command: git clone -b gvm-libs-20.08 --depth 1 https://github.com/greenbone/gvm-libs.git
       - run:
           working_directory: ~/gvm-libs
           name: Configure and compile gvm-libs (Release)
@@ -63,7 +63,7 @@ jobs:
       - run:
           working_directory: ~/gvm-libs
           name: Checkout gvm-libs
-          command: git clone --depth 1 https://github.com/greenbone/gvm-libs.git
+          command: git clone -b gvm-libs-20.08 --depth 1 https://github.com/greenbone/gvm-libs.git
       - run:
           working_directory: ~/gvm-libs
           name: Configure and compile gvm-libs (Release)
@@ -79,7 +79,7 @@ jobs:
       - run:
           working_directory: ~/gvm-libs
           name: Checkout gvm-libs
-          command: git clone --depth 1 https://github.com/greenbone/gvm-libs.git
+          command: git clone -b gvm-libs-20.08 --depth 1 https://github.com/greenbone/gvm-libs.git
       - run:
           working_directory: ~/gvm-libs
           name: Configure and compile gvm-libs (Release)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Extended the output of invalid / missing --feed parameter given to greenbone-feed-sync [#1255](https://github.com/greenbone/gvmd/pull/1255)
 - The xsltproc binary is now marked as mandatory [#1259](https://github.com/greenbone/gvmd/pull/1259)
 - Check feed status without acquiring lock [#1266](https://github.com/greenbone/gvmd/pull/1266)
+- Replace g_file_test with gvm-libs file tests [#1391](https://github.com/greenbone/gvmd/pull/1391)
 
 ### Fixed
 - Add dummy functions to allow restoring old dumps [#1251](https://github.com/greenbone/gvmd/pull/1251)

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -95,6 +95,7 @@
 #include <gvm/base/pwpolicy.h>
 #include <gvm/base/logging.h>
 #include <gvm/base/proctitle.h>
+#include <gvm/util/fileutils.h>
 #include <gvm/util/serverutils.h>
 
 #include "manage.h"
@@ -2145,7 +2146,7 @@ gvmd (int argc, char** argv)
   rc_name = g_build_filename (GVM_SYSCONF_DIR,
                               "gvmd_log.conf",
                               NULL);
-  if (g_file_test (rc_name, G_FILE_TEST_EXISTS))
+  if (gvm_file_is_readable (rc_name))
     log_config = load_log_configuration (rc_name);
   g_free (rc_name);
   setup_log_handlers (log_config);
@@ -2164,9 +2165,11 @@ gvmd (int argc, char** argv)
     {
       if (strcmp (relay_mapper, ""))
         {
-          if (g_file_test (relay_mapper, G_FILE_TEST_EXISTS) == 0)
+          if (gvm_file_exists (relay_mapper) == 0)
             g_warning ("Relay mapper '%s' not found.", relay_mapper);
-          else if (g_file_test (relay_mapper, G_FILE_TEST_IS_EXECUTABLE) == 0)
+          else if (gvm_file_is_readable (relay_mapper) == 0)
+            g_warning ("Relay mapper '%s' is not readable.", relay_mapper);
+          else if (gvm_file_is_executable (relay_mapper) == 0)
             g_warning ("Relay mapper '%s' is not executable.", relay_mapper);
           else
             {
@@ -2346,8 +2349,12 @@ gvmd (int argc, char** argv)
       password_policy = g_build_filename (GVM_SYSCONF_DIR,
                                           "pwpolicy.conf",
                                           NULL);
-      if (g_file_test (password_policy, G_FILE_TEST_EXISTS) == FALSE)
+      if (gvm_file_exists (password_policy) == FALSE)
         g_warning ("%s: password policy missing: %s",
+                   __func__,
+                   password_policy);
+      else if (gvm_file_is_readable (password_policy) == FALSE)
+        g_warning ("%s: password policy not readable: %s",
                    __func__,
                    password_policy);
       g_free (password_policy);

--- a/src/manage.c
+++ b/src/manage.c
@@ -8424,7 +8424,7 @@ sort_data_free (sort_data_t *sort_data)
 gboolean
 manage_gvmd_data_feed_dirs_exist ()
 {
-  return g_file_test (GVMD_FEED_DIR, G_FILE_TEST_EXISTS)
+  return gvm_file_is_readable (GVMD_FEED_DIR)
          && configs_feed_dir_exists ()
          && port_lists_feed_dir_exists ()
          && report_formats_feed_dir_exists ();

--- a/src/manage_configs.c
+++ b/src/manage_configs.c
@@ -31,7 +31,7 @@
 
 #include <errno.h>
 #include <glib.h>
-#include <glib/gstdio.h>
+#include <gvm/util/fileutils.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -456,7 +456,7 @@ sync_configs_with_feed ()
 gboolean
 configs_feed_dir_exists ()
 {
-  return g_file_test (feed_dir_configs (), G_FILE_TEST_EXISTS);
+  return gvm_file_is_readable (feed_dir_configs ());
 }
 
 /**

--- a/src/manage_port_lists.c
+++ b/src/manage_port_lists.c
@@ -29,6 +29,7 @@
 #include "manage_sql_port_lists.h"
 #include "utils.h"
 
+#include <gvm/util/fileutils.h>
 #include <string.h>
 
 #undef G_LOG_DOMAIN
@@ -379,7 +380,7 @@ sync_port_lists_with_feed ()
 gboolean
 port_lists_feed_dir_exists ()
 {
-  return g_file_test (feed_dir_port_lists (), G_FILE_TEST_EXISTS);
+  return gvm_file_is_readable (feed_dir_port_lists ());
 }
 
 /**

--- a/src/manage_report_formats.c
+++ b/src/manage_report_formats.c
@@ -33,6 +33,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <glib.h>
+#include <gvm/util/fileutils.h>
 #include <locale.h>
 #include <stdlib.h>
 #include <string.h>
@@ -740,7 +741,7 @@ sync_report_formats_with_feed ()
 gboolean
 report_formats_feed_dir_exists ()
 {
-  return g_file_test (feed_dir_report_formats (), G_FILE_TEST_EXISTS);
+  return gvm_file_is_readable (feed_dir_report_formats ());
 }
 
 /**

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -9297,7 +9297,7 @@ alert_script_exec (const char *alert_id, const char *command_args,
 
   script = g_build_filename (script_dir, "alert", NULL);
 
-  if (!g_file_test (script, G_FILE_TEST_EXISTS))
+  if (! gvm_file_is_readable (script))
     {
       g_warning ("%s: Failed to find alert script: %s",
            __func__,
@@ -10088,7 +10088,7 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
 
   script = g_build_filename (script_dir, "alert", NULL);
 
-  if (!g_file_test (script, G_FILE_TEST_EXISTS))
+  if (! gvm_file_is_readable (script))
     {
       g_free (report_file);
       g_free (pkcs12_file);
@@ -10408,7 +10408,7 @@ send_to_verinice (const char *url, const char *username, const char *password,
 
   script = g_build_filename (script_dir, "alert", NULL);
 
-  if (!g_file_test (script, G_FILE_TEST_EXISTS))
+  if (! gvm_file_is_readable (script))
     {
       g_warning ("%s: Failed to find alert script: %s",
            __func__,
@@ -46460,7 +46460,7 @@ manage_schema (gchar *format, gchar **output_return, gsize *output_length,
 
     script = g_build_filename (script_dir, "generate", NULL);
 
-    if (!g_file_test (script, G_FILE_TEST_EXISTS))
+    if (! gvm_file_is_readable (script))
       {
         g_free (script);
         g_free (script_dir);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -9297,7 +9297,7 @@ alert_script_exec (const char *alert_id, const char *command_args,
 
   script = g_build_filename (script_dir, "alert", NULL);
 
-  if (! gvm_file_is_readable (script))
+  if (!gvm_file_is_readable (script))
     {
       g_warning ("%s: Failed to find alert script: %s",
            __func__,
@@ -10088,7 +10088,7 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
 
   script = g_build_filename (script_dir, "alert", NULL);
 
-  if (! gvm_file_is_readable (script))
+  if (!gvm_file_is_readable (script))
     {
       g_free (report_file);
       g_free (pkcs12_file);
@@ -10408,7 +10408,7 @@ send_to_verinice (const char *url, const char *username, const char *password,
 
   script = g_build_filename (script_dir, "alert", NULL);
 
-  if (! gvm_file_is_readable (script))
+  if (!gvm_file_is_readable (script))
     {
       g_warning ("%s: Failed to find alert script: %s",
            __func__,
@@ -46460,7 +46460,7 @@ manage_schema (gchar *format, gchar **output_return, gsize *output_length,
 
     script = g_build_filename (script_dir, "generate", NULL);
 
-    if (! gvm_file_is_readable (script))
+    if (!gvm_file_is_readable (script))
       {
         g_free (script);
         g_free (script_dir);

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -590,7 +590,7 @@ save_report_format_files (const gchar *report_id, array_t *files,
                           report_id,
                           NULL);
 
-  if (g_file_test (dir, G_FILE_TEST_EXISTS) && gvm_file_remove_recurse (dir))
+  if (gvm_file_exists (dir) && gvm_file_remove_recurse (dir))
     {
       g_warning ("%s: failed to remove dir %s", __func__, dir);
       g_free (dir);
@@ -1293,7 +1293,7 @@ copy_report_format_dir (const gchar *source_dir, const gchar *copy_parent,
 
   /* Check that the source directory exists. */
 
-  if (!g_file_test (source_dir, G_FILE_TEST_EXISTS))
+  if (! gvm_file_is_readable (source_dir))
     {
       g_warning ("%s: report format directory %s not found",
                  __func__, source_dir);
@@ -1304,7 +1304,7 @@ copy_report_format_dir (const gchar *source_dir, const gchar *copy_parent,
 
   copy_dir = g_build_filename (copy_parent, copy_uuid, NULL);
 
-  if (g_file_test (copy_dir, G_FILE_TEST_EXISTS)
+  if (gvm_file_exists (copy_dir)
       && gvm_file_remove_recurse (copy_dir))
     {
       g_warning ("%s: failed to remove dir %s", __func__, copy_dir);
@@ -1591,7 +1591,7 @@ modify_report_format (const char *report_format_id, const char *name,
 static int
 move_report_format_dir (const char *dir, const char *new_dir)
 {
-  if (g_file_test (dir, G_FILE_TEST_EXISTS)
+  if (gvm_file_is_readable (dir)
       && gvm_file_check_is_dir (dir))
     {
       gchar *new_dir_parent;
@@ -1793,7 +1793,7 @@ delete_report_format (const char *report_format_id, int ultimate)
       report_format_string = g_strdup_printf ("%llu", report_format);
       dir = report_format_trash_dir (report_format_string);
       g_free (report_format_string);
-      if (g_file_test (dir, G_FILE_TEST_EXISTS) && gvm_file_remove_recurse (dir))
+      if (gvm_file_exists (dir) && gvm_file_remove_recurse (dir))
         {
           g_free (dir);
           g_free (base);
@@ -1849,7 +1849,7 @@ delete_report_format (const char *report_format_id, int ultimate)
 
       /* Remove directory. */
 
-      if (g_file_test (dir, G_FILE_TEST_EXISTS) && gvm_file_remove_recurse (dir))
+      if (gvm_file_exists (dir) && gvm_file_remove_recurse (dir))
         {
           g_free (dir);
           sql_rollback ();
@@ -3341,8 +3341,7 @@ run_report_format_script (gchar *report_format_id,
 
   script = g_build_filename (script_dir, "generate", NULL);
 
-  if (!g_file_test (script,
-                    G_FILE_TEST_EXISTS | G_FILE_TEST_IS_REGULAR))
+  if (! gvm_file_is_readable (script))
     {
       g_warning ("%s: No generate script found at %s",
                  __func__, script);
@@ -3350,8 +3349,7 @@ run_report_format_script (gchar *report_format_id,
       g_free (script_dir);
       return -1;
     }
-  else if (!g_file_test (script,
-                         G_FILE_TEST_IS_EXECUTABLE))
+  else if (! gvm_file_is_executable (script))
     {
       g_warning ("%s: script %s is not executable",
                  __func__, script);
@@ -3935,7 +3933,7 @@ empty_trashcan_report_formats ()
       dir = report_format_trash_dir (name);
       g_free (name);
 
-      if (g_file_test (dir, G_FILE_TEST_EXISTS) && gvm_file_remove_recurse (dir))
+      if (gvm_file_exists (dir) && gvm_file_remove_recurse (dir))
         {
           g_warning ("%s: failed to remove trash dir %s", __func__, dir);
           g_free (dir);
@@ -4105,8 +4103,7 @@ delete_report_format_dirs_user (const gchar *user_id, iterator_t *rows)
                           user_id,
                           NULL);
 
-  if (g_file_test (dir, G_FILE_TEST_EXISTS)
-      && gvm_file_remove_recurse (dir))
+  if (gvm_file_exists (dir) && gvm_file_remove_recurse (dir))
     g_warning ("%s: failed to remove dir %s, continuing anyway",
                __func__, dir);
   g_free (dir);

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -1293,7 +1293,7 @@ copy_report_format_dir (const gchar *source_dir, const gchar *copy_parent,
 
   /* Check that the source directory exists. */
 
-  if (! gvm_file_is_readable (source_dir))
+  if (!gvm_file_is_readable (source_dir))
     {
       g_warning ("%s: report format directory %s not found",
                  __func__, source_dir);
@@ -3341,7 +3341,7 @@ run_report_format_script (gchar *report_format_id,
 
   script = g_build_filename (script_dir, "generate", NULL);
 
-  if (! gvm_file_is_readable (script))
+  if (!gvm_file_is_readable (script))
     {
       g_warning ("%s: No generate script found at %s",
                  __func__, script);
@@ -3349,7 +3349,7 @@ run_report_format_script (gchar *report_format_id,
       g_free (script_dir);
       return -1;
     }
-  else if (! gvm_file_is_executable (script))
+  else if (!gvm_file_is_executable (script))
     {
       g_warning ("%s: script %s is not executable",
                  __func__, script);

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -4791,12 +4791,12 @@ try_load_csv ()
                                              "table-affected-ovaldefs.csv",
                                              NULL);
 
-  if (g_file_test (file_cves, G_FILE_TEST_EXISTS)
-      && g_file_test (file_cpes, G_FILE_TEST_EXISTS)
-      && g_file_test (file_affected_products, G_FILE_TEST_EXISTS)
-      && g_file_test (file_ovaldefs, G_FILE_TEST_EXISTS)
-      && g_file_test (file_ovalfiles, G_FILE_TEST_EXISTS)
-      && g_file_test (file_affected_ovaldefs, G_FILE_TEST_EXISTS))
+  if (gvm_file_is_readable (file_cves)
+      && gvm_file_is_readable (file_cpes)
+      && gvm_file_is_readable (file_affected_products)
+      && gvm_file_is_readable (file_ovaldefs)
+      && gvm_file_is_readable (file_ovalfiles)
+      && gvm_file_is_readable (file_affected_ovaldefs))
     {
       /* Create a new schema, "scap2". */
 


### PR DESCRIPTION
**What**:
This replaces the `g_file_test` calls with the functions gvm_file_exists
gvm_file_is_executable and gvm_file_is_readable, which were added
in greenbone/gvm-libs#422.

**Why**:
The new functions use the effective UID/GID when checking if a file is
accessible so gvmd can be used with the file flags to set UID and GID.

**How did you test it**:
* Running gvmd with the `--relay-mapper` option with
  * a file that does not exists
  * a file the user has no permissions for
  * a file the user can access but that is not executable
  * an executable file the user can access
* Exporting a report

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
