### PR TITLE
Remove ifaces element from users

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 246)
+set (GVMD_DATABASE_VERSION 247)
 
 set (GVMD_SCAP_DATABASE_VERSION 19)
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -2413,15 +2413,15 @@ prepare_osp_scan_for_resume (task_t task, const char *scan_id, char **error)
 }
 
 /**
- * @brief Add OSP preferences for limiting ifaces and hosts for users.
+ * @brief Add OSP preferences for limiting hosts for users.
  *
  * @param[in]  scanner_options  The scanner preferences table to add to.
  */
 static void
 add_user_scan_preferences (GHashTable *scanner_options)
 {
-  gchar *hosts, *ifaces, *name;
-  int hosts_allow, ifaces_allow;
+  gchar *hosts, *name;
+  int hosts_allow;
 
   // Limit access to hosts
   hosts = user_hosts (current_credentials.uuid);
@@ -2441,25 +2441,6 @@ add_user_scan_preferences (GHashTable *scanner_options)
                           hosts ? hosts : g_strdup (""));
   else
     g_free (hosts);
-
-  // Limit access to ifaces
-  ifaces = user_ifaces (current_credentials.uuid);
-  ifaces_allow = user_ifaces_allow (current_credentials.uuid);
-
-  if (ifaces_allow == 1)
-    name = g_strdup ("ifaces_allow");
-  else if (ifaces_allow == 0)
-    name = g_strdup ("ifaces_deny");
-  else
-    name = NULL;
-
-  if (name
-      && (ifaces_allow || (ifaces && strlen (ifaces))))
-    g_hash_table_replace (scanner_options,
-                          name,
-                          ifaces ? ifaces : g_strdup (""));
-  else
-    g_free (ifaces);
 }
 
 /**

--- a/src/manage.h
+++ b/src/manage.h
@@ -3361,12 +3361,6 @@ user_iterator_hosts (iterator_t*);
 int
 user_iterator_hosts_allow (iterator_t*);
 
-const char*
-user_iterator_ifaces (iterator_t*);
-
-int
-user_iterator_ifaces_allow (iterator_t*);
-
 void
 init_user_group_iterator (iterator_t *, user_t);
 
@@ -3393,7 +3387,7 @@ user_role_iterator_readable (iterator_t*);
 
 int
 create_user (const gchar *, const gchar *, const gchar *, const gchar *,
-             int, const gchar *, int, const array_t *, array_t *, gchar **,
+             int, const array_t *, array_t *, gchar **,
              array_t *, gchar **, gchar **, user_t *, int);
 
 int
@@ -3401,7 +3395,7 @@ delete_user (const char *, const char *, int, int, const char*, const char*);
 
 int
 modify_user (const gchar *, gchar **, const gchar *, const gchar *,
-             const gchar*, const gchar *, int, const gchar *, int,
+             const gchar*, const gchar *, int,
              const array_t *, array_t *, gchar **, array_t *, gchar **,
              gchar **);
 
@@ -3425,12 +3419,6 @@ user_name (const char *);
 
 char*
 user_uuid (user_t);
-
-gchar*
-user_ifaces (const char *);
-
-int
-user_ifaces_allow (const char *);
 
 gchar*
 user_hosts (const char *);

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -2783,6 +2783,39 @@ migrate_245_to_246 ()
   return 0;
 }
 
+/**
+ * @brief Migrate the database from version 246 to version 247.
+ *
+ * @return 0 success, -1 error.
+ */
+int
+migrate_246_to_247 ()
+{
+  sql_begin_immediate ();
+
+  /* Ensure that the database is currently version 246. */
+
+  if (manage_db_version () != 246)
+    {
+      sql_rollback ();
+      return -1;
+    }
+
+  /* Update the database. */
+
+  /* Per-user limitations on network interfaces have been removed */
+  sql ("ALTER TABLE users DROP COLUMN ifaces;");
+  sql ("ALTER TABLE users DROP COLUMN ifaces_allow;");
+
+  /* Set the database version to 247. */
+
+  set_db_version (247);
+
+  sql_commit ();
+
+  return 0;
+}
+
 
 #undef UPDATE_DASHBOARD_SETTINGS
 
