### PR TITLE
Change some migration and OSP warnings to info

### DIFF
--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -2528,7 +2528,7 @@ gvmd (int argc, char** argv)
             g_info ("   Migration succeeded.");
             return EXIT_SUCCESS;
           case 1:
-            g_warning ("%s: databases are already at the supported version",
+            g_info ("%s: databases are already at the supported version",
                        __func__);
             return EXIT_SUCCESS;
           case 2:

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1959,8 +1959,12 @@ osp_scanner_feed_version (const gchar *update_socket)
   error = NULL;
   if (osp_get_vts_version (connection, &scanner_feed_version, &error))
     {
-      g_warning ("%s: failed to get scanner_feed_version. %s",
-                 __func__, error ? : "");
+      if (error && strcmp (error, "OSPd OpenVAS is still starting") == 0)
+        g_info ("%s: failed to get scanner_feed_version. %s",
+                __func__, error);
+      else
+        g_warning ("%s: failed to get scanner_feed_version. %s",
+                   __func__, error ? : "");
       g_free (error);
       osp_connection_close (connection);
       return NULL;


### PR DESCRIPTION
**What**:
The warnings "databases are already at the supported version"
when attempting a migration and the "OSPd OpenVAS is still starting"
one when getting the feed version from the scanner are changed to info.

**Why**:
In the migration case gvmd is in a correct state and the OSPd one should only
be a minor transient issue that will fix itself after some waiting.

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
