### PR TITLE
Added a backtrace output when a sigsegv occurs.

### DIFF
--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1003,7 +1003,7 @@ handle_sigabrt (int given_signal)
       frame_count = 0;
     }
   for (index = 0; index < frame_count; index++)
-    g_debug ("%s", frames_text[index]);
+    g_debug ("BACKTRACE: %s", frames_text[index]);
   free (frames_text);
 #endif
 
@@ -1035,6 +1035,24 @@ handle_termination_signal (int signal)
 static void
 handle_sigsegv (/* unused */ int given_signal)
 {
+#ifndef NDEBUG
+  void *frames[BA_SIZE];
+  int frame_count, index;
+  char **frames_text;
+
+  /* Print a backtrace. */
+  frame_count = backtrace (frames, BA_SIZE);
+  frames_text = backtrace_symbols (frames, frame_count);
+  if (frames_text == NULL)
+    {
+      perror ("backtrace symbols");
+      frame_count = 0;
+    }
+  for (index = 0; index < frame_count; index++)
+    g_debug ("BACKTRACE: %s", frames_text[index]);
+  free (frames_text);
+#endif
+
   manage_cleanup_process_error (given_signal);
 
   /* This previously called "cleanup", but it seems that the regular manager


### PR DESCRIPTION
**What**:
When a sigsegv occurs in gvmd, a backtrace is now written to the logfile
if the appropriate log levels are set.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
This hopefully helps fixing a bug, where a signal occurs at customer's site.
Addresses AP-1820.
<!-- Why are these changes necessary? -->

**How did you test it**:
Sent a gvmd process a sigsegv signal and checked the logfile.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
