### PR TITLE
Use libtheia for get_license GMP command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Add a new modification_time column to reports [#1513](https://github.com/greenbone/gvmd/pull/1513), [#1519](https://github.com/greenbone/gvmd/pull/1519), [#1590](https://github.com/greenbone/gvmd/pull/1590)
 - Add basic Sentry integration and logging [#1550](https://github.com/greenbone/gvmd/pull/1550)
-- Add GMP get_license and modify_license [#1642](https://github.com/greenbone/gvmd/pull/1642), [#1696](https://github.com/greenbone/gvmd/pull/1696)
-
+- Add GMP get_license and modify_license [#1642](https://github.com/greenbone/gvmd/pull/1642), [#1692](https://github.com/greenbone/gvmd/pull/1692), [#1696](https://github.com/greenbone/gvmd/pull/1696)
 ### Changed
 - Use pg-gvm extension for C PostgreSQL functions [#1400](https://github.com/greenbone/gvmd/pull/1400), [#1453](https://github.com/greenbone/gvmd/pull/1453)
 - Change report timestamp filter and iterator columns [#1512](https://github.com/greenbone/gvmd/pull/1512)

--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -13,6 +13,9 @@ It manages the storage of any vulnerability management configurations and of the
 \fB-h, --help\f1
 Show help options.
 .TP
+\fB--broker-address=\fIADDRESS\fB\f1
+Sets the address for the publish-subscribe message (MQTT) broker. Defaults to localhost:9138. Set to empty to disable. 
+.TP
 \fB--check-alerts\f1
 Check SecInfo alerts.
 .TP

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -53,6 +53,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </optdesc>
     </option>
     <option>
+      <p><opt>--broker-address=<arg>ADDRESS</arg></opt></p>
+      <optdesc>
+        <p>
+          Sets the address for the publish-subscribe message (MQTT) broker.
+          Defaults to localhost:9138. Set to empty to disable.
+        </p>
+      </optdesc>
+    </option>
+    <option>
       <p><opt>--check-alerts</opt></p>
       <optdesc>
         <p>Check SecInfo alerts.</p>

--- a/doc/gvmd.html
+++ b/doc/gvmd.html
@@ -37,6 +37,13 @@
       
     
     
+      <p><b>--broker-address=<em>ADDRESS</em></b></p>
+      
+        <p>Sets the address for the publish-subscribe message (MQTT) broker.
+          Defaults to localhost:9138. Set to empty to disable.</p>
+      
+    
+    
       <p><b>--check-alerts</b></p>
       
         <p>Check SecInfo alerts.</p>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,15 +83,15 @@ else (NOT GPGME)
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 endif (NOT GPGME)
 
-find_package(Theia 1.0.0 QUIET)
-if (Theia_DIR)
-  message (STATUS "Found libtheia ${Theia_VERSION} in ${Theia_DIR}")
+if (WITH_LIBTHEIA)
+  find_package(Theia 1.0.0 REQUIRED)
+  message (STATUS "Using libtheia ${Theia_VERSION} in ${Theia_DIR}")
   add_definitions (-DHAS_LIBTHEIA="1")
   set (OPT_THEIA_TGT Theia::Theia)
-else (Theia_DIR)
-  message (STATUS "No compatible libtheia version found")
+else (WITH_LIBTHEIA)
+  message (STATUS "Not using libtheia - licensing functions disabled")
   set (OPT_THEIA_TGT "")
-endif (Theia_DIR)
+endif (WITH_LIBTHEIA)
 
 include_directories (${LIBGVM_GMP_INCLUDE_DIRS}
                      ${LIBGVM_BASE_INCLUDE_DIRS} ${LIBGVM_UTIL_INCLUDE_DIRS}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,6 +83,16 @@ else (NOT GPGME)
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 endif (NOT GPGME)
 
+find_package(Theia 1.0.0 QUIET)
+if (Theia_DIR)
+  message (STATUS "Found libtheia ${Theia_VERSION} in ${Theia_DIR}")
+  add_definitions (-DHAS_LIBTHEIA="1")
+  set (OPT_THEIA_TGT Theia::Theia)
+else (Theia_DIR)
+  message (STATUS "No compatible libtheia version found")
+  set (OPT_THEIA_TGT "")
+endif (Theia_DIR)
+
 include_directories (${LIBGVM_GMP_INCLUDE_DIRS}
                      ${LIBGVM_BASE_INCLUDE_DIRS} ${LIBGVM_UTIL_INCLUDE_DIRS}
                      ${LIBGVM_OSP_INCLUDE_DIRS}  ${GLIB_INCLUDE_DIRS})
@@ -260,32 +270,32 @@ target_link_libraries (gvmd m
                        ${GNUTLS_LDFLAGS} ${GPGME_LDFLAGS} ${CMAKE_THREAD_LIBS_INIT} ${LINKER_HARDENING_FLAGS} ${LINKER_DEBUG_FLAGS}
                        ${PostgreSQL_LIBRARIES} ${GLIB_LDFLAGS} ${GTHREAD_LDFLAGS}
                        ${LIBGVM_BASE_LDFLAGS} ${LIBGVM_UTIL_LDFLAGS} ${LIBGVM_OSP_LDFLAGS} ${LIBGVM_GMP_LDFLAGS}
-                       ${LIBICAL_LDFLAGS} ${LINKER_HARDENING_FLAGS})
+                       ${LIBICAL_LDFLAGS} ${LINKER_HARDENING_FLAGS} ${OPT_THEIA_TGT})
 target_link_libraries (manage-test cgreen m
                        ${GNUTLS_LDFLAGS} ${GPGME_LDFLAGS} ${CMAKE_THREAD_LIBS_INIT} ${LINKER_HARDENING_FLAGS} ${LINKER_DEBUG_FLAGS}
                        ${PostgreSQL_LIBRARIES} ${GLIB_LDFLAGS} ${GTHREAD_LDFLAGS}
                        ${LIBGVM_BASE_LDFLAGS} ${LIBGVM_UTIL_LDFLAGS} ${LIBGVM_OSP_LDFLAGS} ${LIBGVM_GMP_LDFLAGS}
-                       ${LIBICAL_LDFLAGS} ${LINKER_HARDENING_FLAGS})
+                       ${LIBICAL_LDFLAGS} ${LINKER_HARDENING_FLAGS} ${OPT_THEIA_TGT})
 target_link_libraries (manage-sql-test cgreen m
                        ${GNUTLS_LDFLAGS} ${GPGME_LDFLAGS} ${CMAKE_THREAD_LIBS_INIT} ${LINKER_HARDENING_FLAGS} ${LINKER_DEBUG_FLAGS}
                        ${PostgreSQL_LIBRARIES} ${GLIB_LDFLAGS} ${GTHREAD_LDFLAGS}
                        ${LIBGVM_BASE_LDFLAGS} ${LIBGVM_UTIL_LDFLAGS} ${LIBGVM_OSP_LDFLAGS} ${LIBGVM_GMP_LDFLAGS}
-                       ${LIBICAL_LDFLAGS} ${LINKER_HARDENING_FLAGS})
+                       ${LIBICAL_LDFLAGS} ${LINKER_HARDENING_FLAGS} ${OPT_THEIA_TGT})
 target_link_libraries (manage-utils-test cgreen m
                        ${GNUTLS_LDFLAGS} ${GPGME_LDFLAGS} ${CMAKE_THREAD_LIBS_INIT} ${LINKER_HARDENING_FLAGS} ${LINKER_DEBUG_FLAGS}
                        ${PostgreSQL_LIBRARIES} ${GLIB_LDFLAGS} ${GTHREAD_LDFLAGS}
                        ${LIBGVM_BASE_LDFLAGS} ${LIBGVM_UTIL_LDFLAGS} ${LIBGVM_OSP_LDFLAGS} ${LIBGVM_GMP_LDFLAGS}
-                       ${LIBICAL_LDFLAGS} ${LINKER_HARDENING_FLAGS})
+                       ${LIBICAL_LDFLAGS} ${LINKER_HARDENING_FLAGS} ${OPT_THEIA_TGT})
 target_link_libraries (gmp-tickets-test cgreen m
                        ${GNUTLS_LDFLAGS} ${GPGME_LDFLAGS} ${CMAKE_THREAD_LIBS_INIT} ${LINKER_HARDENING_FLAGS} ${LINKER_DEBUG_FLAGS}
                        ${PostgreSQL_LIBRARIES} ${GLIB_LDFLAGS} ${GTHREAD_LDFLAGS}
                        ${LIBGVM_BASE_LDFLAGS} ${LIBGVM_UTIL_LDFLAGS} ${LIBGVM_OSP_LDFLAGS} ${LIBGVM_GMP_LDFLAGS}
-                       ${LIBICAL_LDFLAGS} ${LINKER_HARDENING_FLAGS})
+                       ${LIBICAL_LDFLAGS} ${LINKER_HARDENING_FLAGS} ${OPT_THEIA_TGT})
 target_link_libraries (utils-test cgreen m
                        ${GNUTLS_LDFLAGS} ${GPGME_LDFLAGS} ${CMAKE_THREAD_LIBS_INIT} ${LINKER_HARDENING_FLAGS} ${LINKER_DEBUG_FLAGS}
                        ${PostgreSQL_LIBRARIES} ${GLIB_LDFLAGS} ${GTHREAD_LDFLAGS}
                        ${LIBGVM_BASE_LDFLAGS} ${LIBGVM_UTIL_LDFLAGS} ${LIBGVM_OSP_LDFLAGS} ${LIBGVM_GMP_LDFLAGS}
-                       ${LIBICAL_LDFLAGS} ${LINKER_HARDENING_FLAGS})
+                       ${LIBICAL_LDFLAGS} ${LINKER_HARDENING_FLAGS} ${OPT_THEIA_TGT})
 target_link_libraries (gvm-pg-server ${GLIB_LDFLAGS} ${GTHREAD_LDFLAGS} ${LIBGVM_BASE_LDFLAGS} ${LIBGVM_UTIL_LDFLAGS} ${LIBICAL_LDFLAGS} ${LINKER_HARDENING_FLAGS})
 
 set_target_properties (gvmd PROPERTIES LINKER_LANGUAGE C)

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -185,6 +185,11 @@
 #define DEFAULT_CLIENT_WATCH_INTERVAL 1
 
 /**
+ * @brief Default broker address
+ */
+#define DEFAULT_BROKER_ADDRESS "localhost:9138"
+
+/**
  * @brief Interval in seconds to check whether client connection was closed.
  */
 static int client_watch_interval = DEFAULT_CLIENT_WATCH_INTERVAL;
@@ -1841,6 +1846,7 @@ gvmd (int argc, char** argv)
   static gchar *role = NULL;
   static gchar *disable = NULL;
   static gchar *value = NULL;
+  static gchar *broker_address = NULL;
   static gchar *feed_lock_path = NULL;
   static int feed_lock_timeout = 0;
   static gchar *vt_verification_collation = NULL;
@@ -1851,6 +1857,11 @@ gvmd (int argc, char** argv)
   GOptionContext *option_context;
   static GOptionEntry option_entries[]
     = {
+        { "broker-address", '\0', 0, G_OPTION_ARG_STRING,
+          &broker_address,
+          "Sets the address for the publish-subscribe message (MQTT) broker."
+          " Defaults to " DEFAULT_BROKER_ADDRESS ". Set to empty to disable.",
+          "<address>" },
         { "check-alerts", '\0', 0, G_OPTION_ARG_NONE,
           &check_alerts,
           "Check SecInfo alerts.",
@@ -2216,6 +2227,11 @@ gvmd (int argc, char** argv)
     {
       client_watch_interval = 0;
     }
+
+  /* Set broker address */
+  set_broker_address (broker_address
+                        ? broker_address
+                        : DEFAULT_BROKER_ADDRESS);
 
   /* Set feed lock path */
   set_feed_lock_path (feed_lock_path);

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1851,6 +1851,8 @@ gvmd (int argc, char** argv)
   static int feed_lock_timeout = 0;
   static gchar *vt_verification_collation = NULL;
 
+  GString *full_disable_commands = g_string_new ("");
+
   int sentry_initialized;
   GError *error = NULL;
   lockfile_t lockfile_checking, lockfile_serving;
@@ -3062,7 +3064,18 @@ gvmd (int argc, char** argv)
   /* Setup global variables. */
 
   if (disable)
-    disabled_commands = g_strsplit (disable, ",", 0);
+    g_string_append (full_disable_commands, disable);
+
+#ifndef HAS_LIBTHEIA
+  if (full_disable_commands->len)
+    g_string_append_c (full_disable_commands, ',');
+  g_string_append (full_disable_commands, "get_license,modify_license");
+#endif
+
+  if (full_disable_commands->len)
+    disabled_commands = g_strsplit (full_disable_commands->str, ",", 0);
+
+  g_string_free(full_disable_commands, TRUE);
 
   scheduling_enabled = (disable_scheduling == FALSE);
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -163,6 +163,11 @@
 #define MAX_HOSTS_DEFAULT "20"
 
 /**
+ * @brief Address of the broker used for publish-subscribe messaging (MQTT).
+ */
+static gchar *broker_address = NULL;
+
+/**
  * @brief Path to the feed lock file
  */
 static gchar *feed_lock_path = NULL;
@@ -5916,6 +5921,32 @@ manage_gvmd_data_feed_dirs_exist ()
          && configs_feed_dir_exists ()
          && port_lists_feed_dir_exists ()
          && report_formats_feed_dir_exists ();
+}
+
+/**
+ * @brief Get the publish-subscribe messaging (MQTT) broker address.
+ *
+ * @return The current broker address.
+ */
+const gchar *
+get_broker_address ()
+{
+  return broker_address;
+}
+
+/**
+ * @brief Set the publish-subscribe messaging (MQTT) broker address.
+ *
+ * @param new_path The new broker address.
+ */
+void
+set_broker_address (const char *new_address)
+{
+  g_free (broker_address);
+  if (new_address && strcmp (new_address, ""))
+    broker_address = g_strdup (new_address);
+  else
+    broker_address = NULL;
 }
 
 /**

--- a/src/manage.c
+++ b/src/manage.c
@@ -5937,7 +5937,7 @@ get_broker_address ()
 /**
  * @brief Set the publish-subscribe messaging (MQTT) broker address.
  *
- * @param new_path The new broker address.
+ * @param new_address The new broker address.
  */
 void
 set_broker_address (const char *new_address)

--- a/src/manage.h
+++ b/src/manage.h
@@ -3612,6 +3612,12 @@ gboolean
 manage_gvmd_data_feed_dirs_exist ();
 
 const gchar *
+get_broker_address ();
+
+void
+set_broker_address (const char *);
+
+const gchar *
 get_feed_lock_path ();
 
 void

--- a/src/manage_license.c
+++ b/src/manage_license.c
@@ -77,13 +77,13 @@ manage_get_license (gchar **status,
 
 #ifdef HAS_LIBTHEIA
   int ret;
-  char *broker_address;
+  const char *broker_address;
   theia_client_t *client;
   theia_get_license_cmd_t *get_license_cmd;
   theia_got_license_info_t *got_license_info;
 
   // TODO: Replace with command line option
-  broker_address = g_strdup ("localhost:9138");
+  broker_address = get_broker_address ();
   if (broker_address == NULL)
     return 1;
 

--- a/src/manage_license.c
+++ b/src/manage_license.c
@@ -27,107 +27,11 @@
 #include "manage_license.h"
 #include "utils.h"
 
-/* Data types */
-
+#undef G_LOG_DOMAIN
 /**
- * @brief Allocates a new license metadata struct
- *
- * @return Newly allocated license metadata. Free with license_meta_free.
+ * @brief GLib log domain.
  */
-license_meta_t *
-license_meta_new ()
-{
-  return g_malloc0 (sizeof (license_meta_t));
-}
-
-/**
- * @brief Frees a license metadata struct and its fields.
- *
- * @param[in]  data  The data struct to free.
- */
-void
-license_meta_free (license_meta_t *data)
-{
-  if (data == NULL)
-    return;
-
-  free (data->id);
-  free (data->version);
-  free (data->title);
-  free (data->type);
-  free (data->customer_name);
-
-  g_free (data);
-}
-
-/**
- * @brief Allocates a new license appliance data struct
- *
- * @return Newly allocated license appliance data. Free with license_meta_free.
- */
-license_appliance_t *
-license_appliance_new ()
-{
-  return g_malloc0 (sizeof (license_appliance_t));
-}
-
-/**
- * @brief Frees a license appliance data struct and its fields.
- *
- * @param[in]  data  The data struct to free.
- */
-void
-license_appliance_free (license_appliance_t *data)
-{
-  if (data == NULL)
-    return;
-
-  free (data->model);
-  free (data->model_type);
-
-  g_free (data);
-}
-
-/**
- * @brief Allocates a new license data struct
- *
- * @return Newly allocated license data. Free with license_meta_free.
- */
-license_data_t *
-license_data_new ()
-{
-  license_data_t *data = g_malloc0 (sizeof (license_data_t));
-
-  data->meta = license_meta_new ();
-  data->appliance = license_appliance_new ();
-
-  data->keys = g_tree_new_full ((GCompareDataFunc) g_ascii_strcasecmp,
-                                NULL, g_free, g_free);
-
-  data->signatures = g_tree_new_full ((GCompareDataFunc) g_ascii_strcasecmp,
-                                      NULL, g_free, g_free);
-
-  return data;
-}
-
-/**
- * @brief Frees a license data struct and its fields.
- *
- * @param[in]  data  The data struct to free.
- */
-void
-license_data_free (license_data_t *data)
-{
-  if (data == NULL)
-    return;
-
-  license_meta_free (data->meta);
-  license_appliance_free (data->appliance);
-  g_tree_destroy (data->keys);
-  g_tree_destroy (data->signatures);
-
-  g_free (data);
-}
+#define G_LOG_DOMAIN "md manage"
 
 /* Actions */
 
@@ -156,46 +60,115 @@ manage_update_license_file (const char *new_license)
  * @param[out] status       The validation status (e.g. "valid", "expired").
  * @param[out] license_data The content of the license organized in a struct.
  *
- * @return 0 success, 1 service unavailable, 99 permission denied.
+ * @return 0 success, 1 service unavailable, 2 error sending command,
+ *         3 error receiving response, 99 permission denied, -1 internal error.
  */
 int
 manage_get_license (gchar **status,
-                    license_data_t **license_data)
+                    theia_license_t **license_data)
 {
+  if (status)
+    *status = NULL;
+  if (license_data)
+    *license_data = NULL;
+
   if (! acl_user_may ("get_license"))
     return 99;
 
+#ifdef HAS_LIBTHEIA
+  int ret;
+  char *broker_address;
+  theia_client_t *client;
+  theia_get_license_cmd_t *get_license_cmd;
+  theia_got_license_info_t *got_license_info;
+
+  // TODO: Replace with command line option
+  broker_address = g_strdup ("localhost:9138");
+  if (broker_address == NULL)
+    return 1;
+
+  client = theia_client_new_mqtt (&client);
+  if (client == NULL)
+    {
+      g_warning ("%s: Failed to create MQTT client", __func__);
+      return -1;
+    }
+
+  ret = theia_client_connect (client, broker_address);
+  if (ret)
+    {
+      g_warning ("%s: Failed to connect to MQTT broker (%s)",
+                 __func__, broker_address);
+      return 1;
+    }
+  else
+    g_debug ("%s: Connected to %s\n", __func__, broker_address);
+
+  ret = theia_new_get_license_cmd (&get_license_cmd);
+  if (ret)
+    {
+      g_warning ("%s: Error preparing get.license command", __func__);
+      theia_client_disconnect (client);
+      free (client);
+      return -1;
+    }
+
+  ret = theia_client_send_cmd (client, THEIA_LICENSE_CMD_TOPIC,
+                               (theia_cmd_t *) get_license_cmd);
+  if (ret)
+    {
+      fprintf (stderr, "Error publishing get.license message.");
+      theia_client_disconnect (client);
+      theia_get_license_cmd_free (get_license_cmd);
+      free (client);
+      return 2;
+    }
+  else
+    g_debug ("%s: Sent get.license command"
+             " (message_id: %s, group_id: %s)\n",
+             __func__,
+             get_license_cmd->message->id,
+             get_license_cmd->message->group_id);
+
+
+  ret = theia_client_get_info_response (client, THEIA_LICENSE_INFO_TOPIC,
+                                        "got.license",
+                                        get_license_cmd->message->group_id,
+                                        (theia_info_t **) &got_license_info);
+  if (ret)
+    {
+      g_debug ("%s: Failed to get got.license response", __func__);
+      theia_client_disconnect (client);
+      theia_get_license_cmd_free (get_license_cmd);
+      free (client);
+      return 3;
+    }
+  else
+    g_debug ("%s: Received got.license response", __func__);
+
+  theia_client_disconnect (client);
+
   if (status)
-    *status = g_strdup ("active");
+    {
+      *status = got_license_info->status;
+      got_license_info->status = NULL;
+    }
 
   if (license_data)
     {
-      *license_data = license_data_new ();
-      license_meta_t *license_meta = (*license_data)->meta;
-      license_appliance_t *license_appliance = (*license_data)->appliance;
-
-      // TODO : replace dummy data with data from license service
-      license_meta->id = g_strdup ("4711");
-      license_meta->version = g_strdup_printf("1.0.0");
-      license_meta->title = g_strdup ("Test License");
-      license_meta->type = g_strdup ("trial");
-      license_meta->customer_name = g_strdup ("Jane Doe");
-      license_meta->created = time (NULL) - 3600;
-      license_meta->begins = time (NULL);
-      license_meta->expires = time (NULL) + 3600 * 24 * 8;
-
-      license_appliance->model = g_strdup ("trial");
-      license_appliance->model_type = g_strdup ("virtual");
-      license_appliance->sensor = FALSE;
-
-      g_tree_replace ((*license_data)->keys,
-                      g_strdup ("feed"),
-                      g_strdup ("*base64 GSF key*"));
-
-      g_tree_replace ((*license_data)->signatures,
-                      g_strdup ("license"),
-                      g_strdup ("*base64 signature*"));
+      *license_data = got_license_info->license;
+      got_license_info->license = NULL;
     }
+
+  theia_got_license_info_free (got_license_info);
+
+#else // HAS_LIBTHEIA
+  if (status)
+    *status = NULL;
+  if (license_data)
+    *license_data = NULL;
+  return 1;
+#endif // HAS_LIBTHEIA
 
   return 0;
 }

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -15546,6 +15546,25 @@ check_db_settings ()
          "  'Feed Import Roles',"
          "  'Roles given access to new resources from feed.',"
          "  '" ROLE_UUID_ADMIN "," ROLE_UUID_USER "');");
+
+#ifdef HAS_LIBTHEIA
+  // This setting is automatically set only here if licensing is available
+  // and intentionally cannot be modified via GMP or CLI
+  if (sql_int ("SELECT count(*) FROM settings"
+               " WHERE uuid = '" SETTING_UUID_LICENSING_ENABLED "'"
+               " AND " ACL_IS_GLOBAL () ";")
+      == 0)
+    sql ("INSERT into settings (uuid, owner, name, comment, value)"
+         " VALUES"
+         " ('" SETTING_UUID_LICENSING_ENABLED "', NULL,"
+         "  'Licensing Enabled',"
+         "  'Whether the theia license management is enabled.',"
+         "  '1');");
+#else
+  // Remove setting if licensing is not available
+  sql ("DELETE FROM settings"
+       " WHERE uuid = '" SETTING_UUID_LICENSING_ENABLED "';");
+#endif
 }
 
 /**

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -133,6 +133,11 @@
 #define SETTING_UUID_FEED_IMPORT_ROLES "ff000362-338f-11ea-9051-28d24461215b"
 
 /**
+ * @brief UUID of 'Licensing Enabled' setting.
+ */
+#define SETTING_UUID_LICENSING_ENABLED "bb051ce6-de58-4bcf-bacd-7743797b22fa"
+
+/**
  * @brief Trust constant for error.
  */
 #define TRUST_ERROR 0

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -12606,6 +12606,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <p>
         The client uses the get_license command to get the current license.
       </p>
