### PR TITLE
Use pg-gvm extension for C PostgreSQL functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [21.10] (unreleased)
 
 ### Added
+
 ### Changed
+- Use pg-gvm extension for C PostgreSQL functions [#1400](https://github.com/greenbone/gvmd/pull/1400), [#1453](https://github.com/greenbone/gvmd/pull/1453)
+
 ### Fixed
+
 ### Removed
 
 [21.4]: https://github.com/greenbone/gvmd/compare/gvmd-21.04...master

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -125,9 +125,14 @@ Certificates`.
     apt install postgresql postgresql-contrib postgresql-server-dev-all
     ```
 
-2.  Run cmake and build gvmd as usual.
+2.  Install the pg-gvm extension.
 
-3.  Setup Postgres User and DB (`/usr/share/doc/postgresql-common/README.Debian.gz`)
+    Install the pg-gvm extension library (https://github.com/greenbone/pg-gvm).
+    For instructions on how to do this, see the README file there.
+
+3.  Run cmake and build gvmd as usual.
+
+4.  Setup Postgres User and DB (`/usr/share/doc/postgresql-common/README.Debian.gz`)
 
     ```sh
     sudo -u postgres bash
@@ -135,31 +140,32 @@ Certificates`.
     createdb -O mattm gvmd
     ```
 
-4.  Setup permissions.
-
-    ```sh
-    sudo -u postgres bash  # if you logged out after step 3
-    psql gvmd
-    create role dba with superuser noinherit;
-    grant dba to mattm;    # mattm is the user created in step 3
-    ```
-
-5.  Create DB extensions (also necessary when the database got dropped).
+5.  Setup permissions.
 
     ```sh
     sudo -u postgres bash  # if you logged out after step 4
     psql gvmd
-    create extension "uuid-ossp";
-    create extension "pgcrypto";
+    create role dba with superuser noinherit;
+    grant dba to mattm;    # mattm is the user created in step 4
     ```
 
-6.  Make Postgres aware of the gvm libraries if not installed
+6.  Create DB extensions (also necessary when the database got dropped).
+
+    ```sh
+    sudo -u postgres bash  # if you logged out after step 5
+    psql gvmd
+    create extension "uuid-ossp";
+    create extension "pgcrypto";
+    create extension "pg-gvm"; # if it is not installed in step 2.
+    ```
+
+7.  Make Postgres aware of the gvm libraries if not installed
     in a ld-aware directory. For example create file `/etc/ld.so.conf.d/gvm.conf`
     with appropriate path and then run `ldconfig`.
 
-7.  Run Manager as usual.
+8.  Run Manager as usual.
 
-8. To run SQL on the database.
+9.  To run SQL on the database.
 
     ```sh
     psql gvmd

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -2917,7 +2917,8 @@ int
 check_db_extensions ()
 {
   if (db_extension_installed ("uuid-ossp")
-      && db_extension_installed ("pgcrypto"))
+      && db_extension_installed ("pgcrypto")
+      && db_extension_installed ("pg-gvm"))
     {
       g_debug ("%s: All required extensions are installed.", __func__);
       return 0;

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -194,22 +194,23 @@ manage_create_sql_functions ()
       return -1;
     }
 
-  /* Functions in C. */
+  /* Functions in C have been moved to the "pg-gvm" extension. */
+  
+  /* Operators */
 
   sql ("SET role dba;");
 
-  sql ("CREATE OR REPLACE FUNCTION hosts_contains (text, text)"
-       " RETURNS boolean"
-       " AS '%s/libgvm-pg-server', 'sql_hosts_contains'"
-       " LANGUAGE C"
-       " IMMUTABLE;",
-       GVM_LIB_INSTALL_DIR);
+  if (sql_int ("SELECT count(*) FROM pg_operator"
+               " WHERE oprname = '?~#';")
+      == 0)
+    {
+      sql ("CREATE OPERATOR ?~#"
+          " (PROCEDURE = regexp, LEFTARG = text, RIGHTARG = text);");
+    }
 
-  sql ("CREATE OR REPLACE FUNCTION max_hosts (text, text)"
-       " RETURNS integer"
-       " AS '%s/libgvm-pg-server', 'sql_max_hosts'"
-       " LANGUAGE C;",
-       GVM_LIB_INSTALL_DIR);
+  sql ("RESET role;");
+
+  /* Functions in pl/pgsql. */
 
   /*
    * This database function is a duplicate of 'level_max_severity' from manage_utils.c
@@ -275,18 +276,6 @@ manage_create_sql_functions ()
        "END;"
        "$$ LANGUAGE plpgsql;");
 
-  sql ("CREATE OR REPLACE FUNCTION next_time_ical (text, text)"
-       " RETURNS integer"
-       " AS '%s/libgvm-pg-server', 'sql_next_time_ical'"
-       " LANGUAGE C;",
-       GVM_LIB_INSTALL_DIR);
-
-  sql ("CREATE OR REPLACE FUNCTION next_time_ical (text, text, integer)"
-       " RETURNS integer"
-       " AS '%s/libgvm-pg-server', 'sql_next_time_ical'"
-       " LANGUAGE C;",
-       GVM_LIB_INSTALL_DIR);
-
   sql ("CREATE OR REPLACE FUNCTION severity_matches_ov (a double precision,"
        "                                                b double precision)"
        "RETURNS BOOLEAN AS $$"
@@ -299,24 +288,6 @@ manage_create_sql_functions ()
        " END;"
        "END;"
        "$$ LANGUAGE plpgsql IMMUTABLE;");
-
-  sql ("CREATE OR REPLACE FUNCTION regexp (text, text)"
-       " RETURNS boolean"
-       " AS '%s/libgvm-pg-server', 'sql_regexp'"
-       " LANGUAGE C;",
-       GVM_LIB_INSTALL_DIR);
-
-  if (sql_int ("SELECT count(*) FROM pg_operator"
-               " WHERE oprname = '?~#';")
-      == 0)
-    {
-      sql ("CREATE OPERATOR ?~#"
-          " (PROCEDURE = regexp, LEFTARG = text, RIGHTARG = text);");
-    }
-
-  sql ("RESET role;");
-
-  /* Functions in pl/pgsql. */
 
   /* Helper function for quoting the individual parts of multi-part
    *  identifiers like "scap", "cpes" and "id" in "scap.cpes.id" where


### PR DESCRIPTION
**What**:
The extension functions written in C are no longer created directly in
gvmd. Instead they will be handled by the extension "pg-gvm".

**Why**:
The extension functions should be independent of gvmd and not be
overwritten by gvmd.

**How did you test it**:
By installing the extension, starting gvmd and then checking if the
extensions functions return the expected values instead of NULL from
the dummy functions.

**Checklist**:

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
