### PR TITLE
Remove Network Source Interface from gvmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix migration to DB version 242 from gvmd 20.08 [#1498](https://github.com/greenbone/gvmd/pull/1498)
 
 ### Removed
+- Remove Network Source Interface from gvmd [#1511](https://github.com/greenbone/gvmd/pull/1511)
 
 [21.4]: https://github.com/greenbone/gvmd/compare/gvmd-21.04...master
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 242)
+set (GVMD_DATABASE_VERSION 243)
 
 set (GVMD_SCAP_DATABASE_VERSION 18)
 

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -16941,7 +16941,7 @@ handle_get_tasks (gmp_parser_t *gmp_parser, GError **error)
       double severity = 0, severity_2 = 0;
       gchar *response;
       iterator_t alerts, groups, roles;
-      gchar *in_assets, *max_checks, *max_hosts, *source_iface;
+      gchar *in_assets, *max_checks, *max_hosts;
       gchar *auto_delete, *auto_delete_data, *assets_apply_overrides;
       gchar *assets_min_qod;
 
@@ -17462,7 +17462,6 @@ handle_get_tasks (gmp_parser_t *gmp_parser, GError **error)
           assets_min_qod = task_preference_value (index, "assets_min_qod");
           max_checks = task_preference_value (index, "max_checks");
           max_hosts = task_preference_value (index, "max_hosts");
-          source_iface = task_preference_value (index, "source_iface");
           auto_delete = task_preference_value (index, "auto_delete");
           auto_delete_data = task_preference_value (index, "auto_delete_data");
 
@@ -17480,13 +17479,6 @@ handle_get_tasks (gmp_parser_t *gmp_parser, GError **error)
             "Maximum concurrently scanned hosts"
             "</name>"
             "<scanner_name>max_hosts</scanner_name>"
-            "<value>%s</value>"
-            "</preference>"
-            "<preference>"
-            "<name>"
-            "Network Source Interface"
-            "</name>"
-            "<scanner_name>source_iface</scanner_name>"
             "<value>%s</value>"
             "</preference>"
             "<preference>"
@@ -17528,7 +17520,6 @@ handle_get_tasks (gmp_parser_t *gmp_parser, GError **error)
             "</task>",
             max_checks ? max_checks : "4",
             max_hosts ? max_hosts : "20",
-            source_iface ? source_iface : "",
             in_assets ? in_assets : "yes",
             assets_apply_overrides ? assets_apply_overrides : "yes",
             assets_min_qod
@@ -17540,7 +17531,6 @@ handle_get_tasks (gmp_parser_t *gmp_parser, GError **error)
           g_free (in_assets);
           g_free (max_checks);
           g_free (max_hosts);
-          g_free (source_iface);
         }
 
       count++;

--- a/src/manage.c
+++ b/src/manage.c
@@ -2459,7 +2459,7 @@ launch_osp_openvas_task (task_t task, target_t target, const char *scan_id,
   GHashTable *vts_hash_table;
   osp_credential_t *ssh_credential, *smb_credential, *esxi_credential;
   osp_credential_t *snmp_credential;
-  gchar *max_checks, *max_hosts, *source_iface, *hosts_ordering;
+  gchar *max_checks, *max_hosts, *hosts_ordering;
   GHashTable *scanner_options;
   int ret;
   config_t config;
@@ -2583,11 +2583,6 @@ launch_osp_openvas_task (task_t task, target_t target, const char *scan_id,
   max_hosts = task_preference_value (task, "max_hosts");
   g_hash_table_insert (scanner_options, g_strdup ("max_hosts"),
                        max_hosts ? max_hosts : g_strdup (MAX_HOSTS_DEFAULT));
-
-  source_iface = task_preference_value (task, "source_iface");
-  if (source_iface)
-    g_hash_table_insert (scanner_options, g_strdup ("source_iface"),
-                        source_iface);
 
   hosts_ordering = task_hosts_ordering (task);
   if (hosts_ordering)

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -2651,6 +2651,39 @@ migrate_241_to_242 ()
   return 0;
 }
 
+/**
+ * @brief Migrate the database from version 242 to version 243.
+ *
+ * @return 0 success, -1 error.
+ */
+int
+migrate_242_to_243 ()
+{
+  sql_begin_immediate ();
+
+  /* Ensure that the database is currently version 242. */
+
+  if (manage_db_version () != 242)
+    {
+      sql_rollback ();
+      return -1;
+    }
+
+  /* Update the database. */
+
+  sql ("ALTER TABLE reports DROP COLUMN source_iface;");
+
+  /* Set the database version to 243. */
+
+  set_db_version (243);
+
+  sql_commit ();
+
+  return 0;
+}
+
+
+
 #undef UPDATE_DASHBOARD_SETTINGS
 
 /**
@@ -2699,6 +2732,7 @@ static migrator_t database_migrators[] = {
   {240, migrate_239_to_240},
   {241, migrate_240_to_241},
   {242, migrate_241_to_242},
+  {243, migrate_242_to_243},
   /* End marker. */
   {-1, NULL}};
 

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -2308,7 +2308,6 @@ create_tables ()
        "  comment text,"
        "  scan_run_status integer,"
        "  slave_progress integer,"
