### PR TITLE
Free alert get data in report_content_for_alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix report host end time check in CVE scans [#1462](https://github.com/greenbone/gvmd/pull/1462)
 - Fix "not regexp ..." filters [#1482](https://github.com/greenbone/gvmd/pull/1482)
 - Escape TLS certificate DNs that are invalid UTF-8 [#1486](https://github.com/greenbone/gvmd/pull/1486)
+- Free alert get data in report_content_for_alert [#1526](https://github.com/greenbone/gvmd/pull/1526) 
 
 ### Removed
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -11911,11 +11911,20 @@ report_content_for_alert (alert_t alert, report_t report, task_t task,
             break;
         case 1:        /* Too few rows in result of query. */
         case -1:
-          g_free(alert_filter_get);
+          if (alert_filter_get)
+            {
+              get_data_reset (alert_filter_get);
+              g_free (alert_filter_get);
+            }
           return -1;
           break;
         default:       /* Programming error. */
           assert (0);
+          if (alert_filter_get)
+            {
+              get_data_reset (alert_filter_get);
+              g_free (alert_filter_get);
+            }
           return -1;
       }
 
@@ -11942,7 +11951,11 @@ report_content_for_alert (alert_t alert, report_t report, task_t task,
                          __func__, format_uuid,
                          alert_method_name (alert_method (alert)));
               g_free (format_uuid);
-              g_free (alert_filter_get);
+              if (alert_filter_get)
+                {
+                  get_data_reset (alert_filter_get);
+                  g_free (alert_filter_get);
+                }
               return -2;
             }
           g_free (format_uuid);
@@ -11957,6 +11970,11 @@ report_content_for_alert (alert_t alert, report_t report, task_t task,
           g_warning ("%s: Could not find report format '%s' for %s",
                      __func__, report_format_lookup,
                      alert_method_name (alert_method (alert)));
+          if (alert_filter_get)
+            {
+              get_data_reset (alert_filter_get);
+              g_free (alert_filter_get);
+            }
           return -2;
         }
     }
@@ -11968,6 +11986,11 @@ report_content_for_alert (alert_t alert, report_t report, task_t task,
           g_warning ("%s: No fallback report format for %s",
                      __func__,
                      alert_method_name (alert_method (alert)));
+          if (alert_filter_get)
+            {
+              get_data_reset (alert_filter_get);
+              g_free (alert_filter_get);
+            }
           return -1;
         }
 
@@ -11980,6 +12003,11 @@ report_content_for_alert (alert_t alert, report_t report, task_t task,
           g_warning ("%s: Could not find fallback RFP '%s' for %s",
                       __func__, fallback_format_id,
                      alert_method_name (alert_method (alert)));
+          if (alert_filter_get)
+            {
+              get_data_reset (alert_filter_get);
+              g_free (alert_filter_get);
+            }
           return -2;
         }
     }


### PR DESCRIPTION
**What**:
The alert get data in report_content_for_alert is now freed correctly
in case of errors.

**Why**:
In error cases the alert_filter_get was not freed correctly.

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
