### PR TITLE
Add --ldap-debug option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Add standard info elem fields for NVTs in get_info [#1426](https://github.com/greenbone/gvmd/pull/1426)
+- Add --ldap-debug option [#1439](https://github.com/greenbone/gvmd/pull/1439)
 
 ### Changed
 

--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -28,6 +28,12 @@ Create admin user USERNAME and exit.
 \fB-d, --database=\fINAME\fB\f1
 Use NAME as database for PostgreSQL.
 .TP
+\fB--db-host=\fIHOST\fB\f1
+Use HOST as database host or socket directory for PostgreSQL.
+.TP
+\fB--db-port=\fIPORT\fB\f1
+Use PORT as database port or socket extension for PostgreSQL.
+.TP
 \fB--delete-scanner=\fISCANNER-UUID\fB\f1
 Delete scanner SCANNER-UUID and exit.
 .TP
@@ -72,6 +78,9 @@ Have USERNAME inherit from deleted user.
 .TP
 \fB-a, --listen=\fIADDRESS\fB\f1
 Listen on ADDRESS.
+.TP
+\fB--ldap-debug\f1
+Enable debugging of LDAP authentication.
 .TP
 \fB--listen2=\fIADDRESS\fB\f1
 Listen also on ADDRESS.
@@ -169,9 +178,6 @@ Time out tasks that are more than TIME minutes overdue. -1 to disable, 0 for min
 .TP
 \fB--secinfo-commit-size=\fINUMBER\fB\f1
 During CERT and SCAP sync, commit updates to the database every NUMBER items, 0 for unlimited.
-.TP
-\fB--slave-commit-size=\fINUMBER\fB\f1
-During slave updates, commit after every NUMBER updated results and hosts, 0 for unlimited.
 .TP
 \fB-c, --unix-socket=\fIFILENAME\fB\f1
 Listen on UNIX socket at FILENAME.

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -186,6 +186,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </optdesc>
     </option>
     <option>
+      <p><opt>--ldap-debug</opt></p>
+      <optdesc>
+        <p>Enable debugging of LDAP authentication.</p>
+      </optdesc>
+    </option>
+    <option>
       <p><opt>--listen2=<arg>ADDRESS</arg></opt></p>
       <optdesc>
         <p>Listen also on ADDRESS.</p>

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -97,6 +97,7 @@
 #include <gvm/base/proctitle.h>
 #include <gvm/util/fileutils.h>
 #include <gvm/util/serverutils.h>
+#include <gvm/util/ldaputils.h>
 
 #include "manage.h"
 #include "manage_sql_nvts.h"
@@ -1729,6 +1730,7 @@ gvmd (int argc, char** argv)
   static gchar *verify_scanner = NULL;
   static gchar *priorities = "NORMAL";
   static gchar *dh_params = NULL;
+  static gboolean ldap_debug = FALSE;
   static gchar *listen_owner = NULL;
   static gchar *listen_group = NULL;
   static gchar *listen_mode = NULL;
@@ -1851,6 +1853,10 @@ gvmd (int argc, char** argv)
           &inheritor,
           "Have <username> inherit from deleted user.",
           "<username>" },
+        { "ldap-debug", '\0', 0, G_OPTION_ARG_NONE,
+          &ldap_debug,
+          "Enable debugging of LDAP authentication",
+          NULL },
         { "listen", 'a', 0, G_OPTION_ARG_STRING,
           &manager_address_string,
           "Listen on <address>.",
@@ -2190,6 +2196,17 @@ gvmd (int argc, char** argv)
         }
       else
         g_debug ("No default relay mapper found.");
+    }
+
+  /**
+   * LDAP debugging
+   */
+  if (ldap_debug)
+    {
+      if (ldap_enable_debug () == 0)
+        g_message ("LDAP debugging enabled");
+      else
+        g_warning ("Could not enable LDAP debugging");
     }
 
 #ifdef GVMD_GIT_REVISION


### PR DESCRIPTION
**What**:
This new option enables extended logging for LDAP authentication, which
can be used for debugging in case of connection issues.

This requires greenbone/gvm-libs#453

**Why**:
To help users with LDAP connection issues.

**How did you test it**:
By running gvmd with and without the new option and checking the log after an attempted LDAP authentication.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
