### PR TITLE
Fix setting the gvmd default args

### DIFF
--- a/.docker/start-gvmd.sh
+++ b/.docker/start-gvmd.sh
@@ -2,7 +2,7 @@
 
 [ -z "$USER" ] && USER="admin"
 [ -z "$PASSWORD" ] && PASSWORD="admin"
-[ -z "$GVMD_ARGS" ] && GVMD_ARGS="--listen-mode 666"
+[ -z "$GVMD_ARGS" ] && GVMD_ARGS="--listen-mode=666"
 [ -z "$GVMD_USER" ] && GVMD_USER="gvmd"
 
 # check for psql connection


### PR DESCRIPTION
**What**:

Fix the gvmd start script for the docker container.

**Why**:

Long arguments require an equal character between argument and value.

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
