### PR TITLE
Fix for parse_iso_time_tz error with musl library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fix sending prefs for whole, growing VT families [#1603](https://github.com/greenbone/gvmd/pull/1603)
 - Add trash columns for target "elevate" credential [#1636](https://github.com/greenbone/gvmd/pull/1636)
+- Fix for parse_iso_time_tz error with musl library [#1644](https://github.com/greenbone/gvmd/pull/1644)
 
 [Unreleased]: https://github.com/greenbone/gvmd/compare/v21.4.2...gvmd-21.04
 
@@ -128,6 +129,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix memory errors in modify_permission [#1613](https://github.com/greenbone/gvmd/pull/1613)
 - Fix sensor connection for performance reports on failure [#1633](https://github.com/greenbone/gvmd/pull/1633)
 - Sort the "host" column by IPv4 address if possible [#1637](https://github.com/greenbone/gvmd/pull/1637)
+- Fix for parse_iso_time_tz error with musl library [#1644](https://github.com/greenbone/gvmd/pull/1644)
 
 [Unreleased]: https://github.com/greenbone/gvmd/compare/v20.8.2...gvmd-20.08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fix sending prefs for whole, growing VT families [#1603](https://github.com/greenbone/gvmd/pull/1603)
 - Add trash columns for target "elevate" credential [#1636](https://github.com/greenbone/gvmd/pull/1636)
-- Fix for parse_iso_time_tz error with musl library [#1644](https://github.com/greenbone/gvmd/pull/1644)
 
 [Unreleased]: https://github.com/greenbone/gvmd/compare/v21.4.2...gvmd-21.04
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -5782,7 +5782,11 @@ manage_scap_update_time ()
   if (strptime (content, "%Y%m%d%H%M", &update_time))
     {
       static char time_string[100];
-      strftime (time_string, 99, "%FT%T.000%z", &update_time);
+      #if !defined(__GLIBC__)
+        strftime (time_string, 99, "%Y-%m-%dT%T.000", &update_time);
+      #else
+        strftime (time_string, 99, "%FT%T.000%z", &update_time);
+      #endif
       return time_string;
     }
   return "";

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -26273,7 +26273,11 @@ host_summary_append (GString *host_summary_buffer, const char *host,
           struct tm start_tm;
 
           memset (&start_tm, 0, sizeof (struct tm));
-          if (strptime (start_iso, "%FT%H:%M:%S", &start_tm) == NULL)
+          #if !defined(__GLIBC__)
+            if (strptime (start_iso, "%Y-%m-%dT%H:%M:%S", &start_tm) == NULL)
+          #else
+            if (strptime (start_iso, "%FT%H:%M:%S", &start_tm) == NULL)
+          #endif
             {
               g_warning ("%s: Failed to parse start", __func__);
               return;
@@ -26293,7 +26297,11 @@ host_summary_append (GString *host_summary_buffer, const char *host,
           struct tm end_tm;
 
           memset (&end_tm, 0, sizeof (struct tm));
-          if (strptime (end_iso, "%FT%H:%M:%S", &end_tm) == NULL)
+          #if !defined(__GLIBC__)
+            if (strptime (end_iso, "%Y-%m-%dT%H:%M:%S", &end_tm) == NULL)
+          #else
+            if (strptime (end_iso, "%FT%H:%M:%S", &end_tm) == NULL)
+          #endif
             {
               g_warning ("%s: Failed to parse end", __func__);
               return;

--- a/src/utils.c
+++ b/src/utils.c
@@ -366,20 +366,31 @@ parse_iso_time_tz (const char *text_time, const char *fallback_tz)
                            secs_str && strcmp (secs_str, "")
                             ? secs_str : ":00",
                            offset_str ? offset_str : "");
-
-      if (strptime_with_reset ((char*) cleaned_text_time, "%FT%T%z", &tm))
+      #if !defined(__GLIBC__)
+        if (strptime_with_reset ((char*) cleaned_text_time, "%Y-%m-%dT%T", &tm))
+      #else
+        if (strptime_with_reset ((char*) cleaned_text_time, "%FT%T%z", &tm))
+      #endif
         {
           /* ISO time with numeric offset (e.g. 2020-06-01T01:02:03+04:30) */
           tm.tm_sec = tm.tm_sec - tm.tm_gmtoff;
           tm.tm_gmtoff = 0;
           epoch_time = mktime_with_tz (&tm, "UTC");
         }
-      else if (strptime_with_reset ((char*) cleaned_text_time, "%FT%TZ", &tm))
+      #if !defined(__GLIBC__)
+        else if (strptime_with_reset ((char*) cleaned_text_time, "%Y-%m-%dT%T", &tm))
+      #else
+        else if (strptime_with_reset ((char*) cleaned_text_time, "%FT%TZ", &tm))
+      #endif
         {
           /* ISO time with "Z" for UTC timezone (e.g. 2020-06-01T01:02:03Z) */
           epoch_time = mktime_with_tz (&tm, "UTC");
         }
-      else if (strptime_with_reset ((char*) cleaned_text_time, "%FT%T", &tm))
+      #if !defined(__GLIBC__)
+        else if (strptime_with_reset ((char*) cleaned_text_time, "%Y-%m-%dT%T", &tm))
+      #else
+        else if (strptime_with_reset ((char*) cleaned_text_time, "%FT%T", &tm))
+      #endif
         {
           /* ISO time without timezone suffix (e.g. 2020-06-01T01:02:03) */
           epoch_time = mktime_with_tz (&tm, fallback_tz ? fallback_tz : "UTC");
@@ -429,7 +440,11 @@ iso_time_internal (time_t *epoch_time, const char **abbrev)
   if (timezone == 0)
 #endif
     {
-      if (strftime (time_string, 98, "%FT%TZ", &tm) == 0)
+      #if !defined(__GLIBC__)
+        if (strftime (time_string, 98, "%Y-%m-%dT%T", &tm) == 0)
+      #else
+        if (strftime (time_string, 98, "%FT%TZ", &tm) == 0)
+      #endif
         return NULL;
 
       if (abbrev)
@@ -439,7 +454,11 @@ iso_time_internal (time_t *epoch_time, const char **abbrev)
     {
       int len;
 
-      if (strftime (time_string, 98, "%FT%T%z", &tm) == 0)
+      #if !defined(__GLIBC__)
+        if (strftime (time_string, 98, "%Y-%m-%dT%T", &tm) == 0)
+      #else
+        if (strftime (time_string, 98, "%FT%T%z", &tm) == 0)
+      #endif
         return NULL;
 
       /* Insert the ISO 8601 colon by hand. */


### PR DESCRIPTION
This patch fixes the error when parsing the time in a format like:
2019-01-18T17:29:00+00:00  with musl.

This behavior is described in the issue #1609

**What**:

Fixes for https://github.com/greenbone/gvmd/issues/1609

