### PR TITLE
Fix collation for VT verification for non-UTF8 DBs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,7 +124,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 ### Fixed
 - Solved a performance problem when filtering results by tags [#1579](https://github.com/greenbone/gvmd/pull/1579)
-- Fix VTs hash check and add --dump-vt-verification [#1611](https://github.com/greenbone/gvmd/pull/1611) [#1629](https://github.com/greenbone/gvmd/pull/1629)
+- Fix VTs hash check and add --dump-vt-verification [#1611](https://github.com/greenbone/gvmd/pull/1611) [#1629](https://github.com/greenbone/gvmd/pull/1629) [#1643](https://github.com/greenbone/gvmd/pull/1643)
 - Fix memory errors in modify_permission [#1613](https://github.com/greenbone/gvmd/pull/1613)
 - Fix sensor connection for performance reports on failure [#1633](https://github.com/greenbone/gvmd/pull/1633)
 - Sort the "host" column by IPv4 address if possible [#1637](https://github.com/greenbone/gvmd/pull/1637)

--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -202,6 +202,9 @@ Verify scanner SCANNER-UUID and exit.
 .TP
 \fB--version\f1
 Print version and exit.
+.TP
+\fB--vt-verification-collation=\fICOLLATION\fB\f1
+Set collation for VT verification to COLLATION, leave empty to choose automatically. Should be 'ucs_default' if DB uses UTF-8 or 'C' for single-byte encodings. 
 .SH SIGNALS
 SIGHUP causes gvmd to rebuild the database with information from the Scanner (openvas).
 .SH EXAMPLES

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -448,6 +448,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <p>Print version and exit.</p>
       </optdesc>
     </option>
+    <option>
+      <p><opt>--vt-verification-collation=<arg>COLLATION</arg></opt></p>
+      <optdesc>
+        <p>
+          Set collation for VT verification to COLLATION, leave empty
+          to choose automatically. Should be 'ucs_default' if DB uses UTF-8
+          or 'C' for single-byte encodings.
+        </p>
+      </optdesc>
+    </option>
   </options>
 
   <section name="SIGNALS">

--- a/doc/gvmd.html
+++ b/doc/gvmd.html
@@ -410,7 +410,14 @@
         <p>Print version and exit.</p>
       
     
-  
+    
+      <p><b>--vt-verification-collation=<em>COLLATION</em></b></p>
+      
+        <p>          
+          Set collation for VT verification to COLLATION, leave empty
+          to choose automatically. Should be 'ucs_default' if DB uses UTF-8
+          or 'C' for single-byte encodings.
+        </p>
 
   <h2>SIGNALS</h2>
 

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1842,6 +1842,7 @@ gvmd (int argc, char** argv)
   static gchar *value = NULL;
   static gchar *feed_lock_path = NULL;
   static int feed_lock_timeout = 0;
+  static gchar *vt_verification_collation = NULL;
 
   int sentry_initialized;
   GError *error = NULL;
@@ -2146,6 +2147,12 @@ gvmd (int argc, char** argv)
           &print_version,
           "Print version and exit.",
           NULL },
+        { "vt-verification-collation", '\0', 0, G_OPTION_ARG_STRING,
+          &vt_verification_collation,
+          "Set collation for VT verification to <collation>, leave empty"
+          " to choose automatically. Should be 'ucs_default' if DB uses UTF-8"
+          " or 'C' for single-byte encodings.",
+          "<collation>" },
         { NULL }
       };
 
@@ -2218,6 +2225,9 @@ gvmd (int argc, char** argv)
   /* Set SecInfo update commit size */
 
   set_secinfo_commit_size (secinfo_commit_size);
+
+  /* Set VT verification collation override */
+  set_vt_verification_collation (vt_verification_collation);
 
   /* Check which type of socket to use. */
 

--- a/src/manage.h
+++ b/src/manage.h
@@ -3715,4 +3715,12 @@ manage_optimize (GSList *, const db_conn_info_t *, const gchar *);
 int
 sql_cancel ();
 
+
+/* General settings */
+const char *
+get_vt_verification_collation ();
+
+void
+set_vt_verification_collation (const char *);
+
 #endif /* not _GVMD_MANAGE_H */

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -879,7 +879,7 @@ manage_create_sql_functions ()
           free (encoding);
         }
 
-      g_message ("Using vt verification collation %s", quoted_collation);
+      g_debug ("Using vt verification collation %s", quoted_collation);
 
       sql ("CREATE OR REPLACE FUNCTION vts_verification_str ()"
            " RETURNS text AS $$"

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -855,6 +855,32 @@ manage_create_sql_functions ()
                sql_database (),
                sql_database ()))
     {
+      char *quoted_collation;
+      if (get_vt_verification_collation ())
+        {
+          gchar *string_quoted_collation;
+          string_quoted_collation
+            = sql_quote (get_vt_verification_collation ());
+          quoted_collation = sql_string ("SELECT quote_ident('%s')",
+                                         string_quoted_collation);
+          g_free (string_quoted_collation);
+        }
+      else
+        {
+          char *encoding;
+          encoding = sql_string ("SHOW server_encoding;");
+
+          if (g_str_match_string ("UTF-8", encoding, 0)
+              || g_str_match_string ("UTF8", encoding, 0))
+            quoted_collation = strdup ("ucs_basic");
+          else
+            quoted_collation = strdup ("C");
+
+          free (encoding);
+        }
+
+      g_message ("Using vt verification collation %s", quoted_collation);
+
       sql ("CREATE OR REPLACE FUNCTION vts_verification_str ()"
            " RETURNS text AS $$"
            " WITH pref_str AS ("
@@ -873,18 +899,22 @@ manage_create_sql_functions ()
            "             || coalesce (string_agg"
            "                            (pref_str.pref, ''"
            "                             ORDER BY (pref_id"
-           "                                       COLLATE ucs_basic)),"
+           "                                       COLLATE %s)),"
            "                          ''))"
            "          AS vt_string"
            "   FROM nvts"
            "   LEFT JOIN pref_str ON nvts.oid = pref_str.oid"
            "   GROUP BY nvts.oid"
-           "   ORDER BY (nvts.oid COLLATE ucs_basic) ASC"
+           "   ORDER BY (nvts.oid COLLATE %s) ASC"
            "  )"
            " SELECT coalesce (string_agg (nvt_str.vt_string, ''), '')"
            "   FROM nvt_str"
            "$$ LANGUAGE SQL"
-           " STABLE;");
+           " STABLE;",
+           quoted_collation,
+           quoted_collation);
+
+      g_free (quoted_collation);
     }
 
   sql ("CREATE OR REPLACE FUNCTION t () RETURNS boolean AS $$"

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -426,6 +426,10 @@ static gboolean in_transaction;
  */
 static struct timeval last_msg;
 
+/**
+ * @brief The VT verification collation override
+ */
+static gchar *vt_verification_collation = NULL;
 
 /* GMP commands. */
 
@@ -55717,4 +55721,29 @@ sql_cancel ()
 {
   g_debug ("%s: cancelling current SQL statement", __func__);
   return sql_cancel_internal ();
+}
+
+/**
+ * @brief Get the VT verification collation override.
+ *
+ * @return The collation or NULL for automatic.
+ */
+const char *
+get_vt_verification_collation ()
+{
+  return vt_verification_collation;
+}
+
+/**
+ * @brief Sets the VT verification collation override.
+ *
+ * This must be done before the SQL functions are created to be effective.
+ *
+ * @param[in]  new_collation  The new collation.
+ */
+void
+set_vt_verification_collation (const char *new_collation)
+{
+  g_free (vt_verification_collation);
+  vt_verification_collation = new_collation ? g_strdup(new_collation) : NULL;
 }


### PR DESCRIPTION
**What**:
During the VTs verification the ucs_basic collation is only used if
database encoding is an UTF-8 one, otherwise C is used.
Also, the vt-verification-collation is added in case the encoding
is not detected properly.

**Why**:
The fixed collation did not work with `SQL_ASCII` encoding (AP-1599).

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
