### PR TITLE
Add --rebuild-gvmd-data command line option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [21.4.4] (unreleased)
 ### Added
+- Add --rebuild-gvmd-data command line option [#1680](https://github.com/greenbone/gvmd/pull/1680)
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -139,6 +139,11 @@ Use port number NUMBER.
 \fB--port2=\fINUMBER\fB\f1
 Use port number NUMBER for address 2.
 .TP
+\fB--rebuild-gvmd-data=\fITYPES\fB\f1
+Reload all gvmd data objects of a given types from feed. 
+
+The types must be "all" or a comma-separated of the following: "configs", "port_lists" and "report_formats". 
+.TP
 \fB--rebuild-scap\f1
 Rebuild all SCAP data. 
 .TP

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -316,6 +316,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </optdesc>
     </option>
     <option>
+      <p><opt>--rebuild-gvmd-data=<arg>TYPES</arg></opt></p>
+      <optdesc>
+        <p>
+          Reload all gvmd data objects of a given types from feed.
+        </p>
+        <p>
+          The types must be &quot;all&quot; or a comma-separated of the
+          following: &quot;configs&quot;, &quot;port_lists&quot; and
+          &quot;report_formats&quot;.
+        </p>
+      </optdesc>
+    </option>
+    <option>
       <p><opt>--rebuild-scap</opt></p>
       <optdesc>
         <p>

--- a/doc/gvmd.html
+++ b/doc/gvmd.html
@@ -276,8 +276,20 @@
       
         <p>Use port number NUMBER for address 2.</p>
       
-    
-    
+      
+      <p><b>--rebuild-gvmd-data=<em>TYPES</em></b></p>
+      
+        <p>
+          Reload all gvmd data objects of a given types from feed.
+        </p>
+
+        <p>
+          The types must be &quot;all&quot; or a comma-separated of the
+          following: &quot;configs&quot;, &quot;port_lists&quot; and
+          &quot;report_formats&quot;.
+        </p>
+
+
       <p><b>--rebuild-scap</b></p>
       
         <p>

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1836,6 +1836,7 @@ gvmd (int argc, char** argv)
   static gchar *rc_name = NULL;
   static gchar *relay_mapper = NULL;
   static gboolean rebuild = FALSE;
+  static gchar *rebuild_gvmd_data = NULL;
   static gboolean rebuild_scap = FALSE;
   static gchar *role = NULL;
   static gchar *disable = NULL;
@@ -2046,6 +2047,12 @@ gvmd (int argc, char** argv)
           &rebuild,
           "Remove NVT db, and rebuild it from the scanner.",
           NULL },
+        { "rebuild-gvmd-data", '\0', 0, G_OPTION_ARG_STRING,
+          &rebuild_gvmd_data,
+          "Reload all gvmd data objects of a given types from feed."
+          " The types must be \"all\" or a comma-separated of the following:"
+          " \"configs\", \"port_lists\" and \"report_formats\"",
+          "<types>" },
         { "rebuild-scap", '\0', 0, G_OPTION_ARG_NONE,
           &rebuild_scap,
           "Rebuild all SCAP data.",
@@ -2561,6 +2568,32 @@ gvmd (int argc, char** argv)
       if (ret)
         {
           printf ("Failed to rebuild NVT cache.\n");
+          return EXIT_FAILURE;
+        }
+      return EXIT_SUCCESS;
+    }
+  
+  if (rebuild_gvmd_data)
+    {
+      int ret;
+      gchar *error_msg;
+      
+      error_msg = NULL;
+
+      proctitle_set ("gvmd: --rebuild-gvmd-data");
+
+      if (option_lock (&lockfile_checking))
+        return EXIT_FAILURE;
+
+      ret = manage_rebuild_gvmd_data_from_feed (rebuild_gvmd_data,
+                                                log_config,
+                                                &database,
+                                                &error_msg);
+      log_config_free ();
+      if (ret)
+        {
+          printf ("Failed to rebuild gvmd data: %s\n", error_msg);
+          g_free (error_msg);
           return EXIT_FAILURE;
         }
       return EXIT_SUCCESS;

--- a/src/manage.c
+++ b/src/manage.c
@@ -5022,6 +5022,11 @@ manage_sync (sigset_t *sigmask_current,
     }
 }
 
+/**
+ * @brief Adds a switch statement for handling the return value of a
+ *        gvmd data rebuild.
+ * @param type  The type as a description string, e.g. "port lists"
+ */
 #define REBUILD_SWITCH(type) \
   switch (ret)                                                              \
     {                                                                       \

--- a/src/manage.c
+++ b/src/manage.c
@@ -5006,11 +5006,19 @@ manage_sync (sigset_t *sigmask_current,
         }
     }
 
