### PR TITLE
Update report run status more consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Also create owner WITH clause for single resources [#1406](https://github.com/greenbone/gvmd/pull/1406)
 - Fix SQL escaping when adding VT references [#1429](https://github.com/greenbone/gvmd/pull/1429)
+- Update report run status more consistently [#1434](https://github.com/greenbone/gvmd/pull/1434) 
 
 ### Removed
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -4508,6 +4508,7 @@ fork_osp_scan_handler (task_t task, target_t target, int from,
   if (run_osp_scan_get_report (task, from, &report_id))
     return -1;
 
+  current_scanner_task = task;
   set_task_run_status (task, TASK_STATUS_REQUESTED);
 
   switch (fork ())
@@ -4526,11 +4527,13 @@ fork_osp_scan_handler (task_t task, target_t target, int from,
         set_report_scan_run_status (global_current_report,
                                     TASK_STATUS_INTERRUPTED);
         global_current_report = (report_t) 0;
+        current_scanner_task = 0;
         g_free (report_id);
         return -9;
       default:
         /* Parent, successfully forked. */
         global_current_report = 0;
+        current_scanner_task = 0;
         if (report_id_return)
           *report_id_return = report_id;
         else
@@ -5757,6 +5760,11 @@ stop_osp_task (task_t task)
   int ret = -1;
   report_t scan_report;
   char *scan_id;
+  task_t previous_task;
+  report_t previous_report;
+
+  previous_task = current_scanner_task;
+  previous_report = global_current_report;
 
   scan_report = task_running_report (task);
   scan_id = report_uuid (scan_report);
@@ -5765,6 +5773,9 @@ stop_osp_task (task_t task)
   connection = osp_scanner_connect (task_scanner (task));
   if (!connection)
     goto end_stop_osp;
+
+  current_scanner_task = task;
+  global_current_report = task_running_report (task);
   set_task_run_status (task, TASK_STATUS_STOP_REQUESTED);
   ret = osp_stop_scan (connection, scan_id, NULL);
   osp_connection_close (connection);
@@ -5789,6 +5800,8 @@ end_stop_osp:
       set_scan_end_time_epoch (scan_report, time (NULL));
       set_report_scan_run_status (scan_report, TASK_STATUS_STOPPED);
     }
+  current_scanner_task = previous_task;
+  global_current_report = previous_report;
   if (ret)
     return -1;
   return 0;
@@ -5805,13 +5818,22 @@ int
 stop_task_internal (task_t task)
 {
   task_status_t run_status;
+  task_t previous_task;
+  report_t previous_report;
+
+  previous_task = current_scanner_task;
+  previous_report = global_current_report;
 
   run_status = task_run_status (task);
   if (run_status == TASK_STATUS_REQUESTED
       || run_status == TASK_STATUS_RUNNING
       || run_status == TASK_STATUS_QUEUED)
     {
+      current_scanner_task = task;
+      global_current_report = task_running_report (task);
       set_task_run_status (task, TASK_STATUS_STOP_REQUESTED);
+      current_scanner_task = previous_task;
+      global_current_report = previous_report;
       return 1;
     }
   else if (run_status == TASK_STATUS_DELETE_REQUESTED
@@ -5829,7 +5851,11 @@ stop_task_internal (task_t task)
         {
           /* A special request from the user to get the task out of a requested
            * state when contact with the slave is lost. */
+          current_scanner_task = task;
+          task_last_report (task, &global_current_report);
           set_task_run_status (task, TASK_STATUS_STOP_REQUESTED_GIVEUP);
+          current_scanner_task = previous_task;
+          global_current_report = previous_report;
           return 1;
         }
     }


### PR DESCRIPTION
**What**:
To ensure the task status changes in fork_osp_scan_handler,
stop_osp_task and stop_task_internal also update the report status
before events are triggered, they will set current_scanner_task and
global_current_report temporarily / within the forked process.

**Why**:
Because the report status was only updated after the status change event,
the "Severity at least" condition on finished reports was evaluated for the
previous report, not the latest one.

**How did you test it**:
I tested this by checking current_scanner_task and global_current_report
set_task_run_status_internal and running a task with an alert that is triggered
when a task changes to "Done" and that has a minimum severity.
In the test runs I switched the target on and off to get different severity scores.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
