### PR TITLE
Add column modification_time to the table reports in manage_pg.c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [21.10] (unreleased)
 
 ### Added
-- Add a new modification_time column to reports [#1513](https://github.com/greenbone/gvmd/pull/1513)
+- Add a new modification_time column to reports [#1513](https://github.com/greenbone/gvmd/pull/1513), [#1519](https://github.com/greenbone/gvmd/pull/1519)
 
 ### Changed
 - Use pg-gvm extension for C PostgreSQL functions [#1400](https://github.com/greenbone/gvmd/pull/1400), [#1453](https://github.com/greenbone/gvmd/pull/1453)

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -2309,7 +2309,7 @@ create_tables ()
        "  scan_run_status integer,"
        "  slave_progress integer,"
        "  flags integer,"
-       "  modification_time);");
+       "  modification_time integer);");
 
   sql ("CREATE TABLE IF NOT EXISTS report_counts"
        " (id SERIAL PRIMARY KEY,"

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -2308,7 +2308,8 @@ create_tables ()
        "  comment text,"
        "  scan_run_status integer,"
        "  slave_progress integer,"
-       "  flags integer);");
+       "  flags integer,"
+       "  modification_time);");
 
   sql ("CREATE TABLE IF NOT EXISTS report_counts"
        " (id SERIAL PRIMARY KEY,"


### PR DESCRIPTION
**What**:
Added the new new column "modification_time" to the CREATE TABLE Statement for the table reports in manage_pg.c.

**Why**:
Make report timestamps more consistent.

**How did you test it**:
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
