### PR TITLE
Fix migration to DB version 242 from gvmd 20.08

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Improve VT version handling for CVE & OVAL results [#1496](https://github.com/greenbone/gvmd/pull/1496)
+- Fix migration to DB version 242 from gvmd 20.08 [#1498](https://github.com/greenbone/gvmd/pull/1498)
 
 [21.4.0]: https://github.com/greenbone/gvmd/compare/v21.4.0...gvmd-21.04
 

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -2627,10 +2627,20 @@ migrate_241_to_242 ()
 
   sql ("ALTER TABLE results_trash DROP COLUMN IF EXISTS score;");
 
-  /* Change the vt_severities table to a CVSS score */
-  sql ("ALTER TABLE vt_severities ALTER COLUMN score"
-       " SET DATA TYPE double precision;");
-  sql ("UPDATE vt_severities SET score = round((score / 10.0)::numeric, 1);");
+  /* Change the vt_severities table to use a CVSS score
+   * if it already exists (migrating from a 21.04 development version) */
+  if (sql_int ("SELECT EXISTS (SELECT * FROM information_schema.tables"
+               "               WHERE table_catalog = '%s'"
+               "               AND table_schema = 'public'"
+               "               AND table_name = 'vt_severities')"
+               " ::integer;",
+               sql_database ()))
+    {
+      sql ("ALTER TABLE vt_severities ALTER COLUMN score"
+           " SET DATA TYPE double precision;");
+      sql ("UPDATE vt_severities"
+           " SET score = round((score / 10.0)::numeric, 1);");
+    }
 
   /* Set the database version to 242. */
 


### PR DESCRIPTION
**What**:
Migration of the vt_severities is skipped if the table does not exist.

**Why**:
When running the migration to DB version 242, the vt_severities table
only exists when migrating from a 21.04 development version, so the
migration for that table must be skipped if it does not exist.

Closes #1497

**How did you test it**:
By creating a new database, running gvmd 20.08 to set it up and load the feed data, then migrating to 21.04.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
