### PR TITLE
Added retry of sensor connection for performance reports on failure.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fix VTs hash check and add --dump-vt-verification [#1611](https://github.com/greenbone/gvmd/pull/1611) [#1629](https://github.com/greenbone/gvmd/pull/1629)
 - Fix memory errors in modify_permission [#1613](https://github.com/greenbone/gvmd/pull/1613)
+- Fix sensor connection for performance reports on failure [#1633](https://github.com/greenbone/gvmd/pull/1633)
 
 [Unreleased]: https://github.com/greenbone/gvmd/compare/v20.8.2...gvmd-20.08
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -4009,7 +4009,7 @@ get_osp_performance_string (scanner_t scanner, int start, int end,
   osp_connection_t *connection = NULL;
   osp_get_performance_opts_t opts;
   gchar *error;
-  int connection_retry;
+  int connection_retry, return_value;
 
   host = scanner_host (scanner);
   port = scanner_port (scanner);
@@ -4040,7 +4040,7 @@ get_osp_performance_string (scanner_t scanner, int start, int end,
   error = NULL;
 
   connection_retry = SCANNER_CONNECTION_RETRY_DEFAULT;
-  int return_value = 1;
+  return_value = 1;
   while (return_value > 0 && connection_retry > 0)
     {
       return_value = osp_get_performance_ext (connection, opts,

--- a/src/manage.c
+++ b/src/manage.c
@@ -4017,8 +4017,8 @@ get_osp_performance_string (scanner_t scanner, int start, int end,
   key_pub = scanner_key_pub (scanner);
   key_priv = scanner_key_priv (scanner);
 
-  connection_retry = get_scanner_connection_retry();
-  while(connection == NULL && connection_retry > 0)
+  connection_retry = get_scanner_connection_retry ();
+  while (connection == NULL && connection_retry > 0)
     {
       connection = osp_connect_with_data (host, port,
                                           ca_pub, key_pub, key_priv);
@@ -4039,7 +4039,7 @@ get_osp_performance_string (scanner_t scanner, int start, int end,
   opts.titles = g_strdup (titles);
   error = NULL;
 
-  connection_retry = get_scanner_connection_retry();
+  connection_retry = get_scanner_connection_retry ();
   return_value = 1;
   while (return_value > 0 && connection_retry > 0)
     {

--- a/src/manage.c
+++ b/src/manage.c
@@ -4017,7 +4017,7 @@ get_osp_performance_string (scanner_t scanner, int start, int end,
   key_pub = scanner_key_pub (scanner);
   key_priv = scanner_key_priv (scanner);
 
-  connection_retry = SCANNER_CONNECTION_RETRY_DEFAULT;
+  connection_retry = get_scanner_connection_retry();
   while(connection == NULL && connection_retry > 0)
     {
       connection = osp_connect_with_data (host, port,
@@ -4039,7 +4039,7 @@ get_osp_performance_string (scanner_t scanner, int start, int end,
   opts.titles = g_strdup (titles);
   error = NULL;
 
-  connection_retry = SCANNER_CONNECTION_RETRY_DEFAULT;
+  connection_retry = get_scanner_connection_retry();
   return_value = 1;
   while (return_value > 0 && connection_retry > 0)
     {

--- a/src/manage.c
+++ b/src/manage.c
@@ -4018,12 +4018,13 @@ get_osp_performance_string (scanner_t scanner, int start, int end,
   key_priv = scanner_key_priv (scanner);
 
   connection_retry = get_scanner_connection_retry ();
+  connection = osp_connect_with_data (host, port, ca_pub, key_pub, key_priv);
   while (connection == NULL && connection_retry > 0)
     {
+      sleep(1);
       connection = osp_connect_with_data (host, port,
                                           ca_pub, key_pub, key_priv);
       connection_retry--;
-      sleep(1);
     }
 
   free (host);
@@ -4040,13 +4041,14 @@ get_osp_performance_string (scanner_t scanner, int start, int end,
   error = NULL;
 
   connection_retry = get_scanner_connection_retry ();
-  return_value = 1;
-  while (return_value > 0 && connection_retry > 0)
+  return_value = osp_get_performance_ext (connection, opts,
+                                          performance_str, &error);
+  while (return_value != 0 && connection_retry > 0)
     {
+      sleep(1);
       return_value = osp_get_performance_ext (connection, opts,
                                               performance_str, &error);
       connection_retry--;
-      sleep(1);
     }
 
   if (return_value)

--- a/src/manage.c
+++ b/src/manage.c
@@ -4006,9 +4006,10 @@ get_osp_performance_string (scanner_t scanner, int start, int end,
 {
   char *host, *ca_pub, *key_pub, *key_priv;
   int port;
-  osp_connection_t *connection;
+  osp_connection_t *connection = NULL;
   osp_get_performance_opts_t opts;
   gchar *error;
+  int connection_retry;
 
   host = scanner_host (scanner);
   port = scanner_port (scanner);
@@ -4016,7 +4017,14 @@ get_osp_performance_string (scanner_t scanner, int start, int end,
   key_pub = scanner_key_pub (scanner);
   key_priv = scanner_key_priv (scanner);
 
-  connection = osp_connect_with_data (host, port, ca_pub, key_pub, key_priv);
+  connection_retry = SCANNER_CONNECTION_RETRY_DEFAULT;
+  while(connection == NULL && connection_retry > 0)
+    {
+      connection = osp_connect_with_data (host, port,
+                                          ca_pub, key_pub, key_priv);
+      connection_retry--;
+      sleep(1);
+    }
 
   free (host);
   free (ca_pub);
@@ -4031,7 +4039,17 @@ get_osp_performance_string (scanner_t scanner, int start, int end,
   opts.titles = g_strdup (titles);
   error = NULL;
 
-  if (osp_get_performance_ext (connection, opts, performance_str, &error))
+  connection_retry = SCANNER_CONNECTION_RETRY_DEFAULT;
+  int return_value = 1;
+  while (return_value > 0 && connection_retry > 0)
+    {
+      return_value = osp_get_performance_ext (connection, opts,
+                                              performance_str, &error);
+      connection_retry--;
+      sleep(1);
+    }
+
+  if (return_value)
     {
       osp_connection_close (connection);
       g_warning ("Error getting OSP performance report: %s", error);


### PR DESCRIPTION
Added retry of sensor connection for performance reports on failure.

**What**
In manage.c in function get_osp_performance_string (..):
  The installation of the connection to the sensor via
  osp_connect_with_data (..) and the access to the
  performance data via osp_get_performance_ext (..) are
  now retried several times on failure.


<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
This fixes a bug.
<!-- Why are these changes necessary? -->

**How did you test it**:
Ran the report that uses the connection several times.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
