### PR TITLE
Add NVT tag "deprecated"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [21.4.1] (unreleased)
 
+### Added
+- Add NVT tag "deprecated" [#1536](https://github.com/greenbone/gvmd/pull/1536)
+
 ### Fixed
 - Improve VT version handling for CVE & OVAL results [#1496](https://github.com/greenbone/gvmd/pull/1496)
 - Update subject alternative name in certificate generation [#1503](https://github.com/greenbone/gvmd/pull/1503)

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1244,7 +1244,7 @@ nvti_from_vt (entity_t vt)
   const char *id;
   entity_t name, summary, insight, affected, impact, detection, solution;
   entity_t creation_time, modification_time;
-  entity_t refs, ref, custom, family, category;
+  entity_t refs, ref, custom, family, category, deprecated;
   entity_t severities, severity;
 
   entities_t children;
@@ -1467,6 +1467,12 @@ nvti_from_vt (entity_t vt)
       return NULL;
     }
   nvti_set_category (nvti, atoi (entity_text (category)));
+
+  deprecated = entity_child (custom, "deprecated");
+  if (deprecated)
+    {
+      nvti_add_tag (nvti, "deprecated", entity_text (deprecated));
+    }
 
   return nvti;
 }


### PR DESCRIPTION
**What**:
The script tag "deprecated" is added to the custom tags stored in the
NVTs "tag" field.

**Why**:

<!-- Why are these changes necessary? -->

**How did you test it**:
By rebuilding the NVTs table (`gvmd --rebuild`) and checking the `nvts` table for the new tag:
`SELECT oid, tag FROM nvts WHERE tag ILIKE '%deprecated=%';`

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
