### PR TITLE
Consider interrupted status when resuming a task.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 ### Fixed
 - Ensure gvmd sends error messages if gvmcg fails [#1682](https://github.com/greenbone/gvmd/pull/1682)
-- Fix resume task. [#1679](https://github.com/greenbone/gvmd/pull/1679)
+- Fix resume task.
+  [#1679](https://github.com/greenbone/gvmd/pull/1679)
+  [#1695](https://github.com/greenbone/gvmd/pull/1695)
 - Added a dedicated error message for the create ticket dialogue when the create permission permission is missing [#1686](https://github.com/greenbone/gvmd/pull/1686)
 - Fix import of report results / errors without host [#1687](https://github.com/greenbone/gvmd/pull/1687)
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -2423,9 +2423,11 @@ prepare_osp_scan_for_resume (task_t task, const char *scan_id, char **error)
       trim_partial_report (global_current_report);
       return 1;
     }
-  else if (status == OSP_SCAN_STATUS_STOPPED)
+  else if (status == OSP_SCAN_STATUS_STOPPED
+           || status == OSP_SCAN_STATUS_INTERRUPTED)
     {
-      g_debug ("%s: Scan %s stopped", __func__, scan_id);
+      g_debug ("%s: Scan %s stopped or interrupted",
+               __func__, scan_id);
       if (osp_delete_scan (connection, scan_id))
         {
           *error = g_strdup ("Failed to delete old report");


### PR DESCRIPTION
**What**:
Consider interrupted status when resumming a task.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
In some cases the scan status can be `interrupted`. In this case, the previous scan must be deleted from OSPD scan table before resuming.

<!-- Why are these changes necessary? -->

**How did you test it**:
Stop and resume task. Sometimes is possible to get an interrupted status.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvmd/blob/master/CHANGELOG.md) Entry
