### PR TITLE
Change default MQTT broker port to 1883

### DIFF
--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -187,7 +187,7 @@
 /**
  * @brief Default broker address
  */
-#define DEFAULT_BROKER_ADDRESS "localhost:9138"
+#define DEFAULT_BROKER_ADDRESS "localhost:1883"
 
 /**
  * @brief Interval in seconds to check whether client connection was closed.


### PR DESCRIPTION
**What**:
The default broker address is changed to "localhost:1883".

**Why**:
Other services expect the MQTT broker to be running on this port as well. 

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
