### PR TITLE
Remove VT family "Local Security Checks: EulerOS"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Change SCAP and CERT data to use "severity" consistently [#1333](https://github.com/greenbone/gvmd/pull/1333) [#1357](https://github.com/greenbone/gvmd/pull/1357) [#1365](https://github.com/greenbone/gvmd/pull/1365) [#1457](https://github.com/greenbone/gvmd/pull/1457) [#1476](https://github.com/greenbone/gvmd/pull/1476)
 - Expect report format scripts to exit with code 0 [#1383](https://github.com/greenbone/gvmd/pull/1383)
 - Send entire families to ospd-openvas using VT_GROUP [#1384](https://github.com/greenbone/gvmd/pull/1384)
-- The internal list of current Local Security Checks for the 'Closed CVEs' feature was updated [#1381](https://github.com/greenbone/gvmd/pull/1381)
 - Limit "whole-only" config families to "growing" and "every nvt" [#1386](https://github.com/greenbone/gvmd/pull/1386)
 - Access current user with an SQL function [#1399](https://github.com/greenbone/gvmd/pull/1399)
 - Refactor modify_config, allowing multiple simultaneous changes [#1404](https://github.com/greenbone/gvmd/pull/1404)

--- a/src/manage.h
+++ b/src/manage.h
@@ -1085,7 +1085,6 @@ user_has_super (const char *, user_t);
   " 'HP-UX Local Security Checks',"                \
   " 'Huawei EulerOS Local Security Checks',"       \
   " 'JunOS Local Security Checks',"                \
-  " 'Local Security Checks: EulerOS',"             \
   " 'Mac OS X Local Security Checks',"             \
   " 'Mageia Linux Local Security Checks',"         \
   " 'Mandrake Local Security Checks',"             \


### PR DESCRIPTION
**What**:
The family ended up being unused while existing VTs use the family
"Huawei EulerOS Local Security Checks", so it is removed from the
list of LSC families.
This effectively reverts #1381.

**Why**:
To get rid of the redundancy.

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