-  if (try_gvmd_data_sync)
+  if (try_gvmd_data_sync
+      && (should_sync_configs ()
+          || should_sync_port_lists ()
+          || should_sync_report_formats ()))
     {
-      manage_sync_configs ();
-      manage_sync_port_lists ();
-      manage_sync_report_formats ();
+      if (feed_lockfile_lock (&lockfile) == 0)
+        {
+          manage_sync_configs ();
+          manage_sync_port_lists ();
+          manage_sync_report_formats ();
+
+          lockfile_unlock (&lockfile);
+        }
     }
 }
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -5022,6 +5022,156 @@ manage_sync (sigset_t *sigmask_current,
     }
 }
 
+#define REBUILD_SWITCH(type) \
+  switch (ret)                                                              \
+    {                                                                       \
+      case 0:                                                               \
+        g_message ("Rebuilt %s from feed.", type);                          \
+        break;                                                              \
+      case 1:                                                               \
+        if (error_msg)                                                      \
+          *error_msg = g_strdup_printf ("No %s feed directory.",            \
+                                        type);                              \
+        return -1;                                                          \
+      case 2:                                                               \
+        if (error_msg)                                                      \
+          *error_msg = g_strdup_printf ("Feed owner not set or invalid"     \
+                                        " while rebuilding %s.",            \
+                                        type);                              \
+        return -1;                                                          \
+      case 3:                                                               \
+        if (error_msg)                                                      \
+          *error_msg = g_strdup_printf ("NVTs must be available"            \
+                                        " while rebuilding %s.",            \
+                                        type);                              \
+        return -1;                                                          \
+      default:                                                              \
+        if (error_msg)                                                      \
+          *error_msg = g_strdup_printf ("Internal error"                    \
+                                        " while rebuilding %s.",            \
+                                        type);                              \
+        return -1;                                                          \
+    }
+
+/**
+ * @brief Rebuild configs, port lists and report formats from feed.
+ * 
+ * @param[in]  types      Comma-separated lists of types to rebuild or "all".
+ * @param[in]  log_config Logging configuration list.
+ * @param[in]  database   Connection info for manage database.
+ * @param[out] error_msg  Error message.
+ * 
+ * @return 0 success, -1 failed.
+ */
+int
+manage_rebuild_gvmd_data_from_feed (const char *types,
+                                    GSList *log_config,
+                                    const db_conn_info_t *database,
+                                    gchar **error_msg)
+{
+  int ret;
+  lockfile_t lockfile;
+  gboolean sync_configs, sync_port_lists, sync_report_formats;
+
+  sync_configs = sync_port_lists = sync_report_formats = FALSE;
+
+  if (strcasecmp (types, "all") == 0)
+    {
+      sync_configs = TRUE;
+      sync_port_lists = TRUE;
+      sync_report_formats = TRUE;
+    }
+  else
+    {
+      gchar **split, **split_iter;
+      split = g_strsplit (types, ",", -1);
+
+      if (*split == NULL)
+        {
+          g_free (split);
+          if (error_msg)
+            *error_msg = g_strdup ("No types given.");
+          return -1;
+        }
+
+      split_iter = split;
+      while (*split_iter)
+        {
+          gchar *type = g_strstrip (*split_iter);
+          
+          if (strcasecmp (type, "configs") == 0)
+            sync_configs = TRUE;
+          else if (strcasecmp (type, "port_lists") == 0)
+            sync_port_lists = TRUE;
+          else if (strcasecmp (type, "report_formats") == 0)
+            sync_report_formats = TRUE;
+          else
+            {
+              if (error_msg)
+                *error_msg = g_strdup_printf ("Invalid type \"%s\""
+                                              " (must be \"configs\","
+                                              " \"port_lists\","
+                                              " \"report_formats\""
+                                              " or \"all\")",
+                                              type);
+              g_strfreev (split);
+              return -1;
+            }
+          split_iter ++;
+        }
+      g_strfreev (split);
+    }
+
+  ret = feed_lockfile_lock_timeout (&lockfile);
+  if (ret == 1)
+    {
+      if (error_msg)
+        *error_msg = g_strdup ("Feed locked.");
+      return -1;
+    }
+  else if (ret)
+    {
+      if (error_msg)
+        *error_msg = g_strdup ("Error acquiring feed lock.");
+      return -1;
+    }
+
+  ret = manage_option_setup (log_config, database);
+  if (ret)
+    {
+      if (error_msg)
+        *error_msg = g_strdup ("Error setting up log config or"
+                               " database connection.");
+      return -1;
+    }
+
+  if (sync_configs)
+    {
+      g_message ("Rebuilding configs from feed...");
+      ret = manage_rebuild_configs ();
+      REBUILD_SWITCH ("configs")
+    }
+
+  if (sync_port_lists)
+    {
+      g_message ("Rebuilding port lists from feed...");
+      ret = manage_rebuild_port_lists ();
+      REBUILD_SWITCH ("port lists")
+    }
+
+  if (sync_report_formats)
+    {
+      g_message ("Rebuilding report formats from feed...");
+      ret = manage_rebuild_report_formats ();
+      REBUILD_SWITCH ("report formats")
+    }
+
+  feed_lockfile_unlock (&lockfile);
+  return 0;
+}
+
+#undef REBUILD_SWITCH
+
 /**
  * @brief Schedule any actions that are due.
  *

--- a/src/manage.h
+++ b/src/manage.h
@@ -2718,6 +2718,12 @@ void
 manage_sync (sigset_t *, int (*fork_update_nvt_cache) (), gboolean);
 
 int
+manage_rebuild_gvmd_data_from_feed (const char *,
+                                    GSList *,
+                                    const db_conn_info_t *,
+                                    gchar **);
+
+int
 manage_schedule (manage_connection_forker_t,
                  gboolean,
                  sigset_t *);

--- a/src/manage_configs.c
+++ b/src/manage_configs.c
@@ -554,6 +554,18 @@ manage_sync_configs ()
 }
 
 /**
+ * @brief Rebuild configs from the feed.
+ * 
+ * @return 0 success, 1 no feed directory, 2 no feed owner, 3 NVTs missing,
+ *         -1 error.
+ */
+int
+manage_rebuild_configs ()
+{
+  return sync_configs_with_feed (TRUE);
+}
+
+/**
  * @brief Checks if the configs should be synced with the feed.
  */
 gboolean

