### PR TITLE
Add standard info elem fields for NVTs in get_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [20.8.2] (unreleased)
 
 ### Added
+- Add standard info elem fields for NVTs in get_info [#1426](https://github.com/greenbone/gvmd/pull/1426)
 
 ### Changed
 

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -13032,53 +13032,11 @@ handle_get_info (gmp_parser_t *gmp_parser, GError **error)
       info_count = cve_info_count;
       get_info_data->get.subtype = g_strdup ("cve");
     }
-  else if ((g_strcmp0 ("nvt", get_info_data->type) == 0)
-            && (get_info_data->name == NULL)
-            && (get_info_data->get.id == NULL))
+  else if (g_strcmp0 ("nvt", get_info_data->type) == 0)
     {
       init_info_iterator = init_nvt_info_iterator;
       info_count = nvt_info_count;
       get_info_data->get.subtype = g_strdup ("nvt");
-    }
-  else if (g_strcmp0 ("nvt", get_info_data->type) == 0)
-    {
-      gchar *result;
-
-      get_info_data->get.subtype = g_strdup ("nvt");
-
-      manage_read_info (get_info_data->type, get_info_data->get.id,
-                        get_info_data->name, &result);
-      if (result)
-        {
-          SEND_GET_START ("info");
-          SEND_TO_CLIENT_OR_FAIL ("<info>");
-          SEND_TO_CLIENT_OR_FAIL (result);
-          SEND_TO_CLIENT_OR_FAIL ("</info>");
-          SEND_TO_CLIENT_OR_FAIL ("<details>1</details>");
-          SEND_GET_END ("info", &get_info_data->get, 1, 1);
-          g_free (result);
-          get_info_data_reset (get_info_data);
-          set_client_state (CLIENT_AUTHENTIC);
-          return;
-        }
-      else
-        {
-          if (send_find_error_to_client ("get_info",
-                                         get_info_data->name
-                                          ? "name"
-                                          : "ID",
-                                         get_info_data->name
-                                          ? get_info_data->name
-                                          : get_info_data->get.id,
-                                         gmp_parser))
-            {
-              error_send_to_client (error);
-              return;
-            }
-          get_info_data_reset (get_info_data);
-          set_client_state (CLIENT_AUTHENTIC);
-          return;
-        }
     }
   else if (g_strcmp0 ("ovaldef", get_info_data->type) == 0)
     {


### PR DESCRIPTION
**What**:
With this change, the standard elements and attributes like
id, name, modification_time etc. are also included in the info element for NVTs.

**Why**:
 for consistency with
other get_info types and the GMP documentation.
This also simplifies the handling of NVTs a bit.

**How did you test it**:
Tested by getting a single NVT via `gvm-cli` and comparing the responses.

**Checklist**:

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
