### PR TITLE
Fix erroneous freeing of ical timezone component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix "not regexp ..." filters [#1482](https://github.com/greenbone/gvmd/pull/1482)
 - Escape TLS certificate DNs that are invalid UTF-8 [#1486](https://github.com/greenbone/gvmd/pull/1486)
 - Free alert get data in report_content_for_alert [#1526](https://github.com/greenbone/gvmd/pull/1526) 
+- Fix erroneous freeing of ical timezone component [#1530](https://github.com/greenbone/gvmd/pull/1530)
 
 ### Removed
 

--- a/src/manage_utils.c
+++ b/src/manage_utils.c
@@ -690,7 +690,7 @@ icalcomponent *
 icalendar_from_string (const char *ical_string, icaltimezone *zone,
                        gchar **error)
 {
-  icalcomponent *ical_new, *ical_parsed;
+  icalcomponent *ical_new, *ical_parsed, *timezone_component;
   icalproperty *error_prop;
   GString *warnings_buffer;
   int vevent_count = 0;
@@ -727,7 +727,9 @@ icalendar_from_string (const char *ical_string, icaltimezone *zone,
   icalcomponent_add_property (ical_new,
                               icalproperty_new_prodid (GVM_PRODID));
 
-  icalcomponent_add_component (ical_new, icaltimezone_get_component (zone));
+  timezone_component
+    = icalcomponent_new_clone (icaltimezone_get_component (zone));
+  icalcomponent_add_component (ical_new, timezone_component);
 
   switch (icalcomponent_isa (ical_parsed))
     {


### PR DESCRIPTION
**What**:
The icalendar component for a given timezone is now duplicated in
icalendar_from_string because it the original one should not be freed.

**Why**:
Freeing the original component would cause double-free errors when
modifying multiple schedules in the same process, e.g. in a single
GMP connection.

**How did you test it**:
By creating several test schedules and modifying them using the script
added in greenbone/gvm-tools#445.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
