### PR TITLE
The upload status of the modify license command is passed to GSA.

### DIFF
--- a/src/gmp_license.c
+++ b/src/gmp_license.c
@@ -363,18 +363,19 @@ modify_license_element_start (gmp_parser_t *gmp_parser,
  *
  * @param[in]  file_content The content of the new license file.
  * @param[in]  allow_empty  Whether to allow an empty file.
+ * @param[out] error_msg    The error message of the license update if any
  * 
  * @return 0 success, 1 service unavailable, 2 empty file not allowed,
  *         99 permission denied. 
  */
 static int
-modify_license (gchar *file_content, gboolean allow_empty)
+modify_license (gchar *file_content, gboolean allow_empty, char **error_msg)
 {
   if (allow_empty == FALSE
       && (file_content == NULL || strcmp (file_content, "") == 0))
     return 4;
 
-  return manage_update_license_file(file_content);
+  return manage_update_license_file(file_content, error_msg);
 }
 
 /**
@@ -388,7 +389,8 @@ modify_license_run (gmp_parser_t *gmp_parser,
                     GError **error)
 {
   entity_t entity, file_entity;
-  const char* allow_empty_str;
+  const char *allow_empty_str;
+  char *error_msg;
   int allow_empty, ret;
 
   entity = (entity_t) modify_license_data.context->first->data;
@@ -398,7 +400,8 @@ modify_license_run (gmp_parser_t *gmp_parser,
 
   file_entity = entity_child (entity, "file");
 
-  ret = modify_license (file_entity ? file_entity->text : NULL, allow_empty);
+  ret = modify_license (file_entity ? file_entity->text : NULL, allow_empty,
+                        &error_msg);
   switch (ret)
     {
       case 0:
@@ -428,9 +431,19 @@ modify_license_run (gmp_parser_t *gmp_parser,
                             "A non-empty FILE is required."));
         break;
       case 5:
-        SENDF_TO_CLIENT_OR_FAIL
-         (XML_ERROR_SYNTAX ("modify_license",
-                            "License could not be updated."));
+        if (error_msg)
+          {
+            SENDF_TO_CLIENT_OR_FAIL
+             (XML_ERROR_SYNTAX ("modify_license", 
+                                "%s"), error_msg);
+            g_free (error_msg);
+          }
+	else
+          {
+            SENDF_TO_CLIENT_OR_FAIL
+             (XML_ERROR_SYNTAX ("modify_license",
+                                "License could not be updated."));
+          }
         break;
       case 99:
         SEND_TO_CLIENT_OR_FAIL (XML_ERROR_ACCESS ("modify_license"));

--- a/src/manage_license.c
+++ b/src/manage_license.c
@@ -39,14 +39,17 @@
  * @brief Update the license file by replacing it with the given one.
  *
  * @param[in]  new_license  The content of the new license.
+ * @param[out] error_msg    The error message of the license update if any
  *
  * @return 0 success, 1 service unavailable, 2 error sending command,
  *         3 error receiving response, 4 no new_license data,
  *         5 error updating license, 99 permission denied, -1 internal error.
  */
 int
-manage_update_license_file (const char *new_license)
+manage_update_license_file (const char *new_license, char **error_msg)
 {
+  *error_msg = NULL;
+
   if (new_license == NULL)
     return 4;
   if (! acl_user_may ("modify_license"))
@@ -130,6 +133,7 @@ manage_update_license_file (const char *new_license)
     {
       g_message ("%s: Upload of new license file failed. Error: %s.\n",
                  __func__, failure_modify_license_info->error);
+      *error_msg = g_strdup (failure_modify_license_info->error);
       theia_client_disconnect (client);
       theia_modified_license_info_free (modified_license_info);
       theia_failure_modify_license_info_free (failure_modify_license_info);

--- a/src/manage_license.h
+++ b/src/manage_license.h
@@ -34,7 +34,7 @@
 /* Actions */
 
 int
-manage_update_license_file (const char *);
+manage_update_license_file (const char *, char **);
 
 int
 manage_get_license (char **, theia_license_t **);


### PR DESCRIPTION
**What**:
The error and validation status of the upload of a license via
the modify license command is now passed to GSA. If no status is
given out, the license is valid and updated correctly.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
This implementation is part of the Theia license project.
Addresses AP-1577
<!-- Why are these changes necessary? -->

**How did you test it**:
Tested the modify license command via gvm-cli in different constellations.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
