### PR TITLE
Fix SQL escaping when adding VT references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Also create owner WITH clause for single resources [#1406](https://github.com/greenbone/gvmd/pull/1406)
+- Fix SQL escaping when adding VT references [#1429](https://github.com/greenbone/gvmd/pull/1429)
 
 ### Removed
 

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -327,16 +327,18 @@ insert_nvt (const nvti_t *nvti)
   for (i = 0; i < nvti_vtref_len (nvti); i++)
     {
       vtref_t *ref;
-      gchar *quoted_id, *quoted_text;
+      gchar *quoted_type, *quoted_id, *quoted_text;
 
       ref = nvti_vtref (nvti, i);
+      quoted_type = sql_quote (vtref_type (ref));
       quoted_id = sql_quote (vtref_id (ref));
       quoted_text = sql_quote (vtref_text (ref) ? vtref_text (ref) : "");
 
       sql ("INSERT into vt_refs (vt_oid, type, ref_id, ref_text)"
            " VALUES ('%s', '%s', '%s', '%s');",
-           nvti_oid (nvti), vtref_type (ref), quoted_id, quoted_text);
+           nvti_oid (nvti), quoted_type, quoted_id, quoted_text);
 
+      g_free (quoted_type);
       g_free (quoted_id);
       g_free (quoted_text);
     }


### PR DESCRIPTION
**What**:
When adding VT references, the type has to be escaped.

**Why**:
Issues in the scanner or VTs can make it send VT references that contain single quotes.

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