@@ -2836,6 +2869,7 @@ static migrator_t database_migrators[] = {
   {244, migrate_243_to_244},
   {245, migrate_244_to_245},
   {246, migrate_245_to_246},
+  {247, migrate_246_to_247},
   /* End marker. */
   {-1, NULL}};
 

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -1753,8 +1753,6 @@ create_tables ()
        "  timezone text,"
        "  hosts text,"
        "  hosts_allow integer,"
-       "  ifaces text,"
-       "  ifaces_allow integer,"
        "  method text,"
        "  creation_time integer,"
        "  modification_time integer);");

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -5803,7 +5803,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <o><e>copy</e></o>
       <o><e>comment</e></o>
       <o><e>hosts</e></o>
-      <o><e>ifaces</e></o>
       <o><e>password</e></o>
       <any><e>role</e></any>
     </pattern>
@@ -5827,18 +5826,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <ele>
       <name>hosts</name>
       <summary>User access rules: a comma-separated list of hosts</summary>
-      <pattern>
-        <attrib>
-          <name>allow</name>
-          <summary>If 1, allow only listed, otherwise forbid listed</summary>
-          <type>boolean</type>
-        </attrib>
-        text
-      </pattern>
-    </ele>
-    <ele>
-      <name>ifaces</name>
-      <summary>User access rules: a comma-separated list of ifaces</summary>
       <pattern>
         <attrib>
           <name>allow</name>
@@ -21127,11 +21114,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <type>text</type>
             <summary>List of host that are either allowed of forbidden</summary>
           </column>
-          <column>
-            <name>ifaces</name>
-            <type>text</type>
-            <summary>List of ifaces that are either allowed of forbidden</summary>
-          </column>
         </filter_keywords>
       </attrib>
       <attrib>
@@ -21177,7 +21159,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <any><e>role</e></any>
           <e>groups</e>
           <e>hosts</e>
-          <e>ifaces</e>
           <e>permissions</e>
           <o><e>user_tags</e></o>
           <e>sources</e>
@@ -21279,26 +21260,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <ele>
           <name>hosts</name>
           <summary>Host access rule for the user</summary>
-          <pattern>
-            <attrib>
-              <name>allow</name>
-              <summary>0 forbidden, 1 allowed, 2 all allowed, 3 custom</summary>
-              <type>
-                <alts>
-                  <alt>0</alt>
-                  <alt>1</alt>
-                  <alt>2</alt>
-                  <alt>3</alt>
-                </alts>
-              </type>
-              <required>1</required>
-            </attrib>
-            text
-          </pattern>
-        </ele>
-        <ele>
-          <name>ifaces</name>
-          <summary>Iface access rule for the user</summary>
           <pattern>
             <attrib>
               <name>allow</name>
@@ -25162,7 +25123,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <o><e>password</e></o>
       <any><e>role</e></any>
       <o><e>hosts</e></o>
-      <o><e>ifaces</e></o>
       <o><e>sources</e></o>
     </pattern>
     <ele>
@@ -25186,18 +25146,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <description>
         User is allowed to access any host if this element is missing.
       </description>
-      <pattern>
-        <attrib>
-          <name>allow</name>
-          <summary>If 1, allow only listed, otherwise forbid listed</summary>
-          <type>boolean</type>
-        </attrib>
-        text
-      </pattern>
-    </ele>
-    <ele>
-      <name>ifaces</name>
-      <summary>User access rules: a comma-separated list of ifaces</summary>
       <pattern>
         <attrib>
           <name>allow</name>
@@ -25788,6 +25736,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   <!-- Compatibility changes between versions. -->
 
+  <change>
+    <command>CREATE_TASK, CREATE_USER, GET_TASKS, GET_USERS, MODIFY_TASK, MODIFY_USER</command>
+    <summary>Removed network interface (iface) options</summary>
+    <description>
+      <p>
+        The option to choose the source interface in the form of the task
+        preference &quot;source_iface&quot; has been removed as well as
+        the &quot;ifaces&quot; element of users to limit the allowed network
+        interfaces.
+      </p>
+    </description>
+    <version>21.10</version>
+  </change>
   <change>
     <command>GET_INFO</command>
     <summary>Removed the Secinfo-type OVALDEF from the GET_INFO command


### PR DESCRIPTION
**What**:
This removes the option to limit the available network interfaces
per user as the scanner no longer handles the ifaces_allow or
ifaces_deny options (AP-1585).

**Why**:
The option is no longer used by the scanner, so it's removed from
GMP for consistency.

**How did you test it**:
By viewing, creating and modifying a user via GSA.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
