### PR TITLE
Improve report counts performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add standard info elem fields for NVTs in get_info [#1426](https://github.com/greenbone/gvmd/pull/1426)
 
 ### Changed
+- Improve report counts performance [#1438](https://github.com/greenbone/gvmd/pull/1438)
 
 ### Fixed
 - Also create owner WITH clause for single resources [#1406](https://github.com/greenbone/gvmd/pull/1406)

--- a/src/manage_acl.c
+++ b/src/manage_acl.c
@@ -1067,7 +1067,7 @@ acl_where_owned_user (const char *user_id, const char *user_sql,
 
   if (owned == 0)
     {
-      if (with_optional)
+      if (with_optional && with)
         {
           g_free (*with);
           *with = NULL;

--- a/src/manage_acl.h
+++ b/src/manage_acl.h
@@ -172,7 +172,7 @@ acl_user_has_access_uuid (const char *, const char *, const char *, int);
 
 gchar *
 acl_where_owned (const char *, const get_data_t *, int, const gchar *, resource_t,
-                 array_t *, gchar **);
+                 array_t *, int, gchar **);
 
 gchar *
 acl_where_owned_for_get (const char *, const char *, gchar **);

--- a/src/manage_acl.h
+++ b/src/manage_acl.h
@@ -175,7 +175,7 @@ acl_where_owned (const char *, const get_data_t *, int, const gchar *, resource_
                  array_t *, int, gchar **);
 
 gchar *
-acl_where_owned_for_get (const char *, const char *, gchar **);
+acl_where_owned_for_get (const char *, const char *, const char *, gchar **);
 
 gchar *
 acl_users_with_access_sql (const char *, const char *, const char *);

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -2765,7 +2765,7 @@ create_tables ()
    * result_new_severities. */
   manage_create_sql_functions ();
 
-  owned_clause = acl_where_owned_for_get ("override", "users.id", NULL);
+  owned_clause = acl_where_owned_for_get ("override", "users.id", NULL, NULL);
 
   sql ("CREATE OR REPLACE VIEW result_overrides AS"
        " SELECT users.id AS user,"

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -4748,6 +4748,8 @@ resource_uuid (const gchar *type, resource_t resource)
  * @param[in]  ignore_id       Whether to ignore id (e.g. for report results).
  * @param[in]  extra_order     Extra ORDER clauses.
  * @param[in]  extra_with      Extra WITH clauses.
+ * @param[in]  acl_with_optional  Whether default permission WITH clauses are
+ *                                 optional.
  * @param[in]  assume_permitted   Whether to skip permission checks.
  *
  * @return 0 success, 1 failed to find resource, 2 failed to find filter, -1
@@ -4766,6 +4768,7 @@ init_get_iterator2_with (iterator_t* iterator, const char *type,
                          int ignore_id,
                          const char *extra_order,
                          const char *extra_with,
+                         int acl_with_optional,
                          int assume_permitted)
 {
   int first, max;
@@ -4863,10 +4866,12 @@ init_get_iterator2_with (iterator_t* iterator, const char *type,
      * in case subqueries depend on it.
      */
     owned_clause = acl_where_owned (type, get, 0, owner_filter, resource,
-                                    permissions, &with_clause);
+                                    permissions, acl_with_optional,
+                                    &with_clause);
   else
     owned_clause = acl_where_owned (type, get, owned, owner_filter, resource,
-                                    permissions, &with_clause);
+                                    permissions, acl_with_optional,
+                                    &with_clause);
 
   if (extra_with)
     {
@@ -5034,7 +5039,7 @@ init_get_iterator2 (iterator_t* iterator, const char *type,
                                  trash_select_columns, where_columns,
                                  trash_where_columns, filter_columns, distinct,
                                  extra_tables, extra_where, extra_where_single,
-                                 owned, ignore_id, extra_order, NULL, 0);
+                                 owned, ignore_id, extra_order, NULL, 0, 0);
 }
 
 /**
@@ -5722,7 +5727,7 @@ count2 (const char *type, const get_data_t *get, column_t *select_columns,
   g_free (filter);
 
   owned_clause = acl_where_owned (type, get, owned, owner_filter, 0,
-                                  permissions, &with);
+                                  permissions, 0, &with);
 
   if (extra_with)
     {
@@ -8501,7 +8506,7 @@ init_task_alert_iterator (iterator_t* iterator, task_t task)
   get.trash = 0;
   permissions = make_array ();
   array_add (permissions, g_strdup ("get_alerts"));
-  owned_clause = acl_where_owned ("alert", &get, 0, "any", 0, permissions,
+  owned_clause = acl_where_owned ("alert", &get, 0, "any", 0, permissions, 0,
                                   &with_clause);
   array_free (permissions);
 
@@ -8558,7 +8563,7 @@ init_event_alert_iterator (iterator_t* iterator, event_t event)
   get.trash = 0;
   permissions = make_array ();
   array_add (permissions, g_strdup ("get_alerts"));
-  owned_clause = acl_where_owned ("alert", &get, 0, "any", 0, permissions,
+  owned_clause = acl_where_owned ("alert", &get, 0, "any", 0, permissions, 0,
                                   &with_clause);
   array_free (permissions);
 
@@ -14428,7 +14433,7 @@ init_alert_task_iterator (iterator_t* iterator, alert_t alert,
   get.trash = 0;
   permissions = make_array ();
   array_add (permissions, g_strdup ("get_tasks"));
-  available = acl_where_owned ("task", &get, 1, "any", 0, permissions,
+  available = acl_where_owned ("task", &get, 1, "any", 0, permissions, 0,
                                &with_clause);
   array_free (permissions);
 
@@ -22414,6 +22419,7 @@ init_result_get_iterator_severity (iterator_t* iterator, const get_data_t *get,
                                  report ? TRUE : FALSE,
                                  extra_order,
                                  with_clause,
+                                 1,
                                  1);
   table_order_if_sort_not_specified = 0;
   column_array_free (filterable_columns);
@@ -32824,7 +32830,7 @@ init_target_task_iterator (iterator_t* iterator, target_t target)
   get.trash = 0;
   permissions = make_array ();
   array_add (permissions, g_strdup ("get_tasks"));
-  available = acl_where_owned ("task", &get, 1, "any", 0, permissions,
+  available = acl_where_owned ("task", &get, 1, "any", 0, permissions, 0,
                                &with_clause);
   array_free (permissions);
 
@@ -36052,7 +36058,7 @@ init_credential_target_iterator (iterator_t* iterator,
   get.trash = 0;
   permissions = make_array ();
   array_add (permissions, g_strdup ("get_targets"));
-  available = acl_where_owned ("target", &get, 1, "any", 0, permissions,
+  available = acl_where_owned ("target", &get, 1, "any", 0, permissions, 0,
                                &with_clause);
   array_free (permissions);
 
@@ -36129,7 +36135,7 @@ init_credential_scanner_iterator (iterator_t* iterator,
   get.trash = 0;
   permissions = make_array ();
   array_add (permissions, g_strdup ("get_scanners"));
-  available = acl_where_owned ("scanner", &get, 1, "any", 0, permissions,
+  available = acl_where_owned ("scanner", &get, 1, "any", 0, permissions, 0,
                                &with_clause);
   array_free (permissions);
 
@@ -39858,7 +39864,7 @@ init_scanner_config_iterator (iterator_t* iterator, scanner_t scanner)
   get.trash = 0;
   permissions = make_array ();
   array_add (permissions, g_strdup ("get_configs"));
-  available = acl_where_owned ("config", &get, 1, "any", 0, permissions,
+  available = acl_where_owned ("config", &get, 1, "any", 0, permissions, 0,
                                &with_clause);
   array_free (permissions);
 
@@ -39925,7 +39931,7 @@ init_scanner_task_iterator (iterator_t* iterator, scanner_t scanner)
   get.trash = 0;
   permissions = make_array ();
   array_add (permissions, g_strdup ("get_tasks"));
-  available = acl_where_owned ("task", &get, 1, "any", 0, permissions,
+  available = acl_where_owned ("task", &get, 1, "any", 0, permissions, 0,
                                &with_clause);
   array_free (permissions);
 
@@ -41709,7 +41715,7 @@ init_schedule_task_iterator (iterator_t* iterator, schedule_t schedule)
   get.trash = 0;
   permissions = make_array ();
   array_add (permissions, g_strdup ("get_tasks"));
-  available = acl_where_owned ("task", &get, 1, "any", 0, permissions,
+  available = acl_where_owned ("task", &get, 1, "any", 0, permissions, 0,
                                &with_clause);
   array_free (permissions);
   init_iterator (iterator,
@@ -46208,7 +46214,7 @@ init_filter_alert_iterator (iterator_t* iterator, filter_t filter)
   get.trash = 0;
   permissions = make_array ();
   array_add (permissions, g_strdup ("get_alerts"));
-  available = acl_where_owned ("alert", &get, 1, "any", 0, permissions,
+  available = acl_where_owned ("alert", &get, 1, "any", 0, permissions, 0,
                                &with_clause);
   array_free (permissions);
 
@@ -49142,6 +49148,7 @@ init_asset_os_iterator (iterator_t *iterator, const get_data_t *get)
                                  FALSE,
                                  NULL,
                                  NULL,
+                                 0,
                                  0);
 
   g_free (extra_tables);
@@ -53489,7 +53496,7 @@ init_user_group_iterator (iterator_t *iterator, user_t user)
   get.trash = 0;
   permissions = make_array ();
   array_add (permissions, g_strdup ("get_groups"));
-  available = acl_where_owned ("group", &get, 1, "any", 0, permissions,
+  available = acl_where_owned ("group", &get, 1, "any", 0, permissions, 0,
                                &with_clause);
   array_free (permissions);
 
@@ -53557,7 +53564,7 @@ init_user_role_iterator (iterator_t *iterator, user_t user)
   get.trash = 0;
   permissions = make_array ();
   array_add (permissions, g_strdup ("get_roles"));
-  available = acl_where_owned ("role", &get, 1, "any", 0, permissions,
+  available = acl_where_owned ("role", &get, 1, "any", 0, permissions, 0,
                                &with_clause);
   array_free (permissions);
 
@@ -55295,7 +55302,7 @@ init_resource_tag_iterator (iterator_t* iterator, const char* type,
   assert (current_credentials.uuid);
 
   get.trash = 0;
-  owned_clause = acl_where_owned ("tag", &get, 1, "any", 0, NULL,
+  owned_clause = acl_where_owned ("tag", &get, 1, "any", 0, NULL, 0,
                                   &with_clause);
 
   init_iterator (iterator,
@@ -56054,7 +56061,7 @@ type_build_select (const char *type, const char *columns_str,
                           &owner_filter);
 
   owned_clause = acl_where_owned (type, get, type_owned (type),
-                                  owner_filter, 0, permissions,
+                                  owner_filter, 0, permissions, 0,
                                   &with);
 
   if (given_extra_where)

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -4405,7 +4405,7 @@ init_config_task_iterator (iterator_t* iterator, config_t config,
   get.trash = 0;
   permissions = make_array ();
   array_add (permissions, g_strdup ("get_tasks"));
-  available = acl_where_owned ("task", &get, 1, "any", 0, permissions,
+  available = acl_where_owned ("task", &get, 1, "any", 0, permissions, 0,
                                &with_clause);
   array_free (permissions);
 

--- a/src/manage_sql_port_lists.c
+++ b/src/manage_sql_port_lists.c
@@ -2317,7 +2317,7 @@ init_port_list_target_iterator (iterator_t* iterator, port_list_t port_list,
   get.trash = 0;
   permissions = make_array ();
   array_add (permissions, g_strdup ("get_targets"));
-  available = acl_where_owned ("target", &get, 1, "any", 0, permissions,
+  available = acl_where_owned ("target", &get, 1, "any", 0, permissions, 0,
                                &with_clause);
   array_free (permissions);
 

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -2853,7 +2853,7 @@ init_report_format_alert_iterator (iterator_t* iterator,
   get.trash = 0;
   permissions = make_array ();
   array_add (permissions, g_strdup ("get_alerts"));
-  available = acl_where_owned ("alert", &get, 1, "any", 0, permissions,
+  available = acl_where_owned ("alert", &get, 1, "any", 0, permissions, 0,
                                &with_clause);
   array_free (permissions);
 

--- a/src/manage_sql_tickets.c
+++ b/src/manage_sql_tickets.c
@@ -555,7 +555,7 @@ init_result_ticket_iterator (iterator_t *iterator, result_t result)
     return -1;
 
   memset (&get, 0, sizeof (get));
-  owned_clause = acl_where_owned ("ticket", &get, 1, "any", 0, NULL,
+  owned_clause = acl_where_owned ("ticket", &get, 1, "any", 0, NULL, 0,
                                   &with_clause);
 
   init_iterator (iterator,


### PR DESCRIPTION
**What**:
This improves the performance of creating the report counts cache by removing unused permission check WITH clauses from the SQL and instead using WITH clauses for the overrides.

**Why**:
Updating the report counts cache is slow, especially when updating overrides.

**How did you test it**:
By running the `modify_override` GMP command and viewing various pages in GSA like results and reports.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
