### PR TITLE
Remove hr_name from gvmd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 247)
+set (GVMD_DATABASE_VERSION 248)
 
 set (GVMD_SCAP_DATABASE_VERSION 19)
 

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -8543,7 +8543,6 @@ buffer_config_preference_xml (GString *buffer, iterator_t *prefs,
                             "<preference>"
                             "<nvt oid=\"%s\"><name>%s</name></nvt>"
                             "<id>%s</id>"
-                            "<hr_name>%s</hr_name>"
                             "<name>%s</name>"
                             "<type>%s</type>",
                             oid ? oid : "",
@@ -11726,9 +11725,8 @@ handle_get_configs (gmp_parser_t *gmp_parser, GError **error)
           init_config_preference_iterator (&prefs, config);
           while (next (&prefs))
             {
-              const char *name, *hr_name, *value, *type, *def;
+              const char *name, *value, *type, *def;
 
-              hr_name = config_preference_iterator_hr_name (&prefs);
               name = config_preference_iterator_name (&prefs);
               value = config_preference_iterator_value (&prefs);
               def = config_preference_iterator_default (&prefs);
@@ -11736,14 +11734,13 @@ handle_get_configs (gmp_parser_t *gmp_parser, GError **error)
               SENDF_TO_CLIENT_OR_FAIL
                ("<preference>"
                 "<nvt oid=\"\"><name/></nvt>"
-                "<hr_name>%s</hr_name>"
                 "<id/>"
                 "<name>%s</name>"
                 "<type>osp_%s</type>"
                 "<value>%s</value>"
                 "<default>%s</default>"
                 "</preference>",
-                hr_name, name, type, value ?: "", def);
+                name, type, value ?: "", def);
             }
           cleanup_iterator (&prefs);
           SEND_TO_CLIENT_OR_FAIL ("</preferences>");

