### PR TITLE
Fix import of report results / errors without host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 ### Fixed
 - Fix resume task. [#1679](https://github.com/greenbone/gvmd/pull/1679)
+- Fix import of report results / errors without host [#1687](https://github.com/greenbone/gvmd/pull/1687)
 
 
 [Unreleased]: https://github.com/greenbone/gvmd/compare/v21.4.3...HEAD

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -18169,8 +18169,9 @@ gmp_xml_handle_result ()
   // https://www.freebsd.org/cgi/man.cgi?query=strcspn&sektion=3
   // strcspn returns the number of chars spanned so it should be safe
   // without double checking.
-  create_report_data
-    ->result_host[strcspn (create_report_data->result_host, "\n")] = 0;
+  if (create_report_data->result_host)
+    create_report_data
+      ->result_host[strcspn (create_report_data->result_host, "\n")] = 0;
   result->host = create_report_data->result_host;
   result->hostname = create_report_data->result_hostname;
   result->nvt_oid = create_report_data->result_nvt_oid;


### PR DESCRIPTION
**What**:
The gmp_xml_handle_result function will now no longer try to
remove newlines from the host if it is NULL.

**Why**:
When importing reports, errors may not have any host assigned,
which caused a segmentation fault without the added check
(AP-1641).

**How did you test it**:
By importing a report with an error message without a host.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
