### PR TITLE
Handle empty --vt-verification-collation correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,7 +126,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 ### Fixed
 - Solved a performance problem when filtering results by tags [#1579](https://github.com/greenbone/gvmd/pull/1579)
-- Fix VTs hash check and add --dump-vt-verification [#1611](https://github.com/greenbone/gvmd/pull/1611) [#1629](https://github.com/greenbone/gvmd/pull/1629) [#1643](https://github.com/greenbone/gvmd/pull/1643)
+- Fix VTs hash check and add --dump-vt-verification [#1611](https://github.com/greenbone/gvmd/pull/1611) [#1629](https://github.com/greenbone/gvmd/pull/1629) [#1643](https://github.com/greenbone/gvmd/pull/1643) [1541](https://github.com/greenbone/gvmd/pull/1651)
 - Fix memory errors in modify_permission [#1613](https://github.com/greenbone/gvmd/pull/1613)
 - Fix sensor connection for performance reports on failure [#1633](https://github.com/greenbone/gvmd/pull/1633)
 - Sort the "host" column by IPv4 address if possible [#1637](https://github.com/greenbone/gvmd/pull/1637)

--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -204,7 +204,7 @@ Verify scanner SCANNER-UUID and exit.
 Print version and exit.
 .TP
 \fB--vt-verification-collation=\fICOLLATION\fB\f1
-Set collation for VT verification to COLLATION, leave empty to choose automatically. Should be 'ucs_default' if DB uses UTF-8 or 'C' for single-byte encodings. 
+Set collation for VT verification to COLLATION, omit or leave empty to choose automatically. Should be 'ucs_default' if DB uses UTF-8 or 'C' for single-byte encodings. 
 .SH SIGNALS
 SIGHUP causes gvmd to rebuild the database with information from the Scanner (openvas).
 .SH EXAMPLES

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -453,7 +453,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <p><opt>--vt-verification-collation=<arg>COLLATION</arg></opt></p>
       <optdesc>
         <p>
-          Set collation for VT verification to COLLATION, leave empty
+          Set collation for VT verification to COLLATION, omit or leave empty
           to choose automatically. Should be 'ucs_default' if DB uses UTF-8
           or 'C' for single-byte encodings.
         </p>

--- a/doc/gvmd.html
+++ b/doc/gvmd.html
@@ -415,7 +415,7 @@
       <p><b>--vt-verification-collation=<em>COLLATION</em></b></p>
       
         <p>          
-          Set collation for VT verification to COLLATION, leave empty
+          Set collation for VT verification to COLLATION, omit or leave empty
           to choose automatically. Should be 'ucs_default' if DB uses UTF-8
           or 'C' for single-byte encodings.
         </p>

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -2150,9 +2150,9 @@ gvmd (int argc, char** argv)
           NULL },
         { "vt-verification-collation", '\0', 0, G_OPTION_ARG_STRING,
           &vt_verification_collation,
-          "Set collation for VT verification to <collation>, leave empty"
-          " to choose automatically. Should be 'ucs_default' if DB uses UTF-8"
-          " or 'C' for single-byte encodings.",
+          "Set collation for VT verification to <collation>, omit or leave"
+          " empty to choose automatically. Should be 'ucs_default' if DB uses"
+          " UTF-8 or 'C' for single-byte encodings.",
           "<collation>" },
         { NULL }
       };

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -56068,5 +56068,8 @@ void
 set_vt_verification_collation (const char *new_collation)
 {
   g_free (vt_verification_collation);
-  vt_verification_collation = new_collation ? g_strdup(new_collation) : NULL;
+  if (new_collation && strcmp (new_collation, ""))
+    vt_verification_collation = g_strdup(new_collation);
+  else
+    vt_verification_collation = NULL;
 }


### PR DESCRIPTION
**What**:
The option will now automatically select the verification if an empty
string is given, not just if the option is missing completely.

**Why**:
The behavior for the option missing and having an empty value should
be consistent (AP-1609).

**How did you test it**:
By running `gvmd --vt-verification-collation ""`

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