--- a/src/gmp_configs.c
+++ b/src/gmp_configs.c
@@ -282,8 +282,8 @@ parse_config_entity (entity_t config, const char **config_id, char **name,
       children = preferences->entities;
       while ((preference = first_entity (children)))
         {
-          entity_t pref_name, pref_nvt_name, hr_name, nvt, alt;
-          char *preference_hr_name, *preference_nvt_oid;
+          entity_t pref_name, pref_nvt_name, nvt, alt;
+          char *preference_nvt_oid;
           array_t *import_alts;
           entities_t alts;
           preference_t *new_preference;
@@ -294,17 +294,6 @@ parse_config_entity (entity_t config, const char **config_id, char **name,
           nvt = entity_child (preference, "nvt");
           if (nvt)
             pref_nvt_name = entity_child (nvt, "name");
-
-          hr_name = entity_child (preference, "hr_name");
-          if (*type == NULL || strcmp (*type, "0") == 0)
-            /* Classic OpenVAS config preference. */
-            preference_hr_name = NULL;
-          else if (hr_name && strlen (entity_text (hr_name)))
-            /* OSP config preference with hr_name given. */
-            preference_hr_name = entity_text (hr_name);
-          else
-            /* Old OSP config without hr_name. */
-            preference_hr_name = text_or_null (pref_name);
 
           import_alts = make_array ();
           alts = preference->entities;
@@ -374,7 +363,6 @@ parse_config_entity (entity_t config, const char **config_id, char **name,
                        preference_nvt_oid,
                        import_alts,
                        text_or_null (entity_child (preference, "default")),
-                       preference_hr_name,
                        0 /* do not free strings */);
             }
 

--- a/src/manage_configs.h
+++ b/src/manage_configs.h
@@ -162,9 +162,6 @@ config_preference_iterator_type (iterator_t *);
 const char*
 config_preference_iterator_default (iterator_t *);
 
-const char*
-config_preference_iterator_hr_name (iterator_t *);
-
 int
 manage_set_config (config_t, const char*, const char *, const char *);
 

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -2816,6 +2816,41 @@ migrate_246_to_247 ()
   return 0;
 }
 
+/**
+ * @brief Migrate the database from version 247 to version 248.
+ *
+ * @return 0 success, -1 error.
+ */
+int
+migrate_247_to_248 ()
+{
+  sql_begin_immediate ();
+
+  /* Ensure that the database is currently version 247. */
+
+  if (manage_db_version () != 247)
+    {
+      sql_rollback ();
+      return -1;
+    }
+
+  /* Update the database. */
+
+  /* OSP-scanners are no longer supported. So delete the
+   * the column hr_name, which was only used by OSP-scanners.
+   */
+  sql ("ALTER TABLE config_preferences DROP COLUMN hr_name;");
+  sql ("ALTER TABLE config_preferences_trash DROP COLUMN hr_name;");
+
+  /* Set the database version to 248. */
+
+  set_db_version (248);
+
+  sql_commit ();
+
+  return 0;
+}
+
 
 #undef UPDATE_DASHBOARD_SETTINGS
 
@@ -2870,6 +2905,7 @@ static migrator_t database_migrators[] = {
   {245, migrate_244_to_245},
   {246, migrate_245_to_246},
   {247, migrate_246_to_247},
+  {248, migrate_247_to_248},
   /* End marker. */
   {-1, NULL}};
 

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -2270,8 +2270,7 @@ create_tables ()
        "  type text,"
        "  name text,"
        "  value text,"
-       "  default_value text,"
-       "  hr_name text);");
+       "  default_value text);");
 
   sql ("CREATE TABLE IF NOT EXISTS config_preferences_trash"
        " (id SERIAL PRIMARY KEY,"
@@ -2279,8 +2278,7 @@ create_tables ()
        "  type text,"
        "  name text,"
        "  value text,"
-       "  default_value text,"
-       "  hr_name text);");
+       "  default_value text);");
 
   sql ("CREATE TABLE IF NOT EXISTS schedules"
        " (id SERIAL PRIMARY KEY,"

--- a/src/manage_preferences.c
+++ b/src/manage_preferences.c
@@ -36,7 +36,6 @@
  * @param[in]  nvt_oid   OID of NVT of preference.
  * @param[in]  alts      Array of gchar's.  Alternative values for type radio.
  * @param[in]  default_value   Default value of preference.
- * @param[in]  hr_name   Extended, more human-readable name of the preference.
  * @param[in]  free_strings Whether string fields are freed by preference_free.
  *
  * @return Newly allocated preference.
@@ -44,7 +43,7 @@
 gpointer
 preference_new (char *id, char *name, char *type, char *value, char *nvt_name,
                 char *nvt_oid, array_t *alts, char* default_value,
-                char *hr_name, int free_strings)
+                int free_strings)
 {
   preference_t *preference;
 
@@ -57,7 +56,6 @@ preference_new (char *id, char *name, char *type, char *value, char *nvt_name,
   preference->nvt_oid = nvt_oid;
   preference->alts = alts;
   preference->default_value = default_value;
-  preference->hr_name = hr_name;
   preference->free_strings = free_strings;
 
   return preference;
@@ -85,7 +83,6 @@ preference_free (preference_t *preference)
       free (preference->nvt_name);
       free (preference->nvt_oid);
       free (preference->default_value);
-      free (preference->hr_name);
     }
 
   g_free (preference);

--- a/src/manage_preferences.h
+++ b/src/manage_preferences.h
@@ -39,14 +39,12 @@ typedef struct
   char *nvt_oid;       ///< OID of NVT preference affects.
   array_t *alts;       ///< Array of gchar's.  Alternate values for radio type.
   char *default_value; ///< Default value of preference.
-  char *hr_name;       ///< Extended, more human-readable name used by OSP.
   int free_strings;    ///< Whether string fields are freed by preference_free.
 } preference_t;
 
 gpointer
 preference_new (char *, char *, char *, char *, char *,
-                char *, array_t *, char*,
-                char *, int);
+                char *, array_t *, char*, int);
 
 void
 preference_free (preference_t *);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -46010,8 +46010,8 @@ manage_restore (const char *id)
       config = sql_last_insert_id ();
 
       sql ("INSERT INTO config_preferences"
-           " (config, type, name, value, default_value, hr_name)"
-           " SELECT %llu, type, name, value, default_value, hr_name"
+           " (config, type, name, value, default_value)"
+           " SELECT %llu, type, name, value, default_value"
            " FROM config_preferences_trash WHERE config = %llu;",
            config,
            resource);

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -2184,11 +2184,11 @@ get_nvt_preference_by_id (const char *nvt_oid,
                           const char *value)
 {
   preference_t *new_pref;
-  char *full_name, *id, *name, *type, *nvt_name, *default_value, *hr_name;
+  char *full_name, *id, *name, *type, *nvt_name, *default_value;
   array_t *alts;
   gchar *quoted_oid, *quoted_id;
 
-  full_name = name = type = nvt_name = default_value = hr_name = NULL;
+  full_name = name = type = nvt_name = default_value = NULL;
 
   /* Check parameters */
   if (nvt_oid == NULL)
@@ -2279,7 +2279,6 @@ get_nvt_preference_by_id (const char *nvt_oid,
                              strdup (nvt_oid),
                              alts,
                              default_value,
-                             hr_name,
                              1);
 
   return new_pref;
@@ -2338,7 +2337,7 @@ config_insert_preferences (config_t config,
         else if (preference->type)
           {
             gchar *quoted_type, *quoted_nvt_oid, *quoted_preference_name;
-            gchar *quoted_default, *quoted_preference_hr_name;
+            gchar *quoted_default;
             gchar *quoted_preference_id;
 
             /* Presume NVT or OSP preference. */
@@ -2357,10 +2356,6 @@ config_insert_preferences (config_t config,
             quoted_nvt_oid = sql_quote (preference->nvt_oid ?: "");
             quoted_preference_id = sql_quote (preference->id ?: "");
             quoted_preference_name = sql_quote (preference->name);
-            quoted_preference_hr_name
-              = preference->hr_name
-                  ? sql_quote (preference->hr_name)
-                  : NULL;
             quoted_type
               = g_str_has_prefix (preference->type, "osp_")
                   ? sql_quote (preference->type + strlen ("osp_"))
@@ -2389,22 +2384,19 @@ config_insert_preferences (config_t config,
               {
                 /* OSP preference */
                 sql ("INSERT into config_preferences"
-                     " (config, type, name, value, default_value, hr_name)"
-                     " VALUES (%llu, '%s', '%s', '%s', '%s', '%s');",
+                     " (config, type, name, value, default_value)"
+                     " VALUES (%llu, '%s', '%s', '%s', '%s');",
                      config,
                      quoted_type,
                      quoted_preference_name,
                      quoted_value,
-                     quoted_default,
-                     quoted_preference_hr_name
-                      ? quoted_preference_name : quoted_preference_hr_name);
+                     quoted_default);
               }
             g_free (quoted_nvt_oid);
             g_free (quoted_preference_name);
             g_free (quoted_type);
             g_free (quoted_value);
             g_free (quoted_default);
-            g_free (quoted_preference_hr_name);
             g_free (quoted_preference_id);
           }
         else
@@ -2718,10 +2710,10 @@ insert_osp_parameter (osp_param_t *param, config_t config)
                config, param_id, param_type, param_def) == 0)
     {
       sql ("INSERT INTO config_preferences (config, name, type, value,"
-           " default_value, hr_name)"
-           " VALUES (%llu, '%s', '%s', '%s', '%s', '%s')",
+           " default_value)"
+           " VALUES (%llu, '%s', '%s', '%s', '%s')",
            config , param_id, param_type, param_value ?: param_def,
-           param_def, param_name);
+           param_def);
       ret = 1;
     }
   g_free (param_name);
