### PR TITLE
Removed the field config_type, readded hr_name for nvt preferences.

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -8508,6 +8508,7 @@ buffer_config_preference_xml (GString *buffer, iterator_t *prefs,
                             "<preference>"
                             "<nvt oid=\"%s\"><name>%s</name></nvt>"
                             "<id>%s</id>"
+			    "<hr_name>%s</hr_name>"
                             "<name>%s</name>"
                             "<type>%s</type>",
                             oid ? oid : "",
@@ -11546,7 +11547,7 @@ handle_get_configs (gmp_parser_t *gmp_parser, GError **error)
   SEND_GET_START ("config");
   while (1)
     {
-      int config_nvts_growing, config_families_growing, config_type;
+      int config_nvts_growing, config_families_growing;
       const char *selector, *usage_type;
       config_t config;
 
@@ -11565,7 +11566,6 @@ handle_get_configs (gmp_parser_t *gmp_parser, GError **error)
       selector = config_iterator_nvt_selector (&configs);
       config = get_iterator_resource (&configs);
       config_nvts_growing = config_iterator_nvts_growing (&configs);
-      config_type = config_iterator_type (&configs);
       usage_type = config_iterator_usage_type (&configs);
       config_families_growing = config_iterator_families_growing
                                  (&configs);
@@ -11578,19 +11578,17 @@ handle_get_configs (gmp_parser_t *gmp_parser, GError **error)
                                "<nvt_count>"
                                "%i<growing>%i</growing>"
                                "</nvt_count>"
-                               "<type>%i</type>"
+			       "<type>0</type>"
                                "<usage_type>%s</usage_type>"
                                "<predefined>%i</predefined>",
                                config_iterator_family_count (&configs),
                                config_families_growing,
                                config_iterator_nvt_count (&configs),
                                config_nvts_growing,
-                               config_type,
                                usage_type,
                                config_iterator_predefined (&configs));
 
-      if (config_type == 0 && (get_configs_data->families
-                               || get_configs_data->get.details))
+      if (get_configs_data->families || get_configs_data->get.details)
         {
           iterator_t families;
           int max_nvt_count = 0, known_nvt_count = 0;
@@ -11656,62 +11654,7 @@ handle_get_configs (gmp_parser_t *gmp_parser, GError **error)
             known_nvt_count);
         }
 
-      if (config_type > 0)
-        {
-          iterator_t prefs;
-          scanner_t scanner;
-          char *s_uuid, *s_name;
-
-          assert (config);
-          scanner = config_iterator_scanner (&configs);
-
-          if (config_iterator_scanner_trash (&configs))
-            {
-              s_uuid = trash_scanner_uuid (scanner);
-              s_name = trash_scanner_name (scanner);
-            }
-          else
-            {
-              s_uuid = scanner_uuid (scanner);
-              s_name = scanner_name (scanner);
-            }
-
-          SENDF_TO_CLIENT_OR_FAIL ("<scanner id='%s'>"
-                                   "%s"
-                                   "<trash>%d</trash>"
-                                   "</scanner>",
-                                   s_uuid, s_name,
-                                   config_iterator_scanner_trash (&configs));
-
-          g_free (s_uuid);
-          g_free (s_name);
-          SEND_TO_CLIENT_OR_FAIL ("<preferences>");
-
-          init_config_preference_iterator (&prefs, config);
-          while (next (&prefs))
-            {
-              const char *name, *value, *type, *def;
-
-              name = config_preference_iterator_name (&prefs);
-              value = config_preference_iterator_value (&prefs);
-              def = config_preference_iterator_default (&prefs);
-              type = config_preference_iterator_type (&prefs);
-              SENDF_TO_CLIENT_OR_FAIL
-               ("<preference>"
-                "<nvt oid=\"\"><name/></nvt>"
-                "<id/>"
-                "<name>%s</name>"
-                "<type>osp_%s</type>"
-                "<value>%s</value>"
-                "<default>%s</default>"
-                "</preference>",
-                name, type, value ?: "", def);
-            }
-          cleanup_iterator (&prefs);
-          SEND_TO_CLIENT_OR_FAIL ("</preferences>");
-        }
-      else if (get_configs_data->preferences
-               || get_configs_data->get.details)
+      if (get_configs_data->preferences || get_configs_data->get.details)
         {
           iterator_t prefs;
 
@@ -11758,7 +11701,7 @@ handle_get_configs (gmp_parser_t *gmp_parser, GError **error)
           SEND_TO_CLIENT_OR_FAIL ("</preferences>");
         }
 
