### PR TITLE
Improve report format sync handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Improve GMP docs around users [#1363](https://github.com/greenbone/gvmd/pull/1363)
 - Cache report counts when Dynamic Severity is enabled [#1389](https://github.com/greenbone/gvmd/pull/1389)
 - Detection entry detection while importing reports [#1405](https://github.com/greenbone/gvmd/pull/1405)
+- Improve report format sync handling [#1465](https://github.com/greenbone/gvmd/pull/1465)
 
 ### Changed
 - Move EXE credential generation to a Python script [#1260](https://github.com/greenbone/gvmd/pull/1260) [#1262](https://github.com/greenbone/gvmd/pull/1262)

--- a/src/manage_report_formats.c
+++ b/src/manage_report_formats.c
@@ -704,14 +704,15 @@ sync_report_formats_with_feed ()
   dir = g_dir_open (feed_dir_report_formats (), 0, &error);
   if (dir == NULL)
     {
-      g_warning ("%s: Failed to open directory '%s': %s",
+      g_message ("%s: Failed to open directory '%s': %s",
                  __func__, feed_dir_report_formats (), error->message);
       g_error_free (error);
       g_free (current_credentials.uuid);
       g_free (current_credentials.username);
       current_credentials.uuid = NULL;
       current_credentials.username = NULL;
-      return -1;
+      /* No directory, nothing to complain about */
+      return 0;
     }
 
   /* Sync each file in the directory. */

--- a/src/manage_report_formats.c
+++ b/src/manage_report_formats.c
@@ -669,7 +669,7 @@ sync_report_format_with_feed (const gchar *path)
 int
 sync_report_formats_with_feed ()
 {
-  GError *error;
+  GError *error = NULL;
   GDir *dir;
   const gchar *report_format_path;
 


### PR DESCRIPTION
**What**:

Don't crash if GError is not initialized and reduce missing report format dir to just a message output.

**Why**:

<!-- Why are these changes necessary? -->

**How did you test it**:



**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