@@ -3102,8 +3094,8 @@ copy_config (const char* name, const char* comment, const char *config_id,
   sql ("UPDATE configs SET predefined = 0 WHERE id = %llu;", new);
 
   sql ("INSERT INTO config_preferences (config, type, name, value,"
-       "                                default_value, hr_name)"
-       " SELECT %llu, type, name, value, default_value, hr_name"
+       "                                default_value)"
+       " SELECT %llu, type, name, value, default_value"
        " FROM config_preferences"
        " WHERE config = %llu;", new, old);
 
@@ -3280,8 +3272,8 @@ delete_config (const char *config_id, int ultimate)
       trash_config = sql_last_insert_id ();
 
       sql ("INSERT INTO config_preferences_trash"
-           " (config, type, name, value, default_value, hr_name)"
-           " SELECT %llu, type, name, value, default_value, hr_name"
+           " (config, type, name, value, default_value)"
+           " SELECT %llu, type, name, value, default_value"
            " FROM config_preferences WHERE config = %llu;",
            trash_config,
            config);
@@ -3324,7 +3316,7 @@ update_config_params (config_t config, const char *config_id, GSList *params)
 
   /* Remove parameters not used anymore. */
   init_iterator (&iterator,
-                 "SELECT id, name, type, default_value, hr_name"
+                 "SELECT id, name, type, default_value"
                  " FROM config_preferences"
                  " WHERE config = %llu;", config);
   while (next (&iterator))
@@ -3360,19 +3352,6 @@ update_config_params (config_t config, const char *config_id, GSList *params)
                      iterator_string (&iterator, 1), config_id);
           sql ("DELETE FROM config_preferences WHERE id = %llu;",
                iterator_int64 (&iterator, 0));
