### PR TITLE
Report row locking

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -1518,6 +1518,11 @@ manage_send_report (report_t, report_t, report_format_t, const get_data_t *,
                     int (*) (const char *, void*), void *, const char *,
                     const gchar *);
 
+void
+begin_report_transaction (report_t);
+
+void
+commit_report_transaction ();
 
 
 /* Reports. */

--- a/src/manage.h
+++ b/src/manage.h
@@ -1518,7 +1518,7 @@ manage_send_report (report_t, report_t, report_format_t, const get_data_t *,
                     int (*) (const char *, void*), void *, const char *,
                     const gchar *);
 
-void
+int
 begin_report_transaction (report_t);
 
 void

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -28962,15 +28962,19 @@ parse_osp_report (task_t task, report_t report, const char *report_xml)
 }
 
 /**
- * @brief Starts a transaction and acquires the row lock for a report
+ * @brief Starts a transaction and acquires the row lock for a report,
+ *        also testing if the report still exists.
  *
  * @param[in]  report  The report to acquire the row lock for.
+ *
+ * @return 0 if lock was acquired and report exists, 1 if report does not exist
  */
-void
+int
 begin_report_transaction (report_t report)
 {
   sql_begin_immediate ();
-  sql ("SELECT * FROM reports WHERE id = %llu FOR UPDATE", report);
+  return sql_int64_0 ("SELECT id FROM reports WHERE id = %llu FOR UPDATE",
+                      report) ? 0 : 1;
 }
 
 /**

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -28961,6 +28961,29 @@ parse_osp_report (task_t task, report_t report, const char *report_xml)
   free_entity (entity);
 }
 
+/**
+ * @brief Starts a transaction and acquires the row lock for a report
+ *
+ * @param[in]  report  The report to acquire the row lock for.
+ */
+void
+begin_report_transaction (report_t report)
+{
+  sql_begin_immediate ();
+  sql ("SELECT * FROM reports WHERE id = %llu FOR UPDATE", report);
+}
+
+/**
+ * @brief Commits a transaction, releasing the locks for the reports.
+ */
+void
+commit_report_transaction (report_t report)
+{
+  (void) report;
+  sql_commit ();
+}
+
+
 
 /* More task stuff. */
 


### PR DESCRIPTION
**What**:
Instead of locking the whole table when deleting reports, only the
affected rows in the reports table are locked using
`SELECT ... FOR UPDATE` statements.

**Why**:
The goal if this change is to reduce the amount of deadlocks waiting
 for the reports table (AP-1506).

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