--- a/src/manage_configs.c
+++ b/src/manage_configs.c
@@ -403,7 +403,8 @@ sync_config_with_feed (const gchar *path)
  * NULL otherwise.
  * @param[in]   set_current_user Whether to set current user to feed owner.
  *
- * @return 0 success, 1 no feed directory or owner, 2 NVTs missing, -1 error
+ * @return 0 success, 1 no feed directory, 2 no feed owner, 3 NVTs missing,
+ *         -1 error.
  */
 static int
 try_open_configs_feed_dir (GDir **dir, gboolean set_current_user)
@@ -425,7 +426,7 @@ try_open_configs_feed_dir (GDir **dir, gboolean set_current_user)
   if (nvt_feed_version == NULL)
     {
       g_debug ("%s: no NVTs so not syncing from feed", __func__);
-      return 2;
+      return 3;
     }
   g_free (nvt_feed_version);
 
@@ -438,14 +439,14 @@ try_open_configs_feed_dir (GDir **dir, gboolean set_current_user)
     {
       /* Sync is disabled by having no "Feed Import Owner". */
       g_debug ("%s: no Feed Import Owner so not syncing from feed", __func__);
-      return 1;
+      return 2;
     }
 
   feed_owner_name = user_name (feed_owner_uuid);
   if (feed_owner_name == NULL)
     {
       g_debug ("%s: unknown Feed Import Owner so not syncing from feed", __func__);
-      return 1;
+      return 2;
     }
 
   /* Open feed import directory. */
@@ -485,7 +486,8 @@ try_open_configs_feed_dir (GDir **dir, gboolean set_current_user)
  * Update configs in the db that have changed on the feed.
  * Do nothing to configs in db that have been removed from the feed.
  *
- * @return 0 success, 1 no feed directory or owner, 2 NVTs missing, -1 error.
+ * @return 0 success, 1 no feed directory, 2 no feed owner, 3 NVTs missing,
+ *         -1 error.
  */
 int
 sync_configs_with_feed ()

--- a/src/manage_configs.c
+++ b/src/manage_configs.c
@@ -567,6 +567,8 @@ manage_rebuild_configs ()
 
 /**
  * @brief Checks if the configs should be synced with the feed.
+ *
+ * @return 1 if configs should be synced, 0 otherwise
  */
 gboolean
 should_sync_configs ()

--- a/src/manage_configs.c
+++ b/src/manage_configs.c
@@ -545,3 +545,26 @@ manage_sync_configs ()
 {
   sync_configs_with_feed ();
 }
