### PR TITLE
Add trash columns for target "elevate" credential 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 ### Fixed
 - Fix sending prefs for whole, growing VT families [#1603](https://github.com/greenbone/gvmd/pull/1603)
+- Add trash columns for target "elevate" credential [#1636](https://github.com/greenbone/gvmd/pull/1636)
 
 [Unreleased]: https://github.com/greenbone/gvmd/compare/v21.4.2...gvmd-21.04
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -31829,6 +31829,12 @@ modify_target (const char *target_id, const char *name, const char *hosts,
    { "trash_target_credential_location (id, CAST ('snmp' AS text))",\
      NULL,                                                          \
      KEYWORD_TYPE_INTEGER },                                        \
+   { "target_credential (id, 1, CAST ('elevate' AS text))",             \
+     NULL,                                                              \
+     KEYWORD_TYPE_INTEGER },                                            \
+   { "trash_target_credential_location (id, CAST ('elevate' AS text))", \
+     NULL,                                                              \
+     KEYWORD_TYPE_INTEGER },                                            \
    { "allow_simultaneous_ips",                                      \
      NULL,                                                          \
      KEYWORD_TYPE_INTEGER },                                        \

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -31768,77 +31768,77 @@ modify_target (const char *target_id, const char *name, const char *hosts,
 /**
  * @brief Target iterator columns for trash case.
  */
-#define TARGET_ITERATOR_TRASH_COLUMNS                               \
- {                                                                  \
-   GET_ITERATOR_COLUMNS (targets_trash),                            \
-   { "hosts", NULL, KEYWORD_TYPE_STRING },                          \
-   { "target_credential (id, 1, CAST ('ssh' AS text))",             \
-     NULL,                                                          \
-     KEYWORD_TYPE_INTEGER },                                        \
-   { "target_login_port (id, 1, CAST ('ssh' AS text))",             \
-     "ssh_port",                                                    \
-     KEYWORD_TYPE_INTEGER },                                        \
-   { "target_credential (id, 1, CAST ('smb' AS text))",             \
-     NULL,                                                          \
-     KEYWORD_TYPE_INTEGER },                                        \
-   { "port_list", NULL, KEYWORD_TYPE_INTEGER },                     \
-   { "trash_target_credential_location (id, CAST ('ssh' AS text))", \
-     NULL,                                                          \
-     KEYWORD_TYPE_INTEGER },                                        \
-   { "trash_target_credential_location (id, CAST ('smb' AS text))", \
-     NULL,                                                          \
-     KEYWORD_TYPE_INTEGER },                                        \
-   {                                                                \
-     "(CASE"                                                        \
-     " WHEN port_list_location = " G_STRINGIFY (LOCATION_TRASH)     \
-     " THEN (SELECT uuid FROM port_lists_trash"                     \
-     "       WHERE port_lists_trash.id = port_list)"                \
-     " ELSE (SELECT uuid FROM port_lists"                           \
-     "       WHERE port_lists.id = port_list)"                      \
-     " END)",                                                       \
-     NULL,                                                          \
-     KEYWORD_TYPE_STRING                                            \
-   },                                                               \
-   {                                                                \
-     "(CASE"                                                        \
-     " WHEN port_list_location = " G_STRINGIFY (LOCATION_TRASH)     \
-     " THEN (SELECT name FROM port_lists_trash"                     \
-     "       WHERE port_lists_trash.id = port_list)"                \
-     " ELSE (SELECT name FROM port_lists"                           \
-     "       WHERE port_lists.id = port_list)"                      \
-     " END)",                                                       \
-     NULL,                                                          \
-     KEYWORD_TYPE_STRING                                            \
-   },                                                               \
-   { "port_list_location = " G_STRINGIFY (LOCATION_TRASH),          \
-     NULL,                                                          \
-     KEYWORD_TYPE_STRING },                                         \
-   { "exclude_hosts", NULL, KEYWORD_TYPE_STRING },                  \
-   { "reverse_lookup_only", NULL, KEYWORD_TYPE_INTEGER },           \
-   { "reverse_lookup_unify", NULL, KEYWORD_TYPE_INTEGER },          \
-   { "alive_test", NULL, KEYWORD_TYPE_INTEGER },                    \
-   { "target_credential (id, 1, CAST ('esxi' AS text))",            \
-     NULL,                                                          \
-     KEYWORD_TYPE_INTEGER },                                        \
-   { "trash_target_credential_location (id, CAST ('esxi' AS text))",\
-     NULL,                                                          \
-     KEYWORD_TYPE_INTEGER },                                        \
-   { "target_credential (id, 1, CAST ('snmp' AS text))",            \
-     NULL,                                                          \
-     KEYWORD_TYPE_INTEGER },                                        \
-   { "trash_target_credential_location (id, CAST ('snmp' AS text))",\
-     NULL,                                                          \
-     KEYWORD_TYPE_INTEGER },                                        \
+#define TARGET_ITERATOR_TRASH_COLUMNS                                   \
+ {                                                                      \
+   GET_ITERATOR_COLUMNS (targets_trash),                                \
+   { "hosts", NULL, KEYWORD_TYPE_STRING },                              \
+   { "target_credential (id, 1, CAST ('ssh' AS text))",                 \
+     NULL,                                                              \
+     KEYWORD_TYPE_INTEGER },                                            \
+   { "target_login_port (id, 1, CAST ('ssh' AS text))",                 \
+     "ssh_port",                                                        \
+     KEYWORD_TYPE_INTEGER },                                            \
+   { "target_credential (id, 1, CAST ('smb' AS text))",                 \
+     NULL,                                                              \
+     KEYWORD_TYPE_INTEGER },                                            \
+   { "port_list", NULL, KEYWORD_TYPE_INTEGER },                         \
+   { "trash_target_credential_location (id, CAST ('ssh' AS text))",     \
+     NULL,                                                              \
+     KEYWORD_TYPE_INTEGER },                                            \
+   { "trash_target_credential_location (id, CAST ('smb' AS text))",     \
+     NULL,                                                              \
+     KEYWORD_TYPE_INTEGER },                                            \
+   {                                                                    \
+     "(CASE"                                                            \
+     " WHEN port_list_location = " G_STRINGIFY (LOCATION_TRASH)         \
+     " THEN (SELECT uuid FROM port_lists_trash"                         \
+     "       WHERE port_lists_trash.id = port_list)"                    \
+     " ELSE (SELECT uuid FROM port_lists"                               \
+     "       WHERE port_lists.id = port_list)"                          \
+     " END)",                                                           \
+     NULL,                                                              \
+     KEYWORD_TYPE_STRING                                                \
+   },                                                                   \
+   {                                                                    \
+     "(CASE"                                                            \
+     " WHEN port_list_location = " G_STRINGIFY (LOCATION_TRASH)         \
+     " THEN (SELECT name FROM port_lists_trash"                         \
+     "       WHERE port_lists_trash.id = port_list)"                    \
+     " ELSE (SELECT name FROM port_lists"                               \
+     "       WHERE port_lists.id = port_list)"                          \
+     " END)",                                                           \
+     NULL,                                                              \
+     KEYWORD_TYPE_STRING                                                \
+   },                                                                   \
+   { "port_list_location = " G_STRINGIFY (LOCATION_TRASH),              \
+     NULL,                                                              \
+     KEYWORD_TYPE_STRING },                                             \
+   { "exclude_hosts", NULL, KEYWORD_TYPE_STRING },                      \
+   { "reverse_lookup_only", NULL, KEYWORD_TYPE_INTEGER },               \
+   { "reverse_lookup_unify", NULL, KEYWORD_TYPE_INTEGER },              \
+   { "alive_test", NULL, KEYWORD_TYPE_INTEGER },                        \
+   { "target_credential (id, 1, CAST ('esxi' AS text))",                \
+     NULL,                                                              \
+     KEYWORD_TYPE_INTEGER },                                            \
+   { "trash_target_credential_location (id, CAST ('esxi' AS text))",    \
+     NULL,                                                              \
+     KEYWORD_TYPE_INTEGER },                                            \
+   { "target_credential (id, 1, CAST ('snmp' AS text))",                \
+     NULL,                                                              \
+     KEYWORD_TYPE_INTEGER },                                            \
+   { "trash_target_credential_location (id, CAST ('snmp' AS text))",    \
+     NULL,                                                              \
+     KEYWORD_TYPE_INTEGER },                                            \
    { "target_credential (id, 1, CAST ('elevate' AS text))",             \
      NULL,                                                              \
      KEYWORD_TYPE_INTEGER },                                            \
    { "trash_target_credential_location (id, CAST ('elevate' AS text))", \
      NULL,                                                              \
      KEYWORD_TYPE_INTEGER },                                            \
-   { "allow_simultaneous_ips",                                      \
-     NULL,                                                          \
-     KEYWORD_TYPE_INTEGER },                                        \
-   { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                             \
+   { "allow_simultaneous_ips",                                          \
+     NULL,                                                              \
+     KEYWORD_TYPE_INTEGER },                                            \
+   { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                                 \
  }
 
 /**


### PR DESCRIPTION
**What**:
This adds the columns for the SSH elevate credential and its location
to TARGET_ITERATOR_TRASH_COLUMNS

**Why**:
The columns for the SSH elevate credential were missing for targets in
the trashcan, so getting targets in the trashcan did not work correctly.
Without the fix the shown credentials may be wrong or getting the targets
in the trash may not work at all.
(Fixes AP-1554)

**How did you test it**:
By creating targets with different SSH elevate credentials, then moving
 them and some of the credentials to the trashcan.
When checking the the trashcan page, they should appear with the correct
credentials in particular.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
