### PR TITLE
Show empty scores in SecInfo where appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Move EXE credential generation to a Python script [#1260](https://github.com/greenbone/gvmd/pull/1260) [#1262](https://github.com/greenbone/gvmd/pull/1262)
 - Clarify documentation for --scan-host parameter [#1277](https://github.com/greenbone/gvmd/pull/1277)
 - In result iterator access severity directly if possible [#1321](https://github.com/greenbone/gvmd/pull/1321)
-- Change SCAP and CERT data to use new severity scoring [#1333](https://github.com/greenbone/gvmd/pull/1333) [#1357](https://github.com/greenbone/gvmd/pull/1357) [#1365](https://github.com/greenbone/gvmd/pull/1365)
+- Change SCAP and CERT data to use new severity scoring [#1333](https://github.com/greenbone/gvmd/pull/1333) [#1357](https://github.com/greenbone/gvmd/pull/1357) [#1365](https://github.com/greenbone/gvmd/pull/1365) [#1457](https://github.com/greenbone/gvmd/pull/1457)
 - Expect report format scripts to exit with code 0 [#1383](https://github.com/greenbone/gvmd/pull/1383)
 - Send entire families to ospd-openvas using VT_GROUP [#1384](https://github.com/greenbone/gvmd/pull/1384)
 - The internal list of current Local Security Checks for the 'Closed CVEs' feature was updated [#1381](https://github.com/greenbone/gvmd/pull/1381)

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -9003,12 +9003,14 @@ results_xml_append_nvt (iterator_t *results, GString *buffer, int cert_loaded)
                                     "<type>ovaldef</type>"
                                     "<name>%s</name>"
                                     "<family/>"
-                                    "<severities score=\"%i\">"
+                                    "<severities score=\"%s\">"
                                     "</severities>"
                                     "<tags>summary=%s</tags>",
                                     oid,
                                     ovaldef_info_iterator_title (&iterator),
-                                    ovaldef_info_iterator_score (&iterator),
+                                    ovaldef_info_iterator_score (&iterator)
+                                      ? ovaldef_info_iterator_score (&iterator)
+                                      : "",
                                     ovaldef_info_iterator_description (&iterator));
           g_free (get.id);
           cleanup_iterator (&iterator);
@@ -13091,13 +13093,15 @@ handle_get_info (gmp_parser_t *gmp_parser, GError **error)
                                cpe_info_iterator_title (&info));
           xml_string_append (result,
                              "<nvd_id>%s</nvd_id>"
-                             "<score>%d</score>"
+                             "<score>%s</score>"
                              "<cve_refs>%s</cve_refs>"
                              "<status>%s</status>",
                              cpe_info_iterator_nvd_id (&info)
                               ? cpe_info_iterator_nvd_id (&info)
                               : "",
-                             cpe_info_iterator_score (&info),
+                             cpe_info_iterator_score (&info)
+                              ? cpe_info_iterator_score (&info)
+                              : "",
                              cpe_info_iterator_cve_refs (&info),
                              cpe_info_iterator_status (&info)
                               ? cpe_info_iterator_status (&info)
@@ -13122,13 +13126,15 @@ handle_get_info (gmp_parser_t *gmp_parser, GError **error)
                                    " id=\"%s\">"
                                    "<vuln:cvss>"
                                    "<cvss:base_metrics>"
-                                   "<cvss:score>%0.1lf</cvss:score>"
+                                   "<cvss:score>%s</cvss:score>"
                                    "</cvss:base_metrics>"
                                    "</vuln:cvss>"
                                    "</entry>"
                                    "</cve>",
                                    cve_iterator_name (&cves),
-                                   cve_iterator_score (&cves) / 10.0);
+                                   cve_iterator_cvss_score (&cves)
+                                    ? cve_iterator_cvss_score (&cves)
+                                    : "");
               cleanup_iterator (&cves);
               g_string_append (result, "</cves>");
             }
@@ -13137,11 +13143,13 @@ handle_get_info (gmp_parser_t *gmp_parser, GError **error)
         {
           xml_string_append (result,
                              "<cve>"
-                             "<score>%d</score>"
+                             "<score>%s</score>"
                              "<cvss_vector>%s</cvss_vector>"
                              "<description>%s</description>"
                              "<products>%s</products>",
-                             cve_info_iterator_score (&info),
+                             cve_info_iterator_score (&info)
+                              ? cve_info_iterator_score (&info)
+                              : "",
                              cve_info_iterator_vector (&info),
                              cve_info_iterator_description (&info),
                              cve_info_iterator_products (&info));
@@ -13216,7 +13224,7 @@ handle_get_info (gmp_parser_t *gmp_parser, GError **error)
                              "<status>%s</status>"
                              "<class>%s</class>"
                              "<title>%s</title>"
-                             "<score>%d</score>"
+                             "<score>%s</score>"
                              "<cve_refs>%s</cve_refs>"
                              "<file>%s</file>",
                              ovaldef_info_iterator_version (&info),
@@ -13224,7 +13232,9 @@ handle_get_info (gmp_parser_t *gmp_parser, GError **error)
                              ovaldef_info_iterator_status (&info),
                              ovaldef_info_iterator_class (&info),
                              ovaldef_info_iterator_title (&info),
-                             ovaldef_info_iterator_score (&info),
+                             ovaldef_info_iterator_score (&info)
+                              ? ovaldef_info_iterator_score (&info)
+                              : "",
                              ovaldef_info_iterator_cve_refs (&info),
                              ovaldef_info_iterator_file (&info));
           description = ovaldef_info_iterator_description (&info);
@@ -13238,22 +13248,26 @@ handle_get_info (gmp_parser_t *gmp_parser, GError **error)
                            "<cert_bund_adv>"
                            "<title>%s</title>"
                            "<summary>%s</summary>"
-                           "<score>%d</score>"
+                           "<score>%s</score>"
                            "<cve_refs>%s</cve_refs>",
                            cert_bund_adv_info_iterator_title (&info),
                            cert_bund_adv_info_iterator_summary (&info),
-                           cert_bund_adv_info_iterator_score(&info),
+                           cert_bund_adv_info_iterator_score(&info)
+                            ? cert_bund_adv_info_iterator_score(&info)
+                            : "",
                            cert_bund_adv_info_iterator_cve_refs (&info));
       else if (g_strcmp0 ("dfn_cert_adv", get_info_data->type) == 0)
         xml_string_append (result,
                            "<dfn_cert_adv>"
                            "<title>%s</title>"
                            "<summary>%s</summary>"
-                           "<score>%d</score>"
+                           "<score>%s</score>"
                            "<cve_refs>%s</cve_refs>",
                            dfn_cert_adv_info_iterator_title (&info),
                            dfn_cert_adv_info_iterator_summary (&info),
-                           dfn_cert_adv_info_iterator_score(&info),
+                           dfn_cert_adv_info_iterator_score(&info)
+                            ? dfn_cert_adv_info_iterator_score(&info)
+                            : "",
                            dfn_cert_adv_info_iterator_cve_refs (&info));
       else if (g_strcmp0 ("nvt", get_info_data->type) == 0)
         {

--- a/src/manage.h
+++ b/src/manage.h
@@ -3138,7 +3138,7 @@ cpe_info_iterator_title (iterator_t*);
 const char*
 cpe_info_iterator_status (iterator_t*);
 
-int
+const char *
 cpe_info_iterator_score (iterator_t*);
 
 const char*
@@ -3155,10 +3155,10 @@ cpe_info_iterator_nvd_id (iterator_t*);
 const char*
 cve_iterator_name (iterator_t*);
 
-int
-cve_iterator_score (iterator_t*);
+const char*
+cve_iterator_cvss_score (iterator_t*);
 
-int
+const char*
 cve_info_iterator_score (iterator_t*);
 
 const char*
@@ -3210,7 +3210,7 @@ ovaldef_info_iterator_file (iterator_t*);
 const char*
 ovaldef_info_iterator_status (iterator_t*);
 
-int
+const char*
 ovaldef_info_iterator_score (iterator_t*);
 
 const char*
@@ -3249,7 +3249,7 @@ cert_bund_adv_info_iterator_summary (iterator_t*);
 const char*
 cert_bund_adv_info_iterator_cve_refs (iterator_t*);
 
-int
+const char*
 cert_bund_adv_info_iterator_score (iterator_t*);
 
 void
@@ -3278,7 +3278,7 @@ dfn_cert_adv_info_iterator_summary (iterator_t*);
 const char*
 dfn_cert_adv_info_iterator_cve_refs (iterator_t*);
 
-int
+const char*
 dfn_cert_adv_info_iterator_score (iterator_t*);
 
 void

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -554,14 +554,9 @@ DEF_ACCESS (cpe_info_iterator_status, GET_ITERATOR_COLUMN_COUNT + 1);
  * @param[in]  iterator  Iterator.
  *
  * @return The highest severity score (10 * CVSS score) of the CPE,
- *         or -1 if iteration is complete. Freed by cleanup_iterator.
+ *         or NULL if iteration is complete. Freed by cleanup_iterator.
  */
-int
-cpe_info_iterator_score (iterator_t *iterator)
-{
-  if (iterator->done) return -1;
-  return iterator_int (iterator, GET_ITERATOR_COLUMN_COUNT + 3);
-}
+DEF_ACCESS (cpe_info_iterator_score, GET_ITERATOR_COLUMN_COUNT + 3);
 
 /**
  * @brief Get the Number of CVE's referencing this cpe from a CPE iterator.
@@ -626,7 +621,8 @@ init_cpe_cve_iterator (iterator_t *iterator, const char *cve, int ascending,
   assert (cve);
   quoted_cpe = sql_quote (cve);
   init_iterator (iterator,
-                 "SELECT id, name, score FROM cves WHERE id IN"
+                 "SELECT id, name, round(score / 10.0, 1) FROM cves"
+                 " WHERE id IN"
                  " (SELECT cve FROM affected_products"
                  "  WHERE cpe ="
                  "  (SELECT id FROM cpes WHERE name = '%s'))"
@@ -652,15 +648,10 @@ DEF_ACCESS (cve_iterator_name, 1);
  *
  * @param[in]  iterator  Iterator.
  *
- * @return The severity score (10 * CVSS score) of the CVE,
- *         or -1 if iteration is complete.  Freed by cleanup_iterator.
+ * @return The CVSS score of the CVE,
+ *         or NULL if iteration is complete.  Freed by cleanup_iterator.
  */
-int
-cve_iterator_score (iterator_t* iterator)
-{
-  if (iterator->done) return -1;
-  return iterator_int (iterator, 2);
-}
+DEF_ACCESS (cve_iterator_cvss_score, 2);
 
 /**
  * @brief Get the CVSS score for a CVE.
@@ -801,14 +792,9 @@ DEF_ACCESS (cve_info_iterator_products, GET_ITERATOR_COLUMN_COUNT + 1);
  * @param[in]  iterator  Iterator.
  *
  * @return The severity score  (10 * CVSS score) of this CVE,
- *         or -1 if iteration is complete. Freed by cleanup_iterator.
+ *         or NULL if iteration is complete. Freed by cleanup_iterator.
  */
-int
-cve_info_iterator_score (iterator_t* iterator)
-{
-  if (iterator->done) return -1;
-  return iterator_int (iterator,  GET_ITERATOR_COLUMN_COUNT + 2);
-}
+DEF_ACCESS (cve_info_iterator_score, GET_ITERATOR_COLUMN_COUNT + 2);
 
 /**
  * @brief Get the Summary for this CVE.
@@ -996,15 +982,10 @@ DEF_ACCESS (ovaldef_info_iterator_status, GET_ITERATOR_COLUMN_COUNT + 6);
  * @param[in]  iterator  Iterator.
  *
  * @return The maximum severity score  (10 * CVSS score) of the OVAL
- *         definition, or -1 if iteration is complete.
+ *         definition, or NULL if iteration is complete.
  *         Freed by cleanup_iterator.
  */
-int
-ovaldef_info_iterator_score (iterator_t* iterator)
-{
-  if (iterator->done) return -1;
-  return iterator_int (iterator,  GET_ITERATOR_COLUMN_COUNT + 7);
-}
+DEF_ACCESS (ovaldef_info_iterator_score, GET_ITERATOR_COLUMN_COUNT + 7);
 
 /**
  * @brief Get number of referenced CVEs from an OVALDEF iterator.
@@ -1271,15 +1252,10 @@ DEF_ACCESS (cert_bund_adv_info_iterator_cve_refs,
  * @param[in]  iterator  Iterator.
  *
  * @return The maximum severity score (10 * CVSS score) of the CVEs referenced
- *         in the CERT-Bund advisory, or -1 if iteration is complete.
+ *         in the CERT-Bund advisory, or NULL if iteration is complete.
  *         Freed by cleanup_iterator.
  */
-int
-cert_bund_adv_info_iterator_score (iterator_t* iterator)
-{
-  if (iterator->done) return -1;
-  return iterator_int (iterator,  GET_ITERATOR_COLUMN_COUNT + 3);
-}
+DEF_ACCESS (cert_bund_adv_info_iterator_score, GET_ITERATOR_COLUMN_COUNT + 3);
 
 /**
  * @brief Initialise CVE iterator, for CVEs referenced by a CERT-Bund advisory.
@@ -1480,15 +1456,10 @@ DEF_ACCESS (dfn_cert_adv_info_iterator_cve_refs, GET_ITERATOR_COLUMN_COUNT + 2);
  * @param[in]  iterator  Iterator.
  *
  * @return The maximum score (10 * CVSS score) of the CVEs referenced
- *         in the DFN-CERT advisory, or -1 if iteration is complete.
+ *         in the DFN-CERT advisory, or NULL if iteration is complete.
  *         Freed by cleanup_iterator.
  */
-int
-dfn_cert_adv_info_iterator_score (iterator_t* iterator)
-{
-  if (iterator->done) return -1;
-  return iterator_int (iterator,  GET_ITERATOR_COLUMN_COUNT + 3);
-}
+DEF_ACCESS (dfn_cert_adv_info_iterator_score, GET_ITERATOR_COLUMN_COUNT + 3);
 
 /**
  * @brief Initialise CVE iterator, for CVEs referenced by a DFN-CERT advisory.


### PR DESCRIPTION
**What**:
CPEs, OVAL definitions and CERT advisories that do not have any severity
info because they have no CVE references will have an empty score in
the GMP response instead of score 0.

**Why**:
This is more consistent with the filtering and aggregates, where 0
and no score are also distinguished.

**How did you test it**:
By getting lists of CPE etc. with and without a `severity=""` filter and 
checking the score elements in the responses.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
