### PR TITLE
Add auto retry on scanner connection lost during a runnning task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add standard info elem fields for NVTs in get_info [#1426](https://github.com/greenbone/gvmd/pull/1426)
 - Add --ldap-debug option [#1439](https://github.com/greenbone/gvmd/pull/1439)
 - Add check if PostgreSQL extensions are installed [#1444](https://github.com/greenbone/gvmd/pull/1444)
+- Add auto retry on scanner connection lost during a running task [#1452](https://github.com/greenbone/gvmd/pull/1452)
 
 ### Changed
 - Improve report counts performance [#1438](https://github.com/greenbone/gvmd/pull/1438)

--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -173,11 +173,17 @@ Scanner type for --create-scanner and --modify-scanner.
 
 Either 'OpenVAS', 'OSP', 'GMP', 'OSP-Sensor' or a number as used in GMP.
 .TP
+\fB--scanner-connection-retry=\fINUMBER\fB\f1
+During a running task, number of auto retry on scanner connection lost, default 3.
+.TP
 \fB--schedule-timeout=\fITIME\fB\f1
 Time out tasks that are more than TIME minutes overdue. -1 to disable, 0 for minimum time.
 .TP
 \fB--secinfo-commit-size=\fINUMBER\fB\f1
 During CERT and SCAP sync, commit updates to the database every NUMBER items, 0 for unlimited.
+.TP
+\fB--slave-commit-size=\fINUMBER\fB\f1
+During slave updates, commit after every NUMBER updated results and hosts, 0 for unlimited.
 .TP
 \fB-c, --unix-socket=\fIFILENAME\fB\f1
 Listen on UNIX socket at FILENAME.
@@ -203,23 +209,14 @@ gvmd --port 1241
 
 Serve GMP clients on port 1241 and connect to an OpenVAS scanner via the default OTP file socket.
 .SH SEE ALSO
-\fBopenvas(8)\f1, \fBgsad(8)\f1, \fBospd-openvas(8)\f1, \fBgreenbone-certdata-sync(8)\f1, \fBgreenbone-scapdata-sync(8)\f1,
+\fBopenvas(8)\f1, \fBgsad(8)\f1, \fBospd-openvas(8)\f1, \fBgreenbone-certdata-sync(8)\f1, \fBgreenbone-scapdata-sync(8)\f1, 
 .SH MORE INFORMATION
 The canonical places where you will find more information about the Greenbone Vulnerability Manager are: 
 
-.RS
-.UR https://community.greenbone.net
-Community Portal
-.UE
-.br
-.UR https://github.com/greenbone
-Development Platform
-.UE
-.br
-.UR https://www.greenbone.net
-Greenbone Website
-.UE
-.RE
+\fBhttps://community.greenbone.net\f1 (Community Portal) 
 
+\fBhttps://github.com/greenbone\f1 (Development Platform) 
+
+\fBhttps://www.greenbone.net\f1 (Greenbone Website) 
 .SH COPYRIGHT
 The Greenbone Vulnerability Manager is released under the GNU GPL, version 2, or, at your option, any later version. 

--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -174,7 +174,7 @@ Scanner type for --create-scanner and --modify-scanner.
 Either 'OpenVAS', 'OSP', 'GMP', 'OSP-Sensor' or a number as used in GMP.
 .TP
 \fB--scanner-connection-retry=\fINUMBER\fB\f1
-During a running task, number of auto retry on scanner connection lost, default 3.
+Number of auto retries if scanner connection is lost in a running task.
 .TP
 \fB--schedule-timeout=\fITIME\fB\f1
 Time out tasks that are more than TIME minutes overdue. -1 to disable, 0 for minimum time.

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -385,8 +385,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <option>
       <p><opt>--scanner-connection-retry=<arg>NUMBER</arg></opt></p>
       <optdesc>
-        <p>During a running task, number of auto retry on scanner connection
-           lost, default 3.</p>
+        <p>Number of auto retries if scanner connection is lost
+           in a running task.</p>
       </optdesc>
     </option>    
     <option>

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -383,6 +383,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </optdesc>
     </option>
     <option>
+      <p><opt>--scanner-connection-retry=<arg>NUMBER</arg></opt></p>
+      <optdesc>
+        <p>During a running task, number of auto retry on scanner connection
+           lost, default 3.</p>
+      </optdesc>
+    </option>    
+    <option>
       <p><opt>--schedule-timeout=<arg>TIME</arg></opt></p>
       <optdesc>
         <p>Time out tasks that are more than TIME minutes overdue.

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -2088,6 +2088,9 @@ gvmd (int argc, char** argv)
 
   set_schedule_timeout (schedule_timeout);
 
+  /* Set the connection auto retry */
+  set_scanner_connection_retry (scanner_connection_retry);
+
   /* Set slave commit size */
   set_slave_commit_size (slave_commit_size);
 

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1723,6 +1723,7 @@ gvmd (int argc, char** argv)
   static gchar *scanner_credential = NULL;
   static gchar *scanner_key_pub = NULL;
   static gchar *scanner_key_priv = NULL;
+  static int scanner_connection_retry = SCANNER_CONNECTION_RETRY_DEFAULT;
   static int schedule_timeout = SCHEDULE_TIMEOUT_DEFAULT;
   static int secinfo_commit_size = SECINFO_COMMIT_SIZE_DEFAULT;
   static int slave_commit_size = SLAVE_COMMIT_SIZE_DEFAULT;
@@ -1958,6 +1959,11 @@ gvmd (int argc, char** argv)
           &scanner_ca_pub,
           "Scanner CA Certificate path for --[create|modify]-scanner.",
           "<scanner-ca-pub>" },
+        { "scanner-connection-retry", '\0', 0, G_OPTION_ARG_INT,
+          &scanner_connection_retry,
+          "During a running task, number of auto retry on lost connection,"
+          " default: "G_STRINGIFY (SCANNER_CONNECTION_RETRY),
+          "<number>" },
         { "scanner-credential", '\0', 0, G_OPTION_ARG_STRING,
           &scanner_credential,
           "Scanner credential for --create-scanner and --modify-scanner."

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1961,8 +1961,8 @@ gvmd (int argc, char** argv)
           "<scanner-ca-pub>" },
         { "scanner-connection-retry", '\0', 0, G_OPTION_ARG_INT,
           &scanner_connection_retry,
-          "During a running task, number of auto retry on lost connection,"
-          " default: "G_STRINGIFY (SCANNER_CONNECTION_RETRY),
+          "Number of auto retries if scanner connection is lost in a running task,"
+          " default: "G_STRINGIFY (SCANNER_CONNECTION_RETRY_DEFAULT),
           "<number>" },
         { "scanner-credential", '\0', 0, G_OPTION_ARG_STRING,
           &scanner_credential,

--- a/src/manage.c
+++ b/src/manage.c
@@ -3580,7 +3580,8 @@ handle_osp_scan (task_t task, report_t report, const char *scan_id)
   connection_retry = get_scanner_connection_retry ();
 
   retry = connection_retry;
-  while (1 && retry >= 0)
+  rc = -1;
+  while (retry >= 0)
     {
       int run_status, progress;
       osp_scan_status_t osp_scan_status;

--- a/src/manage.c
+++ b/src/manage.c
@@ -3567,7 +3567,7 @@ handle_osp_scan (task_t task, report_t report, const char *scan_id)
   int rc, port;
   scanner_t scanner;
   gboolean started, queued_status_updated;
-  int retry;
+  int retry, connection_retry;
 
   scanner = task_scanner (task);
   host = scanner_host (scanner);
@@ -3577,8 +3577,9 @@ handle_osp_scan (task_t task, report_t report, const char *scan_id)
   key_priv = scanner_key_priv (scanner);
   started = FALSE;
   queued_status_updated = FALSE;
+  connection_retry = get_scanner_connection_retry ();
 
-  retry = 3;
+  retry = connection_retry;
   while (1 && retry >= 0)
     {
       int run_status, progress;
@@ -3718,7 +3719,7 @@ handle_osp_scan (task_t task, report_t report, const char *scan_id)
             }
         }
 
-      retry = 3;
+      retry = connection_retry;
       gvm_sleep (5);
     }
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -186,7 +186,8 @@ static int relay_migrate_sensors = 0;
 static int schedule_timeout = SCHEDULE_TIMEOUT_DEFAULT;
 
 /**
- * @brief Default for max auto retry on connection to scanner lost.
+ * @brief Default number of auto retries if scanner connection is
+ *        lost in a running task.
  */
 static int scanner_connection_retry = SCANNER_CONNECTION_RETRY_DEFAULT;
 
@@ -4687,9 +4688,9 @@ run_osp_task (task_t task, int from, char **report_id)
 }
 
 /**
- * @brief Get the number of retry on a scanner connection lost.
+ * @brief Get the number of retries on a scanner connection lost.
  *
- * @return The number of retry on a scanner connection lost.
+ * @return The number of retries on a scanner connection lost.
  */
 int
 get_scanner_connection_retry ()
@@ -4698,9 +4699,9 @@ get_scanner_connection_retry ()
 }
 
 /**
- * @brief Set the number of retry on a scanner connection lost.
+ * @brief Set the number of retries on a scanner connection lost.
  *
- * @param new_retry The number of retry on a scanner connection lost.
+ * @param new_retry The number of retries on a scanner connection lost.
  */
 void
 set_scanner_connection_retry (int new_retry)

--- a/src/manage.c
+++ b/src/manage.c
@@ -185,6 +185,11 @@ static int relay_migrate_sensors = 0;
  */
 static int schedule_timeout = SCHEDULE_TIMEOUT_DEFAULT;
 
+/**
+ * @brief Default for max auto retry on connection to scanner lost.
+ */
+static int scanner_connection_retry = SCANNER_CONNECTION_RETRY_DEFAULT;
+
 
 /* Certificate and key management. */
 
@@ -4677,6 +4682,29 @@ run_osp_task (task_t task, int from, char **report_id)
       return -1;
     }
   return 0;
+}
+
+/**
+ * @brief Get the number of retry on a scanner connection lost.
+ *
+ * @return The number of retry on a scanner connection lost.
+ */
+int
+get_scanner_connection_retry ()
+{
+  return scanner_connection_retry;
+}
+
+/**
+ * @brief Set the number of retry on a scanner connection lost.
+ *
+ * @param new_retry The number of retry on a scanner connection lost.
+ */
+void
+set_scanner_connection_retry (int new_retry)
+{
+  if (new_retry > 1)
+    scanner_connection_retry = new_retry;
 }
 
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -4704,7 +4704,7 @@ get_scanner_connection_retry ()
 void
 set_scanner_connection_retry (int new_retry)
 {
-  if (new_retry > 1)
+  if (new_retry >= 0)
     scanner_connection_retry = new_retry;
 }
 

--- a/src/manage.h
+++ b/src/manage.h
@@ -2432,6 +2432,11 @@ manage_system_report (const char *, const char *, const char *, const char *,
  */
 #define SLAVE_COMMIT_SIZE_DEFAULT 0
 
+/**
+ * @brief Default for max auto retry on connection to scanner lost.
+ */
+#define SCANNER_CONNECTION_RETRY_DEFAULT 3
+
 int
 manage_create_scanner (GSList *, const db_conn_info_t *, const char *,
                        const char *, const char *, const char *, const char *,

--- a/src/manage.h
+++ b/src/manage.h
@@ -2605,6 +2605,12 @@ osp_connection_t *
 osp_scanner_connect (scanner_t);
 
 int
+get_scanner_connection_retry ();
+
+void
+set_scanner_connection_retry (int);
+
+int
 verify_scanner (const char *, char **);
 
 void


### PR DESCRIPTION
**What**:
￼Add auto retry on scanner connection lost during a runnning task
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
During a running scan, gvmd set immediately the task as "stopped". This patch adds an option to retry to connect.
<!-- Why are these changes necessary? -->

**How did you test it**:
- Start a scan.
- chmod the ospd-openvas socket with 400 permission.
- check the logs
- 
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
