### PR TITLE
Change failed call to xsltproc to a warning

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -5374,11 +5374,11 @@ xsl_transform (gchar *stylesheet, gchar *xmlfile, gchar **param_names,
       || (WIFEXITED (exit_status) == 0)
       || WEXITSTATUS (exit_status))
     {
-      g_debug ("%s: failed to transform the xml: %d (WIF %i, WEX %i)",
-               __func__,
-               exit_status,
-               WIFEXITED (exit_status),
-               WEXITSTATUS (exit_status));
+      g_warning ("%s: failed to transform the xml: %d (WIF %i, WEX %i)",
+                 __func__,
+                 exit_status,
+                 WIFEXITED (exit_status),
+                 WEXITSTATUS (exit_status));
       g_debug ("%s: stderr: %s", __func__, standard_err);
       g_debug ("%s: stdout: %s", __func__, standard_out);
       success = FALSE;


### PR DESCRIPTION
**What**:

Failing things must be logged as a warning because this might indicate
serious issues.

**Why**:

Without logging this error as warning a user might not find the issue.

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
