### PR TITLE
Log warning if --rebuild-gvmd-data fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [21.4.4] (unreleased)
 ### Added
-- Add --rebuild-gvmd-data command line option [#1680](https://github.com/greenbone/gvmd/pull/1680)
+- Add --rebuild-gvmd-data command line option [#1680](https://github.com/greenbone/gvmd/pull/1680) [#1683](https://github.com/greenbone/gvmd/pull/1683)
 
 ### Changed
 ### Deprecated

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -2589,13 +2589,15 @@ gvmd (int argc, char** argv)
                                                 log_config,
                                                 &database,
                                                 &error_msg);
-      log_config_free ();
       if (ret)
         {
+          g_warning ("Failed to rebuild gvmd data: %s\n", error_msg);
           printf ("Failed to rebuild gvmd data: %s\n", error_msg);
           g_free (error_msg);
+          log_config_free ();
           return EXIT_FAILURE;
         }
+      log_config_free ();
       return EXIT_SUCCESS;
     }
 


### PR DESCRIPTION
**What**:
In addition to printing it to stdout the failure message will also
be written to the gvmd log.

**Why**:
Having a warning in the log helps finding the reason for a failure
if the rebuild is automated.

**How did you test it**:
By making the rebuild fail due to a concurrent `gvmd --rebuild`.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
