### PR TITLE
Use deprecation as warning for g_memdup

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -396,8 +396,10 @@ get_certificate_info (const gchar* certificate, gssize certificate_len,
                          __func__);
               return -1;
             }
-
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wdeprecated-declarations"
           cert_truncated = g_memdup (certificate, certificate_len);
+#pragma GCC diagnostic pop
           certificate_format_internal = GNUTLS_X509_FMT_DER;
         }
 


### PR DESCRIPTION
**What**:

 Fix: g_memdup is depcreated; it is recommended to use g_memdup2 instead

Fix warning:
```
warning: 'g_memdup' is deprecated: Use 'g_memdup2' instead [-Wdeprecated-declarations]
```

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
