### PR TITLE
Removed the Business Process Map from gvmd.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove Network Source Interface from gvmd [#1511](https://github.com/greenbone/gvmd/pull/1511)
 - Removed OVAL definitions from gvmd [#1525](https://github.com/greenbone/gvmd/pull/1525)
 - Removed OVAL definitions from GMP and gvmd documentation [1551](https://github.com/greenbone/gvmd/pull/1551)
+- Removed the Business Process Map from gvmd [1627](https://github.com/greenbone/gvmd/pull/1627)
 
 [Unreleased]: https://github.com/greenbone/gvmd/compare/gvmd-21.04...master
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 245)
+set (GVMD_DATABASE_VERSION 246)
 
 set (GVMD_SCAP_DATABASE_VERSION 19)
 

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -2745,6 +2745,44 @@ migrate_244_to_245 ()
   return 0;
 }
 
+/**
+ * @brief Migrate the database from version 245 to version 246.
+ *
+ * @return 0 success, -1 error.
+ */
+int
+migrate_245_to_246 ()
+{
+  sql_begin_immediate ();
+
+  /* Ensure that the database is currently version 245. */
+
+  if (manage_db_version () != 245)
+    {
+      sql_rollback ();
+      return -1;
+    }
+
+  /* Update the database. */
+
+  /* The support of Business Process Maps has been discontinued. Therefore
+   * any entry in the settings table where "Business Process Map" data are
+   * stored can be deleted
+   */
+
+  /* Delete any setting for "Business Process Maps" . */
+  sql ("DELETE FROM settings WHERE uuid = '3232d608-e5bb-415e-99aa-019f16eede8d';");
+  sql ("DELETE FROM settings WHERE uuid = '3ce2d136-bb52-448a-93f0-20069566f877';");
+
+  /* Set the database version to 246. */
+
+  set_db_version (246);
+
+  sql_commit ();
+
+  return 0;
+}
+
 
 #undef UPDATE_DASHBOARD_SETTINGS
 
@@ -2797,6 +2835,7 @@ static migrator_t database_migrators[] = {
   {243, migrate_242_to_243},
   {244, migrate_243_to_244},
   {245, migrate_244_to_245},
+  {246, migrate_245_to_246},
   /* End marker. */
   {-1, NULL}};
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -49901,16 +49901,6 @@ modify_setting (const gchar *uuid, const gchar *name,
       /* Tickets */
       else if (strcmp (uuid, "70b0626f-a835-478e-8194-e09f97887a15") == 0)
         setting_name = g_strdup ("Tickets Top Dashboard Configuration");
-
-      /* Business Process Model (BPM) */
-      else if (strcmp (uuid, "3232d608-e5bb-415e-99aa-019f16eede8d") == 0)
-        setting_name = g_strdup ("BPM Dashboard Configuration");
-
-      /*
-       * Client data for Business Process Modeling (BPM)
-       */
-      else if (strcmp (uuid, "3ce2d136-bb52-448a-93f0-20069566f877") == 0)
-        setting_name = g_strdup ("BPM Data");
     }
 
   if (setting_name)


### PR DESCRIPTION
Removed the Business Process Map from gvmd.

**What**:
In manage_sql.c in function "modify_settings ()":
  Removed the definition of the setting-IDs and setting names
  for the Business Process Model from the function and thereby
  also their saving.

In manage_migrators.c:
  Added the new function "migrate_245_to_246 ()" to delete the
  Business Process Model settings from the settings table.

In CMakeLists.txt:
  Set up the database version from 245 to 246.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The Business Process Map is not supported any more.
<!-- Why are these changes necessary? -->

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
