### PR TITLE
Flexible-docker-entrypoint

### DIFF
--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec gosu gvmd "$@"

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -116,6 +116,7 @@ RUN addgroup --gid 1001 --system gvmd && \
     adduser --no-create-home --shell /bin/false --disabled-password --uid 1001 --system --group gvmd
 
 RUN mkdir -p /run/gvmd && \
+    mkdir -p /var/lib/gvm && \
     mkdir -p /var/log/gvm && \
     chown -R gvmd:gvmd /etc/gvm && \
     chown -R gvmd:gvmd /run/gvmd && \

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -85,6 +85,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     dpkg \
     fakeroot \
+    gosu \
     gnupg \
     gpgsm \
     libgpgme11 \

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -112,6 +112,7 @@ RUN apt-get update && \
 COPY --from=builder /install/ /
 
 COPY .docker/start-gvmd.sh /usr/local/bin/start-gvmd
+COPY .docker/entrypoint.sh /usr/local/bin/entrypoint
 
 RUN addgroup --gid 1001 --system gvmd && \
     adduser --no-create-home --shell /bin/false --disabled-password --uid 1001 --system --group gvmd
@@ -123,8 +124,9 @@ RUN mkdir -p /run/gvmd && \
     chown -R gvmd:gvmd /run/gvmd && \
     chown -R gvmd:gvmd /var/lib/gvm && \
     chown -R gvmd:gvmd /var/log/gvm && \
+    chmod 755 /usr/local/bin/entrypoint && \
     chmod 755 /usr/local/bin/start-gvmd
 
-USER gvmd
+ENTRYPOINT [ "/usr/local/bin/entrypoint" ]
 
 CMD [ "/usr/local/bin/start-gvmd" ]


### PR DESCRIPTION
**What**:

Use gosu to run gvmd as dedicated gvmd user.

**Why**:

Alllow to become root for debugging purposes.

```
> docker run -it --rm greenbone/gvmd:unstable id                
uid=1001(gvmd) gid=1001(gvmd) groups=1001(gvmd)

> docker run -it --rm --entrypoint='' greenbone/gvmd:unstable id 
uid=0(root) gid=0(root) groups=0(root)
```

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