+
+/**
+ * @brief Checks if the configs should be synced with the feed.
+ */
+gboolean
+should_sync_configs ()
+{
+  GDir *dir;
+  const gchar *config_path;
+  config_t config;
+
+  if (try_open_configs_feed_dir (&dir, FALSE))
+    return FALSE;
+
+  while ((config_path = g_dir_read_name (dir)))
+    if (g_str_has_prefix (config_path, ".") == 0
+        && strlen (config_path) >= (36 /* UUID */ + strlen (".xml"))
+        && g_str_has_suffix (config_path, ".xml")
+        && should_sync_config_from_path (config_path, &config))
+      return TRUE;
+
+  return FALSE;
+}

--- a/src/manage_configs.c
+++ b/src/manage_configs.c
@@ -485,26 +485,23 @@ try_open_configs_feed_dir (GDir **dir, gboolean set_current_user)
  * Update configs in the db that have changed on the feed.
  * Do nothing to configs in db that have been removed from the feed.
  *
- * @return 0 success, -1 error.
+ * @return 0 success, 1 no feed directory or owner, 2 NVTs missing, -1 error.
  */
 int
 sync_configs_with_feed ()
 {
+  int ret;
   GDir *dir;
   const gchar *config_path;
 
-  switch (try_open_configs_feed_dir (&dir, TRUE))
+  ret = try_open_configs_feed_dir (&dir, TRUE);
+  switch (ret)
     {
       case 0:
         // Successfully opened directory
         break;
-      case 1:
-      case 2:
-        // No feed directory, feed owner, or NVTs
-        return 0; 
       default:
-        // Error
-        return -1;
+        return ret;
     }
 
   /* Sync each file in the directory. */

--- a/src/manage_configs.h
+++ b/src/manage_configs.h
@@ -197,4 +197,7 @@ configs_feed_dir_exists ();
 void
 manage_sync_configs ();
 
+gboolean
+should_sync_configs ();
+
 #endif /* not _GVMD_MANAGE_CONFIGS_H */

--- a/src/manage_configs.h
+++ b/src/manage_configs.h
@@ -197,6 +197,9 @@ configs_feed_dir_exists ();
 void
 manage_sync_configs ();
 
+int
+manage_rebuild_configs ();
+
 gboolean
 should_sync_configs ();
 

--- a/src/manage_port_lists.c
+++ b/src/manage_port_lists.c
@@ -326,20 +326,21 @@ sync_port_list_with_feed (const gchar *path)
 }
 
 /**
- * @brief Sync all port lists with the feed.
+ * @brief Open the port lists feed directory if it is available and the
+ * feed owner is set. Also set the current user to the feed owner.
+ * 
+ * The sync will be skipped if the feed directory does not exist or
+ *  the feed owner is not set. 
+ * 
+ * @param[out]  dir The directory as GDir if available and feed owner is set,
+ * NULL otherwise.
  *
- * Create port lists that exists in the feed but not in the db.
- * Update port lists in the db that have changed on the feed.
- * Do nothing to db port lists that have been removed from the feed.
- *
- * @return 0 success, -1 error.
+ * @return 0 success, 1 no feed directory or owner, -1 error
  */
