### PR TITLE
Revert "Add immutable "Licensing Enabled" setting"

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -15546,25 +15546,6 @@ check_db_settings ()
          "  'Feed Import Roles',"
          "  'Roles given access to new resources from feed.',"
          "  '" ROLE_UUID_ADMIN "," ROLE_UUID_USER "');");
-
-#ifdef HAS_LIBTHEIA
-  // This setting is automatically set only here if licensing is available
-  // and intentionally cannot be modified via GMP or CLI
-  if (sql_int ("SELECT count(*) FROM settings"
-               " WHERE uuid = '" SETTING_UUID_LICENSING_ENABLED "'"
-               " AND " ACL_IS_GLOBAL () ";")
-      == 0)
-    sql ("INSERT into settings (uuid, owner, name, comment, value)"
-         " VALUES"
-         " ('" SETTING_UUID_LICENSING_ENABLED "', NULL,"
-         "  'Licensing Enabled',"
-         "  'Whether the theia license management is enabled.',"
-         "  '1');");
-#else
-  // Remove setting if licensing is not available
-  sql ("DELETE FROM settings"
-       " WHERE uuid = '" SETTING_UUID_LICENSING_ENABLED "';");
-#endif
 }
 
 /**

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -133,11 +133,6 @@
 #define SETTING_UUID_FEED_IMPORT_ROLES "ff000362-338f-11ea-9051-28d24461215b"
 
 /**
- * @brief UUID of 'Licensing Enabled' setting.
- */
-#define SETTING_UUID_LICENSING_ENABLED "bb051ce6-de58-4bcf-bacd-7743797b22fa"
-
-/**
  * @brief Trust constant for error.
  */
 #define TRUST_ERROR 0


### PR DESCRIPTION
**What**:
This reverts commit 95370bb4a0270cd3c5d56a5b597f9356ba5c7305, thus
removing the setting that was made obsolete by the automatic disabling
of license commands in 3afd1a6bb66905e52e4663dc93fa19b13c1af933.

**Why**:
The setting is no longer needed because it is enough to check if the 
`get_license` command is enabled.

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
