### PR TITLE
Added a new modification_time column to reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [21.10] (unreleased)
 
 ### Added
+- Add a new modification_time column to reports [#1513](https://github.com/greenbone/gvmd/pull/1513)
 
 ### Changed
 - Use pg-gvm extension for C PostgreSQL functions [#1400](https://github.com/greenbone/gvmd/pull/1400), [#1453](https://github.com/greenbone/gvmd/pull/1453)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 243)
+set (GVMD_DATABASE_VERSION 244)
 
 set (GVMD_SCAP_DATABASE_VERSION 18)
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -3113,6 +3113,7 @@ cve_scan_host (task_t task, report_t report, gvm_host_t *gvm_host)
               report_host_set_end_time (prognosis_report_host, time (NULL));
               insert_report_host_detail (report, ip, "cve", "",
                                          "CVE Scanner", "CVE Scan", "1");
+              update_report_modification_time (report);
             }
         }
       cleanup_iterator (&report_hosts);

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -2682,6 +2682,37 @@ migrate_242_to_243 ()
   return 0;
 }
 
+/**
+ * @brief Migrate the database from version 243 to version 244.
+ *
+ * @return 0 success, -1 error.
+ */
+int
+migrate_243_to_244 ()
+{
+  sql_begin_immediate ();
+
+  /* Ensure that the database is currently version 243. */
+
+  if (manage_db_version () != 243)
+    {
+      sql_rollback ();
+      return -1;
+    }
+
+  /* Update the database. */
+
+  sql ("ALTER TABLE reports ADD COLUMN modification_time integer;");
+  sql ("UPDATE reports SET modification_time = end_time;");
+
+  /* Set the database version to 244. */
+
+  set_db_version (244);
+
+  sql_commit ();
+
+  return 0;
+}
 
 
 #undef UPDATE_DASHBOARD_SETTINGS
@@ -2733,6 +2764,7 @@ static migrator_t database_migrators[] = {
   {241, migrate_240_to_241},
   {242, migrate_241_to_242},
   {243, migrate_242_to_243},
+  {244, migrate_243_to_244},
   /* End marker. */
   {-1, NULL}};
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -12021,13 +12021,13 @@ generate_report_filename (report_t report, report_format_t report_format,
   report_id = report_uuid (report);
 
   creation_time
-    = sql_string ("SELECT iso_time (start_time)"
+    = sql_string ("SELECT iso_time (date)"
                   " FROM reports"
                   " WHERE id = %llu",
                   report);
 
   modification_time
-    = sql_string ("SELECT iso_time (end_time)"
+    = sql_string ("SELECT iso_time (modification_time)"
                   " FROM reports"
                   " WHERE id = %llu",
                   report);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -20905,9 +20905,9 @@ report_add_result (report_t report, result_t result)
    { "iso_time (date)", "name", KEYWORD_TYPE_STRING },                       \
    { "''", NULL, KEYWORD_TYPE_STRING },                                      \
    { "iso_time (date)", NULL, KEYWORD_TYPE_STRING },                         \
-   { "iso_time (end_time)", NULL, KEYWORD_TYPE_STRING },                     \
+   { "iso_time (modification_time)", NULL, KEYWORD_TYPE_STRING },            \
    { "date", "created", KEYWORD_TYPE_INTEGER },                              \
-   { "end_time", "modified", KEYWORD_TYPE_INTEGER },                         \
+   { "modification_time", "modified", KEYWORD_TYPE_INTEGER },                \
    { "(SELECT name FROM users WHERE users.id = reports.owner)",              \
      "_owner",                                                               \
      KEYWORD_TYPE_STRING },                                                  \

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -23636,6 +23636,22 @@ set_report_scan_run_status (report_t report, task_status_t status)
 }
 
 /**
+ * @brief Update modification_time of a report to current time.
+ *
+ * @param[in]   report  Report.
+ *
+ * @return 0.
+ */
+int
+update_report_modification_time (report_t report)
+{
+  sql("UPDATE reports SET modification_time = m_now() WHERE id = %llu;",
+      report);
+
+  return 0;
+}
+
+/**
  * @brief Get the result severity counts for a report.
  *
  * @param[in]  report     Report.

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -296,6 +296,8 @@ int delete_report_internal (report_t);
 
 int set_report_scan_run_status (report_t, task_status_t);
 
+int update_report_modification_time (report_t);
+
 int set_report_slave_progress (report_t, int);
 
 void init_task_file_iterator (iterator_t *, task_t, const char *);


### PR DESCRIPTION
**What**:
Added the new function "migrate_243_to_244 ()" in manage_migrators.c to add
the new column "modification_time" to the "reports" table.

Adjusted GVMD_DATABASE_VERSION in CMakelists.txt.

Adjusted the corresponding entries in the REPORT_ITERATOR_COLUMNS in
manage_sql.c.

Added update of modification_time for reports during scans.

**Why**:
Make report timestamps more consistent.

**How did you test it**:
Checked reports and report filters.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
