### PR TITLE
Remove BID from GMP documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Deprecated
 ### Removed
+*  Remove BID from GMP documentation [#1673](https://github.com/greenbone/gvmd/pull/1673)
+
 ### Fixed
 
 [20.8.4]: https://github.com/greenbone/gvmd/compare/v20.8.3...gvmd-20.08

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -920,7 +920,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <e>cvss_base</e>
           <e>severities</e>
           <o><e>cve</e></o>
-          <o><e>bid</e></o>
         </pattern>
         <ele>
           <name>name</name>
@@ -944,11 +943,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <name>cve</name>
           <summary>CVE value associated with the NVT</summary>
           <pattern>text</pattern>
-        </ele>
-        <ele>
-          <name>bid</name>
-          <summary>BID associated with the NVT</summary>
-          <pattern><t>integer</t></pattern>
         </ele>
       </ele>
       <ele>
@@ -1276,7 +1270,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <e>cvss_base</e>
           <e>severities</e>
           <o><e>cve</e></o>
-          <o><e>bid</e></o>
         </pattern>
         <ele>
           <name>name</name>
@@ -1300,11 +1293,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <name>cve</name>
           <summary>CVE value associated with the NVT</summary>
           <pattern>text</pattern>
-        </ele>
-        <ele>
-          <name>bid</name>
-          <summary>BID associated with the NVT</summary>
-          <pattern><t>integer</t></pattern>
         </ele>
       </ele>
       <ele>
@@ -1597,7 +1585,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </attrib>
             <attrib>
               <name>type</name>
-              <summary>Type of the reference, for example "cve", "bid", "dfn-cert", "cert-bund"
+              <summary>Type of the reference, for example "cve", "dfn-cert", "cert-bund"
               </summary>
               <type>text</type>
             </attrib>
@@ -12620,7 +12608,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <cvss_base>5</cvss_base>
                 <severities score="50"/>
                 <cve></cve>
-                <bid></bid>
               </nvt>
               <threat>Medium</threat>
               <description>Warning with control char between fullstops: . .</description>
@@ -12887,7 +12874,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               </attrib>
               <attrib>
                 <name>type</name>
-                <summary>Type of the reference, for example "cve", "bid", "dfn-cert", "cert-bund"</summary>
+                <summary>Type of the reference, for example "cve", "dfn-cert", "cert-bund"</summary>
                 <type>text</type>
               </attrib>
             </pattern>
@@ -15412,7 +15399,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     <tags>NOTAGS</tags>
                     <refs>
                       <ref id="CVE-2013-1406" type="cve"/>
-                      <ref id="51702" type="bid"/>
                       <ref id="DFN-CERT-2013-0246" type="dfn-cert"/>
                     </refs>
                   </nvt>
@@ -16447,7 +16433,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <tags>NOTAGS</tags>
               <refs>
                  <ref type="cve" id="CVE-2009-3095"/>
-                 <ref type="bid" id="36254"/>
               </refs>
             </nvt>
             <threat>Medium</threat>
@@ -16510,7 +16495,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <tags>NOTAGS</tags>
               <refs>
                  <ref type="cve" id="CVE-2009-3095"/>
-                 <ref type="bid" id="36254"/>
               </refs>
             </nvt>
             <threat>High</threat>


### PR DESCRIPTION
**What**:
The BID elements are no longer used and have been replaced by generic
elements for references. Also, the reference type "bid" has become
obsolete with the shutdown of Bugtraq.
(Addresses AP-1306)

**Why**:
To remove obsolete references.

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
