### PR TITLE
Fix whole-only config family selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Improve VT version handling for CVE & OVAL results [#1496](https://github.com/greenbone/gvmd/pull/1496)
 - Fix migration to DB version 242 from gvmd 20.08 [#1498](https://github.com/greenbone/gvmd/pull/1498)
 - Update subject alternative name in certificate generation [#1503](https://github.com/greenbone/gvmd/pull/1503)
+- Fix whole-only config family selection [#1517](https://github.com/greenbone/gvmd/pull/1517)
 
 [21.4.0]: https://github.com/greenbone/gvmd/compare/v21.4.0...gvmd-21.04
 

--- a/src/gmp_configs.c
+++ b/src/gmp_configs.c
@@ -904,12 +904,15 @@ modify_config_handle_family_selection (config_t config,
                                        gmp_parser_t *gmp_parser,
                                        GError **error)
 {
+  gchar *rejected_family;
+
   switch (manage_set_config_families
              (config,
               families_growing_all,
               families_static_all,
               families_growing_empty,
-              family_selection_growing))
+              family_selection_growing,
+              &rejected_family))
     {
       case 0:
         return 0;
@@ -919,9 +922,13 @@ modify_config_handle_family_selection (config_t config,
         return -1;
       case 2:
         SENDF_TO_CLIENT_OR_FAIL_WITH_RETURN
-          (-1, XML_ERROR_SYNTAX ("modify_config",
-                            "Whole-only families must include entire"
-                            " family and be growing"));
+          (-1,
+           XML_ERROR_SYNTAX ("modify_config",
+                             "Family &quot;%s&quot; must be growing and"
+                             " include all VTs or it must be static and"
+                             " empty."),
+           rejected_family);
+        g_free (rejected_family);
         return -1;
       case -1:
         SENDF_TO_CLIENT_OR_FAIL_WITH_RETURN

--- a/src/manage_configs.h
+++ b/src/manage_configs.h
@@ -172,7 +172,8 @@ int
 manage_set_config_nvts (config_t, const char*, GPtrArray*);
 
 int
-manage_set_config_families (config_t, GPtrArray*, GPtrArray*, GPtrArray*, int);
+manage_set_config_families (config_t, GPtrArray*, GPtrArray*, GPtrArray*, int,
+                            gchar **);
 
 void
 init_config_timeout_iterator (iterator_t*, config_t);


### PR DESCRIPTION
**What**:
When modifying the family selection of a scan config, "whole-only" must
be either growing with all VTs or static and empty.
The error message if this is not the case now also includes the name of
the (first) rejected family.

**Why**:
This selection should ensure that these special families are either selected
completely or not at all and the growing/static ensures they stay that way
if new NVTs are added. 

**How did you test it**:
By modifying a config in GSA to include some of the "whole-only" LSC families
and exclude others.
With greenbone/gsa#2905 the config should be accepted, without the changes
there should be an error message for the first unselected "whole-only" family.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
