### PR TITLE
Update default log config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [21.4.1] (unreleased)
 
+### Changed
+- Update default log config [#1501](https://github.com/greenbone/gvmd/pull/1501)
+
 ### Fixed
 - Improve VT version handling for CVE & OVAL results [#1496](https://github.com/greenbone/gvmd/pull/1496)
 - Fix migration to DB version 242 from gvmd 20.08 [#1498](https://github.com/greenbone/gvmd/pull/1498)

--- a/src/gvmd_log_conf.cmake_in
+++ b/src/gvmd_log_conf.cmake_in
@@ -10,20 +10,6 @@ prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
 file=${GVM_LOG_DIR}/gvmd.log
 level=127
 
-[md   comm]
-prepend=%t %s %p
-separator=:
-prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
-file=${GVM_LOG_DIR}/gvmd.log
-level=127
-
-[md   file]
-prepend=%t %s %p
-separator=:
-prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
-file=${GVM_LOG_DIR}/gvmd.log
-level=127
-
 [md manage]
 prepend=%t %s %p
 separator=:
@@ -38,7 +24,14 @@ prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
 file=${GVM_LOG_DIR}/gvmd.log
 level=127
 
-[md    otp]
+[md  crypt]
+prepend=%t %s %p
+separator=:
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=${GVM_LOG_DIR}/gvmd.log
+level=127
+
+[md  utils]
 prepend=%t %s %p
 separator=:
 prepend_time_format=%Y-%m-%d %Hh%M.%S %Z

--- a/src/gvmd_log_conf.cmake_in
+++ b/src/gvmd_log_conf.cmake_in
@@ -38,6 +38,34 @@ prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
 file=${GVM_LOG_DIR}/gvmd.log
 level=127
 
+[libgvm base]
+prepend=%t %s %p
+separator=:
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=${GVM_LOG_DIR}/gvmd.log
+level=127
+
+[libgvm gmp]
+prepend=%t %s %p
+separator=:
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=${GVM_LOG_DIR}/gvmd.log
+level=127
+
+[libgvm osp]
+prepend=%t %s %p
+separator=:
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=${GVM_LOG_DIR}/gvmd.log
+level=127
+
+[libgvm util]
+prepend=%t %s %p
+separator=:
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=${GVM_LOG_DIR}/gvmd.log
+level=127
+
 [event syslog]
 prepend=%t %s %p
 separator=:


### PR DESCRIPTION
**What**:
This removes some unused GLib log domains from the default log configs and
 adds missing "md" ones as well as the new "libgvm" ones from greenbone/gvm-libs#479.

**Why**:
To make it clearer which domains actually have an effect in the log config.

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
