### PR TITLE
circle ci using buster images and various memory handling changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           command: clang-format -i -style=file src/gmp.h src/gmp_base.h src/gmp_delete.h src/gmp_get.h src/gmp_tickets.h src/gmpd.h src/iterator.h src/manage_utils.h src/sql.h src/types.h src/utils.h && git diff --exit-code
   test_units:
     docker:
-      - image: greenbone/build-env-gvm-master-debian-stretch-gcc-postgresql
+      - image: greenbone/build-env-gvm-master-debian-buster-gcc-postgresql
     steps:
       - run:
           working_directory: ~/gvm-libs
@@ -26,7 +26,7 @@ jobs:
           command: mkdir build && cd build/ && cmake -DBACKEND=POSTGRESQL -DCMAKE_BUILD_TYPE=Release -DENABLE_COVERAGE=1 .. && make && make tests && CTEST_OUTPUT_ON_FAILURE=1 make test && lcov --directory . --capture --output-file coverage.info && genhtml -o coverage coverage.info
   build_postgresql_debug:
     docker:
-      - image: greenbone/build-env-gvm-master-debian-stretch-gcc-postgresql
+      - image: greenbone/build-env-gvm-master-debian-buster-gcc-postgresql
     steps:
       - run:
           working_directory: ~/gvm-libs
@@ -42,7 +42,7 @@ jobs:
           command: mkdir build && cd build/ && cmake -DBACKEND=POSTGRESQL -DCMAKE_BUILD_TYPE=Debug .. && make install
   build_postgresql_release:
     docker:
-      - image: greenbone/build-env-gvm-master-debian-stretch-gcc-postgresql
+      - image: greenbone/build-env-gvm-master-debian-buster-gcc-postgresql
     steps:
       - run:
           working_directory: ~/gvm-libs
@@ -58,7 +58,7 @@ jobs:
           command: mkdir build && cd build/ && cmake -DBACKEND=POSTGRESQL -DCMAKE_BUILD_TYPE=Release .. && make install
   build_postgresql_debug_clang:
     docker:
-      - image: greenbone/build-env-gvm-master-debian-stretch-clang-postgresql
+      - image: greenbone/build-env-gvm-master-debian-buster-clang-postgresql
     steps:
       - run:
           working_directory: ~/gvm-libs
@@ -74,7 +74,7 @@ jobs:
           command: mkdir build && cd build/ && cmake -DCMAKE_C_COMPILER=clang -DCMAKE_C_FLAGS="-Wno-ignored-attributes" -DBACKEND=POSTGRESQL -DCMAKE_BUILD_TYPE=Debug .. && make install
   scan_build_postgresql_debug:
     docker:
