### PR TITLE
Don't require report format for XML report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Access current user with an SQL function [#1399](https://github.com/greenbone/gvmd/pull/1399)
 - Refactor modify_config, allowing multiple simultaneous changes [#1404](https://github.com/greenbone/gvmd/pull/1404)
 - Add retry on a deadlock within sql#sql [#1460](https://github.com/greenbone/gvmd/pull/1460)
+- Don't require report format plugin for XML report [#1466](https://github.com/greenbone/gvmd/pull/1466)
 
 ### Fixed
 - Use GMP version with leading zero for feed dirs [#1287](https://github.com/greenbone/gvmd/pull/1287)

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -14568,6 +14568,7 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
                                 get_reports_data->lean,
                                 /* Special case the XML report, bah. */
                                 (!no_report_format)
+                                && get_reports_data->format_id
                                 && strcmp
                                     (get_reports_data->format_id,
                                      "a994b278-1f62-11e1-96ac-406186ea4fc5")

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -14233,7 +14233,8 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
       return;
     }
 
-  no_report_format = (get_reports_data->format_id == NULL) || (strcmp(get_reports_data->format_id, "") == 0);
+  no_report_format = (get_reports_data->format_id == NULL)
+                      || (strcmp(get_reports_data->format_id, "") == 0);
 
   if ((!no_report_format)
       && find_report_format_with_permission (get_reports_data->format_id,
@@ -14451,8 +14452,12 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
       GString *prefix;
 
       prefix = g_string_new ("");
-      content_type = no_report_format ? g_strdup("application/xml") : report_format_content_type (report_format);
-      extension = no_report_format ? g_strdup("") : report_format_extension (report_format);
+      content_type = no_report_format
+                        ? g_strdup("application/xml")
+                        : report_format_content_type (report_format);
+      extension = no_report_format
+                    ? g_strdup("")
+                    : report_format_extension (report_format);
 
       if (get_reports_data->alert_id == NULL)
         g_string_append_printf (prefix,

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -3583,12 +3583,11 @@ run_report_format_script (gchar *report_format_id,
  *
  * @return 0 success, -1 error.
  */
-static int
+int
 print_report_xml_end (gchar *xml_start, gchar *xml_full,
                       report_format_t report_format)
 {
   FILE *out;
-  iterator_t params;
 
   if (gvm_file_copy (xml_start, xml_full) == FALSE)
     {
@@ -3607,16 +3606,20 @@ print_report_xml_end (gchar *xml_start, gchar *xml_full,
 
   /* A bit messy having report XML here, but simplest for now. */
 
-  PRINT (out, "<report_format>");
-  init_report_format_param_iterator (&params, report_format, 0, 1, NULL);
-  while (next (&params))
-    PRINT (out,
-           "<param><name>%s</name><value>%s</value></param>",
-           report_format_param_iterator_name (&params),
-           report_format_param_iterator_value (&params));
-  cleanup_iterator (&params);
+  if (report_format > 0)
+    {
+      iterator_t params;
+      PRINT (out, "<report_format>");
+      init_report_format_param_iterator (&params, report_format, 0, 1, NULL);
+      while (next (&params))
+        PRINT (out,
+               "<param><name>%s</name><value>%s</value></param>",
+               report_format_param_iterator_name (&params),
+               report_format_param_iterator_value (&params));
+      cleanup_iterator (&params);
 
-  PRINT (out, "</report_format>");
+      PRINT (out, "</report_format>");
+    }
 
   PRINT (out, "</report>");
 

--- a/src/manage_sql_report_formats.h
+++ b/src/manage_sql_report_formats.h
@@ -85,4 +85,7 @@ check_db_report_formats ();
 int
 check_db_report_formats_trash ();
 
+int
+print_report_xml_end (gchar *, gchar *, report_format_t);
+
 #endif /* not _GVMD_MANAGE_SQL_REPORT_FORMATS_H */


### PR DESCRIPTION
**What**:

Allow to download the XML report without having to install the XML
report format plugin which actually does nothing.

**Why**:

Remove GOS specific patch.

**How did you test it**:
This can be tested by deleting the XML report format and trying to access a report.
Without the patch the get_reports command will fail with a 404 error message:
"Failed to find report format 'a994b278-1f62-11e1-96ac-406186ea4fc5'" while
the XML can be fetched if no report format is selected.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
