### PR TITLE
Change maintainers to a group (20.08)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # default reviewers
-*                 @timopollmeier @mattmundell
+*                 @greenbone/gvmd-maintainers


### PR DESCRIPTION


**What**:
This is applies the changes from 3ac3c77ac0e81bd4c5e2ab1bcc649b3a62d0897b to the 20.08 branch. 

**Why**:
It is easier to handler code owners via a group.

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry N/A
