### PR TITLE
Improve "Failed to find..." messages (20.08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Allow config to sync even if NVT family is not available [#1366](https://github.com/greenbone/gvmd/pull/1366)
 - Delete report format dirs last when deleting a user [#1368](https://github.com/greenbone/gvmd/pull/1368)
 - Fix sorting in get_aggregates and its documentation [#1375](https://github.com/greenbone/gvmd/pull/1375)
+- Improve get_info "Failed to find..." message [#1395](https://github.com/greenbone/gvmd/pull/1395)
 
 ### Removed
 - Remove DROP from vulns creation [#1281](http://github.com/greenbone/gvmd/pull/1281)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Allow config to sync even if NVT family is not available [#1366](https://github.com/greenbone/gvmd/pull/1366)
 - Delete report format dirs last when deleting a user [#1368](https://github.com/greenbone/gvmd/pull/1368)
 - Fix sorting in get_aggregates and its documentation [#1375](https://github.com/greenbone/gvmd/pull/1375)
-- Improve get_info "Failed to find..." message [#1395](https://github.com/greenbone/gvmd/pull/1395)
+- Improve "Failed to find..." messages [#1395](https://github.com/greenbone/gvmd/pull/1395)
 
 ### Removed
 - Remove DROP from vulns creation [#1281](http://github.com/greenbone/gvmd/pull/1281)

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -13112,8 +13112,13 @@ handle_get_info (gmp_parser_t *gmp_parser, GError **error)
       switch (ret)
         {
         case 1:
-          if (send_find_error_to_client ("get_info", "type",
-                                         get_info_data->type,
+          if (send_find_error_to_client ("get_info",
+                                         get_info_data->name
+                                          ? "name"
+                                          : "ID",
+                                         get_info_data->name
+                                          ? get_info_data->name
+                                          : get_info_data->get.id,
                                          gmp_parser))
             {
               error_send_to_client (error);

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -11133,7 +11133,7 @@ handle_get_alerts (gmp_parser_t *gmp_parser, GError **error)
             break;
           case 2:
             if (send_find_error_to_client
-                  ("get_alerts", "alert", get_alerts_data->get.filt_id,
+                  ("get_alerts", "filter", get_alerts_data->get.filt_id,
                    gmp_parser))
               {
                 error_send_to_client (error);
@@ -11697,7 +11697,7 @@ handle_get_configs (gmp_parser_t *gmp_parser, GError **error)
             break;
           case 2:
             if (send_find_error_to_client
-                 ("get_configs", "config", get_configs_data->get.filt_id,
+                 ("get_configs", "filter", get_configs_data->get.filt_id,
                   gmp_parser))
               {
                 error_send_to_client (error);
@@ -12067,7 +12067,7 @@ handle_get_credentials (gmp_parser_t *gmp_parser, GError **error)
             break;
           case 2:
             if (send_find_error_to_client ("get_credentials",
-                                           "credential",
+                                           "filter",
                                            get_credentials_data->get.filt_id,
                                            gmp_parser))
               {
@@ -12856,7 +12856,7 @@ handle_get_groups (gmp_parser_t *gmp_parser, GError **error)
             break;
           case 2:
             if (send_find_error_to_client
-                  ("get_groups", "group", get_groups_data->get.filt_id,
+                  ("get_groups", "filter", get_groups_data->get.filt_id,
                    gmp_parser))
               {
                 error_send_to_client (error);
@@ -14032,7 +14032,7 @@ handle_get_port_lists (gmp_parser_t *gmp_parser, GError **error)
             break;
           case 2:
             if (send_find_error_to_client
-                  ("get_port_lists", "port_list",
+                  ("get_port_lists", "filter",
                    get_port_lists_data->get.filt_id, gmp_parser))
               {
                 error_send_to_client (error);
@@ -15365,7 +15365,7 @@ handle_get_roles (gmp_parser_t *gmp_parser, GError **error)
             break;
           case 2:
             if (send_find_error_to_client
-                  ("get_roles", "role", get_roles_data->get.filt_id,
+                  ("get_roles", "filter", get_roles_data->get.filt_id,
                   gmp_parser))
               {
                 error_send_to_client (error);
@@ -16945,7 +16945,7 @@ handle_get_tasks (gmp_parser_t *gmp_parser, GError **error)
             break;
           case 2:
             if (send_find_error_to_client
-                  ("get_tasks", "task", get_tasks_data->get.filt_id,
+                  ("get_tasks", "filter", get_tasks_data->get.filt_id,
                   gmp_parser))
               {
                 error_send_to_client (error);
@@ -17663,7 +17663,7 @@ handle_get_users (gmp_parser_t *gmp_parser, GError **error)
             break;
           case 2:
             if (send_find_error_to_client
-                  ("get_users", "user", get_users_data->get.filt_id,
+                  ("get_users", "filter", get_users_data->get.filt_id,
                    gmp_parser))
               {
                 error_send_to_client (error);

--- a/src/gmp_base.c
+++ b/src/gmp_base.c
@@ -151,10 +151,10 @@ send_find_error_to_client (const char* command, const char* type,
   gchar *msg;
   gboolean ret;
 
-  msg = g_strdup_printf ("<%s_response status=\""
-                         STATUS_ERROR_MISSING
-                         "\" status_text=\"Failed to find %s '%s'\"/>",
-                         command, type, id);
+  msg = g_markup_printf_escaped ("<%s_response status=\""
+                                 STATUS_ERROR_MISSING
+                                 "\" status_text=\"Failed to find %s '%s'\"/>",
+                                 command, type, id);
   ret = send_to_client (msg, gmp_parser->client_writer,
                         gmp_parser->client_writer_data);
   g_free (msg);


### PR DESCRIPTION
**What**:
This fixes the following issues with the "Failed to find..." messages.

1. If a SecInfo entry cannot be found by ID or name, the error message will
say it cannot find the given ID or name instead of a message that the
type could not be found.
2. XML escaping is applied to the error messages.
3. Error messages if a filter given by `filt_id` cannot be found now say "filter"
 instead of using the type of the `get_` command.

**Why**:
1. The previous message was misleading and should only be used if
an invalid `info_type` was used.
2. When requesting a name or id with quote marks and possibly other
 reserved characters, the response would be invalid.
3. The message was wrong and misleading.

**How did you test it**:
1. Tested by requesting a nonexistent CPE via GSA.
2. Tested by requesting a an id containing a quote mark via gvm-cli.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
