### PR TITLE
Fix size calculation in `--optimize vacuum`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix SQL escaping when adding VT references [#1429](https://github.com/greenbone/gvmd/pull/1429)
 - Update report run status more consistently [#1434](https://github.com/greenbone/gvmd/pull/1434) 
 - Improve modify_override errors, fix no NVT case [#1435](https://github.com/greenbone/gvmd/pull/1435)
+- Fix size calculation in `--optimize vacuum` [#1447](https://github.com/greenbone/gvmd/pull/1447)
 
 ### Removed
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -56454,9 +56454,6 @@ manage_optimize (GSList *log_config, const db_conn_info_t *database,
       gchar *quoted_db_name;
       unsigned long long int old_size, new_size;
 
-      old_size = 0LL;
-      new_size = 0LL;
-
       quoted_db_name = sql_quote (sql_database ());
 
       old_size = sql_int64_0 ("SELECT pg_database_size ('%s')",

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -56451,50 +56451,40 @@ manage_optimize (GSList *log_config, const db_conn_info_t *database,
   ret = 0;
   if (strcasecmp (name, "vacuum") == 0)
     {
-      struct stat state;
-      long long int old_size, new_size;
+      gchar *quoted_db_name;
+      unsigned long long int old_size, new_size;
 
       old_size = 0LL;
       new_size = 0LL;
-      ret = stat (database->name, &state);
-      if (ret)
-        switch (errno)
-          {
-            case ENOENT:
-              break;
-            default:
-              g_warning ("%s: failed to stat database: %s",
-                          __func__,
-                          strerror (errno));
-          }
-      else
-        old_size = state.st_size;
+
+      quoted_db_name = sql_quote (sql_database ());
+
+      old_size = sql_int64_0 ("SELECT pg_database_size ('%s')",
+                              quoted_db_name);
 
       sql ("VACUUM;");
 
-      ret = stat (database->name, &state);
-      if (ret)
-        switch (errno)
-          {
-            case ENOENT:
-              break;
-            default:
-              g_warning ("%s: failed to stat database: %s",
-                          __func__,
-                          strerror (errno));
-          }
-      else
-        new_size = state.st_size;
+      new_size = sql_int64_0 ("SELECT pg_database_size ('%s')",
+                              quoted_db_name);
 
-      if (old_size && new_size)
+      g_free (quoted_db_name);
+
+      if (old_size <= 0 || new_size <= 0)
+        success_text = g_strdup_printf ("Optimized: vacuum.");
+      else if (new_size <= old_size)
         success_text = g_strdup_printf ("Optimized: vacuum."
                                         " Database file size reduced by"
-                                        " %lld MiB (%0.1f %%).\n",
+                                        " %llu MiB (%0.1f %%).\n",
                                         (old_size - new_size) / (1024 * 1024),
                                         (old_size - new_size)
                                           * 100.0 / old_size);
       else
-        success_text = g_strdup_printf ("Optimized: vacuum.");
+        success_text = g_strdup_printf ("Optimized: vacuum."
+                                        " Database file size *increased* by"
+                                        " %llu MiB (%0.1f %%).\n",
+                                        (new_size - old_size) / (1024 * 1024),
+                                        (new_size - old_size)
+                                          * 100.0 / old_size);
     }
   else if (strcasecmp (name, "analyze") == 0)
     {


### PR DESCRIPTION
**What**:
The database size was still trying to stat a filesystem path as used
by SQLite as the database name.
This is changed to use the SQL function pg_database_size instead and
also the case where the size increases is now handled.

**Why**:
This fixes the warnings about the failed stats reported in #1432.

**How did you test it**:
By running `gvmd --optimize vacuum` after importing and deleting several reports.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
