### PR TITLE
Include new ssh elevate credential login data in OSP request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Add a new modification_time column to reports [#1513](https://github.com/greenbone/gvmd/pull/1513), [#1519](https://github.com/greenbone/gvmd/pull/1519)
-- Extend GMP for new privilege escalation credential[#1535](https://github.com/greenbone/gvmd/pull/1535)
+- Extend GMP for new privilege escalation credential [#1535](https://github.com/greenbone/gvmd/pull/1535)
+- Include new ssh elevate (escalation) credential in OSP request [#1539](https://github.com/greenbone/gvmd/pull/1539)
 
 ### Changed
 - Use pg-gvm extension for C PostgreSQL functions [#1400](https://github.com/greenbone/gvmd/pull/1400), [#1453](https://github.com/greenbone/gvmd/pull/1453)

--- a/src/manage.c
+++ b/src/manage.c
@@ -2125,7 +2125,7 @@ target_osp_ssh_credential (target_t target)
           g_free (base64);
         }
 
-      if(ssh_elevate_credential && !strcmp (type, "up"))
+      if(ssh_elevate_credential)
         {
           const char *elevate_type;
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -2135,7 +2135,7 @@ target_osp_ssh_credential (target_t target)
             {
               g_warning ("%s: SSH Elevate Credential not found.", __func__);
               cleanup_iterator (&ssh_elevate_iter);
-              free(osp_credential);
+              osp_credential_free(osp_credential);
               return NULL;
             }
           elevate_type = credential_iterator_type (&ssh_elevate_iter);
@@ -2143,7 +2143,7 @@ target_osp_ssh_credential (target_t target)
             {
               g_warning ("%s: SSH Elevate Credential not of type up", __func__);
               cleanup_iterator (&ssh_elevate_iter);
-              free(osp_credential);
+              osp_credential_free(osp_credential);
               return NULL;
             }
           osp_credential_set_auth_data (osp_credential,

--- a/src/manage.c
+++ b/src/manage.c
@@ -2135,6 +2135,7 @@ target_osp_ssh_credential (target_t target)
             {
               g_warning ("%s: SSH Elevate Credential not found.", __func__);
               cleanup_iterator (&ssh_elevate_iter);
+              free(osp_credential);
               return NULL;
             }
           elevate_type = credential_iterator_type (&ssh_elevate_iter);
@@ -2142,6 +2143,7 @@ target_osp_ssh_credential (target_t target)
             {
               g_warning ("%s: SSH Elevate Credential not of type up", __func__);
               cleanup_iterator (&ssh_elevate_iter);
+              free(osp_credential);
               return NULL;
             }
           osp_credential_set_auth_data (osp_credential,

--- a/src/manage.c
+++ b/src/manage.c
@@ -2077,16 +2077,19 @@ launch_osp_task (task_t task, target_t target, const char *scan_id,
 static osp_credential_t *
 target_osp_ssh_credential (target_t target)
 {
-  credential_t credential;
+  credential_t credential, ssh_elevate_credential;
   credential = target_ssh_credential (target);
+  ssh_elevate_credential = target_ssh_elevate_credential (target);
+
   if (credential)
     {
-      iterator_t iter;
+      iterator_t iter, ssh_elevate_iter;
       const char *type;
       char *ssh_port;
       osp_credential_t *osp_credential;
 
       init_credential_iterator_one (&iter, credential);
+
       if (!next (&iter))
         {
           g_warning ("%s: SSH Credential not found.", __func__);
@@ -2111,6 +2114,7 @@ target_osp_ssh_credential (target_t target)
       osp_credential_set_auth_data (osp_credential,
                                     "password",
                                     credential_iterator_password (&iter));
+
       if (strcmp (type, "usk") == 0)
         {
           const char *private_key = credential_iterator_private_key (&iter);
@@ -2119,8 +2123,38 @@ target_osp_ssh_credential (target_t target)
           osp_credential_set_auth_data (osp_credential,
                                         "private", base64);
           g_free (base64);
-
         }
+
+      if(ssh_elevate_credential && !strcmp (type, "up"))
+        {
+          const char *elevate_type;
+
+          init_credential_iterator_one (&ssh_elevate_iter,
+                                        ssh_elevate_credential);
+          if (!next (&ssh_elevate_iter))
+            {
+              g_warning ("%s: SSH Elevate Credential not found.", __func__);
+              cleanup_iterator (&ssh_elevate_iter);
+              return NULL;
+            }
+          elevate_type = credential_iterator_type (&ssh_elevate_iter);
+          if (strcmp (elevate_type, "up"))
+            {
+              g_warning ("%s: SSH Elevate Credential not of type up", __func__);
+              cleanup_iterator (&ssh_elevate_iter);
+              return NULL;
+            }
+          osp_credential_set_auth_data (osp_credential,
+                                        "priv_username",
+                                        credential_iterator_login
+                                          (&ssh_elevate_iter));
+          osp_credential_set_auth_data (osp_credential,
+                                        "priv_password",
+                                        credential_iterator_password
+                                          (&ssh_elevate_iter));
+          cleanup_iterator (&ssh_elevate_iter);
+        }
+
       cleanup_iterator (&iter);
       return osp_credential;
     }


### PR DESCRIPTION
**What**:
Appended the ssh elevate login data to the login
data of the target osp ssh credential in function
target_osp_ssh_credential() in manage.c.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
A customer requested the new functionality.
<!-- Why are these changes necessary? -->

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
