### PR TITLE
Change report timestamp filter and iterator columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Update default log config [#1501](https://github.com/greenbone/gvmd/pull/1501)
+- Change report timestamp filter and iterator columns [#1512](https://github.com/greenbone/gvmd/pull/1512)
 
 ### Fixed
 - Improve VT version handling for CVE & OVAL results [#1496](https://github.com/greenbone/gvmd/pull/1496)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -20892,6 +20892,7 @@ report_add_result (report_t report, result_t result)
    "task", "severity", "false_positive", "log", "low", "medium", "high",       \
    "hosts", "result_hosts", "fp_per_host", "log_per_host", "low_per_host",     \
    "medium_per_host", "high_per_host", "duration", "duration_per_host",        \
+   "start_time", "end_time", "scan_start", "scan_end",                         \
    NULL }
 
 /**
@@ -20901,16 +20902,18 @@ report_add_result (report_t report, result_t result)
  {                                                                           \
    { "id", NULL, KEYWORD_TYPE_INTEGER },                                     \
    { "uuid", NULL, KEYWORD_TYPE_STRING },                                    \
-   { "iso_time (start_time)", "name", KEYWORD_TYPE_STRING },                 \
+   { "iso_time (date)", "name", KEYWORD_TYPE_STRING },                       \
    { "''", NULL, KEYWORD_TYPE_STRING },                                      \
-   { "iso_time (start_time)", NULL, KEYWORD_TYPE_STRING },                   \
+   { "iso_time (date)", NULL, KEYWORD_TYPE_STRING },                         \
    { "iso_time (end_time)", NULL, KEYWORD_TYPE_STRING },                     \
-   { "start_time", "created", KEYWORD_TYPE_INTEGER },                        \
+   { "date", "created", KEYWORD_TYPE_INTEGER },                              \
    { "end_time", "modified", KEYWORD_TYPE_INTEGER },                         \
    { "(SELECT name FROM users WHERE users.id = reports.owner)",              \
      "_owner",                                                               \
      KEYWORD_TYPE_STRING },                                                  \
    { "owner", NULL, KEYWORD_TYPE_INTEGER },                                  \
+   { "start_time", "scan_start", KEYWORD_TYPE_INTEGER },                     \
+   { "end_time", "scan_end", KEYWORD_TYPE_INTEGER },                         \
    { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                                      \
  }
 

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -15103,6 +15103,26 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <type>integer</type>
             <summary>Number of high severity results per host with results</summary>
           </column>
+          <column>
+	    <name>start_time</name>
+            <type>iso_time</type>
+            <summary>Scan start time</summary>
+          </column>
+          <column>
+	    <name>end_time</name>
+            <type>iso_time</type>
+            <summary>Scan end time</summary>
+          </column>
+          <column>
+	    <name>scan_start</name>
+            <type>iso_time</type>
+            <summary>Scan start time</summary>
+          </column>
+          <column>
+	    <name>scan_end</name>
+            <type>iso_time</type>
+            <summary>Scan end time</summary>
+          </column>
         </filter_keywords>
       </attrib>
       <attrib>


### PR DESCRIPTION

**What**:
Added start_time, end_time, scan_start, scan_end to the filter
and iterator columns.
Changed creation time "created" and "name" to use date column.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**: Make report timestamps more consistent.

<!-- Why are these changes necessary? -->

**How did you test it**: Checked report filters and reports

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
