### PR TITLE
Fix resume task.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Deprecated
 ### Removed
 ### Fixed
+- Fix resume task. [#1679](https://github.com/greenbone/gvmd/pull/1679)
+
 
 [Unreleased]: https://github.com/greenbone/gvmd/compare/v21.4.3...HEAD
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -2389,7 +2389,7 @@ prepare_osp_scan_for_resume (task_t task, const char *scan_id, char **error)
   else if (status == OSP_SCAN_STATUS_RUNNING
            || status == OSP_SCAN_STATUS_QUEUED)
     {
-      g_debug ("%s: Scan %s queued, running or finished", __func__, scan_id);
+      g_debug ("%s: Scan %s queued or running", __func__, scan_id);
       /* It would be possible to simply continue getting the results
        * from the scanner, but gvmd may have crashed while receiving
        * or storing the results, so some may be missing. */


### PR DESCRIPTION
**What**:
Fix resume task.

Jira: AP-1472

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
An already finished scan, can not be stopped, and must be deleted directly.
Also, there is a connection issue after asking for the scan status. As workaround
the connection is reset.

<!-- Why are these changes necessary? -->

**How did you test it**:
- Start a scan with many host.
- Wait until some hosts finish and interrupt the scan changing the permissions in the openvas socket. The task will be set as interrupted.
- Wait until ospd finished the scan successfully
- Change the socket permissions again.
- Resume the scan. 
- Check the logs (ospd, openvas and gvmd).


<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
