### PR TITLE
Improve modify_override errors, fix no NVT case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Also create owner WITH clause for single resources [#1406](https://github.com/greenbone/gvmd/pull/1406)
 - Fix SQL escaping when adding VT references [#1429](https://github.com/greenbone/gvmd/pull/1429)
+- Improve modify_override errors, fix no NVT case [#1435](https://github.com/greenbone/gvmd/pull/1435)
 
 ### Removed
 

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -23804,6 +23804,38 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                                 modify_override_data->override_id,
                                 "modified");
                 break;
+              case 8:
+                SEND_TO_CLIENT_OR_FAIL
+                 (XML_ERROR_SYNTAX ("modify_override",
+                                    "Error in threat specification"));
+                log_event_fail ("override", "Override",
+                                modify_override_data->override_id,
+                                "modified");
+                break;
+              case 9:
+                SEND_TO_CLIENT_OR_FAIL
+                 (XML_ERROR_SYNTAX ("modify_override",
+                                    "Error in new_threat specification"));
+                log_event_fail ("override", "Override",
+                                modify_override_data->override_id,
+                                "modified");
+                break;
+              case 10:
+                SEND_TO_CLIENT_OR_FAIL
+                 (XML_ERROR_SYNTAX ("modify_override",
+                                    "Error in new_severity specification"));
+                log_event_fail ("override", "Override",
+                                modify_override_data->override_id,
+                                "modified");
+                break;
+              case 11:
+                SEND_TO_CLIENT_OR_FAIL
+                 (XML_ERROR_SYNTAX ("modify_override",
+                                    "new_severity is required"));
+                log_event_fail ("override", "Override",
+                                modify_override_data->override_id,
+                                "modified");
+                break;
               case -1:
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_INTERNAL_ERROR ("modify_override"));


### PR DESCRIPTION
**What**:
The command will now return relevant syntax errors if the threat or
severity elements are invalid or required ones are missing.
Also, the case where no NVT OID is given has been fixed.

**Why**:
The improved error messages help clarify to users what kind of input
is expected and the NVT case make the behavior consistent with the
GMP specification.

**How did you test it**:
By running the command via gvm-pyshell.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
