### PR TITLE
Fix stop resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Free alert get data in report_content_for_alert [#1526](https://github.com/greenbone/gvmd/pull/1526) 
 - Fix erroneous freeing of ical timezone component [#1530](https://github.com/greenbone/gvmd/pull/1530)
 - Fixed the sorting / filter by username functionality for remediation tickets [#1546](https://github.com/greenbone/gvmd/pull/1546)
+- Fix stop resume feature. [#1568](https://github.com/greenbone/gvmd/pull/1568)
 
 ### Removed
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -4202,7 +4202,7 @@ launch_osp_openvas_task (task_t task, target_t target, const char *scan_id,
 {
   osp_connection_t *connection;
   char *hosts_str, *ports_str, *exclude_hosts_str, *finished_hosts_str;
-  gchar *clean_hosts, *clean_exclude_hosts;
+  gchar *clean_hosts, *clean_exclude_hosts, *clean_finished_hosts_str;
   int alive_test, reverse_lookup_only, reverse_lookup_unify;
   osp_target_t *osp_target;
   GSList *osp_targets, *vts;
@@ -4233,9 +4233,13 @@ launch_osp_openvas_task (task_t task, target_t target, const char *scan_id,
       else if (ret == -1)
         return -1;
       finished_hosts_str = report_finished_hosts_str (global_current_report);
+      clean_finished_hosts_str = clean_hosts_string (finished_hosts_str);
     }
   else
-    finished_hosts_str = NULL;
+    {
+      finished_hosts_str = NULL;
+      clean_finished_hosts_str = NULL;
+    }
 
   /* Set up target(s) */
   hosts_str = target_hosts (target);
@@ -4260,7 +4264,7 @@ launch_osp_openvas_task (task_t task, target_t target, const char *scan_id,
 
       new_exclude_hosts = g_strdup_printf ("%s,%s",
                                            clean_exclude_hosts,
-                                           finished_hosts_str);
+                                           clean_finished_hosts_str);
       free (clean_exclude_hosts);
       clean_exclude_hosts = new_exclude_hosts;
     }
@@ -4277,6 +4281,7 @@ launch_osp_openvas_task (task_t task, target_t target, const char *scan_id,
   free (finished_hosts_str);
   g_free (clean_hosts);
   g_free (clean_exclude_hosts);
+  g_free (clean_finished_hosts_str);
   osp_targets = g_slist_append (NULL, osp_target);
 
   ssh_credential = target_osp_ssh_credential (target);

--- a/src/manage.c
+++ b/src/manage.c
@@ -4259,10 +4259,10 @@ launch_osp_openvas_task (task_t task, target_t target, const char *scan_id,
       gchar *new_exclude_hosts;
 
       new_exclude_hosts = g_strdup_printf ("%s,%s",
-                                           exclude_hosts_str,
+                                           clean_exclude_hosts,
                                            finished_hosts_str);
-      free (exclude_hosts_str);
-      exclude_hosts_str = new_exclude_hosts;
+      free (clean_exclude_hosts);
+      clean_exclude_hosts = new_exclude_hosts;
     }
 
   osp_target = osp_target_new (clean_hosts, ports_str, clean_exclude_hosts,


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Fix stop resume feature by sending the correct exclude list to ospd-openvas.

**Why**:

<!-- Why are these changes necessary? -->

Fix bug.

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

It can be reproduced with **any** scan which has multiple hosts and is stopped and resumed. The following only makes it a bit simpler to see in the openvas.log.

max_checks = 1
max_hosts = 1
scan config: only host_alive_detection.nasl (formally ping_host.nasl)
scan_alive_hosts_only = no
target: something like 192.168.56.10-110
exclude hosts: something like 192.168.56.10-20

Start task. Stop task after some percentage. Resume task. See in the openvas.log that all previously finished hosts are scanned again. The finished hosts are not taken into account at all. Its basically the same as starting the task again (not resuming).

For every hosts which is scanned again there are duplicate results in the report.

With the fix resume works as intended. 

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
