### PR TITLE
Fix security issues: replace localtime with localtime_r

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -11043,7 +11043,7 @@ alert_subject_print (const gchar *subject, event_t event,
                 {
                   char time_string[100];
                   time_t date;
-                  struct tm *tm;
+                  struct tm tm;
 
                   if (event_data && (strcasecmp (event_data, "nvt") == 0))
                     date = nvts_check_time ();
@@ -11051,14 +11051,14 @@ alert_subject_print (const gchar *subject, event_t event,
                     date = scap_check_time ();
                   else
                     date = cert_check_time ();
-                  tm = localtime (&date);
-                  if (tm == NULL)
+
+                  if (localtime_r (&date, &tm) == NULL)
                     {
                       g_warning ("%s: localtime failed, aborting",
                                  __func__);
                       abort ();
                     }
-                  if (strftime (time_string, 98, "%F", tm) == 0)
+                  if (strftime (time_string, 98, "%F", &tm) == 0)
                     break;
                   g_string_append (new_subject, time_string);
                 }
@@ -11214,7 +11214,7 @@ alert_message_print (const gchar *message, event_t event,
                 {
                   char time_string[100];
                   time_t date;
-                  struct tm *tm;
+                  struct tm tm;
 
                   if (event_data && (strcasecmp (event_data, "nvt") == 0))
                     date = nvts_check_time ();
@@ -11222,14 +11222,14 @@ alert_message_print (const gchar *message, event_t event,
                     date = scap_check_time ();
                   else
                     date = cert_check_time ();
-                  tm = localtime (&date);
-                  if (tm == NULL)
+
+                  if (localtime_r (&date, &tm) == NULL)
                     {
                       g_warning ("%s: localtime failed, aborting",
                                  __func__);
                       abort ();
                     }
-                  if (strftime (time_string, 98, "%F", tm) == 0)
+                  if (strftime (time_string, 98, "%F", &tm) == 0)
                     break;
                   g_string_append (new_message, time_string);
                 }
@@ -11432,7 +11432,7 @@ scp_alert_path_print (const gchar *message, task_t task)
               {
                 char time_string[9];
                 time_t current_time;
-                struct tm *tm;
+                struct tm tm;
                 const gchar *format_str;
 
                 if (*point == 'T')
@@ -11442,14 +11442,14 @@ scp_alert_path_print (const gchar *message, task_t task)
 
                 memset(&time_string, 0, 9);
                 current_time = time (NULL);
-                tm = localtime (&current_time);
-                if (tm == NULL)
+                
+                if (localtime_r (&current_time, &tm) == NULL)
                   {
                     g_warning ("%s: localtime failed, aborting",
                                 __func__);
                     abort ();
                   }
-                if (strftime (time_string, 9, format_str, tm))
+                if (strftime (time_string, 9, format_str, &tm))
                   g_string_append (new_message, time_string);
                 break;
               }

--- a/src/manage_utils.c
+++ b/src/manage_utils.c
@@ -63,7 +63,7 @@ current_offset (const char *zone)
   gchar *tz;
   long offset;
   time_t now;
-  struct tm *now_broken;
+  struct tm now_broken;
 
   if (zone == NULL)
     return 0;
@@ -83,8 +83,7 @@ current_offset (const char *zone)
   tzset ();
 
   time (&now);
-  now_broken = localtime (&now);
-  if (now_broken == NULL)
+  if (localtime_r (&now, &now_broken) == NULL)
     {
       g_warning ("%s: localtime failed", __func__);
       if (tz != NULL)
@@ -101,7 +100,7 @@ current_offset (const char *zone)
       return 0;
     }
   tzset ();
-  offset = - (now - mktime (now_broken));
+  offset = - (now - mktime (&now_broken));
 
   /* Revert to stored TZ. */
   if (tz)
@@ -131,14 +130,15 @@ current_offset (const char *zone)
 time_t
 add_months (time_t time, int months)
 {
-  struct tm *broken = localtime (&time);
-  if (broken == NULL)
+  struct tm broken;
+  
+  if (localtime_r (&time, &broken) == NULL)
     {
       g_warning ("%s: localtime failed", __func__);
       return 0;
     }
-  broken->tm_mon += months;
-  return mktime (broken);
+  broken.tm_mon += months;
+  return mktime (&broken);
 }
 
 /**

--- a/src/utils.c
+++ b/src/utils.c
@@ -416,19 +416,18 @@ parse_iso_time_tz (const char *text_time, const char *fallback_tz)
 static char *
 iso_time_internal (time_t *epoch_time, const char **abbrev)
 {
-  struct tm *tm;
+  struct tm tm;
   static char time_string[100];
 
-  tm = localtime (epoch_time);
-  if (tm == NULL)
+  if (localtime_r (epoch_time, &tm) == NULL)
     return NULL;
 #ifdef __FreeBSD__
-  if (tm->tm_gmtoff == 0)
+  if (tm.tm_gmtoff == 0)
 #else
   if (timezone == 0)
 #endif
     {
-      if (strftime (time_string, 98, "%FT%TZ", tm) == 0)
+      if (strftime (time_string, 98, "%FT%TZ", &tm) == 0)
         return NULL;
 
       if (abbrev)
@@ -438,7 +437,7 @@ iso_time_internal (time_t *epoch_time, const char **abbrev)
     {
       int len;
 
-      if (strftime (time_string, 98, "%FT%T%z", tm) == 0)
+      if (strftime (time_string, 98, "%FT%T%z", &tm) == 0)
         return NULL;
 
       /* Insert the ISO 8601 colon by hand. */
@@ -451,7 +450,7 @@ iso_time_internal (time_t *epoch_time, const char **abbrev)
       if (abbrev)
         {
           static char abbrev_string[100];
-          if (strftime (abbrev_string, 98, "%Z", tm) == 0)
+          if (strftime (abbrev_string, 98, "%Z", &tm) == 0)
             return NULL;
           *abbrev = abbrev_string;
         }


### PR DESCRIPTION
**What**:

* CodeQL mentioned that using `localtime` is insecure and it should be replaced by `localtime_r`

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
