### PR TITLE
Clean up log config, add gvm-libs log domains (20.08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Improve report counts performance [#1438](https://github.com/greenbone/gvmd/pull/1438)
+- Clean up log config, add gvm-libs log domains [#1502](https://github.com/greenbone/gvmd/pull/1502)
 
 ### Fixed
 - Also create owner WITH clause for single resources [#1406](https://github.com/greenbone/gvmd/pull/1406)

--- a/src/gvmd_log_conf.cmake_in
+++ b/src/gvmd_log_conf.cmake_in
@@ -10,20 +10,6 @@ prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
 file=${GVM_LOG_DIR}/gvmd.log
 level=127
 
-[md   comm]
-prepend=%t %s %p
-separator=:
-prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
-file=${GVM_LOG_DIR}/gvmd.log
-level=127
-
-[md   file]
-prepend=%t %s %p
-separator=:
-prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
-file=${GVM_LOG_DIR}/gvmd.log
-level=127
-
 [md manage]
 prepend=%t %s %p
 separator=:
@@ -38,7 +24,14 @@ prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
 file=${GVM_LOG_DIR}/gvmd.log
 level=127
 
-[md    otp]
+[md  crypt]
+prepend=%t %s %p
+separator=:
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=${GVM_LOG_DIR}/gvmd.log
+level=127
+
+[md  utils]
 prepend=%t %s %p
 separator=:
 prepend_time_format=%Y-%m-%d %Hh%M.%S %Z

--- a/src/gvmd_log_conf.cmake_in
+++ b/src/gvmd_log_conf.cmake_in
@@ -38,6 +38,69 @@ prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
 file=${GVM_LOG_DIR}/gvmd.log
 level=127
 
+[base networking]
+prepend=%t %s %p
+separator=:
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=${GVM_LOG_DIR}/gvmd.log
+level=127
+
+[base plcy]
+prepend=%t %s %p
+separator=:
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=${GVM_LOG_DIR}/gvmd.log
+level=127
+
+[lib  auth]
+prepend=%t %s %p
+separator=:
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=${GVM_LOG_DIR}/gvmd.log
+level=127
+
+[lib  ldap]
+prepend=%t %s %p
+separator=:
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=${GVM_LOG_DIR}/gvmd.log
+level=127
+
+[lib  nvti]
+prepend=%t %s %p
+separator=:
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=${GVM_LOG_DIR}/gvmd.log
+level=127
+
+[lib  osp]
+prepend=%t %s %p
+separator=:
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=${GVM_LOG_DIR}/gvmd.log
+level=127
+
+[lib  serv]
+prepend=%t %s %p
+separator=:
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=${GVM_LOG_DIR}/gvmd.log
+level=127
+
+[lib   xml]
+prepend=%t %s %p
+separator=:
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=${GVM_LOG_DIR}/gvmd.log
+level=127
+
+[util gpgme]
+prepend=%t %s %p
+separator=:
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=${GVM_LOG_DIR}/gvmd.log
+level=127
+
 [event syslog]
 prepend=%t %s %p
 separator=:


### PR DESCRIPTION
**What**:
This cleans up unused GLib log domains and adds the ones from gvm-libs.

**Why**:
To make it clear which domains are used by gvmd.

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
