### PR TITLE
Use a saner default for GVM_FEED_LOCK_PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [20.8.4] - Unreleased
 ### Added
 ### Changed
-* Changed defaults for installation locations [#1662](https://github.com/greenbone/gvmd/pull/1662)
+* Changed defaults for installation locations [#1662](https://github.com/greenbone/gvmd/pull/1662) [#1665](https://github.com/greenbone/gvmd/pull/1665)
     * SYSCONFDIR is /etc by default now
     * LOCALSTATEDIR is /var by default now
     * GVM_RUN_DIR is /run/gvm by default now
     * OPENVAS_DEFAULT_SOCKET is /run/ospd/ospd-openvas.sock by default now
     * SYSTEMD_SERVICE_DIR is /lib/systemd/system by default now
     * Removed gvmd.default file and adjusted gvmd.service file accordingly
+    * GVM_FEED_LOCK_PATH is /var/lib/gvm/feed-update.lock by default now
 
 ### Deprecated
 ### Removed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,7 +200,7 @@ if (NOT GVM_RUN_DIR)
 endif (NOT GVM_RUN_DIR)
 
 if (NOT GVM_FEED_LOCK_PATH)
-  set (GVM_FEED_LOCK_PATH "${GVM_RUN_DIR}/feed-update.lock")
+  set (GVM_FEED_LOCK_PATH "${GVM_STATE_DIR}/feed-update.lock")
 endif (NOT GVM_FEED_LOCK_PATH)
 add_definitions (-DGVM_FEED_LOCK_PATH="${GVM_FEED_LOCK_PATH}")
 


### PR DESCRIPTION
**What**:

Use a saner default for GVM_FEED_LOCK_PATH

**Why**:

The GVM_FEED_LOCK_PATH is also used by the greenbone-feed-sync script.
If gvmd is not running and not started by the systemd service file the
/run/gvm directory (GVM_STATE_DIR) may not be available. Therefore use
a saner default: /var/lib/gvm/feed-update.lock which corresponds to a
similar lock file location in openvas scanner.

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
