### PR TITLE
Add empty CHANGELOG section post 20.8.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [20.8.2] (unreleased)
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
+[20.8.2]: https://github.com/greenbone/gvmd/compare/v20.8.1...gvmd-20.08
+
+
 ## [20.8.1] (2021-02-02)
 
 ### Added


### PR DESCRIPTION
**What**:
This adds an empty section for unreleased changes to the 20.08 branch

**Why**:
To prepare for new changes.

**How did you test it**:
N/A

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
