### PR TITLE
Don't add "modify_license" permission to User role

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -15973,6 +15973,7 @@ check_db_permissions ()
     {
       if (strstr (command[0].name, "DESCRIBE_AUTH") == NULL
           && strcmp (command[0].name, "GET_VERSION")
+          && strcmp (command[0].name, "MODIFY_LICENSE")
           && strstr (command[0].name, "GROUP") == NULL
           && strstr (command[0].name, "ROLE") == NULL
           && strstr (command[0].name, "SYNC") == NULL


### PR DESCRIPTION
**What**:
The role "User" will no longer automatically get the "modify_license"
permission.

**Why**:
Only Admin users should have access to this via the "everything"
permission.

**How did you test it**:

By removing all predefined permissions with the SQL
```sql
DELETE FROM permissions WHERE owner IS NULL;
```
and restarting gvmd to rebuild the permissions, then checking the permissions table with
```sql
SELECT * FROM permissions WHERE name ILIKE '%license';
```
which should only return "get_license" commands for the User and
Observer roles.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
