### PR TITLE
Fix score recalculation in migrate_241_to_242

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [21.4] (unreleased)
 
 ### Added
-- Extend GMP for extended severities [#1326](https://github.com/greenbone/gvmd/pull/1326) [#1329](https://github.com/greenbone/gvmd/pull/1329) [#1359](https://github.com/greenbone/gvmd/pull/1359) [#1371](https://github.com/greenbone/gvmd/pull/1371) [#1477](https://github.com/greenbone/gvmd/pull/1477)
+- Extend GMP for extended severities [#1326](https://github.com/greenbone/gvmd/pull/1326) [#1329](https://github.com/greenbone/gvmd/pull/1329) [#1359](https://github.com/greenbone/gvmd/pull/1359) [#1371](https://github.com/greenbone/gvmd/pull/1371) [#1477](https://github.com/greenbone/gvmd/pull/1477) [#1488](https://github.com/greenbone/gvmd/pull/1488)
 - Parameter `--db-user` to set a database user [#1327](https://github.com/greenbone/gvmd/pull/1327)
 - Add `allow_simultaneous_ips` field for targets [#1346](https://github.com/greenbone/gvmd/pull/1346) [#1396](https://github.com/greenbone/gvmd/pull/1396)
 - Speed up GET_VULNS [#1354](https://github.com/greenbone/gvmd/pull/1354) [#1355](https://github.com/greenbone/gvmd/pull/1354)

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -2630,7 +2630,7 @@ migrate_241_to_242 ()
   /* Change the vt_severities table to a CVSS score */
   sql ("ALTER TABLE vt_severities ALTER COLUMN score"
        " SET DATA TYPE double precision;");
-  sql ("UPDATE vt_severities SET score = round(score / 10.0, 1);");
+  sql ("UPDATE vt_severities SET score = round((score / 10.0)::numeric, 1);");
 
   /* Set the database version to 242. */
 


### PR DESCRIPTION
**What**:
The two parameter version of the round() functions requires the first
parameter to be of the type "numeric" and there is no implicit cast,
so an explicit type cast is added.

**Why**:
This is required for the migration to work.

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
