### PR TITLE
Fix "not regexp ..." filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Improve modify_override errors, fix no NVT case [#1435](https://github.com/greenbone/gvmd/pull/1435)
 - Fix size calculation in `--optimize vacuum` [#1447](https://github.com/greenbone/gvmd/pull/1447)
 - Fix report host end time check in CVE scans [#1462](https://github.com/greenbone/gvmd/pull/1462)
+- Fix "not regexp ..." filters [#1482](https://github.com/greenbone/gvmd/pull/1482)
 
 ### Removed
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -3794,20 +3794,30 @@ filter_clause (const char* type, const char* filter,
 
                 if (keyword_applies_to_column (keyword, filter_column)
                     && select_column && column_type_matches)
-                  g_string_append_printf (clause,
-                                          "%s"
-                                          "(%s IS NULL"
-                                          " OR CAST (%s AS TEXT)"
-                                          "    NOT %s '%s%s%s')",
-                                          (index ? " AND " : ""),
-                                          select_column,
-                                          select_column,
-                                          last_was_re
-                                           ? sql_regexp_op ()
-                                           : sql_ilike_op (),
-                                          last_was_re ? "" : "%%",
-                                          quoted_keyword,
-                                          last_was_re ? "" : "%%");
+                  {
+                    if (last_was_re)
+                      g_string_append_printf (clause,
+                                              "%s"
+                                              "(%s IS NULL"
+                                              " OR NOT (CAST (%s AS TEXT)"
+                                              "         %s '%s'))",
+                                              (index ? " AND " : ""),
+                                              select_column,
+                                              select_column,
+                                              sql_regexp_op (),
+                                              quoted_keyword);
+                    else
+                      g_string_append_printf (clause,
+                                              "%s"
+                                              "(%s IS NULL"
+                                              " OR CAST (%s AS TEXT)"
+                                              "    NOT %s '%%%s%%')",
+                                              (index ? " AND " : ""),
+                                              select_column,
+                                              select_column,
+                                              sql_ilike_op (),
+                                              quoted_keyword);
+                  }
                 else
                   g_string_append_printf (clause,
                                           "%s t ()",


### PR DESCRIPTION
**What**:
This fixes the way SQL for negated regexp clauses is generated.

**Why**:
Using the filters where a "regexp" clause was negated generated invalid
SQL.

**How did you test it**:
By using a filter that contained a negated "regexp", e.g.
`not regexp CVE-(2000-1050|2001-0404)`
and one that contained a negated columnless "like" / "~" filter, e.g.
`not ~"CVE-2000"`

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
