### PR TITLE
Sort missing severity as lowest value in GMP get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Improve report counts performance [#1438](https://github.com/greenbone/gvmd/pull/1438)
 - Clean up log config, add gvm-libs log domains [#1502](https://github.com/greenbone/gvmd/pull/1502)
+- Sort missing severity as lowest value in GMP get [#1508](https://github.com/greenbone/gvmd/pull/1508)
 
 ### Fixed
 - Also create owner WITH clause for single resources [#1406](https://github.com/greenbone/gvmd/pull/1406)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -3025,8 +3025,10 @@ filter_clause (const char* type, const char* filter,
                                                   keyword->string);
                   g_string_append_printf (order,
                                           " ORDER BY CASE CAST (%s AS text)"
-                                          " WHEN '' THEN NULL"
-                                          " ELSE CAST (%s AS REAL) END ASC",
+                                          " WHEN '' THEN '-Infinity'::real"
+                                          " ELSE coalesce(%s::real,"
+                                          "               '-Infinity'::real)"
+                                          " END ASC",
                                           column,
                                           column);
                 }
@@ -3215,8 +3217,10 @@ filter_clause (const char* type, const char* filter,
                                                   keyword->string);
                   g_string_append_printf (order,
                                           " ORDER BY CASE CAST (%s AS text)"
-                                          " WHEN '' THEN NULL"
-                                          " ELSE CAST (%s AS REAL) END DESC",
+                                          " WHEN '' THEN '-Infinity'::real"
+                                          " ELSE coalesce(%s::real,"
+                                          "               '-Infinity'::real)"
+                                          " END DESC",
                                           column,
                                           column);
                 }


### PR DESCRIPTION
**What**:
When a filter sorting by severity (or similar fields like cvss_base) is
used in GMP get_... commands, missing values will be sorted as lower
than any other value like 0.0 (log) or -1.0 (false positive).

**Why**:
When sorting SecInfo items by descending severity, those with known
high severity should be shown first. Items without severity info are often
deprecated, so they should be shown last.

**How did you test it**:
By sorting various SecInfo list pages by severity in GSA.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
