### PR TITLE
Backport #1724 to oldstable: CHANGE: Use full path GVMD_PID_PATH for PID files, use GVMD_RUN_DIR instead of GVM_RUN_DIR

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -50,10 +50,10 @@ COPY .docker/start-gvmd.sh /usr/local/bin/start-gvmd
 RUN addgroup --gid 1001 --system gvmd && \
     adduser --no-create-home --shell /bin/false --disabled-password --uid 1001 --system --group gvmd
 
-RUN mkdir -p /run/gvm && \
+RUN mkdir -p /run/gvmd && \
     mkdir -p /var/log/gvm && \
     chown -R gvmd:gvmd /etc/gvm && \
-    chown -R gvmd:gvmd /run/gvm && \
+    chown -R gvmd:gvmd /run/gvmd && \
     chown -R gvmd:gvmd /var/lib/gvm && \
     chown -R gvmd:gvmd /var/log/gvm && \
     chmod 755 /usr/local/bin/start-gvmd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,6 +309,8 @@ add_subdirectory (doc)
 
 install (DIRECTORY DESTINATION ${GVMD_STATE_DIR})
 
+install (DIRECTORY DESTINATION ${GVMD_RUN_DIR})
+
 install (FILES ${CMAKE_BINARY_DIR}/src/gvmd_log.conf
          DESTINATION ${GVM_SYSCONF_DIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,12 +195,12 @@ set (GVM_CLIENT_CERTIFICATE  "${GVM_STATE_DIR}/CA/clientcert.pem")
 set (GVM_CLIENT_KEY          "${GVM_STATE_DIR}/private/CA/clientkey.pem")
 set (GVM_CA_CERTIFICATE      "${GVM_STATE_DIR}/CA/cacert.pem")
 
-if (NOT GVM_RUN_DIR)
-  set (GVM_RUN_DIR      "/run/gvm")
-endif (NOT GVM_RUN_DIR)
+if (NOT GVMD_RUN_DIR)
+  set (GVMD_RUN_DIR      "/run/gvmd")
+endif (NOT GVMD_RUN_DIR)
 
 if (NOT GVMD_PID_PATH)
-  set (GVMD_PID_PATH     "/run/gvmd/gvmd.pid")
+  set (GVMD_PID_PATH     "${GVMD_RUN_DIR}/gvmd.pid")
 endif (NOT GVMD_PID_PATH)
 
 if (NOT GVM_FEED_LOCK_PATH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,10 @@ if (NOT GVM_RUN_DIR)
   set (GVM_RUN_DIR      "/run/gvm")
 endif (NOT GVM_RUN_DIR)
 
+if (NOT GVMD_PID_PATH)
+  set (GVMD_PID_PATH     "/run/gvmd/gvmd.pid")
+endif (NOT GVMD_PID_PATH)
+
 if (NOT GVM_FEED_LOCK_PATH)
   set (GVM_FEED_LOCK_PATH "${GVM_STATE_DIR}/feed-update.lock")
 endif (NOT GVM_FEED_LOCK_PATH)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -363,9 +363,9 @@ if (GVMD_STATE_DIR)
   add_definitions (-DGVMD_STATE_DIR="${GVMD_STATE_DIR}")
 endif (GVMD_STATE_DIR)
 
-if (GVM_RUN_DIR)
-        add_definitions (-DGVM_RUN_DIR="${GVM_RUN_DIR}")
-endif (GVM_RUN_DIR)
+if (GVMD_RUN_DIR)
+        add_definitions (-DGVMD_RUN_DIR="${GVMD_RUN_DIR}")
+endif (GVMD_RUN_DIR)
 
 if (GVMD_PID_PATH)
         add_definitions (-DGVMD_PID_PATH="${GVMD_PID_PATH}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -367,6 +367,10 @@ if (GVM_RUN_DIR)
         add_definitions (-DGVM_RUN_DIR="${GVM_RUN_DIR}")
 endif (GVM_RUN_DIR)
 
+if (GVMD_PID_PATH)
+        add_definitions (-DGVMD_PID_PATH="${GVMD_PID_PATH}")
+endif (GVMD_PID_PATH)
+
 if (GVM_SYSCONF_DIR)
         add_definitions (-DGVM_SYSCONF_DIR="${GVM_SYSCONF_DIR}")
 endif (GVM_SYSCONF_DIR)

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -2190,7 +2190,7 @@ gvmd (int argc, char** argv)
       else
         {
           use_tls = 0;
-          manager_address_string_unix = g_build_filename (GVM_RUN_DIR,
+          manager_address_string_unix = g_build_filename (GVMD_RUN_DIR,
                                                           "gvmd.sock",
                                                           NULL);
         }

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -925,7 +925,7 @@ cleanup ()
   if (log_config) log_config_free ();
 
   /* Delete pidfile if this process is the parent. */
-  if (is_parent == 1) pidfile_remove ("gvmd");
+  if (is_parent == 1) pidfile_remove (GVMD_PID_PATH);
 }
 
 #ifndef NDEBUG
@@ -2942,7 +2942,7 @@ gvmd (int argc, char** argv)
 
   /* Set our pidfile. */
 
-  if (pidfile_create ("gvmd")) exit (EXIT_FAILURE);
+  if (pidfile_create (GVMD_PID_PATH)) exit (EXIT_FAILURE);
 
   /* Setup global variables. */
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -568,7 +568,7 @@ lock_internal (lockfile_t *lockfile, const gchar *lockfile_name,
   if (name_is_full_path)
     full_name = g_strdup (lockfile_name);
   else
-    full_name = g_build_filename (GVM_RUN_DIR, lockfile_name, NULL);
+    full_name = g_build_filename (GVMD_RUN_DIR, lockfile_name, NULL);
 
   old_umask = umask (0);
   fd = open (full_name, O_RDWR | O_CREAT,


### PR DESCRIPTION
**What**:
This is a backport of #1724 to the oldstable branch

**Why**:

<!-- Why are these changes necessary? -->

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
