### PR TITLE
Rename the date column of reports to creation_time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update default log config [#1501](https://github.com/greenbone/gvmd/pull/1501)
 - Change report timestamp filter and iterator columns [#1512](https://github.com/greenbone/gvmd/pull/1512)
+- Rename the date column of reports to creation_time [#1520](https://github.com/greenbone/gvmd/pull/1520)
 
 ### Fixed
 - Improve VT version handling for CVE & OVAL results [#1496](https://github.com/greenbone/gvmd/pull/1496)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 244)
+set (GVMD_DATABASE_VERSION 245)
 
 set (GVMD_SCAP_DATABASE_VERSION 18)
 

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -2736,42 +2736,6 @@ migrate_244_to_245 ()
 
   sql ("ALTER TABLE reports RENAME COLUMN date TO creation_time;");
 
-
-  sql ("CREATE OR REPLACE FUNCTION task_last_report (integer)"
-       " RETURNS integer AS $$"
-       /* Get the report from the most recently completed invocation of task. */
-       "  SELECT id FROM reports WHERE task = $1 AND scan_run_status = %u"
-       "  ORDER BY creation_time DESC LIMIT 1;"
-       "$$ LANGUAGE SQL;",
-       TASK_STATUS_DONE);
-
-  sql ("CREATE OR REPLACE FUNCTION task_second_last_report (integer)"
-       " RETURNS integer AS $$"
-       /* Get report from second most recently completed invocation of task. */
-       "  SELECT id FROM reports WHERE task = $1 AND scan_run_status = %u"
-       "  ORDER BY creation_time DESC LIMIT 1 OFFSET 1;"
-       "$$ LANGUAGE SQL;",
-       TASK_STATUS_DONE);
-
-  sql ("CREATE OR REPLACE FUNCTION task_severity (integer,"  // task
-       "                                          integer,"  // overrides
-       "                                          integer)"  // min_qod
-       " RETURNS double precision AS $$"
-       /* Calculate the severity of a task. */
-       "  SELECT CASE"
-       "         WHEN (SELECT target = 0"
-       "               FROM tasks WHERE id = $1)"
-       "         THEN CAST (NULL AS double precision)"
-       "         ELSE"
-       "         (SELECT report_severity ((SELECT id FROM reports"
-       "                                   WHERE task = $1"
-       "                                   AND scan_run_status = %u"
-       "                                   ORDER BY creation_time DESC"
-       "                                   LIMIT 1 OFFSET 0), $2, $3))"
-       "         END;"
-       "$$ LANGUAGE SQL;",
-       TASK_STATUS_DONE);
-
   /* Set the database version to 245. */
 
   set_db_version (245);

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -1117,25 +1117,25 @@ manage_create_sql_functions ()
       /* column date in table reports was renamed to creation_time in version 245 */
       if (current_db_version >= 245)
         {
-        sql ("CREATE OR REPLACE FUNCTION task_last_report (integer)"
-             " RETURNS integer AS $$"
-             /* Get the report from the most recently completed invocation of task. */
-             "  SELECT id FROM reports WHERE task = $1 AND scan_run_status = %u"
-             "  ORDER BY creation_time DESC LIMIT 1;"
-             "$$ LANGUAGE SQL;",
-             TASK_STATUS_DONE);
+          sql ("CREATE OR REPLACE FUNCTION task_last_report (integer)"
+               " RETURNS integer AS $$"
+               /* Get the report from the most recently completed invocation of task. */
+               "  SELECT id FROM reports WHERE task = $1 AND scan_run_status = %u"
+               "  ORDER BY creation_time DESC LIMIT 1;"
+               "$$ LANGUAGE SQL;",
+               TASK_STATUS_DONE);
         }
 
       /* column date in table reports was renamed to creation_time in version 245 */
       if (current_db_version >= 245)
         {
-        sql ("CREATE OR REPLACE FUNCTION task_second_last_report (integer)"
-             " RETURNS integer AS $$"
-             /* Get report from second most recently completed invocation of task. */
-             "  SELECT id FROM reports WHERE task = $1 AND scan_run_status = %u"
-             "  ORDER BY creation_time DESC LIMIT 1 OFFSET 1;"
-             "$$ LANGUAGE SQL;",
-             TASK_STATUS_DONE);
+          sql ("CREATE OR REPLACE FUNCTION task_second_last_report (integer)"
+               " RETURNS integer AS $$"
+               /* Get report from second most recently completed invocation of task. */
+               "  SELECT id FROM reports WHERE task = $1 AND scan_run_status = %u"
+               "  ORDER BY creation_time DESC LIMIT 1 OFFSET 1;"
+               "$$ LANGUAGE SQL;",
+               TASK_STATUS_DONE);
         }
 
       /* result_nvt column (in OVERRIDES_SQL) was added in version 189.           */
@@ -1143,24 +1143,24 @@ manage_create_sql_functions ()
       /* column date in table reports was renamed to creation_time in version 245 */
       if (current_db_version >= 245)
         {
-        sql ("CREATE OR REPLACE FUNCTION task_severity (integer,"  // task
-             "                                          integer,"  // overrides
-             "                                          integer)"  // min_qod
-             " RETURNS double precision AS $$"
-             /* Calculate the severity of a task. */
-             "  SELECT CASE"
-             "         WHEN (SELECT target = 0"
-             "               FROM tasks WHERE id = $1)"
-             "         THEN CAST (NULL AS double precision)"
-             "         ELSE"
-             "         (SELECT report_severity ((SELECT id FROM reports"
-             "                                   WHERE task = $1"
-             "                                   AND scan_run_status = %u"
-             "                                   ORDER BY creation_time DESC"
-             "                                   LIMIT 1 OFFSET 0), $2, $3))"
-             "         END;"
-             "$$ LANGUAGE SQL;",
-             TASK_STATUS_DONE);
+          sql ("CREATE OR REPLACE FUNCTION task_severity (integer,"  // task
+               "                                          integer,"  // overrides
+               "                                          integer)"  // min_qod
+               " RETURNS double precision AS $$"
+               /* Calculate the severity of a task. */
+               "  SELECT CASE"
+               "         WHEN (SELECT target = 0"
+               "               FROM tasks WHERE id = $1)"
+               "         THEN CAST (NULL AS double precision)"
+               "         ELSE"
+               "         (SELECT report_severity ((SELECT id FROM reports"
+               "                                   WHERE task = $1"
+               "                                   AND scan_run_status = %u"
+               "                                   ORDER BY creation_time DESC"
+               "                                   LIMIT 1 OFFSET 0), $2, $3))"
+               "         END;"
+               "$$ LANGUAGE SQL;",
+               TASK_STATUS_DONE);
         }
 
       sql ("CREATE OR REPLACE FUNCTION task_trend (integer, integer, integer)"

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -1114,24 +1114,32 @@ manage_create_sql_functions ()
              "         END;"
              "$$ LANGUAGE SQL;");
 
-      sql ("CREATE OR REPLACE FUNCTION task_last_report (integer)"
-           " RETURNS integer AS $$"
-           /* Get the report from the most recently completed invocation of task. */
-           "  SELECT id FROM reports WHERE task = $1 AND scan_run_status = %u"
-           "  ORDER BY date DESC LIMIT 1;"
-           "$$ LANGUAGE SQL;",
-           TASK_STATUS_DONE);
+      /* column date in table reports was renamed to creation_time in version 245 */
+      if (current_db_version >= 245) {
+        sql ("CREATE OR REPLACE FUNCTION task_last_report (integer)"
+             " RETURNS integer AS $$"
+             /* Get the report from the most recently completed invocation of task. */
+             "  SELECT id FROM reports WHERE task = $1 AND scan_run_status = %u"
+             "  ORDER BY creation_time DESC LIMIT 1;"
+             "$$ LANGUAGE SQL;",
+             TASK_STATUS_DONE);
+      }
 
-      sql ("CREATE OR REPLACE FUNCTION task_second_last_report (integer)"
-           " RETURNS integer AS $$"
-           /* Get report from second most recently completed invocation of task. */
-           "  SELECT id FROM reports WHERE task = $1 AND scan_run_status = %u"
-           "  ORDER BY date DESC LIMIT 1 OFFSET 1;"
-           "$$ LANGUAGE SQL;",
-           TASK_STATUS_DONE);
+      /* column date in table reports was renamed to creation_time in version 245 */
+      if (current_db_version >= 245) {
+        sql ("CREATE OR REPLACE FUNCTION task_second_last_report (integer)"
+             " RETURNS integer AS $$"
+             /* Get report from second most recently completed invocation of task. */
+             "  SELECT id FROM reports WHERE task = $1 AND scan_run_status = %u"
+             "  ORDER BY creation_time DESC LIMIT 1 OFFSET 1;"
+             "$$ LANGUAGE SQL;",
+             TASK_STATUS_DONE);
+      }
 
-      /* result_nvt column (in OVERRIDES_SQL) was added in version 189. */
-      if (current_db_version >= 189)
+      /* result_nvt column (in OVERRIDES_SQL) was added in version 189.           */
+      /* if (current_db_version >= 189)                                           */
+      /* column date in table reports was renamed to creation_time in version 245 */
+      if (current_db_version >= 245) {
         sql ("CREATE OR REPLACE FUNCTION task_severity (integer,"  // task
              "                                          integer,"  // overrides
              "                                          integer)"  // min_qod
@@ -1145,11 +1153,12 @@ manage_create_sql_functions ()
              "         (SELECT report_severity ((SELECT id FROM reports"
              "                                   WHERE task = $1"
              "                                   AND scan_run_status = %u"
-             "                                   ORDER BY date DESC"
+             "                                   ORDER BY creation_time DESC"
              "                                   LIMIT 1 OFFSET 0), $2, $3))"
              "         END;"
              "$$ LANGUAGE SQL;",
              TASK_STATUS_DONE);
+      }
 
       sql ("CREATE OR REPLACE FUNCTION task_trend (integer, integer, integer)"
            " RETURNS text AS $$"
@@ -2302,13 +2311,14 @@ create_tables ()
        "  uuid text UNIQUE NOT NULL,"
        "  owner integer REFERENCES users (id) ON DELETE RESTRICT,"
        "  task integer REFERENCES tasks (id) ON DELETE RESTRICT,"
-       "  date integer,"
+       "  creation_time integer,"
        "  start_time integer,"
        "  end_time integer,"
        "  comment text,"
        "  scan_run_status integer,"
        "  slave_progress integer,"
-       "  flags integer);");
+       "  flags integer,"
+       "  modification_time integer);");
 
   sql ("CREATE TABLE IF NOT EXISTS report_counts"
        " (id SERIAL PRIMARY KEY,"

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -1115,7 +1115,8 @@ manage_create_sql_functions ()
              "$$ LANGUAGE SQL;");
 
       /* column date in table reports was renamed to creation_time in version 245 */
-      if (current_db_version >= 245) {
+      if (current_db_version >= 245)
+        {
         sql ("CREATE OR REPLACE FUNCTION task_last_report (integer)"
              " RETURNS integer AS $$"
              /* Get the report from the most recently completed invocation of task. */
@@ -1123,10 +1124,11 @@ manage_create_sql_functions ()
              "  ORDER BY creation_time DESC LIMIT 1;"
              "$$ LANGUAGE SQL;",
              TASK_STATUS_DONE);
-      }
+        }
 
       /* column date in table reports was renamed to creation_time in version 245 */
-      if (current_db_version >= 245) {
+      if (current_db_version >= 245)
+        {
         sql ("CREATE OR REPLACE FUNCTION task_second_last_report (integer)"
              " RETURNS integer AS $$"
              /* Get report from second most recently completed invocation of task. */
@@ -1134,12 +1136,13 @@ manage_create_sql_functions ()
              "  ORDER BY creation_time DESC LIMIT 1 OFFSET 1;"
              "$$ LANGUAGE SQL;",
              TASK_STATUS_DONE);
-      }
+        }
 
       /* result_nvt column (in OVERRIDES_SQL) was added in version 189.           */
       /* if (current_db_version >= 189)                                           */
       /* column date in table reports was renamed to creation_time in version 245 */
-      if (current_db_version >= 245) {
+      if (current_db_version >= 245)
+        {
         sql ("CREATE OR REPLACE FUNCTION task_severity (integer,"  // task
              "                                          integer,"  // overrides
              "                                          integer)"  // min_qod
@@ -1158,7 +1161,7 @@ manage_create_sql_functions ()
              "         END;"
              "$$ LANGUAGE SQL;",
              TASK_STATUS_DONE);
-      }
+        }
 
       sql ("CREATE OR REPLACE FUNCTION task_trend (integer, integer, integer)"
            " RETURNS text AS $$"

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -17811,7 +17811,7 @@ task_report_previous (task_t task, report_t report, report_t *previous)
                      " WHERE task = %llu"
                      " AND scan_run_status = %u"
                      " AND creation_time < (SELECT creation_time FROM reports"
-                     " WHERE id = %llu)"
+                     "                      WHERE id = %llu)"
                      " ORDER BY creation_time DESC LIMIT 1;",
                      task,
                      TASK_STATUS_DONE,

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -2931,7 +2931,7 @@ filter_clause (const char* type, const char* filter,
                   "             FROM (SELECT report_progress (id) AS temp"
                   "                   FROM reports"
                   "                   WHERE task = tasks.id"
-                  "                   ORDER BY date DESC LIMIT 1)"
+                  "                   ORDER BY creation_time DESC LIMIT 1)"
                   "                  AS temp_sub)"
                   "    END)"
                   " ASC");
@@ -3123,7 +3123,7 @@ filter_clause (const char* type, const char* filter,
                   "             FROM (SELECT report_progress (id) AS temp"
                   "                   FROM reports"
                   "                   WHERE task = tasks.id"
-                  "                   ORDER BY date DESC LIMIT 1)"
+                  "                   ORDER BY creation_time DESC LIMIT 1)"
                   "                  AS temp_sub)"
                   "    END)"
                   " DESC");
@@ -12022,7 +12022,7 @@ generate_report_filename (report_t report, report_format_t report_format,
   report_id = report_uuid (report);
 
   creation_time
-    = sql_string ("SELECT iso_time (date)"
+    = sql_string ("SELECT iso_time (creation_time)"
                   " FROM reports"
                   " WHERE id = %llu",
                   report);
@@ -14545,7 +14545,7 @@ append_to_task_string (task_t task, const char* field, const char* value)
      "(SELECT uuid FROM reports WHERE task = tasks.id"                      \
      /* TODO 1 == TASK_STATUS_DONE */                                       \
      " AND scan_run_status = 1"                                             \
-     " ORDER BY date ASC LIMIT 1)",                                         \
+     " ORDER BY creation_time ASC LIMIT 1)",                                \
      "first_report",                                                        \
      KEYWORD_TYPE_STRING                                                    \
    },                                                                       \
@@ -14554,7 +14554,7 @@ append_to_task_string (task_t task, const char* field, const char* value)
      "(SELECT uuid FROM reports WHERE task = tasks.id"                      \
      /* TODO 1 == TASK_STATUS_DONE */                                       \
      " AND scan_run_status = 1"                                             \
-     " ORDER BY date DESC LIMIT 1)",                                        \
+     " ORDER BY creation_time DESC LIMIT 1)",                               \
      "last_report",                                                         \
      KEYWORD_TYPE_STRING                                                    \
    },                                                                       \
@@ -14607,18 +14607,18 @@ append_to_task_string (task_t task, const char* field, const char* value)
      KEYWORD_TYPE_INTEGER                                                    \
    },                                                                        \
    {                                                                         \
-     "(SELECT date FROM reports WHERE task = tasks.id"                       \
+     "(SELECT creation_time FROM reports WHERE task = tasks.id"              \
      /* TODO 1 == TASK_STATUS_DONE */                                        \
      " AND scan_run_status = 1"                                              \
-     " ORDER BY date ASC LIMIT 1)",                                          \
+     " ORDER BY creation_time ASC LIMIT 1)",                                 \
      "first",                                                                \
      KEYWORD_TYPE_INTEGER                                                    \
    },                                                                        \
    {                                                                         \
-     "(SELECT date FROM reports WHERE task = tasks.id"                       \
+     "(SELECT creation_time FROM reports WHERE task = tasks.id"              \
      /* TODO 1 == TASK_STATUS_DONE */                                        \
      " AND scan_run_status = 1"                                              \
-     " ORDER BY date DESC LIMIT 1)",                                         \
+     " ORDER BY creation_time DESC LIMIT 1)",                                \
      "last",                                                                 \
      KEYWORD_TYPE_INTEGER                                                    \
    },                                                                        \
@@ -17810,9 +17810,9 @@ task_report_previous (task_t task, report_t report, report_t *previous)
                      "SELECT id FROM reports"
                      " WHERE task = %llu"
                      " AND scan_run_status = %u"
-                     " AND date < (SELECT date FROM reports"
+                     " AND creation_time < (SELECT creation_time FROM reports"
                      "             WHERE id = %llu)"
-                     " ORDER BY date DESC LIMIT 1;",
+                     " ORDER BY creation_time DESC LIMIT 1;",
                      task,
                      TASK_STATUS_DONE,
                      report))
@@ -17846,7 +17846,7 @@ task_last_report (task_t task, report_t *report)
   switch (sql_int64 (report,
                      "SELECT id FROM reports WHERE task = %llu"
                      " AND scan_run_status = %u"
-                     " ORDER BY date DESC LIMIT 1;",
+                     " ORDER BY creation_time DESC LIMIT 1;",
                      task,
                      TASK_STATUS_DONE))
     {
@@ -17878,7 +17878,7 @@ task_last_report_any_status (task_t task, report_t *report)
 {
   switch (sql_int64 (report,
                      "SELECT id FROM reports WHERE task = %llu"
-                     " ORDER BY date DESC LIMIT 1;",
+                     " ORDER BY creation_time DESC LIMIT 1;",
                      task))
     {
       case 0:
@@ -17910,7 +17910,7 @@ task_second_last_report (task_t task, report_t *report)
   switch (sql_int64 (report,
                      "SELECT id FROM reports WHERE task = %llu"
                      " AND scan_run_status = %u"
-                     " ORDER BY date DESC LIMIT 1 OFFSET 1;",
+                     " ORDER BY creation_time DESC LIMIT 1 OFFSET 1;",
                      task,
                      TASK_STATUS_DONE))
     {
@@ -17944,7 +17944,7 @@ task_last_resumable_report (task_t task, report_t *report)
                      "SELECT id FROM reports WHERE task = %llu"
                      " AND (scan_run_status = %u"
                      "      OR scan_run_status = %u)"
-                     " ORDER BY date DESC LIMIT 1;",
+                     " ORDER BY creation_time DESC LIMIT 1;",
                      task,
                      TASK_STATUS_STOPPED,
                      TASK_STATUS_INTERRUPTED))
@@ -17976,7 +17976,7 @@ task_second_last_report_id (task_t task)
 {
   return sql_string ("SELECT uuid FROM reports WHERE task = %llu"
                      " AND scan_run_status = %u"
-                     " ORDER BY date DESC LIMIT 1 OFFSET 1;",
+                     " ORDER BY creation_time DESC LIMIT 1 OFFSET 1;",
                      task,
                      TASK_STATUS_DONE);
 }
@@ -18442,7 +18442,7 @@ task_severity_double (task_t task, int overrides, int min_qod, int offset)
              "SELECT id FROM reports"
              "           WHERE reports.task = %llu"
              "           AND reports.scan_run_status = %u"
-             "           ORDER BY reports.date DESC"
+             "           ORDER BY reports.creation_time DESC"
              "           LIMIT 1 OFFSET %d",
              task, TASK_STATUS_DONE, offset);
 
@@ -20108,7 +20108,7 @@ report_clear_count_cache (report_t report,
 report_t
 make_report (task_t task, const char* uuid, task_status_t status)
 {
-  sql ("INSERT into reports (uuid, owner, task, date, comment,"
+  sql ("INSERT into reports (uuid, owner, task, creation_time, comment,"
        " scan_run_status, slave_progress)"
        " VALUES ('%s',"
        " (SELECT owner FROM tasks WHERE tasks.id = %llu),"
@@ -20924,11 +20924,11 @@ report_add_result (report_t report, result_t result)
  * @brief Filter columns for report iterator.
  */
 #define REPORT_ITERATOR_FILTER_COLUMNS                                         \
- { ANON_GET_ITERATOR_FILTER_COLUMNS, "task_id", "name", "date", "status",      \
-   "task", "severity", "false_positive", "log", "low", "medium", "high",       \
-   "hosts", "result_hosts", "fp_per_host", "log_per_host", "low_per_host",     \
-   "medium_per_host", "high_per_host", "duration", "duration_per_host",        \
-   "start_time", "end_time", "scan_start", "scan_end",                         \
+ { ANON_GET_ITERATOR_FILTER_COLUMNS, "task_id", "name", "creation_time",       \
+   "status", "task", "severity", "false_positive", "log", "low", "medium",     \
+   "high", "hosts", "result_hosts", "fp_per_host", "log_per_host",             \
+   "low_per_host", "medium_per_host", "high_per_host", "duration",             \
+   "duration_per_host", "start_time", "end_time", "scan_start", "scan_end",    \
    NULL }
 
 /**
@@ -20938,11 +20938,11 @@ report_add_result (report_t report, result_t result)
  {                                                                           \
    { "id", NULL, KEYWORD_TYPE_INTEGER },                                     \
    { "uuid", NULL, KEYWORD_TYPE_STRING },                                    \
-   { "iso_time (date)", "name", KEYWORD_TYPE_STRING },                       \
+   { "iso_time (creation_time)", "name", KEYWORD_TYPE_STRING },              \
    { "''", NULL, KEYWORD_TYPE_STRING },                                      \
-   { "iso_time (date)", NULL, KEYWORD_TYPE_STRING },                         \
+   { "iso_time (creation_time)", NULL, KEYWORD_TYPE_STRING },                \
    { "iso_time (modification_time)", NULL, KEYWORD_TYPE_STRING },            \
-   { "date", "created", KEYWORD_TYPE_INTEGER },                              \
+   { "creation_time", "created", KEYWORD_TYPE_INTEGER },                     \
    { "modification_time", "modified", KEYWORD_TYPE_INTEGER },                \
    { "(SELECT name FROM users WHERE users.id = reports.owner)",              \
      "_owner",                                                               \
@@ -20964,7 +20964,7 @@ report_add_result (report_t report, result_t result)
      "task_id",                                                              \
      KEYWORD_TYPE_STRING                                                     \
    },                                                                        \
-   { "date", NULL, KEYWORD_TYPE_INTEGER },                                   \
+   { "creation_time", NULL, KEYWORD_TYPE_INTEGER },                          \
    { "(SELECT name FROM tasks WHERE tasks.id = task)", "task" },             \
    {                                                                         \
      "report_severity (id, opts.override, opts.min_qod)",                    \
@@ -23626,7 +23626,7 @@ int
 report_timestamp (const char* report_id, gchar** timestamp)
 {
   const char* stamp;
-  time_t time = sql_int ("SELECT date FROM reports where uuid = '%s';",
+  time_t time = sql_int ("SELECT creation_time FROM reports where uuid = '%s';",
                          report_id);
   stamp = iso_time (&time);
   if (stamp == NULL) return -1;

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -17811,7 +17811,7 @@ task_report_previous (task_t task, report_t report, report_t *previous)
                      " WHERE task = %llu"
                      " AND scan_run_status = %u"
                      " AND creation_time < (SELECT creation_time FROM reports"
-                     "             WHERE id = %llu)"
+                     " WHERE id = %llu)"
                      " ORDER BY creation_time DESC LIMIT 1;",
                      task,
                      TASK_STATUS_DONE,
@@ -20925,8 +20925,8 @@ report_add_result (report_t report, result_t result)
  */
 #define REPORT_ITERATOR_FILTER_COLUMNS                                         \
  { ANON_GET_ITERATOR_FILTER_COLUMNS, "task_id", "name", "creation_time",       \
-   "status", "task", "severity", "false_positive", "log", "low", "medium",     \
-   "high", "hosts", "result_hosts", "fp_per_host", "log_per_host",             \
+   "date", "status", "task", "severity", "false_positive", "log", "low",       \
+   "medium", "high", "hosts", "result_hosts", "fp_per_host", "log_per_host",   \
    "low_per_host", "medium_per_host", "high_per_host", "duration",             \
    "duration_per_host", "start_time", "end_time", "scan_start", "scan_end",    \
    NULL }
@@ -20964,7 +20964,7 @@ report_add_result (report_t report, result_t result)
      "task_id",                                                              \
      KEYWORD_TYPE_STRING                                                     \
    },                                                                        \
-   { "creation_time", NULL, KEYWORD_TYPE_INTEGER },                          \
+   { "creation_time", "date", KEYWORD_TYPE_INTEGER },                        \
    { "(SELECT name FROM tasks WHERE tasks.id = task)", "task" },             \
    {                                                                         \
      "report_severity (id, opts.override, opts.min_qod)",                    \


### PR DESCRIPTION


**What**:
Changed all relevant entries in manage_sql.c from date
to creation_time. Changed the relevant entries for the
creation of the database in manage_pg.c accordingly.
Added a function for the necessary database changes in
manage_migrators.c. Set the Databaseversion to 245.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Make report timestamps more consistent
<!-- Why are these changes necessary? -->

**How did you test it**:
Checked scan runs, reports and filters
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
