### PR TITLE
Enhance datetime parsing when using h instead of :

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Try to install PostgreSQL extensions automatically [#1444](https://github.com/greenbone/gvmd/pull/1444) [#1483](https://github.com/greenbone/gvmd/pull/1483)
 - Add auto retry on scanner connection lost during a running task [#1452](https://github.com/greenbone/gvmd/pull/1452)
 - Add --feed-lock-timeout option [#1472](https://github.com/greenbone/gvmd/pull/1472)
+- datetime parser for `%Y-%m-%dT%Hh%M` for keywords [1518](https://github.com/greenbone/gvmd/pull/1518)
 
 ### Changed
 - Improve report counts performance [#1438](https://github.com/greenbone/gvmd/pull/1438)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -1222,16 +1222,45 @@ parse_keyword (keyword_t* keyword)
                                                atoi (keyword->string) * 12);
           keyword->type = KEYWORD_TYPE_INTEGER;
         }
+      // Add cases for t%H:%M although it is incorrect sometimes it is easier
+      // to call filter.lower on the frontend then it can happen that the
+      // T indicator is lowered as well.
+      else if (strptime (keyword->string, "%Y-%m-%dt%H:%M", &date))
+        {
+          keyword->integer_value = mktime (&date);
+          keyword->type = KEYWORD_TYPE_INTEGER;
+          g_debug ("Parsed Y-m-dtH:M %s to timestamp %d.",
+                   keyword->string, keyword->integer_value);
+        }
+      else if (strptime (keyword->string, "%Y-%m-%dt%Hh%M", &date))
+        {
+          keyword->integer_value = mktime (&date);
+          keyword->type = KEYWORD_TYPE_INTEGER;
+          g_debug ("Parsed Y-m-dtHhM %s to timestamp %d.",
+                   keyword->string, keyword->integer_value);
+        }
       else if (strptime (keyword->string, "%Y-%m-%dT%H:%M", &date))
         {
           keyword->integer_value = mktime (&date);
           keyword->type = KEYWORD_TYPE_INTEGER;
+          g_debug ("Parsed Y-m-dTH:M %s to timestamp %d.",
+                   keyword->string, keyword->integer_value);
+        }
+      // Add T%Hh%M for downwards compatible filter
+      else if (strptime (keyword->string, "%Y-%m-%dT%Hh%M", &date))
+        {
+          keyword->integer_value = mktime (&date);
+          keyword->type = KEYWORD_TYPE_INTEGER;
+          g_debug ("Parsed Y-m-dTHhM %s to timestamp %d.",
+                   keyword->string, keyword->integer_value);
         }
       else if (memset (&date, 0, sizeof (date)),
                strptime (keyword->string, "%Y-%m-%d", &date))
         {
           keyword->integer_value = mktime (&date);
           keyword->type = KEYWORD_TYPE_INTEGER;
+          g_debug ("Parsed Y-m-d %s to timestamp %d.",
+                   keyword->string, keyword->integer_value);
         }
       else if (sscanf (keyword->string, "%d%1s", &parsed_integer, dummy) == 1)
         {
@@ -1995,6 +2024,7 @@ manage_report_filter_controls (const gchar *filter, int *first, int *max,
     return;
 
   split = split_filter (filter);
+  
   point = (keyword_t**) split->pdata;
   if (first)
     {
@@ -3812,7 +3842,6 @@ filter_clause (const char* type, const char* filter,
           last_was_re = 0;
         }
       g_free (quoted_keyword);
-
       point++;
     }
   filter_free (split);
@@ -3834,7 +3863,6 @@ filter_clause (const char* type, const char* filter,
 
   if (strlen (clause->str))
     return g_string_free (clause, FALSE);
-
   g_string_free (clause, TRUE);
   return NULL;
 }


### PR DESCRIPTION
When doing:
```
from gvm.connections import UnixSocketConnection
from gvm.protocols.gmp import Gmp
from gvm.xml import pretty_print

connection = UnixSocketConnection(path="/tmp/gvmd_socket/gvmd.sock")

with Gmp(connection) as gmp:
    gmp.authenticate("username", "password")
    #    pretty_print(gmp.get_results(filter="created>2021-05-05T11:45"))
    pretty_print(gmp.get_results(filter="created>2021-05-05T11h45"))
```

then the query with T11h45 is not working.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
