### PR TITLE
Add --feed-lock-timeout option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Improve GMP docs around users [#1363](https://github.com/greenbone/gvmd/pull/1363)
 - Cache report counts when Dynamic Severity is enabled [#1389](https://github.com/greenbone/gvmd/pull/1389)
 - Detection entry detection while importing reports [#1405](https://github.com/greenbone/gvmd/pull/1405)
+- Add --feed-lock-timeout option [#1472](https://github.com/greenbone/gvmd/pull/1472)
 
 ### Changed
 - Move EXE credential generation to a Python script [#1260](https://github.com/greenbone/gvmd/pull/1260) [#1262](https://github.com/greenbone/gvmd/pull/1262)

--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -61,6 +61,9 @@ Disable task scheduling.
 \fB--feed-lock-path=\fIPATH\fB\f1
 Sets the path to the feed lock file.
 .TP
+\fB--feed-lock-timeout=\fITIMEOUT\fB\f1
+Sets the number of seconds to retry for if the feed is locked in contexts (like migration or rebuilds) that do not retry on their own (like automatic syncs). Defaults to 0.
+.TP
 \fB-f, --foreground\f1
 Run in foreground.
 .TP
@@ -181,9 +184,6 @@ Time out tasks that are more than TIME minutes overdue. -1 to disable, 0 for min
 .TP
 \fB--secinfo-commit-size=\fINUMBER\fB\f1
 During CERT and SCAP sync, commit updates to the database every NUMBER items, 0 for unlimited.
-.TP
-\fB--slave-commit-size=\fINUMBER\fB\f1
-During slave updates, commit after every NUMBER updated results and hosts, 0 for unlimited.
 .TP
 \fB-c, --unix-socket=\fIFILENAME\fB\f1
 Listen on UNIX socket at FILENAME.

--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -62,7 +62,7 @@ Disable task scheduling.
 Sets the path to the feed lock file.
 .TP
 \fB--feed-lock-timeout=\fITIMEOUT\fB\f1
-Sets the number of seconds to retry for if the feed is locked in contexts (like migration or rebuilds) that do not retry on their own (like automatic syncs). Defaults to 0.
+Sets the number of seconds to retry for if the feed is locked in contexts (like migration or rebuilds) that do not retry on their own (like automatic syncs). Defaults to 0 (no retry).
 .TP
 \fB-f, --foreground\f1
 Run in foreground.

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -155,7 +155,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <p>
           Sets the number of seconds to retry for if the feed is locked
           in contexts (like migration or rebuilds) that do not retry
-          on their own (like automatic syncs). Defaults to 0.
+          on their own (like automatic syncs). Defaults to 0 (no retry).
         </p>
       </optdesc>
     </option>

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -150,6 +150,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </optdesc>
     </option>
     <option>
+      <p><opt>--feed-lock-timeout=<arg>TIMEOUT</arg></opt></p>
+      <optdesc>
+        <p>
+          Sets the number of seconds to retry for if the feed is locked
+          in contexts (like migration or rebuilds) that do not retry
+          on their own (like automatic syncs). Defaults to 0.
+        </p>
+      </optdesc>
+    </option>
+    <option>
       <p><opt>-f, --foreground</opt></p>
       <optdesc>
         <p>Run in foreground.</p>

--- a/doc/gvmd.html
+++ b/doc/gvmd.html
@@ -122,6 +122,12 @@
       
     
     
+      <p><b>--feed-lock-timeout=<em>TIMEOUT</em></b></p>
+      
+        <p>Sets the number of seconds to retry for if the feed is locked in contexts (like migration or rebuilds) that do not retry on their own (like automatic syncs). Defaults to 0.</p>
+      
+    
+    
       <p><b>-f, --foreground</b></p>
       
         <p>Run in foreground.</p>

--- a/doc/gvmd.html
+++ b/doc/gvmd.html
@@ -124,7 +124,7 @@
     
       <p><b>--feed-lock-timeout=<em>TIMEOUT</em></b></p>
       
-        <p>Sets the number of seconds to retry for if the feed is locked in contexts (like migration or rebuilds) that do not retry on their own (like automatic syncs). Defaults to 0.</p>
+        <p>Sets the number of seconds to retry for if the feed is locked in contexts (like migration or rebuilds) that do not retry on their own (like automatic syncs). Defaults to 0 (no retry).</p>
       
     
     

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1753,6 +1753,7 @@ gvmd (int argc, char** argv)
   static gchar *disable = NULL;
   static gchar *value = NULL;
   static gchar *feed_lock_path = NULL;
+  static int feed_lock_timeout = 0;
   GError *error = NULL;
   lockfile_t lockfile_checking, lockfile_serving;
   GOptionContext *option_context;
@@ -1833,6 +1834,12 @@ gvmd (int argc, char** argv)
           &feed_lock_path,
           "Sets the path to the feed lock file.",
           "<path>" },
+        { "feed-lock-timeout", '\0', 0, G_OPTION_ARG_INT,
+          &feed_lock_timeout,
+          "Sets the number of seconds to retry for if the feed is locked"
+          " in contexts (like migration or rebuilds) that do not retry"
+          " on their own (like automatic syncs). Defaults to 0.",
+          "<timeout>" },
         { "foreground", 'f', 0, G_OPTION_ARG_NONE,
           &foreground,
           "Run in foreground.",
@@ -2081,6 +2088,9 @@ gvmd (int argc, char** argv)
 
   /* Set feed lock path */
   set_feed_lock_path (feed_lock_path);
+  
+  /* Set feed lock timeout */
+  set_feed_lock_timeout (feed_lock_timeout);
 
   /* Set schedule_timeout */
 

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1838,7 +1838,7 @@ gvmd (int argc, char** argv)
           &feed_lock_timeout,
           "Sets the number of seconds to retry for if the feed is locked"
           " in contexts (like migration or rebuilds) that do not retry"
-          " on their own (like automatic syncs). Defaults to 0.",
+          " on their own (like automatic syncs). Defaults to 0 (no retry).",
           "<timeout>" },
         { "foreground", 'f', 0, G_OPTION_ARG_NONE,
           &foreground,

--- a/src/manage.c
+++ b/src/manage.c
@@ -6035,7 +6035,7 @@ feed_lockfile_lock (lockfile_t *lockfile)
 int
 feed_lockfile_lock_timeout (lockfile_t *lockfile)
 {
-  int ret;
+  int lock_status;
   gboolean log_timeout;
   time_t timeout_end;
 
@@ -6045,8 +6045,9 @@ feed_lockfile_lock_timeout (lockfile_t *lockfile)
   timeout_end = time (NULL) + feed_lock_timeout;
   do
     {
-      ret = lockfile_lock_path_nb (lockfile, get_feed_lock_path ());
-      if (ret == 1 && timeout_end > time (NULL))
+      lock_status = feed_lockfile_lock (lockfile);
+      if (lock_status == 1 /* already locked, but no error */
+          && timeout_end > time (NULL))
         {
           if (log_timeout)
             {
@@ -6057,14 +6058,11 @@ feed_lockfile_lock_timeout (lockfile_t *lockfile)
             }
           gvm_sleep (1);
         }
-      else if (ret)
+      else if (lock_status) /* error */
         {
-          return ret;
+          return lock_status;
         }
-    } while (ret);
-
-  /* Write the file contents (timestamp) */
-  write_sync_start (lockfile->fd);
+    } while (lock_status); /* lock is acquired when lock_status is 0 */
 
   return 0;
 }

--- a/src/manage.h
+++ b/src/manage.h
@@ -3693,11 +3693,20 @@ get_feed_lock_path ();
 void
 set_feed_lock_path (const char *);
 
+int
+get_feed_lock_timeout ();
+
+void
+set_feed_lock_timeout (int);
+
 void
 write_sync_start (int);
 
 int
 feed_lockfile_lock (lockfile_t *);
+
+int
+feed_lockfile_lock_timeout (lockfile_t*);
 
 int
 feed_lockfile_unlock (lockfile_t *);

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -2203,7 +2203,7 @@ manage_rebuild (GSList *log_config, const db_conn_info_t *database)
 
   g_info ("   Rebuilding NVTs.");
 
-  switch (feed_lockfile_lock (&lockfile))
+  switch (feed_lockfile_lock_timeout (&lockfile))
     {
       case 1:
         printf ("A feed sync is already running.\n");

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -4944,7 +4944,7 @@ rebuild_scap ()
   int ret = -1;
   lockfile_t lockfile;
 
-  ret = feed_lockfile_lock (&lockfile);
+  ret = feed_lockfile_lock_timeout (&lockfile);
   if (ret == 1)
     return 2;
   else if (ret)


### PR DESCRIPTION
**What**:
This new option sets a number of seconds to retry for if the feed is
locked in contexts (like migration or rebuilds) that do not retry on
their own (like automatic syncs).

**Why**:
This is intended to help automated upgrades of GVM modules where
ospd-openvas needs to be restarted, which locks the feed while the
VTs are reloaded.

**How did you test it**:
By doing the following:
* locking the feed lockfile and running `gvmd --rebuild-scap` - this should fail immediately.
* retrying with `gvmd --rebuild-scap --feed-lock-timeout 15` with the lock still active - this should generate a gvmd log message "Feed is currently locked..." and fail about 15 seconds later.
* running `gvmd --rebuild-scap --feed-lock-timeout 15` with the lock still active and releasing the lock while gvmd is waiting - this should leave a "Feed is currently locked..." gvmd log message and start the rebuild once the lock is released. 
* running `gvmd --rebuild-scap --feed-lock-timeout 15` without locking - this should start the rebuild immediately without a "Feed is currently locked..." log message.


**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
