### PR TITLE
 Send the script timeout to the scanner as script preferences instead as server preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [middleware]
+### Changed
+Send the script timeout to the scanner as script preferences [#1669](https://github.com/greenbone/gvmd/pull/1669)
+
+[middleware]: https://github.com/greenbone/gvmd/compare/master...middleware
+
 ## [21.10] (unreleased)
 
 ### Added

--- a/src/manage.c
+++ b/src/manage.c
@@ -2523,7 +2523,7 @@ launch_osp_openvas_task (task_t task, target_t target, const char *scan_id,
   hosts_str = target_hosts (target);
   ports_str = target_port_range (target);
   exclude_hosts_str = target_exclude_hosts (target);
-  
+
   clean_hosts = clean_hosts_string (hosts_str);
   clean_exclude_hosts = clean_hosts_string (exclude_hosts_str);
 
@@ -2578,57 +2578,14 @@ launch_osp_openvas_task (task_t task, target_t target, const char *scan_id,
   if (snmp_credential)
     osp_target_add_credential (osp_target, snmp_credential);
 
-  /* Setup general scanner preferences */
-  scanner_options
-    = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
-  init_preference_iterator (&scanner_prefs_iter, config, "SERVER_PREFS");
-  while (next (&scanner_prefs_iter))
-    {
-      const char *name, *value;
-      name = preference_iterator_name (&scanner_prefs_iter);
-      value = preference_iterator_value (&scanner_prefs_iter);
-      if (name && value)
-        {
-          const char *osp_value;
-
-          // Workaround for boolean scanner preferences
-          if (strcmp (value, "yes") == 0)
-            osp_value = "1";
-          else if (strcmp (value, "no") == 0)
-            osp_value = "0";
-          else
-            osp_value = value;
-          g_hash_table_replace (scanner_options,
-                                g_strdup (name),
-                                g_strdup (osp_value));
-        }
-    }
-  cleanup_iterator (&scanner_prefs_iter);
-
-  /* Setup user-specific scanner preference */
-  add_user_scan_preferences (scanner_options);
-
-  /* Setup general task preferences */
-  max_checks = task_preference_value (task, "max_checks");
-  g_hash_table_insert (scanner_options, g_strdup ("max_checks"),
-                       max_checks ? max_checks : g_strdup (MAX_CHECKS_DEFAULT));
-
-  max_hosts = task_preference_value (task, "max_hosts");
-  g_hash_table_insert (scanner_options, g_strdup ("max_hosts"),
-                       max_hosts ? max_hosts : g_strdup (MAX_HOSTS_DEFAULT));
-
-  hosts_ordering = task_hosts_ordering (task);
-  if (hosts_ordering)
-    g_hash_table_insert (scanner_options, g_strdup ("hosts_ordering"),
-                         hosts_ordering);
-
-  /* Setup vulnerability tests (without preferences) */
+  /* Initialize vts table for vulnerability tests and their preferences */
   vts = NULL;
   vts_hash_table
     = g_hash_table_new_full (g_str_hash, g_str_equal, g_free,
                              /* Value is freed in vts list. */
                              NULL);
 
+  /*  Setup of vulnerability tests (without preferences) */
   init_family_iterator (&families, 0, NULL, 1);
   while (next (&families))
     {
@@ -2652,6 +2609,65 @@ launch_osp_openvas_task (task_t task, target_t target, const char *scan_id,
         }
     }
   cleanup_iterator (&families);
+
+  /* Setup general scanner preferences */
+  scanner_options
+    = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+  init_preference_iterator (&scanner_prefs_iter, config, "SERVER_PREFS");
+  while (next (&scanner_prefs_iter))
+    {
+      const char *name, *value;
+      name = preference_iterator_name (&scanner_prefs_iter);
+      value = preference_iterator_value (&scanner_prefs_iter);
+      if (name && value && !g_str_has_prefix (name, "timeout."))
+        {
+          const char *osp_value;
+
+          // Workaround for boolean scanner preferences
+          if (strcmp (value, "yes") == 0)
+            osp_value = "1";
+          else if (strcmp (value, "no") == 0)
+            osp_value = "0";
+          else
+            osp_value = value;
+          g_hash_table_replace (scanner_options,
+                                g_strdup (name),
+                                g_strdup (osp_value));
+        }
+      /* Timeouts are stored as SERVER_PREFS, but are actually
+         script preferences. This prefs is converted into a
+         script preference to be sent to the scanner. */
+      else if (name && value && g_str_has_prefix (name, "timeout."))
+        {
+          char **oid = NULL;
+          osp_vt_single_t *osp_vt = NULL;
+
+          oid = g_strsplit (name, ".", 2);
+          osp_vt = g_hash_table_lookup (vts_hash_table, oid[1]);
+          if (osp_vt)
+            osp_vt_single_add_value (osp_vt, "0", value);
+          g_strfreev (oid);
+        }
+
+    }
+  cleanup_iterator (&scanner_prefs_iter);
+
+  /* Setup user-specific scanner preference */
+  add_user_scan_preferences (scanner_options);
+
+  /* Setup general task preferences */
+  max_checks = task_preference_value (task, "max_checks");
+  g_hash_table_insert (scanner_options, g_strdup ("max_checks"),
+                       max_checks ? max_checks : g_strdup (MAX_CHECKS_DEFAULT));
+
+  max_hosts = task_preference_value (task, "max_hosts");
+  g_hash_table_insert (scanner_options, g_strdup ("max_hosts"),
+                       max_hosts ? max_hosts : g_strdup (MAX_HOSTS_DEFAULT));
+
+  hosts_ordering = task_hosts_ordering (task);
+  if (hosts_ordering)
+    g_hash_table_insert (scanner_options, g_strdup ("hosts_ordering"),
+                         hosts_ordering);
 
   /* Setup VT preferences */
   init_preference_iterator (&prefs, config, "PLUGINS_PREFS");


### PR DESCRIPTION
Close SC-355

Depends on greenbone/gvm-libs#578 and greenbone/openvas-scanner#841

**What**:
 Send the script timeout to the scanner as script preferences instead as server preference
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Currently is sent to openvas as `timeout.<OID>`
Now is sent as as a script preference as param with ID 0  subelemet of the vt_single in the vt_selection.

<!-- Why are these changes necessary? -->

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