-        }
-      else if (strcmp (osp_param_name (element->data),
-                       iterator_string (&iterator, 4)))
-        {
-          // Update hr_name (= OSP name)
-          gchar *quoted_name;
-          quoted_name = sql_quote (osp_param_name (element->data));
-          g_message ("Updating name of config preference %s in config '%s'",
-                     iterator_string (&iterator, 1), config_id);
-          sql ("UPDATE config_preferences SET hr_name='%s' WHERE id = %llu;",
-               quoted_name,
-               iterator_int64 (&iterator, 0));
-          g_free (quoted_name);
         }
     }
   cleanup_iterator (&iterator);
@@ -3793,7 +3772,7 @@ init_config_preference_iterator (iterator_t* iterator, config_t config)
 {
   gchar* sql;
 
-  sql = g_strdup_printf ("SELECT name, value, type, default_value, hr_name"
+  sql = g_strdup_printf ("SELECT name, value, type, default_value"
                          " FROM config_preferences"
                          " WHERE config = %llu;",
                          config);
@@ -3842,19 +3821,6 @@ DEF_ACCESS (config_preference_iterator_type, 2);
  *         complete.  Freed by cleanup_iterator.
  */
 DEF_ACCESS (config_preference_iterator_default, 3);
-
-/**
- * @brief Get the hr_name from a preference iterator.
- *
- * Note: This corresponds to the "name" in OSP and is not defined for classic
- *  OpenVAS config preferences.
- *
- * @param[in]  iterator  Iterator.
- *
- * @return The hr_name of the preference iterator, or NULL if iteration is
- *         complete.  Freed by cleanup_iterator.
- */
-DEF_ACCESS (config_preference_iterator_hr_name, 4);
 
 /**
  * @brief Initialise a config preference iterator, with defaults.

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -7564,7 +7564,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <name>preference</name>
             <pattern>
               <e>nvt</e>
-              <e>hr_name</e>
               <e>name</e>
               <e>id</e>
               <e>type</e>
@@ -7588,11 +7587,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <summary>The name of the NVT</summary>
                 <pattern><t>name</t></pattern>
               </ele>
-            </ele>
-            <ele>
-              <name>hr_name</name>
-              <summary>The full, more "human readable" name of the preference</summary>
-              <pattern><t>name</t></pattern>
             </ele>
             <ele>
               <name>name</name>
@@ -13136,7 +13130,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <pattern>
               <e>nvt</e>
               <e>name</e>
-              <e>hr_name</e>
               <e>id</e>
               <e>type</e>
               <e>value</e>
@@ -13163,11 +13156,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <ele>
               <name>name</name>
               <summary>The name of the preference</summary>
-              <pattern>text</pattern>
-            </ele>
-            <ele>
-              <name>hr_name</name>
-              <summary>The full, more "human readable" name of the preference</summary>
               <pattern>text</pattern>
             </ele>
             <ele>
@@ -14690,7 +14678,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <name>preference</name>
         <pattern>
           <e>nvt</e>
-          <e>hr_name</e>
           <e>name</e>
           <e>id</e>
           <e>type</e>
@@ -14714,11 +14701,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <summary>The name of the NVT</summary>
             <pattern><t>name</t></pattern>
           </ele>
-        </ele>
-        <ele>
-          <name>hr_name</name>
-          <summary>The full, more "human readable" name of the preference</summary>
-          <pattern><t>name</t></pattern>
         </ele>
         <ele>
           <name>name</name>


### PR DESCRIPTION
**What**:
OSP scanners are no longer supported and the corresponding code is
being removed from gvmd. Because the field "hr_name" is only used by
OSP scanners, it is also removed from gvmd.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
OSP scanners are no longer supported.
<!-- Why are these changes necessary? -->

**How did you test it**:
Tested scan configs, scanner preferences, the scanner dialog and scans in GSA.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
