### PR TITLE
Add check if PostgreSQL extensions are installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Add standard info elem fields for NVTs in get_info [#1426](https://github.com/greenbone/gvmd/pull/1426)
 - Add --ldap-debug option [#1439](https://github.com/greenbone/gvmd/pull/1439)
+- Add check if PostgreSQL extensions are installed [#1444](https://github.com/greenbone/gvmd/pull/1444)
 
 ### Changed
 - Improve report counts performance [#1438](https://github.com/greenbone/gvmd/pull/1438)

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -3036,6 +3036,51 @@ check_db_sequences ()
   cleanup_iterator (&sequence_tables);
 }
 
+/**
+ * @brief Check if an extension is installed.
+ * 
+ * @param[in]  extname  Name of the extension to check.
+ *
+ * @return TRUE extension is installed, FALSE otherwise.
+ */
+static gboolean
+db_extension_installed (const char *extname)
+{
+  if (sql_int ("SELECT count(*) FROM pg_extension WHERE extname = '%s'",
+               extname))
+    {
+      g_debug ("%s: Extension '%s' is installed.",
+                 __func__, extname);
+      return TRUE;
+    }
+  else
+    {
+      g_message ("%s: Extension '%s' is not installed.",
+                 __func__, extname);
+      return FALSE;
+    }
+}
+
+/**
+ * @brief Check if all extensions are installed.
+ *
+ * @return 0 success, 1 extension missing.
+ */
+int
+check_db_extensions ()
+{
+  if (db_extension_installed ("uuid-ossp")
+      && db_extension_installed ("pgcrypto"))
+    {
+      g_debug ("%s: All required extensions are installed.", __func__);
+      return 0;
+    }
+  else
+    {
+      g_warning ("%s: A required extension is not installed.", __func__);
+      return 1;
+    }
+}
 
 /* SecInfo. */
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -133,6 +133,9 @@ create_tables ();
 void
 check_db_sequences ();
 
+int
+check_db_extensions ();
+
 static int
 check_db_encryption_key ();
 
@@ -16155,6 +16158,8 @@ check_db (int check_encryption_key)
    * process accessing the db.  Nothing else should be accessing the db, access
    * should always go through Manager. */
   sql_begin_immediate ();
+  if (check_db_extensions ())
+    goto fail;
   create_tables ();
   check_db_sequences ();
   set_db_version (GVMD_DATABASE_VERSION);


### PR DESCRIPTION
**What**:
On startup, gvmd will now check if the required extensions "uuid-ossp"
and "pgcrypto" are installed.

**Why**:
So missing extensions due to installation or migration issues can be
identified more easily.

**How did you test it**:
By starting gvmd without and with the pgcrypto extension installed.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
