### PR TITLE
Fix a typo.

### DIFF
--- a/src/gmp_configs.c
+++ b/src/gmp_configs.c
@@ -1022,9 +1022,9 @@ modify_config_handle_nvt_selection (config_t config,
 /**
  * @brief Modifies a single preference inside a modify_config command.
  *
- * @param[in]  config     The config to modify
+ * @param[in]  config     The config to modify.
  * @param[in]  nvt_oid    VT OID of the preference or NULL for scanner pref.
- * @param[in]  name       Name of the prefernce to Changes
+ * @param[in]  name       Name of the preference to change.
  * @param[in]  value      Value to set for the preference.
  * @param[in]  gmp_parser The GMP parser.
  * @param[out] error      GError output.


### PR DESCRIPTION
From codespell:

```
./src/gmp_configs.c:1030: prefernce ==> preference
```

Also fixed the sentence and added an ending dot.

Seems that typo doesn't exist in the gvmd-20.08 branch so i have created the PR against master.