### PR TITLE
Added a test, if the ssh_elevate_credential is different from the ssh_credential.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add NVT tag "deprecated" [#1536](https://github.com/greenbone/gvmd/pull/1536)
 - Extend GMP for new privilege escalation credential [#1535](https://github.com/greenbone/gvmd/pull/1535)
 - Include new ssh elevate (escalation) credential in OSP request [#1539](https://github.com/greenbone/gvmd/pull/1539)
+- Add test if the ssh elevate credential is different from the ssh credential [#1582](https://github.com/greenbone/gvmd/pull/1582)
 
 ### Changed
 - Update default log config [#1501](https://github.com/greenbone/gvmd/pull/1501)

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -21778,6 +21778,13 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                                     " an SSH credential"));
                 log_event_fail ("target", "Target", NULL, "created");
                 break;
+              case 15:
+                SEND_TO_CLIENT_OR_FAIL
+                 (XML_ERROR_SYNTAX ("create_target",
+                                    "The elevate credential must be"
+                                    " different from the SSH credential"));
+                log_event_fail ("target", "Target", NULL, "created");
+                break;
               case 99:
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("create_target",
@@ -24486,6 +24493,14 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                  (XML_ERROR_SYNTAX ("modify_target",
                                     "The elevate credential requires"
                                     " an SSH credential"));
+                log_event_fail ("target", "Target",
+                                modify_target_data->target_id, "modified");
+                break;
+              case 25:
+                SEND_TO_CLIENT_OR_FAIL
+                 (XML_ERROR_SYNTAX ("modify_target",
+                                    "The elevate credential must be different"
+                                    " from the SSH credential"));
                 log_event_fail ("target", "Target",
                                 modify_target_data->target_id, "modified");
                 break;

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -30669,6 +30669,9 @@ create_target (const char* name, const char* asset_hosts_filter,
   if (ssh_elevate_credential && (!ssh_credential))
     return 14;
 
+  if (ssh_elevate_credential == ssh_credential)
+    return 15;
+
   sql_begin_immediate ();
 
   if (acl_user_may ("create_target") == 0)
@@ -31153,6 +31156,12 @@ modify_target (const char *target_id, const char *name, const char *hosts,
     {
       sql_rollback ();
       return 24;
+    }
+
+  if (ssh_elevate_credential_id == ssh_credential_id)
+    {
+      sql_rollback ();
+      return 25;
     }
 
   target = 0;


### PR DESCRIPTION

**What**:
In manage_sql.c:
  Added a test, if the ssh_elevate_credential is different from
  the ssh_credential in function "create_target(...)" and in
  function "modify_target(...)".

In gmp.c:
  Added the error messages for the case that the
  ssh_elevate_credential is equal to the ssh_credential
  in the function "gmp_xml_handle_end_element(...)" in
  the create_target section and in the modify_target
  section.


<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
This is a part of a requirement.
<!-- Why are these changes necessary? -->

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
