### PR TITLE
Rename and fix preference allow_simultaneous_ips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Extend GMP for extended severities [#1326](https://github.com/greenbone/gvmd/pull/1326) [#1329](https://github.com/greenbone/gvmd/pull/1329) [#1359](https://github.com/greenbone/gvmd/pull/1359) [#1371](https://github.com/greenbone/gvmd/pull/1371)
 - Parameter `--db-user` to set a database user [#1327](https://github.com/greenbone/gvmd/pull/1327)
-- Add `allow_simult_ips_same_host` field for targets [#1346](https://github.com/greenbone/gvmd/pull/1346)
+- Add `allow_simultaneous_ips` field for targets [#1346](https://github.com/greenbone/gvmd/pull/1346) [#1396](https://github.com/greenbone/gvmd/pull/1396)
 - Speed up GET_VULNS [#1354](https://github.com/greenbone/gvmd/pull/1354) [#1355](https://github.com/greenbone/gvmd/pull/1354)
 - Speed up result counting iterator [#1358](https://github.com/greenbone/gvmd/pull/1358) [#1361](https://github.com/greenbone/gvmd/pull/1361)
 - Speed up result iterator [#1370](https://github.com/greenbone/gvmd/pull/1358) [#1361](https://github.com/greenbone/gvmd/pull/1370)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 240)
+set (GVMD_DATABASE_VERSION 241)
 
 set (GVMD_SCAP_DATABASE_VERSION 17)
 

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -915,7 +915,7 @@ create_schedule_data_reset (create_schedule_data_t *data)
 typedef struct
 {
   char *alive_tests;             ///< Alive tests.
-  char *allow_simult_ips_same_host; ///< Boolean. Whether to scan multiple IPs of a host simultaneously.
+  char *allow_simultaneous_ips;  ///< Boolean. Whether to scan multiple IPs of a host simultaneously.
   char *asset_hosts_filter;      ///< Asset hosts.
   char *comment;                 ///< Comment.
   char *exclude_hosts;           ///< Hosts to exclude from set.
@@ -946,7 +946,7 @@ static void
 create_target_data_reset (create_target_data_t *data)
 {
   free (data->alive_tests);
-  free (data->allow_simult_ips_same_host);
+  free (data->allow_simultaneous_ips);
   free (data->asset_hosts_filter);
   free (data->comment);
   free (data->exclude_hosts);
@@ -2834,7 +2834,7 @@ modify_setting_data_reset (modify_setting_data_t *data)
 typedef struct
 {
   char *alive_tests;             ///< Alive tests.
-  char *allow_simult_ips_same_host; ///< Boolean. Whether to scan multiple IPs of a host simultaneously.
+  char *allow_simultaneous_ips;  ///< Boolean. Whether to scan multiple IPs of a host simultaneously.
   char *comment;                 ///< Comment.
   char *exclude_hosts;           ///< Hosts to exclude from set.
   char *reverse_lookup_only;     ///< Boolean. Whether to consider only hosts that reverse lookup.
@@ -2863,7 +2863,7 @@ static void
 modify_target_data_reset (modify_target_data_t *data)
 {
   free (data->alive_tests);
-  free (data->allow_simult_ips_same_host);
+  free (data->allow_simultaneous_ips);
   free (data->exclude_hosts);
   free (data->reverse_lookup_only);
   free (data->reverse_lookup_unify);
@@ -4266,7 +4266,7 @@ typedef enum
   CLIENT_CREATE_TAG_VALUE,
   CLIENT_CREATE_TARGET,
   CLIENT_CREATE_TARGET_ALIVE_TESTS,
-  CLIENT_CREATE_TARGET_ALLOW_SIMULT_IPS_SAME_HOST,
+  CLIENT_CREATE_TARGET_ALLOW_SIMULTANEOUS_IPS,
   CLIENT_CREATE_TARGET_ASSET_HOSTS,
   CLIENT_CREATE_TARGET_EXCLUDE_HOSTS,
   CLIENT_CREATE_TARGET_REVERSE_LOOKUP_ONLY,
@@ -4513,7 +4513,7 @@ typedef enum
   CLIENT_MODIFY_TAG_VALUE,
   CLIENT_MODIFY_TARGET,
   CLIENT_MODIFY_TARGET_ALIVE_TESTS,
-  CLIENT_MODIFY_TARGET_ALLOW_SIMULT_IPS_SAME_HOST,
+  CLIENT_MODIFY_TARGET_ALLOW_SIMULTANEOUS_IPS,
   CLIENT_MODIFY_TARGET_COMMENT,
   CLIENT_MODIFY_TARGET_ESXI_CREDENTIAL,
   CLIENT_MODIFY_TARGET_ESXI_LSC_CREDENTIAL,
@@ -6596,8 +6596,8 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
           set_client_state (CLIENT_MODIFY_TARGET_REVERSE_LOOKUP_UNIFY);
         else if (strcasecmp ("ALIVE_TESTS", element_name) == 0)
           set_client_state (CLIENT_MODIFY_TARGET_ALIVE_TESTS);
-        else if (strcasecmp ("ALLOW_SIMULT_IPS_SAME_HOST", element_name) == 0)
-          set_client_state (CLIENT_MODIFY_TARGET_ALLOW_SIMULT_IPS_SAME_HOST);
+        else if (strcasecmp ("ALLOW_SIMULTANEOUS_IPS", element_name) == 0)
+          set_client_state (CLIENT_MODIFY_TARGET_ALLOW_SIMULTANEOUS_IPS);
         else if (strcasecmp ("COMMENT", element_name) == 0)
           {
             gvm_append_string (&modify_target_data->comment, "");
@@ -7565,8 +7565,8 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
           set_client_state (CLIENT_CREATE_TARGET_REVERSE_LOOKUP_UNIFY);
         else if (strcasecmp ("ALIVE_TESTS", element_name) == 0)
           set_client_state (CLIENT_CREATE_TARGET_ALIVE_TESTS);
-        else if (strcasecmp ("ALLOW_SIMULT_IPS_SAME_HOST", element_name) == 0)
-          set_client_state (CLIENT_CREATE_TARGET_ALLOW_SIMULT_IPS_SAME_HOST);
+        else if (strcasecmp ("ALLOW_SIMULTANEOUS_IPS", element_name) == 0)
+          set_client_state (CLIENT_CREATE_TARGET_ALLOW_SIMULTANEOUS_IPS);
         else if (strcasecmp ("COMMENT", element_name) == 0)
           set_client_state (CLIENT_CREATE_TARGET_COMMENT);
         else if (strcasecmp ("COPY", element_name) == 0)
@@ -16536,7 +16536,7 @@ handle_get_targets (gmp_parser_t *gmp_parser, GError **error)
           char *esxi_name, *esxi_uuid, *snmp_name, *snmp_uuid;
           const char *port_list_uuid, *port_list_name, *ssh_port;
           const char *hosts, *exclude_hosts, *reverse_lookup_only;
-          const char *reverse_lookup_unify, *allow_simult_ips_same_host;
+          const char *reverse_lookup_unify, *allow_simultaneous_ips;
           credential_t ssh_credential, smb_credential;
           credential_t esxi_credential, snmp_credential;
           int port_list_trash, max_hosts, port_list_available;
@@ -16699,8 +16699,8 @@ handle_get_targets (gmp_parser_t *gmp_parser, GError **error)
                                   (&targets);
           reverse_lookup_unify = target_iterator_reverse_lookup_unify
                                   (&targets);
-          allow_simult_ips_same_host
-            = target_iterator_allow_simult_ips_same_host (&targets);
+          allow_simultaneous_ips
+            = target_iterator_allow_simultaneous_ips (&targets);
 
           SENDF_TO_CLIENT_OR_FAIL ("<hosts>%s</hosts>"
                                    "<exclude_hosts>%s</exclude_hosts>"
@@ -16776,13 +16776,13 @@ handle_get_targets (gmp_parser_t *gmp_parser, GError **error)
                                    "%s"
                                    "</reverse_lookup_unify>"
                                    "<alive_tests>%s</alive_tests>"
-                                   "<allow_simult_ips_same_host>"
+                                   "<allow_simultaneous_ips>"
                                    "%s"
-                                   "</allow_simult_ips_same_host>",
+                                   "</allow_simultaneous_ips>",
                                    reverse_lookup_only,
                                    reverse_lookup_unify,
                                    target_iterator_alive_tests (&targets),
-                                   allow_simult_ips_same_host);
+                                   allow_simultaneous_ips);
 
           if (get_targets_data->get.details)
             SENDF_TO_CLIENT_OR_FAIL ("<port_range>%s</port_range>",
@@ -21885,7 +21885,7 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                          create_target_data->reverse_lookup_only,
                          create_target_data->reverse_lookup_unify,
                          create_target_data->alive_tests,
-                         create_target_data->allow_simult_ips_same_host,
+                         create_target_data->allow_simultaneous_ips,
                          &new_target))
             {
               case 1:
@@ -22003,7 +22003,7 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
       CLOSE (CLIENT_CREATE_TARGET, REVERSE_LOOKUP_ONLY);
       CLOSE (CLIENT_CREATE_TARGET, REVERSE_LOOKUP_UNIFY);
       CLOSE (CLIENT_CREATE_TARGET, ALIVE_TESTS);
-      CLOSE (CLIENT_CREATE_TARGET, ALLOW_SIMULT_IPS_SAME_HOST);
+      CLOSE (CLIENT_CREATE_TARGET, ALLOW_SIMULTANEOUS_IPS);
       CLOSE (CLIENT_CREATE_TARGET, COPY);
       CLOSE (CLIENT_CREATE_TARGET, HOSTS);
       CLOSE (CLIENT_CREATE_TARGET, NAME);
@@ -24505,7 +24505,7 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                          modify_target_data->reverse_lookup_only,
                          modify_target_data->reverse_lookup_unify,
                          modify_target_data->alive_tests,
-                         modify_target_data->allow_simult_ips_same_host))
+                         modify_target_data->allow_simultaneous_ips))
             {
               case 1:
                 SEND_TO_CLIENT_OR_FAIL
@@ -24748,7 +24748,7 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
       CLOSE (CLIENT_MODIFY_TARGET, REVERSE_LOOKUP_ONLY);
       CLOSE (CLIENT_MODIFY_TARGET, REVERSE_LOOKUP_UNIFY);
       CLOSE (CLIENT_MODIFY_TARGET, ALIVE_TESTS);
-      CLOSE (CLIENT_MODIFY_TARGET, ALLOW_SIMULT_IPS_SAME_HOST);
+      CLOSE (CLIENT_MODIFY_TARGET, ALLOW_SIMULTANEOUS_IPS);
       CLOSE (CLIENT_MODIFY_TARGET, COMMENT);
       CLOSE (CLIENT_MODIFY_TARGET, HOSTS);
       CLOSE (CLIENT_MODIFY_TARGET, NAME);
@@ -26594,8 +26594,8 @@ gmp_xml_handle_text (/* unused */ GMarkupParseContext* context,
       APPEND (CLIENT_CREATE_TARGET_ALIVE_TESTS,
               &create_target_data->alive_tests);
 
-      APPEND (CLIENT_CREATE_TARGET_ALLOW_SIMULT_IPS_SAME_HOST,
-              &create_target_data->allow_simult_ips_same_host);
+      APPEND (CLIENT_CREATE_TARGET_ALLOW_SIMULTANEOUS_IPS,
+              &create_target_data->allow_simultaneous_ips);
 
       APPEND (CLIENT_CREATE_TARGET_COMMENT,
               &create_target_data->comment);
@@ -26909,8 +26909,8 @@ gmp_xml_handle_text (/* unused */ GMarkupParseContext* context,
       APPEND (CLIENT_MODIFY_TARGET_ALIVE_TESTS,
               &modify_target_data->alive_tests);
 
-      APPEND (CLIENT_MODIFY_TARGET_ALLOW_SIMULT_IPS_SAME_HOST,
-              &modify_target_data->allow_simult_ips_same_host);
+      APPEND (CLIENT_MODIFY_TARGET_ALLOW_SIMULTANEOUS_IPS,
+              &modify_target_data->allow_simultaneous_ips);
 
       APPEND (CLIENT_MODIFY_TARGET_COMMENT,
               &modify_target_data->comment);

--- a/src/manage.c
+++ b/src/manage.c
@@ -1590,7 +1590,7 @@ task_scanner_options (task_t task, target_t target)
   GHashTable *table;
   config_t config;
   iterator_t prefs;
-  char *allow_simult_ips_same_host;
+  char *allow_simultaneous_ips;
 
   config = task_config (task);
   init_config_preference_iterator (&prefs, config);
@@ -1671,16 +1671,16 @@ task_scanner_options (task_t task, target_t target)
   cleanup_iterator (&prefs);
 
   // Target options sent as scanner preferences
-  allow_simult_ips_same_host = target_allow_simult_ips_same_host (target);
-  if (allow_simult_ips_same_host)
+  allow_simultaneous_ips = target_allow_simultaneous_ips (target);
+  if (allow_simultaneous_ips)
     {
       g_hash_table_replace (table,
-                            g_strdup (strcmp (allow_simult_ips_same_host, "0")
+                            g_strdup ("allow_simultaneous_ips"),
+                            g_strdup (strcmp (allow_simultaneous_ips, "0")
                                         ? "yes" 
-                                        : "no"),
-                            g_strdup (allow_simult_ips_same_host));
+                                        : "no"));
     }
-  free (allow_simult_ips_same_host);
+  free (allow_simultaneous_ips);
 
   return table;
 }

--- a/src/manage.h
+++ b/src/manage.h
@@ -1651,7 +1651,7 @@ int
 target_iterator_snmp_trash (iterator_t*);
 
 const char*
-target_iterator_allow_simult_ips_same_host (iterator_t*);
+target_iterator_allow_simultaneous_ips (iterator_t*);
 
 const char*
 target_iterator_port_list_uuid (iterator_t*);
@@ -1693,7 +1693,7 @@ char*
 target_reverse_lookup_unify (target_t);
 
 char*
-target_allow_simult_ips_same_host (target_t);
+target_allow_simultaneous_ips (target_t);
 
 char*
 target_port_range (target_t);

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -2516,7 +2516,7 @@ migrate_238_to_239 ()
 
   /* Update the database. */
 
-  /* Table results also got a score column, for extended severities. */
+  /* Table targets(_trash) got a allow_simult_ips_same_host column. */
 
   sql ("ALTER TABLE targets ADD COLUMN"
        " allow_simult_ips_same_host integer DEFAULT 1;");
@@ -2560,6 +2560,43 @@ migrate_239_to_240 ()
   /* Set the database version to 240. */
 
   set_db_version (240);
+
+  sql_commit ();
+
+  return 0;
+}
+
+/**
+ * @brief Migrate the database from version 240 to version 241.
+ *
+ * @return 0 success, -1 error.
+ */
+int
+migrate_240_to_241 ()
+{
+  sql_begin_immediate ();
+
+  /* Ensure that the database is currently version 240. */
+
+  if (manage_db_version () != 240)
+    {
+      sql_rollback ();
+      return -1;
+    }
+
+  /* Update the database. */
+
+  /* Rename allow_simult_ips_same_host column to allow_simultaneous_ips */
+
+  sql ("ALTER TABLE targets RENAME COLUMN"
+       " allow_simult_ips_same_host TO allow_simultaneous_ips;");
+
+  sql ("ALTER TABLE targets_trash RENAME COLUMN"
+       " allow_simult_ips_same_host TO allow_simultaneous_ips;");
+
+  /* Set the database version to 241. */
+
+  set_db_version (241);
 
   sql_commit ();
 
@@ -2612,6 +2649,7 @@ static migrator_t database_migrators[] = {
   {238, migrate_237_to_238},
   {239, migrate_238_to_239},
   {240, migrate_239_to_240},
+  {241, migrate_240_to_241},
   /* End marker. */
   {-1, NULL}};
 

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -2043,7 +2043,7 @@ create_tables ()
        "  alive_test integer,"
        "  creation_time integer,"
        "  modification_time integer,"
-       "  allow_simult_ips_same_host integer DEFAULT 1);");
+       "  allow_simultaneous_ips integer DEFAULT 1);");
 
   sql ("CREATE TABLE IF NOT EXISTS targets_trash"
        " (id SERIAL PRIMARY KEY,"
@@ -2060,7 +2060,7 @@ create_tables ()
        "  alive_test integer,"
        "  creation_time integer,"
        "  modification_time integer,"
-       "  allow_simult_ips_same_host integer DEFAULT 1);");
+       "  allow_simultaneous_ips integer DEFAULT 1);");
 
   sql ("CREATE TABLE IF NOT EXISTS targets_login_data"
        " (id SERIAL PRIMARY KEY,"

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -30480,7 +30480,7 @@ target_login_port (target_t target, const char* type)
  * @param[in]   reverse_lookup_only   Scanner preference reverse_lookup_only.
  * @param[in]   reverse_lookup_unify  Scanner preference reverse_lookup_unify.
  * @param[in]   alive_tests     Alive tests.
- * @param[in]   allow_simult_ips_same_host  Scanner preference allow_simult_ips_same_host.
+ * @param[in]   allow_simultaneous_ips  Scanner preference allow_simultaneous_ips.
  * @param[out]  target          Created target.
  *
  * @return 0 success, 1 target exists already, 2 error in host specification,
@@ -30499,7 +30499,7 @@ create_target (const char* name, const char* asset_hosts_filter,
                credential_t esxi_credential, credential_t snmp_credential,
                const char *reverse_lookup_only,
                const char *reverse_lookup_unify, const char *alive_tests,
-               const char *allow_simult_ips_same_host,
+               const char *allow_simultaneous_ips,
                target_t* target)
 {
   gchar *quoted_name, *quoted_hosts, *quoted_exclude_hosts, *quoted_comment;
@@ -30636,11 +30636,11 @@ create_target (const char* name, const char* asset_hosts_filter,
     reverse_lookup_unify = "0";
   else
     reverse_lookup_unify = "1";
-  if (allow_simult_ips_same_host
-      && strcmp (allow_simult_ips_same_host, "0") == 0)
-    allow_simult_ips_same_host = "0";
+  if (allow_simultaneous_ips
+      && strcmp (allow_simultaneous_ips, "0") == 0)
+    allow_simultaneous_ips = "0";
   else
-    allow_simult_ips_same_host = "1";
+    allow_simultaneous_ips = "1";
 
   quoted_name = sql_quote (name ?: "");
 
@@ -30652,7 +30652,7 @@ create_target (const char* name, const char* asset_hosts_filter,
   sql ("INSERT INTO targets"
        " (uuid, name, owner, hosts, exclude_hosts, comment, "
        "  port_list, reverse_lookup_only, reverse_lookup_unify, alive_test,"
-       "  allow_simult_ips_same_host,"
+       "  allow_simultaneous_ips,"
        "  creation_time, modification_time)"
        " VALUES (make_uuid (), '%s',"
        " (SELECT id FROM users WHERE users.uuid = '%s'),"
@@ -30662,7 +30662,7 @@ create_target (const char* name, const char* asset_hosts_filter,
         quoted_name, current_credentials.uuid,
         quoted_hosts, quoted_exclude_hosts, quoted_comment, port_list,
         reverse_lookup_only, reverse_lookup_unify, alive_test,
-        allow_simult_ips_same_host);
+        allow_simultaneous_ips);
 
   new_target = sql_last_insert_id ();
   if (target)
@@ -30767,7 +30767,7 @@ copy_target (const char* name, const char* comment, const char *target_id,
   ret = copy_resource ("target", name, comment, target_id,
                        "hosts, exclude_hosts, port_list, reverse_lookup_only,"
                        " reverse_lookup_unify, alive_test,"
-                       " allow_simult_ips_same_host",
+                       " allow_simultaneous_ips",
                        1, new_target, &old_target);
   if (ret)
     return ret;
@@ -30864,12 +30864,12 @@ delete_target (const char *target_id, int ultimate)
            " (uuid, owner, name, hosts, exclude_hosts, comment,"
            "  port_list, port_list_location,"
            "  reverse_lookup_only, reverse_lookup_unify, alive_test,"
-           "  allow_simult_ips_same_host,"
+           "  allow_simultaneous_ips,"
            "  creation_time, modification_time)"
            " SELECT uuid, owner, name, hosts, exclude_hosts, comment,"
            "        port_list, " G_STRINGIFY (LOCATION_TABLE) ","
            "        reverse_lookup_only, reverse_lookup_unify, alive_test,"
-           "        allow_simult_ips_same_host,"
+           "        allow_simultaneous_ips,"
            "        creation_time, modification_time"
            " FROM targets WHERE id = %llu;",
            target);
@@ -30938,7 +30938,7 @@ delete_target (const char *target_id, int ultimate)
  * @param[in]   reverse_lookup_only   Scanner preference reverse_lookup_only.
  * @param[in]   reverse_lookup_unify  Scanner preference reverse_lookup_unify.
  * @param[in]   alive_tests     Alive tests.
- * @param[in]   allow_simult_ips_same_host Scanner preference allow_simult_ips_same_host.
+ * @param[in]   allow_simultaneous_ips Scanner preference allow_simultaneous_ips.
  *
  * @return 0 success, 1 target exists already, 2 error in host specification,
  *         3 too many hosts, 4 error in port range, 5 error in SSH port,
@@ -30960,7 +30960,7 @@ modify_target (const char *target_id, const char *name, const char *hosts,
                const char *esxi_credential_id, const char* snmp_credential_id,
                const char *reverse_lookup_only,
                const char *reverse_lookup_unify, const char *alive_tests,
-               const char *allow_simult_ips_same_host)
+               const char *allow_simultaneous_ips)
 {
   target_t target;
 
@@ -31034,7 +31034,7 @@ modify_target (const char *target_id, const char *name, const char *hosts,
       g_free (quoted_comment);
     }
 
-  if (allow_simult_ips_same_host)
+  if (allow_simultaneous_ips)
     {
       if (target_in_use (target))
         {
@@ -31043,10 +31043,10 @@ modify_target (const char *target_id, const char *name, const char *hosts,
         }
 
       sql ("UPDATE targets SET"
-           " allow_simult_ips_same_host = '%i',"
+           " allow_simultaneous_ips = '%i',"
            " modification_time = m_now ()"
            " WHERE id = %llu;",
-           strcmp (allow_simult_ips_same_host, "0") ? 1 : 0,
+           strcmp (allow_simultaneous_ips, "0") ? 1 : 0,
            target);
     }
 
@@ -31431,7 +31431,7 @@ modify_target (const char *target_id, const char *name, const char *hosts,
      NULL,                                                  \
      KEYWORD_TYPE_INTEGER },                                \
    { "0", NULL, KEYWORD_TYPE_INTEGER },                     \
-   { "allow_simult_ips_same_host",                          \
+   { "allow_simultaneous_ips",                              \
      NULL,                                                  \
      KEYWORD_TYPE_INTEGER },                                \
    {                                                        \
@@ -31537,7 +31537,7 @@ modify_target (const char *target_id, const char *name, const char *hosts,
    { "trash_target_credential_location (id, CAST ('snmp' AS text))",\
      NULL,                                                          \
      KEYWORD_TYPE_INTEGER },                                        \
-   { "allow_simult_ips_same_host",                                  \
+   { "allow_simultaneous_ips",                                      \
      NULL,                                                          \
      KEYWORD_TYPE_INTEGER },                                        \
    { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                             \
@@ -31860,13 +31860,13 @@ target_iterator_snmp_trash (iterator_t* iterator)
 }
 
 /**
- * @brief Get the allow_simult_ips_same_host value from a target iterator.
+ * @brief Get the allow_simultaneous_ips value from a target iterator.
  *
  * @param[in]  iterator  Iterator.
  *
  * @return allow_simult_ips_same_host or NULL if iteration is complete.
  */
-DEF_ACCESS (target_iterator_allow_simult_ips_same_host,
+DEF_ACCESS (target_iterator_allow_simultaneous_ips,
             GET_ITERATOR_COLUMN_COUNT + 18);
 
 /**
@@ -32051,16 +32051,16 @@ target_reverse_lookup_unify (target_t target)
 }
 
 /**
- * @brief Return the allow_simult_ips_same_host value of a target.
+ * @brief Return the allow_simultaneous_ips value of a target.
  *
  * @param[in]  target  Target.
  *
- * @return The allow_simult_ips_same_host value if available, else NULL.
+ * @return The allow_simultaneous_ips value if available, else NULL.
  */
 char*
-target_allow_simult_ips_same_host (target_t target)
+target_allow_simultaneous_ips (target_t target)
 {
-  return sql_string ("SELECT allow_simult_ips_same_host FROM targets"
+  return sql_string ("SELECT allow_simultaneous_ips FROM targets"
                      " WHERE id = %llu;", target);
 }
 
@@ -46267,11 +46267,11 @@ manage_restore (const char *id)
       sql ("INSERT INTO targets"
            " (uuid, owner, name, hosts, exclude_hosts, comment,"
            "  port_list, reverse_lookup_only, reverse_lookup_unify,"
-           "  alive_test, allow_simult_ips_same_host,"
+           "  alive_test, allow_simultaneous_ips,"
            "  creation_time, modification_time)"
            " SELECT uuid, owner, name, hosts, exclude_hosts, comment,"
            "        port_list, reverse_lookup_only, reverse_lookup_unify,"
-           "        alive_test, allow_simult_ips_same_host,"
+           "        alive_test, allow_simultaneous_ips,"
            "        creation_time, modification_time"
            " FROM targets_trash WHERE id = %llu;",
            resource);

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -5200,6 +5200,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <o><e>smb_lsc_credential</e></o>
       <o><e>esxi_lsc_credential</e></o>
       <o><e>alive_tests</e></o>
+      <o><e>allow_simultaneous_ips</e></o>
       <o><e>reverse_lookup_only</e></o>
       <o><e>reverse_lookup_unify</e></o>
       <or>
@@ -5349,6 +5350,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <pattern>
         <t>alive_test</t>
       </pattern>
+    </ele>
+    <ele>
+      <name>allow_simultaneous_ips</name>
+      <summary>
+        Whether to scan multiple IPs of the same host simultaneously
+      </summary>
+      <pattern><t>boolean</t></pattern>
     </ele>
     <ele>
       <name>reverse_lookup_only</name>
@@ -18897,7 +18905,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <e>alive_tests</e>
           <e>reverse_lookup_only</e>
           <e>reverse_lookup_unify</e>
-          <e>allow_simult_ips_same_host</e>
+          <e>allow_simultaneous_ips</e>
           <o><e>tasks</e></o>
         </pattern>
         <ele>
@@ -19212,7 +19220,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <pattern><t>boolean</t></pattern>
         </ele>
         <ele>
-          <name>allow_simult_ips_same_host</name>
+          <name>allow_simultaneous_ips</name>
           <summary>
             Whether to scan multiple IPs of the same host simultaneously
           </summary>
@@ -24670,7 +24678,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <o><e>alive_tests</e></o>
       <o><e>reverse_lookup_only</e></o>
       <o><e>reverse_lookup_unify</e></o>
-      <o><e>allow_simult_ips_same_host</e></o>
+      <o><e>allow_simultaneous_ips</e></o>
     </pattern>
     <ele>
       <name>comment</name>
@@ -24807,7 +24815,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <pattern><t>boolean</t></pattern>
     </ele>
     <ele>
-      <name>allow_simult_ips_same_host</name>
+      <name>allow_simultaneous_ips</name>
       <summary>
         Whether to scan multiple IPs of the same host simultaneously
       </summary>


### PR DESCRIPTION
**What**:

The target field and scanner preference allow_simult_ips_same_host is
renamed to allow_simultaneous_ips.
Also, sending the preference now uses the correct name and missing GMP
documentation for create_target has been added.

**Why**:
The field and preference were renamed to avoid abbreviations while also
shortening it a bit.

**How did you test it**:
- Checking the field in the GSA HTTP responses
- Using an updated python-gvm to create and modify targets

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