-int
-sync_port_lists_with_feed ()
+static int
+try_open_port_lists_feed_dir (GDir **dir)
 {
   GError *error;
-  GDir *dir;
-  const gchar *port_list_path;
 
   /* Test if base feed directory exists */
 
@@ -355,21 +356,21 @@ sync_port_lists_with_feed ()
     {
       /* Sync is disabled by having no "Feed Import Owner". */
       g_debug ("%s: no Feed Import Owner so not syncing from feed", __func__);
-      return 0;
+      return 1;
     }
 
   current_credentials.username = user_name (current_credentials.uuid);
   if (current_credentials.username == NULL)
     {
       g_debug ("%s: unknown Feed Import Owner so not syncing from feed", __func__);
-      return 0;
+      return 1;
     }
 
   /* Open feed import directory. */
 
   error = NULL;
-  dir = g_dir_open (feed_dir_port_lists (), 0, &error);
-  if (dir == NULL)
+  *dir = g_dir_open (feed_dir_port_lists (), 0, &error);
+  if (*dir == NULL)
     {
       g_warning ("%s: Failed to open directory '%s': %s",
                  __func__, feed_dir_port_lists (), error->message);
@@ -379,6 +380,36 @@ sync_port_lists_with_feed ()
       current_credentials.uuid = NULL;
       current_credentials.username = NULL;
       return -1;
+    }
+  return 0;
+}
+  
+/**
+ * @brief Sync all port lists with the feed.
+ *
+ * Create port lists that exists in the feed but not in the db.
+ * Update port lists in the db that have changed on the feed.
+ * Do nothing to db port lists that have been removed from the feed.
+ *
+ * @return 0 success, -1 error.
+ */
+int
+sync_port_lists_with_feed ()
+{
+  GDir *dir;
+  const gchar *port_list_path;
+
+  switch (try_open_port_lists_feed_dir (&dir))
+    {
+      case 0:
+        // Successfully opened directory
+        break;
+      case 1:
+        // No feed directory or feed owner
+        return 0; 
+      default:
+        // Error
+        return -1;
     }
 
   /* Sync each file in the directory. */

--- a/src/manage_port_lists.c
+++ b/src/manage_port_lists.c
@@ -337,7 +337,7 @@ sync_port_list_with_feed (const gchar *path)
  * NULL otherwise.
  * @param[in]   set_current_user Whether to set current user to feed owner.
  *
- * @return 0 success, 1 no feed directory or owner, -1 error
+ * @return 0 success, 1 no feed directory, 2 no feed owner, -1 error.
  */
 static int
 try_open_port_lists_feed_dir (GDir **dir, gboolean set_current_user)
@@ -348,7 +348,7 @@ try_open_port_lists_feed_dir (GDir **dir, gboolean set_current_user)
   /* Test if base feed directory exists */
 
   if (port_lists_feed_dir_exists () == FALSE)
-    return 0;
+    return 1;
 
   /* Setup owner. */
 
@@ -359,14 +359,14 @@ try_open_port_lists_feed_dir (GDir **dir, gboolean set_current_user)
     {
       /* Sync is disabled by having no "Feed Import Owner". */
       g_debug ("%s: no Feed Import Owner so not syncing from feed", __func__);
-      return 1;
+      return 2;
     }
 
   feed_owner_name = user_name (feed_owner_uuid);
   if (feed_owner_name == NULL)
     {
       g_debug ("%s: unknown Feed Import Owner so not syncing from feed", __func__);
-      return 1;
+      return 2;
     }
 
   /* Open feed import directory. */

--- a/src/manage_port_lists.c
+++ b/src/manage_port_lists.c
@@ -412,7 +412,7 @@ try_open_port_lists_feed_dir (GDir **dir, gboolean set_current_user)
  *
  * @param[in]  rebuild  Whether ignore timestamps to force a rebuild.
  *
- * @return 0 success, 1 no feed directory or owner, -1 error.
+ * @return 0 success, 1 no feed directory, 2 no feed owner, -1 error.
  */
 int
 sync_port_lists_with_feed (gboolean rebuild)
@@ -468,6 +468,17 @@ void
 manage_sync_port_lists ()
 {
   sync_port_lists_with_feed (FALSE);
+}
+
+/**
+ * @brief Rebuild port lists from the feed.
+ *
+ * @return 0 success, 1 no feed directory, 2 no feed owner, -1 error.
+ */
+int
+manage_rebuild_port_lists ()
+{
+  return sync_port_lists_with_feed (TRUE);
 }
 
 /**

--- a/src/manage_port_lists.c
+++ b/src/manage_port_lists.c
@@ -463,3 +463,26 @@ manage_sync_port_lists ()
 {
   sync_port_lists_with_feed ();
 }
+
+/**
+ * @brief Checks if the port lists should be synced with the feed.
+ */
+gboolean
+should_sync_port_lists ()
+{
+  GDir *dir;
+  const gchar *port_list_path;
+  port_list_t port_list;
+
+  if (try_open_port_lists_feed_dir (&dir, FALSE))
+    return FALSE;
+
+  while ((port_list_path = g_dir_read_name (dir)))
+    if (g_str_has_prefix (port_list_path, ".") == 0
+        && strlen (port_list_path) >= (36 /* UUID */ + strlen (".xml"))
+        && g_str_has_suffix (port_list_path, ".xml")
+        && should_sync_port_list_from_path (port_list_path, &port_list))
+      return TRUE;
+
+  return FALSE;
+}

--- a/src/manage_port_lists.c
+++ b/src/manage_port_lists.c
@@ -404,25 +404,23 @@ try_open_port_lists_feed_dir (GDir **dir, gboolean set_current_user)
  * Update port lists in the db that have changed on the feed.
  * Do nothing to db port lists that have been removed from the feed.
  *
- * @return 0 success, -1 error.
+ * @return 0 success, 1 no feed directory or owner, -1 error.
  */
 int
 sync_port_lists_with_feed ()
 {
+  int ret;
   GDir *dir;
   const gchar *port_list_path;
 
-  switch (try_open_port_lists_feed_dir (&dir, TRUE))
+  ret = try_open_port_lists_feed_dir (&dir, TRUE);
+  switch (ret)
     {
       case 0:
         // Successfully opened directory
         break;
-      case 1:
-        // No feed directory or feed owner
-        return 0; 
       default:
-        // Error
-        return -1;
+        return ret;
     }
 
   /* Sync each file in the directory. */

--- a/src/manage_port_lists.c
+++ b/src/manage_port_lists.c
@@ -327,19 +327,22 @@ sync_port_list_with_feed (const gchar *path)
 
 /**
  * @brief Open the port lists feed directory if it is available and the
- * feed owner is set. Also set the current user to the feed owner.
+ * feed owner is set.
+ * Optionally set the current user to the feed owner on success.
  * 
  * The sync will be skipped if the feed directory does not exist or
  *  the feed owner is not set. 
  * 
  * @param[out]  dir The directory as GDir if available and feed owner is set,
  * NULL otherwise.
+ * @param[in]   set_current_user Whether to set current user to feed owner.
  *
  * @return 0 success, 1 no feed directory or owner, -1 error
  */
 static int
-try_open_port_lists_feed_dir (GDir **dir)
+try_open_port_lists_feed_dir (GDir **dir, gboolean set_current_user)
 {
+  char *feed_owner_uuid, *feed_owner_name;
   GError *error;
 
   /* Test if base feed directory exists */
@@ -349,18 +352,18 @@ try_open_port_lists_feed_dir (GDir **dir)
 
   /* Setup owner. */
 
-  setting_value (SETTING_UUID_FEED_IMPORT_OWNER, &current_credentials.uuid);
+  setting_value (SETTING_UUID_FEED_IMPORT_OWNER, &feed_owner_uuid);
 
-  if (current_credentials.uuid == NULL
-      || strlen (current_credentials.uuid) == 0)
+  if (feed_owner_uuid == NULL
+      || strlen (feed_owner_uuid) == 0)
     {
       /* Sync is disabled by having no "Feed Import Owner". */
       g_debug ("%s: no Feed Import Owner so not syncing from feed", __func__);
       return 1;
     }
 
-  current_credentials.username = user_name (current_credentials.uuid);
-  if (current_credentials.username == NULL)
+  feed_owner_name = user_name (feed_owner_uuid);
+  if (feed_owner_name == NULL)
     {
       g_debug ("%s: unknown Feed Import Owner so not syncing from feed", __func__);
       return 1;
@@ -375,12 +378,22 @@ try_open_port_lists_feed_dir (GDir **dir)
       g_warning ("%s: Failed to open directory '%s': %s",
                  __func__, feed_dir_port_lists (), error->message);
       g_error_free (error);
-      g_free (current_credentials.uuid);
-      g_free (current_credentials.username);
-      current_credentials.uuid = NULL;
-      current_credentials.username = NULL;
+      free (feed_owner_uuid);
+      free (feed_owner_name);
       return -1;
     }
+
+  if (set_current_user)
+    {
+      current_credentials.uuid = feed_owner_uuid;
+      current_credentials.username = feed_owner_name;
+    }
+  else
+    {
+      free (feed_owner_uuid);
+      free (feed_owner_name);
+    }
+
   return 0;
 }
   
@@ -399,7 +412,7 @@ sync_port_lists_with_feed ()
   GDir *dir;
   const gchar *port_list_path;
 
-  switch (try_open_port_lists_feed_dir (&dir))
+  switch (try_open_port_lists_feed_dir (&dir, TRUE))
     {
       case 0:
         // Successfully opened directory

--- a/src/manage_port_lists.c
+++ b/src/manage_port_lists.c
@@ -483,6 +483,8 @@ manage_rebuild_port_lists ()
 
 /**
  * @brief Checks if the port lists should be synced with the feed.
+ *
+ * @return 1 if port lists should be synced, 0 otherwise
  */
 gboolean
 should_sync_port_lists ()

--- a/src/manage_port_lists.h
+++ b/src/manage_port_lists.h
@@ -133,4 +133,7 @@ port_lists_feed_dir_exists ();
 void
 manage_sync_port_lists ();
 
+gboolean
+should_sync_port_lists ();
+
 #endif /* not _GVMD_MANAGE_PORT_LISTS_H */

--- a/src/manage_port_lists.h
+++ b/src/manage_port_lists.h
@@ -133,6 +133,9 @@ port_lists_feed_dir_exists ();
 void
 manage_sync_port_lists ();
 
+int
+manage_rebuild_port_lists ();
+
 gboolean
 should_sync_port_lists ();
 

--- a/src/manage_report_formats.c
+++ b/src/manage_report_formats.c
@@ -773,7 +773,7 @@ try_open_report_formats_feed_dir (GDir **dir, gboolean set_current_user)
  *
  * @param[in]  rebuild  Whether ignore timestamps to force a rebuild.
  *
- * @return 0 success, 1 no feed directory or owner, -1 error.
+ * @return 0 success, 1 no feed directory, 2 no feed owner, -1 error.
  */
 int
 sync_report_formats_with_feed (gboolean rebuild)
@@ -829,6 +829,17 @@ void
 manage_sync_report_formats ()
 {
   sync_report_formats_with_feed (FALSE);
+}
+
+/**
+ * @brief Rebuild port lists from the feed.
+ *
+ * @return 0 success, 1 no feed directory, 2 no feed owner, -1 error.
+ */
+int
+manage_rebuild_report_formats ()
+{
+  return sync_report_formats_with_feed (TRUE);
 }
 
 /**

--- a/src/manage_report_formats.c
+++ b/src/manage_report_formats.c
@@ -824,3 +824,27 @@ manage_sync_report_formats ()
 {
   sync_report_formats_with_feed ();
 }
+
+/**
+ * @brief Checks if the report formats should be synced with the feed.
+ */
+gboolean
+should_sync_report_formats ()
+{
+  GDir *dir;
+  const gchar *report_format_path;
+  report_format_t report_format;
+
+  if (try_open_report_formats_feed_dir (&dir, FALSE))
+    return FALSE;
+
+  while ((report_format_path = g_dir_read_name (dir)))
+    if (g_str_has_prefix (report_format_path, ".") == 0
+        && strlen (report_format_path) >= (36 /* UUID */ + strlen (".xml"))
+        && g_str_has_suffix (report_format_path, ".xml")
+        && should_sync_report_format_from_path (report_format_path,
+                                                &report_format))
+      return TRUE;
+
+  return FALSE;
+}

--- a/src/manage_report_formats.c
+++ b/src/manage_report_formats.c
@@ -844,6 +844,8 @@ manage_rebuild_report_formats ()
 
 /**
  * @brief Checks if the report formats should be synced with the feed.
+ *
+ * @return 1 if report formats should be synced, 0 otherwise
  */
 gboolean
 should_sync_report_formats ()

--- a/src/manage_report_formats.c
+++ b/src/manage_report_formats.c
@@ -765,25 +765,23 @@ try_open_report_formats_feed_dir (GDir **dir, gboolean set_current_user)
  * Update report formats in the db that have changed on the feed.
  * Do nothing to report formats in db that have been removed from the feed.
  *
- * @return 0 success, -1 error.
+ * @return 0 success, 1 no feed directory or owner, -1 error.
  */
 int
 sync_report_formats_with_feed ()
 {
+  int ret;
   GDir *dir;
   const gchar *report_format_path;
 
-  switch (try_open_report_formats_feed_dir (&dir, TRUE))
+  ret = try_open_report_formats_feed_dir (&dir, TRUE);
+  switch (ret)
     {
       case 0:
         // Successfully opened directory
         break;
-      case 1:
-        // No feed directory or feed owner
-        return 0; 
       default:
-        // Error
-        return -1;
+        return ret;
     }
 
   /* Sync each file in the directory. */

--- a/src/manage_report_formats.c
+++ b/src/manage_report_formats.c
@@ -697,7 +697,7 @@ sync_report_format_with_feed (const gchar *path)
  * NULL otherwise.
  * @param[in]   set_current_user Whether to set current user to feed owner.
  *
- * @return 0 success, 1 no feed directory or owner, -1 error
+ * @return 0 success, 1 no feed directory, 2 no feed owner, -1 error.
  */
 static int
 try_open_report_formats_feed_dir (GDir **dir, gboolean set_current_user)
@@ -708,7 +708,7 @@ try_open_report_formats_feed_dir (GDir **dir, gboolean set_current_user)
   /* Test if base feed directory exists */
 
   if (report_formats_feed_dir_exists () == FALSE)
-    return 0;
+    return 1;
 
   /* Setup owner. */
 
@@ -719,7 +719,7 @@ try_open_report_formats_feed_dir (GDir **dir, gboolean set_current_user)
     {
       /* Sync is disabled by having no "Feed Import Owner". */
       g_debug ("%s: no Feed Import Owner so not syncing from feed", __func__);
-      return 1;
+      return 2;
     }
 
   feed_owner_name = user_name (feed_owner_uuid);
@@ -727,7 +727,7 @@ try_open_report_formats_feed_dir (GDir **dir, gboolean set_current_user)
     {
       g_debug ("%s: unknown Feed Import Owner so not syncing from feed",
                __func__);
-      return 1;
+      return 2;
     }
 
   /* Open feed import directory. */

--- a/src/manage_report_formats.h
+++ b/src/manage_report_formats.h
@@ -234,4 +234,7 @@ report_formats_feed_dir_exists ();
 void
 manage_sync_report_formats ();
 
+gboolean
+should_sync_report_formats ();
+
 #endif /* not _GVMD_MANAGE_REPORT_FORMATS_H */

--- a/src/manage_report_formats.h
+++ b/src/manage_report_formats.h
@@ -234,6 +234,9 @@ report_formats_feed_dir_exists ();
 void
 manage_sync_report_formats ();
 
+int
+manage_rebuild_report_formats ();
+
 gboolean
 should_sync_report_formats ();
 

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -48,7 +48,7 @@
 /* Static headers for internal non-SQL functions. */
 
 int
-sync_configs_with_feed ();
+sync_configs_with_feed (gboolean);
 
 
 /* Static headers. */
@@ -4936,7 +4936,7 @@ check_db_configs ()
 {
   migrate_predefined_configs ();
 
-  if (sync_configs_with_feed () <= -1)
+  if (sync_configs_with_feed (FALSE) <= -1)
     g_warning ("%s: Failed to sync configs with feed", __func__);
 
   /* Warn about feed resources in the trash. */

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -4936,7 +4936,7 @@ check_db_configs ()
 {
   migrate_predefined_configs ();
 
-  if (sync_configs_with_feed ())
+  if (sync_configs_with_feed () <= -1)
     g_warning ("%s: Failed to sync configs with feed", __func__);
 
   /* Warn about feed resources in the trash. */

--- a/src/manage_sql_port_lists.c
+++ b/src/manage_sql_port_lists.c
@@ -2596,7 +2596,7 @@ check_db_port_lists ()
 {
   migrate_predefined_port_lists ();
 
-  if (sync_port_lists_with_feed ())
+  if (sync_port_lists_with_feed () <= -1)
     g_warning ("%s: Failed to sync port lists with feed", __func__);
 
   /*

--- a/src/manage_sql_port_lists.c
+++ b/src/manage_sql_port_lists.c
@@ -45,7 +45,7 @@
 /* Static headers for internal non-SQL functions. */
 
 int
-sync_port_lists_with_feed ();
+sync_port_lists_with_feed (gboolean);
 
 
 /* Port list functions. */
@@ -2596,7 +2596,7 @@ check_db_port_lists ()
 {
   migrate_predefined_port_lists ();
 
-  if (sync_port_lists_with_feed () <= -1)
+  if (sync_port_lists_with_feed (FALSE) <= -1)
     g_warning ("%s: Failed to sync port lists with feed", __func__);
 
   /*

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -59,7 +59,7 @@
 /* Non-SQL internals defined in manage_report_formats.c. */
 
 int
-sync_report_formats_with_feed ();
+sync_report_formats_with_feed (gboolean);
 
 
 /* Static headers. */
@@ -4553,7 +4553,7 @@ check_db_report_formats ()
   if (migrate_predefined_report_formats ())
     return -1;
 
-  if (sync_report_formats_with_feed () <= -1)
+  if (sync_report_formats_with_feed (FALSE) <= -1)
     g_warning ("%s: Failed to sync report formats with feed", __func__);
 
   if (check_db_trash_report_formats ())

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -4553,7 +4553,7 @@ check_db_report_formats ()
   if (migrate_predefined_report_formats ())
     return -1;
 
-  if (sync_report_formats_with_feed ())
+  if (sync_report_formats_with_feed () <= -1)
     g_warning ("%s: Failed to sync report formats with feed", __func__);
 
   if (check_db_trash_report_formats ())


### PR DESCRIPTION
**What**:
The new option allows forcing gvmd to rebuild the gvmd data objects 
(configs, port lists and report formats) provided by the feed.

**Why**:
This addresses AP-1645 and AP-1646

**How did you test it**:
By running the command with various types given when there was either
no feed activity or while a `--rebuild` of the NVTs was active (to test the
"Feed locked" error).

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