-      if (config_type == 0 && get_configs_data->get.details)
+      if (get_configs_data->get.details)
         {
           iterator_t selectors;
 
@@ -17181,7 +17124,6 @@ handle_get_tasks (gmp_parser_t *gmp_parser, GError **error)
                        "<usage_type>%s</usage_type>"
                        "<config id=\"%s\">"
                        "<name>%s</name>"
-                       "<type>%i</type>"
                        "<trash>%i</trash>"
                        "%s"
                        "</config>"
@@ -17211,7 +17153,6 @@ handle_get_tasks (gmp_parser_t *gmp_parser, GError **error)
                        task_iterator_usage_type (&tasks),
                        config_uuid ?: "",
                        config_name_escaped ?: "",
-                       config_type (task_config (index)),
                        task_config_in_trash (index),
                        config_available ? "" : "<permissions/>",
                        task_target_uuid ?: "",

--- a/src/gmp_configs.c
+++ b/src/gmp_configs.c
@@ -363,6 +363,7 @@ parse_config_entity (entity_t config, const char **config_id, char **name,
                        preference_nvt_oid,
                        import_alts,
                        text_or_null (entity_child (preference, "default")),
+                       NULL,
                        0 /* do not free strings */);
             }
 
@@ -443,7 +444,6 @@ create_config_run (gmp_parser_t *gmp_parser, GError **error)
                              all_selector,
                              import_nvt_selectors,
                              import_preferences,
-                             type,
                              usage_type_text,
                              &new_config,
                              &created_name))

--- a/src/manage_configs.c
+++ b/src/manage_configs.c
@@ -238,7 +238,6 @@ create_config_from_file (const gchar *path)
                                 all_selector,
                                 nvt_selectors,
                                 preferences,
-                                type,
                                 usage_type,
                                 &new_config,
                                 &created_name))

--- a/src/manage_configs.h
+++ b/src/manage_configs.h
@@ -45,7 +45,7 @@ typedef struct
 
 int
 create_config (const char*, const char*, int, const char*, int, const array_t*,
-               const array_t*, const char*, const char*, config_t*, char**);
+               const array_t*, const char*, config_t*, char**);
 
 int
 copy_config (const char*, const char*, const char *, const char *, config_t*);
@@ -58,9 +58,6 @@ find_config_with_permission (const char*, config_t*, const char *);
 
 char *
 config_uuid (config_t);
-
-int
-config_type (config_t);
 
 char *
 config_nvt_timeout (config_t, const char *);

--- a/src/manage_preferences.c
+++ b/src/manage_preferences.c
@@ -43,7 +43,7 @@
 gpointer
 preference_new (char *id, char *name, char *type, char *value, char *nvt_name,
                 char *nvt_oid, array_t *alts, char* default_value,
-                int free_strings)
+                char *hr_name, int free_strings)
 {
   preference_t *preference;
 
@@ -56,6 +56,7 @@ preference_new (char *id, char *name, char *type, char *value, char *nvt_name,
   preference->nvt_oid = nvt_oid;
   preference->alts = alts;
   preference->default_value = default_value;
+  preference->hr_name = hr_name;
   preference->free_strings = free_strings;
 
   return preference;

--- a/src/manage_preferences.c
+++ b/src/manage_preferences.c
@@ -36,6 +36,7 @@
  * @param[in]  nvt_oid   OID of NVT of preference.
  * @param[in]  alts      Array of gchar's.  Alternative values for type radio.
  * @param[in]  default_value   Default value of preference.
+ * @param[in]  hr_name   The hr_name of the nvt_preference.
  * @param[in]  free_strings Whether string fields are freed by preference_free.
  *
  * @return Newly allocated preference.

--- a/src/manage_preferences.h
+++ b/src/manage_preferences.h
@@ -39,12 +39,13 @@ typedef struct
   char *nvt_oid;       ///< OID of NVT preference affects.
   array_t *alts;       ///< Array of gchar's.  Alternate values for radio type.
   char *default_value; ///< Default value of preference.
+  char *hr_name;       ///< Extended, more human-readable name.
   int free_strings;    ///< Whether string fields are freed by preference_free.
 } preference_t;
 
 gpointer
 preference_new (char *, char *, char *, char *, char *,
-                char *, array_t *, char*, int);
+                char *, array_t *, char*, char *, int);
 
 void
 preference_free (preference_t *);

--- a/src/manage_sql_configs.h
+++ b/src/manage_sql_configs.h
@@ -73,7 +73,7 @@ configs_extra_where (const char *);
 int
 create_config_no_acl (const char *, const char *, int, const char *,
                       int, const array_t *, const array_t *, const char *,
-                      const char *, config_t *, char **);
+                      config_t *, char **);
 
 gboolean
 find_config_no_acl (const char *, config_t *);


### PR DESCRIPTION
Since the field config_type was only used for OSP scanners the
field and the corresponding code is removed from the gvmd sources.
Further the field hr_name was rebuilt for NVT preferences.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
