### PR TITLE
Send dedicated error message to the create ticket dialogue if create permission permission is missing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Deprecated
 ### Removed
 ### Fixed
+-Added a dedicated error message for the create ticket dialogue when the create permission permission is missing [#1686](https://github.com/greenbone/gvmd/pull/1686)
 
 [Unreleased]: https://github.com/greenbone/gvmd/compare/v21.4.3...HEAD
 

--- a/src/gmp_tickets.c
+++ b/src/gmp_tickets.c
@@ -540,6 +540,12 @@ create_ticket_run (gmp_parser_t *gmp_parser, GError **error)
             return;
           }
         break;
+      case 98:
+        SEND_TO_CLIENT_OR_FAIL
+         (XML_ERROR_SYNTAX ("create_ticket",
+                            "Permission to create permission denied"));
+        log_event_fail ("ticket", "Ticket", NULL, "created");
+        break;
       case 99:
         SEND_TO_CLIENT_OR_FAIL
          (XML_ERROR_SYNTAX ("create_ticket",


### PR DESCRIPTION
If the create permission permission is missing when creating a
ticket, a new, dedicated error message is now sent to GSA.

**What**:
In manage_sql_tickets.c in function create_ticket (..):
  A new error code is returned in case of a missing create
  permission permission.

In gmp_tickets.c in function create_ticket_run (..):
  A new error message is sent to GSA if the create permission
  permission is missing.


<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
This change is part of a bug-fix.
<!-- Why are these changes necessary? -->

**How did you test it**:
Tried to create a ticket with and without the create permission permission.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
