### PR TITLE
Fix memory errors in modify_permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Deprecated
 ### Removed
 ### Fixed
+- Fix memory errors in modify_permission [#1613](https://github.com/greenbone/gvmd/pull/1613)
 
 [Unreleased]: https://github.com/greenbone/gvmd/compare/v20.8.2...gvmd-20.08
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -43631,6 +43631,7 @@ modify_permission (const char *permission_id, const char *name_arg,
       free (new_resource_id);
       free (existing_subject_type);
       free (new_subject_id);
+      g_free (subject_where_old);
       sql_rollback ();
       return ret;
     }
@@ -43683,7 +43684,6 @@ modify_permission (const char *permission_id, const char *name_arg,
           || (resource_id == NULL));
 
   quoted_name = sql_quote (name);
-  g_free (name);
 
   sql ("UPDATE permissions SET"
        " name = '%s',"
@@ -43767,6 +43767,7 @@ modify_permission (const char *permission_id, const char *name_arg,
   free (new_resource_id);
   free (existing_subject_type);
   free (new_subject_id);
+  g_free (name);
   free (old_name);
   free (old_resource_type);
   g_free (subject_where);


### PR DESCRIPTION
**What**:
The string "subject_where_old" was not freed when returning if
check_permission_args failed.
The string "name" was still used after being freed.

**Why**:

<!-- Why are these changes necessary? -->

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