+      <p>
+        This command is only available if gvmd is built with the licensing
+        library (libtheia).
+      </p>
     </description>
     <pattern>
     </pattern>
@@ -23811,6 +23815,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </p>
       <p>
         The license has to be provided as a valid license TOML file.
+      </p>
+      <p>
+        This command is only available if gvmd is built with the licensing
+        library (libtheia).
       </p>
     </description>
     <pattern>

--- a/src/theia_dummy.h
+++ b/src/theia_dummy.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020-2021 Greenbone Networks GmbH
+/* Copyright (C) 2021 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
@@ -17,24 +17,11 @@
  */
 
 /**
- * @file manage_license.c
- * @brief GVM management layer: License information headers.
- *
- * Headers for non-SQL license information code for the GVM management layer.
+ * @file theia_dummy.h
+ * @brief Dummy definitions and headers for libtheia.
  */
 
-#include <glib.h>
-
-#ifdef HAS_LIBTHEIA
-#include <theia/client.h>
-#else
-#include "theia_dummy.h"
-#endif
-
-/* Actions */
-
-int
-manage_update_license_file (const char *);
-
-int
-manage_get_license (char **, theia_license_t **);
+/**
+ * @brief Dummy for license information struct.
+ */
+typedef void theia_license_t;


### PR DESCRIPTION
**What**:
This replaces the dummy license with actual data fetched using the
optional licensing client library libtheia.
If the library is not available, license commands will always return
"Service not available" responses.

**Why**:
This is part of integrating the licensing service into gvmd.

**How did you test it**:
By building gvmd with and without libtheia and requesting license info via gvm-cli in the following situations:
* licensing service running with license file available
* licensing service running without a license file
* licensing service not running

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
