### PR TITLE
Always quote C collation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 ### Fixed
 - Solved a performance problem when filtering results by tags [#1579](https://github.com/greenbone/gvmd/pull/1579)
-- Fix VTs hash check and add --dump-vt-verification [#1611](https://github.com/greenbone/gvmd/pull/1611) [#1629](https://github.com/greenbone/gvmd/pull/1629) [#1643](https://github.com/greenbone/gvmd/pull/1643) [1541](https://github.com/greenbone/gvmd/pull/1651)
+- Fix VTs hash check and add --dump-vt-verification
+  [#1611](https://github.com/greenbone/gvmd/pull/1611)
+  [#1629](https://github.com/greenbone/gvmd/pull/1629)
+  [#1641](https://github.com/greenbone/gvmd/pull/1651)
+  [#1643](https://github.com/greenbone/gvmd/pull/1643)
+  [#1655](https://github.com/greenbone/gvmd/pull/1655)
 - Fix memory errors in modify_permission [#1613](https://github.com/greenbone/gvmd/pull/1613)
 - Fix sensor connection for performance reports on failure [#1633](https://github.com/greenbone/gvmd/pull/1633)
 - Sort the "host" column by IPv4 address if possible [#1637](https://github.com/greenbone/gvmd/pull/1637)

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -974,7 +974,10 @@ manage_create_sql_functions ()
               || g_str_match_string ("UTF8", encoding, 0))
             quoted_collation = strdup ("ucs_basic");
           else
-            quoted_collation = strdup ("C");
+            // quote C collation because this seems to be required
+            // without quoting it an error is raised
+            // other collations don't need quoting
+            quoted_collation = strdup ("\"C\"");
 
           free (encoding);
         }


### PR DESCRIPTION
**What**:

Always quote C collation when creating the vts_verification_str function.

**Why**:

It seems in contrast to other collations it is always required to quote
the C collation. Otherwise creating the vts_verification_str raises an
error when falling back to the C collation for DB with SQL_ASCII
encoding. At least that's the behavior with Postgres 11 on Debian
Buster.

Closes AP-1619

**How did you test it**:

Tested on two systems. One with a DB using SQL_ASCII and one with UTF-8 encoding. Manually inserted the SQL for the function and tested the calculated digest.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
