### PR TITLE
Add retry if a deadlock occurs on postgres within sql#sql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Limit "whole-only" config families to "growing" and "every nvt" [#1386](https://github.com/greenbone/gvmd/pull/1386)
 - Access current user with an SQL function [#1399](https://github.com/greenbone/gvmd/pull/1399)
 - Refactor modify_config, allowing multiple simultaneous changes [#1404](https://github.com/greenbone/gvmd/pull/1404)
+- Add retry on a deadlock within sql#sql [#1460](https://github.com/greenbone/gvmd/pull/1460)
 
 ### Fixed
 - Use GMP version with leading zero for feed dirs [#1287](https://github.com/greenbone/gvmd/pull/1287)

--- a/src/sql_pg.c
+++ b/src/sql_pg.c
@@ -523,7 +523,15 @@ sql_exec_internal (int retry, sql_stmt_t *stmt)
               g_warning ("%s: SQL: %s", __func__, stmt->sql);
               return -4;
             }
-
+            else if (sqlstate && (strcmp (sqlstate, "40P01") == 0))
+              {
+                /* deadlock_detected */
+                g_debug ("%s: deadlock: %s",
+                         __func__,
+                         PQresultErrorMessage (result));
+                g_debug ("%s: SQL: %s", __func__, stmt->sql);
+                return -5;
+              }
           if (log_errors)
             {
               g_warning ("%s: PQexec failed: %s (%i)",


### PR DESCRIPTION
Instead of giving up within sql.c it should wait a short period and then
retry the SQL command when a deadlock occurs.

Under some circumstances it will prevent status uploading when creating
a lot of reports via gvm-tools.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
