### PR TITLE
Mergify: configuration update: Fix name of 21.04 to 20.08 backport

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -28,7 +28,7 @@ pull_request_rules:
         branches:
           - master
 
-  - name: backport 21.04 patches to master branch
+  - name: backport 21.04 patches to 20.08 branch
     conditions:
       - base=gvmd-21.04
       - label=backport-to-20.08


### PR DESCRIPTION
This change has been made by @timopollmeier from https://mergify.io config editor.