### PR TITLE
Escape TLS certificate DNs that are invalid UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix size calculation in `--optimize vacuum` [#1447](https://github.com/greenbone/gvmd/pull/1447)
 - Fix report host end time check in CVE scans [#1462](https://github.com/greenbone/gvmd/pull/1462)
 - Fix "not regexp ..." filters [#1482](https://github.com/greenbone/gvmd/pull/1482)
+- Escape TLS certificate DNs that are invalid UTF-8 [#1486](https://github.com/greenbone/gvmd/pull/1486)
 
 ### Removed
 

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -851,9 +851,9 @@ make_tls_certificate_214 (user_t owner,
   quoted_certificate_b64
     = certificate_b64 ? sql_quote (certificate_b64) : NULL;
   quoted_subject_dn
-    = subject_dn ? sql_quote (subject_dn) : NULL;
+    = subject_dn ? sql_ascii_escape_and_quote (subject_dn) : NULL;
   quoted_issuer_dn
-    = issuer_dn ? sql_quote (issuer_dn) : NULL;
+    = issuer_dn ? sql_ascii_escape_and_quote (issuer_dn) : NULL;
   quoted_md5_fingerprint
     = md5_fingerprint ? sql_quote (md5_fingerprint) : NULL;
   quoted_sha256_fingerprint

--- a/src/manage_sql_tls_certificates.c
+++ b/src/manage_sql_tls_certificates.c
@@ -585,9 +585,9 @@ make_tls_certificate (const char *name,
   quoted_sha256_fingerprint
     = sql_quote (sha256_fingerprint ? sha256_fingerprint : "");
   quoted_subject_dn
-    = sql_quote (subject_dn ? subject_dn : "");
+    = sql_ascii_escape_and_quote (subject_dn ? subject_dn : "");
   quoted_issuer_dn
-    = sql_quote (issuer_dn ? issuer_dn : "");
+    = sql_ascii_escape_and_quote (issuer_dn ? issuer_dn : "");
   quoted_serial
     = sql_quote (serial ? serial : "");
 

--- a/src/sql.c
+++ b/src/sql.c
@@ -141,6 +141,43 @@ sql_quote (const char* string)
 }
 
 /**
+ * @brief Quotes a string for use in SQL statements, also ASCII escaping it
+ *         if it is not valid UTF-8.
+ *
+ * @param[in]  string  String to quote, has to be \\0 terminated.
+ *
+ * @return Freshly allocated, quoted string. Free with g_free.
+ */
+gchar*
+sql_ascii_escape_and_quote (const char* string)
+{
+  gchar *quoted_string;
+
+  assert (string);
+
+  if (string == NULL)
+    {
+      return NULL;
+    }
+  else if (g_utf8_validate (string, -1, NULL))
+    {
+      // Quote valid UTF-8 without ASCII escaping
+      quoted_string = sql_quote (string);
+    }
+  else
+    {
+      // Assume invalid UTF-8 uses a different, unknown encoding and
+      //  ASCII-escape it.
+      gchar *escaped_string;
+      escaped_string = g_strescape (string, "");
+      quoted_string = sql_quote (escaped_string);
+      g_free (escaped_string);
+    }
+
+  return quoted_string;
+}
+
+/**
  * @brief Get the SQL insert expression for a string.
  *
  * @param[in]  string  The string, which may be NULL.

--- a/src/sql.h
+++ b/src/sql.h
@@ -80,6 +80,9 @@ gchar *
 sql_quote (const char *);
 
 gchar *
+sql_ascii_escape_and_quote (const char *);
+
+gchar *
 sql_insert (const char *);
 
 void


### PR DESCRIPTION
**What**:
The subject and issuer DNs are checked whether they are valid UTF-8
before storing them in the database. If they are not, all non-ASCII
characters are escaped.

**Why**:
The invalid characters would cause SQL errors when then TLS
certificates are added at the end of a scan.

**How did you test it**:
* Created a self-signed certificate with the GnuTLS `certtool`
where the subject contained an ISO 8859-1 encoded umlaut
* Ran a test HTTPS server with this certificate using `gnutls-serv`
* Scanned the host with the test server

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
