### PR TITLE
Also create owner WITH clause for single resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 ### Fixed
+- Also create owner WITH clause for single resources [#1406](https://github.com/greenbone/gvmd/pull/1406)
 
 ### Removed
 

--- a/src/manage_acl.c
+++ b/src/manage_acl.c
@@ -1011,50 +1011,7 @@ acl_where_owned_user (const char *user_id, const char *user_sql,
   guint index;
 
   if (with)
-    *with = NULL;
-
-  if (owned == 0)
-   return g_strdup (" t ()");
-
-  permission_or = g_string_new ("");
-  index = 0;
-  if (permissions == NULL || permissions->len == 0)
     {
-      /* Treat filters with no permissions keyword as "any". */
-      permission_or = g_string_new ("t ()");
-      index = 1;
-    }
-  else if (permissions)
-    for (; index < permissions->len; index++)
-      {
-        gchar *permission, *quoted;
-        permission = (gchar*) g_ptr_array_index (permissions, index);
-        if (strcasecmp (permission, "any") == 0)
-          {
-            g_string_free (permission_or, TRUE);
-            permission_or = g_string_new ("t ()");
-            index = 1;
-            break;
-          }
-        quoted = sql_quote (permission);
-        if (index == 0)
-          g_string_append_printf (permission_or, "name = '%s'", quoted);
-        else
-          g_string_append_printf (permission_or, " OR name = '%s'",
-                                  quoted);
-        g_free (quoted);
-      }
-
-  table_trash = get->trash && strcasecmp (type, "task");
-  if (resource || (user_id == NULL))
-    owned_clause
-     = g_strdup (" (t ())");
-  else if (with)
-    {
-      gchar *permission_clause;
-
-      /* Caller supports WITH clause. */
-
       *with = g_strdup_printf
                ("WITH permissions_subject"
                 "     AS (SELECT * FROM permissions"
@@ -1098,6 +1055,49 @@ acl_where_owned_user (const char *user_id, const char *user_sql,
                 user_sql,
                 user_sql,
                 user_sql);
+    }
+
+  if (owned == 0)
+   return g_strdup (" t ()");
+
+  permission_or = g_string_new ("");
+  index = 0;
+  if (permissions == NULL || permissions->len == 0)
+    {
+      /* Treat filters with no permissions keyword as "any". */
+      permission_or = g_string_new ("t ()");
+      index = 1;
+    }
+  else if (permissions)
+    for (; index < permissions->len; index++)
+      {
+        gchar *permission, *quoted;
+        permission = (gchar*) g_ptr_array_index (permissions, index);
+        if (strcasecmp (permission, "any") == 0)
+          {
+            g_string_free (permission_or, TRUE);
+            permission_or = g_string_new ("t ()");
+            index = 1;
+            break;
+          }
+        quoted = sql_quote (permission);
+        if (index == 0)
+          g_string_append_printf (permission_or, "name = '%s'", quoted);
+        else
+          g_string_append_printf (permission_or, " OR name = '%s'",
+                                  quoted);
+        g_free (quoted);
+      }
+
+  table_trash = get->trash && strcasecmp (type, "task");
+  if (resource || (user_id == NULL))
+    owned_clause
+     = g_strdup (" (t ())");
+  else if (with)
+    {
+      gchar *permission_clause;
+
+      /* Caller supports WITH clause. */
 
       permission_clause = NULL;
       if (user_id && index)


### PR DESCRIPTION
**What**:
The function init_get_iterator2_with will now also use acl_where_owned
to generate a WITH clause in case permissions_subject is used in a
subquery.
The init_result_get_iterator_severity had to be adjusted to not generate
the same WITH clause twice.

**Why**:
This change fixes an error getting details pages for types use the
WITH clauses for permission checks.

**How did you test it**:
I confirmed it fixed the error by following the link to an OS asset from a host asset in GSA.
I also quickly checked other pages for regressions, including the report details.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
