### PR TITLE
Improve VT version handling for CVE & OVAL results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [21.4.1] (unreleased)
+
+### Fixed
+- Improve VT version handling for CVE & OVAL results [#1496](https://github.com/greenbone/gvmd/pull/1496)
+
+[21.4.0]: https://github.com/greenbone/gvmd/compare/v21.4.0...gvmd-21.04
+
 ## [21.4.0] (2021-04-16)
 
 ### Added
@@ -50,7 +57,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove severity type "debug" [#1316](https://github.com/greenbone/gvmd/pull/1316)
 - Remove element "threat" of element "notes" [#1324](https://github.com/greenbone/gvmd/pull/1324)
 
-[21.4.0]: https://github.com/greenbone/gvmd/compare/gvmd-20.08...v21.04.0
+[21.4.0]: https://github.com/greenbone/gvmd/compare/gvmd-20.08...v21.4.0
 
 ## [20.8.2] (unreleased)
 


### PR DESCRIPTION
**What**:
The functions make_result and make_cve_result now add a timestamp
as nvt_version for CVE and OVAL results.

**Why**:
To have the VT version available in results more consistently.

**How did you test it**:
By running a CVE scan and checking the scan_nvt_version of the results.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
