### PR TITLE
Use less report cache SQL when adding results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [21.4.3] (Unreleased)
 ### Added
 ### Changed
+- Use less report cache SQL when adding results [#1618](https://github.com/greenbone/gvmd/pull/1618)
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/src/manage.c
+++ b/src/manage.c
@@ -3061,9 +3061,11 @@ cve_scan_host (task_t task, report_t report, gvm_host_t *gvm_host)
         {
           iterator_t prognosis;
           int prognosis_report_host, start_time;
+          GArray *results;
 
           /* Add report_host with prognosis results and host details. */
 
+          results = g_array_new (TRUE, TRUE, sizeof (result_t));
           start_time = time (NULL);
           prognosis_report_host = 0;
           init_host_prognosis_iterator (&prognosis, report_host);
@@ -3136,11 +3138,14 @@ cve_scan_host (task_t task, report_t report, gvm_host_t *gvm_host)
               result = make_cve_result (task, ip, cve, severity, desc);
               g_free (desc);
 
-              report_add_result (report, result);
+              g_array_append_val (results, result);
 
               g_string_free (locations, TRUE);
             }
           cleanup_iterator (&prognosis);
+
+          report_add_results_array (report, results);
+          g_array_free (results, TRUE);
 
           if (prognosis_report_host)
             {

--- a/src/manage.h
+++ b/src/manage.h
@@ -1256,6 +1256,9 @@ create_report (array_t*, const char *, const char *, const char *, const char *,
 void
 report_add_result (report_t, result_t);
 
+void
+report_add_results_array (report_t, GArray *);
+
 char*
 report_uuid (report_t);
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -21006,6 +21006,9 @@ report_add_result (report_t report, result_t result)
 
 /**
  * @brief Add results from an array to a report.
+ * 
+ * @param[in]  report   The report to add the results to.
+ * @param[in]  results  GArray containing the row ids of the results to add.
  */
 void
 report_add_results_array (report_t report, GArray *results)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -21005,6 +21005,57 @@ report_add_result (report_t report, result_t result)
 }
 
 /**
+ * @brief Add results from an array to a report.
+ */
+void
+report_add_results_array (report_t report, GArray *results)
+{
+  GString *array_sql;
+  int index;
+
+  if (report == 0 || results == NULL || results->len == 0)
+    return;
+
+  array_sql = g_string_new ("(");
+  for (index = 0; index < results->len; index++)
+    {
+      result_t result;
+      result = g_array_index (results, result_t, index);
+      
+      if (index)
+        g_string_append (array_sql, ", ");
+      g_string_append_printf (array_sql, "%llu", result);
+    }
+  g_string_append_c (array_sql, ')');
+
+  sql ("UPDATE results SET report = %llu,"
+       "                   owner = (SELECT reports.owner"
+       "                            FROM reports WHERE id = %llu)"
+       " WHERE id IN %s;",
+       report, report, array_sql->str);
+
+  for (index = 0; index < results->len; index++)
+    {
+      result_t result;
+      result = g_array_index (results, result_t, index);
+      
+      // TODO: Use array to insert multiple results at once
+      report_add_result_for_buffer (report, result);
+    }
+
+  sql ("UPDATE report_counts"
+       " SET end_time = (SELECT coalesce(min(overrides.end_time), 0)"
+       "                 FROM overrides, results"
+       "                 WHERE overrides.nvt = results.nvt"
+       "                 AND results.report = %llu"
+       "                 AND overrides.end_time >= m_now ())"
+       " WHERE report = %llu AND override = 1;",
+       report, report);
+
+  g_string_free (array_sql, TRUE);
+}
+
+/**
  * @brief Filter columns for report iterator.
  */
 #define REPORT_ITERATOR_FILTER_COLUMNS                                         \
@@ -28742,6 +28793,7 @@ parse_osp_report (task_t task, report_t report, const char *report_xml)
   char *defs_file = NULL;
   time_t start_time, end_time;
   gboolean has_results = FALSE;
+  GArray *results_array;
 
   assert (task);
   assert (report);
@@ -28755,6 +28807,7 @@ parse_osp_report (task_t task, report_t report, const char *report_xml)
 
   sql_begin_immediate ();
   /* Set the report's start and end times. */
+  results_array = g_array_new (TRUE, TRUE, sizeof (result_t));
   start_time = 0;
   str = entity_attribute (entity, "start_time");
   if (str)
@@ -28876,7 +28929,7 @@ parse_osp_report (task_t task, report_t report, const char *report_xml)
                                     severity_str ?: severity,
                                     qod_int,
                                     path);
-          report_add_result (report, result);
+          g_array_append_val (results_array, result);
         }
       g_free (nvt_id);
       g_free (desc);
@@ -28885,11 +28938,16 @@ parse_osp_report (task_t task, report_t report, const char *report_xml)
     }
 
   if (has_results)
-    sql ("UPDATE reports SET modification_time = m_now() WHERE id = %llu;", 
-	 report);
+    {
+      sql ("UPDATE reports SET modification_time = m_now() WHERE id = %llu;", 
+           report);
+      report_add_results_array (report, results_array);
+    }
+  
 
  end_parse_osp_report:
   sql_commit ();
+  g_array_free (results_array, TRUE);
   g_free (defs_file);
   free_entity (entity);
 }

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -21042,7 +21042,6 @@ report_add_results_array (report_t report, GArray *results)
       result_t result;
       result = g_array_index (results, result_t, index);
       
-      // TODO: Use array to insert multiple results at once
       report_add_result_for_buffer (report, result);
     }
 


### PR DESCRIPTION
**What**:
When multiple results are added when handling an OSP get_scan response
or a host in a CVE scan, only one SQL statement each is run to update
the report and owner of the results and to update the end times of the
report_counts cache of the report.

**Why**:
This addresses AP-1495: Updating the report_counts for each result
can cause performance issues if the scanner returns a large amount of
results.

**How did you test it**:
By running a normal scan and a CVE one.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