-       "  source_iface text,"
        "  flags integer);");
 
   sql ("CREATE TABLE IF NOT EXISTS report_counts"

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -20723,20 +20723,6 @@ report_compliance_by_uuid (const char *report_id,
 }
 
 /**
- * @brief Return the source interface of a report.
- *
- * @param[in]  report  Report.
- *
- * @return Source interface.
- */
-static char*
-report_source_iface (report_t report)
-{
-  return sql_string ("SELECT source_iface FROM reports WHERE id = %llu;",
-                     report);
-}
-
-/**
  * @brief Add a result to a report.
  *
  * @param[in]  report  The report.
@@ -27558,36 +27544,6 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
       PRINT (out,
              "</task>");
 
-      {
-        char *source_iface;
-
-        /* Info about the situation at the time of scan. */
-
-        PRINT (out,
-               "<scan>"
-               "<task>");
-
-        source_iface = report_source_iface (report);
-
-        if (source_iface)
-          /* VALUE "" means preference was not set.  Missing PREFERENCE means
-           * we don't know. */
-          PRINT (out,
-                 "<preferences>"
-                 "<preference>"
-                 "<name>Network Source Interface</name>"
-                 "<scanner_name>source_iface</scanner_name>"
-                 "<value>%s</value>"
-                 "</preference>"
-                 "</preferences>",
-                 source_iface);
-
-        free (source_iface);
-
-        PRINT (out,
-               "</task>"
-               "</scan>");
-      }
     }
 
   uuid = report_uuid (report);

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -1930,7 +1930,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <e>result_count</e>
             <e>severity</e>
             <e>task</e>
-            <e>scan</e>
             <e>ports</e>
             <e>results</e>
             <e>hosts</e>
@@ -2481,48 +2480,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <name>comment</name>
               <summary>Comment for the tag</summary>
               <pattern>text</pattern>
-            </ele>
-          </ele>
-        </ele>
-      </ele>
-      <ele>
-        <name>scan</name>
-        <summary>Info from scan time</summary>
-        <pattern>
-          <e>task</e>
-        </pattern>
-        <ele>
-          <name>task</name>
-          <pattern>
-            <e>preferences</e>
-          </pattern>
-          <ele>
-            <name>preferences</name>
-            <summary>Currently only "source_iface"</summary>
-            <pattern>
-              <any><e>preference</e></any>
-            </pattern>
-            <ele>
-              <name>preference</name>
-              <pattern>
-                <e>name</e>
-                <e>scanner_name</e>
-                <e>value</e>
-              </pattern>
-              <ele>
-                <name>name</name>
-                <summary>Full name of preference, suitable for end users</summary>
-                <pattern>text</pattern>
-              </ele>
-              <ele>
-                <name>scanner_name</name>
-                <summary>Compact name of preference, from scanner</summary>
-                <pattern>text</pattern>
-              </ele>
-              <ele>
-                <name>value</name>
-                <pattern>text</pattern>
-              </ele>
             </ele>
           </ele>
         </ele>


### PR DESCRIPTION
**What**: Deleted column source_iface from table reports and added migrator. Changed functions handle_get_tasks, launch_osp_openvas_task, print_report_xml_start to remove source_iface from reports and tasks. Removed function report_source_iface. Adjusted GMP documentation.

<!--
  
-->

**Why**: The Network Source Interface setting is no longer supported.

<!-- Why are these changes necessary? -->

**How did you test it**: Ran gvmd --migrate, executed test-scans and checked the reports.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
