### PR TITLE
Fixed the sorting / filter by username functionality for remediation tickets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update subject alternative name in certificate generation [#1503](https://github.com/greenbone/gvmd/pull/1503)
 - Fix whole-only config family selection [#1517](https://github.com/greenbone/gvmd/pull/1517)
 - Migrate GMP Scanners to OSP Sensors [#1533](https://github.com/greenbone/gvmd/pull/1533)
-- Resolved remediation ticket sorting issue [#1546](https://github.com/greenbone/gvmd/pull/1546)
 
 [21.4.0]: https://github.com/greenbone/gvmd/compare/v21.4.0...gvmd-21.04
 
@@ -99,6 +98,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Escape TLS certificate DNs that are invalid UTF-8 [#1486](https://github.com/greenbone/gvmd/pull/1486)
 - Free alert get data in report_content_for_alert [#1526](https://github.com/greenbone/gvmd/pull/1526) 
 - Fix erroneous freeing of ical timezone component [#1530](https://github.com/greenbone/gvmd/pull/1530)
+- Fixed the sorting / filter by username functionality for remediation tickets [#1546](https://github.com/greenbone/gvmd/pull/1546)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update subject alternative name in certificate generation [#1503](https://github.com/greenbone/gvmd/pull/1503)
 - Fix whole-only config family selection [#1517](https://github.com/greenbone/gvmd/pull/1517)
 - Migrate GMP Scanners to OSP Sensors [#1533](https://github.com/greenbone/gvmd/pull/1533)
+- Resolved remediation ticket sorting issue [#1546](https://github.com/greenbone/gvmd/pull/1546)
 
 [21.4.0]: https://github.com/greenbone/gvmd/compare/v21.4.0...gvmd-21.04
 

--- a/src/manage_sql_tickets.c
+++ b/src/manage_sql_tickets.c
@@ -78,7 +78,7 @@ ticket_status_integer (const char *status)
 #define TICKET_ITERATOR_FILTER_COLUMNS                                        \
  { GET_ITERATOR_FILTER_COLUMNS, "severity", "host", "location",               \
    "solution_type", "status", "opened", "fixed", "closed", "orphan",          \
-   "result_id", NULL }
+   "result_id", "username", NULL }
 
 /**
  * @brief Ticket iterator columns.
@@ -154,7 +154,7 @@ ticket_status_integer (const char *status)
    { "nvt", NULL, KEYWORD_TYPE_STRING },                                      \
    {                                                                          \
      "(SELECT name FROM users WHERE id = assigned_to)",                       \
-     NULL,                                                                    \
+     "username",                                                              \
      KEYWORD_TYPE_STRING                                                      \
    },                                                                         \
    {                                                                          \


### PR DESCRIPTION
**What**:
Resolved the issue, that one could not sort / filter the remediation tickets
by username

  In manage_sql_tickets.c: Added the alias "username" to the
    according row of the TICKET_ITERATOR_COLUMNS. Added the
    "username" to the TICKET_ITERATOR_FILTER_COLUMNS.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
This fixes a bug.
<!-- Why are these changes necessary? -->

**How did you test it**:
Tested the sorting in GSA.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
