### PR TITLE
Migrate GMP Scanners to OSP Sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Improve VT version handling for CVE & OVAL results [#1496](https://github.com/greenbone/gvmd/pull/1496)
 - Update subject alternative name in certificate generation [#1503](https://github.com/greenbone/gvmd/pull/1503)
 - Fix whole-only config family selection [#1517](https://github.com/greenbone/gvmd/pull/1517)
+- Migrate GMP Scanners to OSP Sensors [#1533](https://github.com/greenbone/gvmd/pull/1533)
 
 [21.4.0]: https://github.com/greenbone/gvmd/compare/v21.4.0...gvmd-21.04
 

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -2342,9 +2342,9 @@ migrate_233_to_234 ()
        " DROP column slave_host,"
        " DROP column slave_port;");
 
-  /* Convert existing GMP Scanners to OSP Scanners. */
-  sql ("UPDATE scanners SET type = 2 WHERE type = 4;");
-  sql ("UPDATE scanners_trash SET type = 2 WHERE type = 4;");
+  /* Convert existing GMP Scanners to OSP Sensors. */
+  sql ("UPDATE scanners SET type = 5 WHERE type = 4;");
+  sql ("UPDATE scanners_trash SET type = 5 WHERE type = 4;");
 
   /* Set the database version to 234. */
 


### PR DESCRIPTION
**What**:
In migrate_233_to_234, GMP Scanners are now migrated to OSP Sensors
instead of OpenVAS Scanners.

**Why**:
The latter type should only be used for the default local scanner.

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
