### PR TITLE
Fix report host end time check in CVE scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update report run status more consistently [#1434](https://github.com/greenbone/gvmd/pull/1434) 
 - Improve modify_override errors, fix no NVT case [#1435](https://github.com/greenbone/gvmd/pull/1435)
 - Fix size calculation in `--optimize vacuum` [#1447](https://github.com/greenbone/gvmd/pull/1447)
+- Fix report host end time check in CVE scans [#1462](https://github.com/greenbone/gvmd/pull/1462)
 
 ### Removed
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -25953,7 +25953,7 @@ host_nthlast_report_host (const char *host, report_host_t *report_host,
                      "      AND task_preferences.task = tasks.id"
                      "      AND task_preferences.name = 'in_assets')"
                      "     = 'yes'"
-                     " AND report_hosts.end_time IS NOT NULL"
+                     " AND report_hosts.end_time > 0"
                      " AND NOT EXISTS (SELECT * FROM report_host_details"
                      "                 WHERE report_host = report_hosts.id"
                      "                 AND name = 'CVE Scan')"


### PR DESCRIPTION
**What**:
When looking up the latest finished report_host for a CVE scan, the
query will also consider the end_time being set to 0 instead of NULL
when the scan of the host is unfinished.

**Why**:
Without this the CVE scan could return no or less results for hosts
being scanned at the moment.

**How did you test it**:
* ran an authenticated "Full and Fast" scan of a single host with vulnerable applications, 
* confirmed that the applications were detected after the scan was finished
* ran a CVE scan using the same target and confirmed that it produced results
* started the "Full and Fast" task again
* started the CVE scan again while the other task was running and at a low progress percentage (1-2%)

Without the fix the second CVE scan produced no results, while it produces the same results as the first scan with the fix.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