-      - image: greenbone/build-env-gvm-master-debian-stretch-clang-postgresql
+      - image: greenbone/build-env-gvm-master-debian-buster-clang-postgresql
     steps:
       - run:
           working_directory: ~/gvm-libs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Delete report format dirs last when deleting a user [#1368](https://github.com/greenbone/gvmd/pull/1368)
 - Fix sorting in get_aggregates and its documentation [#1375](https://github.com/greenbone/gvmd/pull/1375)
 - Improve "Failed to find..." messages [#1395](https://github.com/greenbone/gvmd/pull/1395)
+- Memory handling in various occasions [#1417](https://github.com/greenbone/gvmd/pull/1417)
 
 ### Removed
 - Remove DROP from vulns creation [#1281](http://github.com/greenbone/gvmd/pull/1281)

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -10482,22 +10482,23 @@ buffer_aggregate_xml (GString *xml, iterator_t* aggregate, const gchar* type,
                                       iso_time (&max),
                                       iso_time (&mean));
             }
-          else{
-            g_string_append_printf (xml,
-                                    "<stats column=\"%s\">"
-                                    "<min>%g</min>"
-                                    "<max>%g</max>"
-                                    "<mean>%g</mean>"
-                                    "<sum>%g</sum>"
-                                    "<c_sum>%g</c_sum>"
-                                    "</stats>",
-                                    data_column,
-                                    aggregate_iterator_min (aggregate, index),
-                                    aggregate_iterator_max (aggregate, index),
-                                    aggregate_iterator_mean (aggregate, index),
-                                    aggregate_iterator_sum (aggregate, index),
-                                    subgroup_column && subgroup_c_sum
-                                      ? *subgroup_c_sum : c_sum);
+          else
+            {
+              g_string_append_printf (xml,
+                                      "<stats column=\"%s\">"
+                                      "<min>%g</min>"
+                                      "<max>%g</max>"
+                                      "<mean>%g</mean>"
+                                      "<sum>%g</sum>"
+                                      "<c_sum>%g</c_sum>"
+                                      "</stats>",
+                                      data_column,
+                                      aggregate_iterator_min (aggregate, index),
+                                      aggregate_iterator_max (aggregate, index),
+                                      aggregate_iterator_mean (aggregate, index),
+                                      aggregate_iterator_sum (aggregate, index),
+                                      subgroup_column && subgroup_c_sum
+                                        ? *subgroup_c_sum : c_sum);
           }
         }
 

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -10482,7 +10482,7 @@ buffer_aggregate_xml (GString *xml, iterator_t* aggregate, const gchar* type,
                                       iso_time (&max),
                                       iso_time (&mean));
             }
-          else
+          else{
             g_string_append_printf (xml,
                                     "<stats column=\"%s\">"
                                     "<min>%g</min>"
@@ -10496,8 +10496,9 @@ buffer_aggregate_xml (GString *xml, iterator_t* aggregate, const gchar* type,
                                     aggregate_iterator_max (aggregate, index),
                                     aggregate_iterator_mean (aggregate, index),
                                     aggregate_iterator_sum (aggregate, index),
-                                    subgroup_column
+                                    subgroup_column && subgroup_c_sum
                                       ? *subgroup_c_sum : c_sum);
+          }
         }
 
       for (index = 0; index < text_columns->len; index++)
@@ -22241,12 +22242,11 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
 
           if (create_task_data->groups->len)
             {
-              int fail;
               gchar *fail_group_id;
 
-              switch ((fail = set_task_groups (create_task_data->task,
+              switch (set_task_groups (create_task_data->task,
                                                create_task_data->groups,
-                                               &fail_group_id)))
+                                               &fail_group_id))
                 {
                   case 0:
                     break;

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -17006,9 +17006,9 @@ handle_get_tasks (gmp_parser_t *gmp_parser, GError **error)
       report_t running_report;
       char *owner, *observers;
       int target_in_trash, scanner_in_trash;
-      int debugs, holes = 0, infos = 0, logs, warnings = 0;
+      int debugs = 0, holes = 0, infos = 0, logs = 0, warnings = 0;
       int holes_2 = 0, infos_2 = 0, warnings_2 = 0;
-      int false_positives, task_scanner_type;
+      int false_positives = 0, task_scanner_type;
       int target_available, config_available;
       int scanner_available;
       double severity = 0, severity_2 = 0;

--- a/src/manage.c
+++ b/src/manage.c
@@ -9109,10 +9109,13 @@ manage_run_wizard (const gchar *wizard_name,
 
                       if (g_regex_match_simple (regex, pair->value, 0, 0) == 0)
                         {
-                          *command_error
-                            = g_strdup_printf ("Value '%s' is not valid for"
-                                              " parameter '%s'.",
-                                              pair->value, name);
+                          if (command_error)
+                            {
+                              *command_error
+                                = g_strdup_printf ("Value '%s' is not valid for"
+                                                  " parameter '%s'.",
+                                                  pair->value, name);
+                            }
                           free_entity (entity);
                           g_string_free (params_xml, TRUE);
                           return 6;
@@ -9123,9 +9126,12 @@ manage_run_wizard (const gchar *wizard_name,
 
           if (optional == 0 && param_found == 0)
             {
-              *command_error = g_strdup_printf ("Mandatory wizard param '%s'"
-                                                " missing",
-                                                name);
+              if (command_error)
+                {
+                  *command_error = g_strdup_printf ("Mandatory wizard param '%s'"
+                                                    " missing",
+                                                    name);
+                }
               free_entity (entity);
               return 6;
             }

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -25625,6 +25625,10 @@ add_port (GTree *ports, iterator_t *results)
       *old_severity = *severity;
       g_free (severity);
     }
+  else
+    {
+      g_free (severity);
+    }
 }
 
 /**

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -5322,7 +5322,7 @@ init_aggregate_iterator (iterator_t* iterator, const char *type,
             int index;
             order_column = NULL;
             for (index = 0;
-                 index < data_columns->len && order_column == NULL;
+                 data_columns && index < data_columns->len && order_column == NULL;
                  index++)
               {
                 gchar *column = g_array_index (data_columns, gchar*, index);
@@ -5347,7 +5347,7 @@ init_aggregate_iterator (iterator_t* iterator, const char *type,
               }
 
             for (index = 0;
-                index < text_columns->len && order_column == NULL;
+                text_columns && index < text_columns->len && order_column == NULL;
                 index++)
               {
                 gchar *column = g_array_index (text_columns, gchar*, index);
@@ -10249,7 +10249,6 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
 
                 /* Parent on success.  Wait for child, and check result. */
 
-                g_free (command);
 
                 while (waitpid (pid, &status, 0) < 0)
                   {
@@ -10272,6 +10271,7 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
                       g_warning ("%s: and chdir failed",
                                  __func__);
                     g_free (previous_dir);
+                    g_free (command);
                     return -1;
                   }
                 if (WIFEXITED (status))
@@ -10288,6 +10288,7 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
                         g_warning ("%s: and chdir failed",
                                    __func__);
                       g_free (previous_dir);
+                      g_free (command);
                       return -1;
                     }
                 else
@@ -10299,11 +10300,12 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
                       g_warning ("%s: and chdir failed",
                                  __func__);
                     g_free (previous_dir);
+                    g_free (command);
                     return -1;
                   }
 
                 /* Child succeeded, continue to process result. */
-
+                g_free (command);
                 break;
               }
           }
@@ -10709,7 +10711,8 @@ buffer_vfire_call_input (gchar *key, gchar *value, GString *buffer)
                        param);                                                \
   else                                                                        \
     {                                                                         \
-      *message = g_strdup ("Mandatory " G_STRINGIFY(param) " missing.");      \
+      if (message)                                                            \
+        *message = g_strdup ("Mandatory " G_STRINGIFY(param) " missing.");    \
       g_warning ("%s: Missing " G_STRINGIFY(param) ".", __func__);        \
       g_string_free (config_xml, TRUE);                                       \
       return -1;                                                              \
@@ -10860,7 +10863,7 @@ send_to_vfire (const char *base_url, const char *client_id,
       g_warning ("%s: Alert script exited with status %d",
                  __func__, exit_status);
       g_message ("%s: stderr: %s",
-                 __func__, *message);
+                 __func__, message ? *message: "");
       ret = -5;
     }
 
@@ -11918,6 +11921,7 @@ report_content_for_alert (alert_t alert, report_t report, task_t task,
             break;
         case 1:        /* Too few rows in result of query. */
         case -1:
+          g_free(alert_filter_get);
           return -1;
           break;
         default:       /* Programming error. */
@@ -11948,6 +11952,7 @@ report_content_for_alert (alert_t alert, report_t report, task_t task,
                          __func__, format_uuid,
                          alert_method_name (alert_method (alert)));
               g_free (format_uuid);
+              g_free (alert_filter_get);
               return -2;
             }
           g_free (format_uuid);
@@ -52908,7 +52913,6 @@ modify_user (const gchar * user_id, gchar **name, const gchar *new_name,
       user_name = sql_string ("SELECT name FROM users WHERE id = %llu",
                               user);
       errstr = gvm_validate_password (password, user_name);
-      g_free (user_name);
       if (errstr)
         {
           g_warning ("new password for '%s' rejected: %s", user_name, errstr);
@@ -52917,8 +52921,10 @@ modify_user (const gchar * user_id, gchar **name, const gchar *new_name,
           else
             g_free (errstr);
           sql_rollback ();
+          g_free (user_name);
           return -1;
         }
+      g_free (user_name);
     }
 
   /* Check hosts. */

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -41999,7 +41999,7 @@ buffer_insert (GString *results_buffer, GString *result_nvts_buffer,
     }
   else
     {
-      qod = G_STRINGIFY (QOD_DEFAULT);
+      qod = g_strdup (G_STRINGIFY (QOD_DEFAULT));
       qod_type = g_strdup ("''");
       nvt_revision = g_strdup ("");
     }

--- a/src/manage_sql_port_lists.c
+++ b/src/manage_sql_port_lists.c
@@ -1304,7 +1304,6 @@ create_port_list_internal (int check_access, const char *id, const char *name,
       array_free (ranges);
       if (ret)
         {
-          g_free (quoted_name);
           sql_rollback ();
           return ret;
         }

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -3862,8 +3862,14 @@ apply_report_format (gchar *report_format_id,
     {
       temp_files = g_list_remove (temp_files, temp_files->data);
     }
-  g_free (temp_dirs->data);
-  g_free (temp_files->data);
+  if (temp_dirs)
+    {
+      g_free (temp_dirs->data);
+    }
+  if (temp_files)
+    {
+      g_free (temp_files->data);
+    }
   g_free (files_xml);
   g_hash_table_destroy (subreports);
   if (close (output_fd))

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -3485,7 +3485,6 @@ run_report_format_script (gchar *report_format_id,
 
               /* Parent on success.  Wait for child, and check result. */
 
-              g_free (command);
 
               while (waitpid (pid, &status, 0) < 0)
                 {
@@ -3524,6 +3523,7 @@ run_report_format_script (gchar *report_format_id,
                         g_warning ("%s: and chdir failed",
                                     __func__);
                       g_free (previous_dir);
+                      g_free (command);
                       return -1;
                   }
               else
@@ -3534,9 +3534,11 @@ run_report_format_script (gchar *report_format_id,
                   if (chdir (previous_dir))
                     g_warning ("%s: and chdir failed",
                                 __func__);
+                  g_free (command);
                   g_free (previous_dir);
                   return -1;
                 }
+              g_free (command);
 
               /* Child succeeded, continue to process result. */
 
@@ -3854,14 +3856,14 @@ apply_report_format (gchar *report_format_id,
   while (temp_dirs)
     {
       gvm_file_remove_recurse (temp_dirs->data);
-      g_free (temp_dirs->data);
       temp_dirs = g_list_remove (temp_dirs, temp_dirs->data);
     }
   while (temp_files)
     {
-      g_free (temp_files->data);
       temp_files = g_list_remove (temp_files, temp_files->data);
     }
+  g_free (temp_dirs->data);
+  g_free (temp_files->data);
   g_free (files_xml);
   g_hash_table_destroy (subreports);
   if (close (output_fd))

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -3856,19 +3856,15 @@ apply_report_format (gchar *report_format_id,
   while (temp_dirs)
     {
       gvm_file_remove_recurse (temp_dirs->data);
-      temp_dirs = g_list_remove (temp_dirs, temp_dirs->data);
+      gpointer data = temp_dirs->data;
+      temp_dirs = g_list_remove (temp_dirs, data);
+      g_free (data);
     }
   while (temp_files)
     {
-      temp_files = g_list_remove (temp_files, temp_files->data);
-    }
-  if (temp_dirs)
-    {
-      g_free (temp_dirs->data);
-    }
-  if (temp_files)
-    {
-      g_free (temp_files->data);
+      gpointer data = temp_files->data;
+      temp_files = g_list_remove (temp_files, data);
+      g_free (data);
     }
   g_free (files_xml);
   g_hash_table_destroy (subreports);

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -278,10 +278,10 @@ split_xml_file (gchar *path, const gchar *size, const gchar *tail)
                  WIFEXITED (ret) ? WEXITSTATUS (ret) : 0,
                  command);
       g_free (command);
-      g_free (previous_dir);
 
       if (chdir (previous_dir))
         g_warning ("%s: and failed to chdir back", __func__);
+      g_free (previous_dir);
 
       return NULL;
     }
@@ -3845,7 +3845,7 @@ oval_files_free ()
   int index;
 
   index = 0;
-  while (index < oval_files->len)
+  while (oval_files && index < oval_files->len)
     {
       gchar **pair;
 
@@ -3980,7 +3980,6 @@ update_scap_ovaldefs (int private)
           if (g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
             {
               g_warning ("No user data directory '%s' found.", oval_dir);
-              g_free (oval_dir);
               g_error_free (error);
             }
           else


### PR DESCRIPTION
Due to a new libnet library dependency within gvm-libs gvmd should use
the buster build images instead of stretch.

Because of that various memory handling issues were detected and got fixed.
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
