### PR TITLE
Fix typos.

### DIFF
--- a/src/gmp_configs.c
+++ b/src/gmp_configs.c
@@ -1031,7 +1031,7 @@ modify_config_handle_nvt_selection (config_t config,
  *
  * @param[in]  config     The config to modify
  * @param[in]  nvt_oid    VT OID of the preference or NULL for scanner pref.
- * @param[in]  name       Name of the prefernce to Changes
+ * @param[in]  name       Name of the preference to Changes
  * @param[in]  value      Value to set for the preference.
  * @param[in]  gmp_parser The GMP parser.
  * @param[out] error      GError output.

--- a/src/sql.c
+++ b/src/sql.c
@@ -40,7 +40,7 @@
  */
 #define G_LOG_DOMAIN "md manage"
 /**
- * @brief amount of ms sql should wait before retrying when a deadlock occured
+ * @brief amount of ms sql should wait before retrying when a deadlock occurred
  */
 #define DEADLOCK_SLEEP 1000
 
@@ -284,7 +284,7 @@ sql (char* sql, ...)
         {
             if (deadlock_amount++ > DEADLOCK_THRESHOLD)
               {
-                  g_warning("%s: %d deadlocks detected, wating and retrying %s", __func__, deadlock_amount, sql);
+                  g_warning("%s: %d deadlocks detected, waiting and retrying %s", __func__, deadlock_amount, sql);
               } 
             gvm_usleep (DEADLOCK_SLEEP);
             continue;


### PR DESCRIPTION
Found via codespell:

```
./src/sql.c:43: occured ==> occurred
./src/sql.c:290: wating ==> waiting
./src/gmp_configs.c:1037: prefernce ==> preference
```