### PR TITLE
Improves the init_preference_iterator SQL query performance

### DIFF
--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -3421,15 +3421,14 @@ init_preference_iterator (iterator_t* iterator,
                  " UNION"
                  " SELECT nvt_preferences.name, nvt_preferences.value"
                  " FROM nvt_preferences"
-                 " WHERE nvt_preferences.name %s"
-                 " AND (SELECT COUNT(*) FROM config_preferences"
-                 "      WHERE config = %llu"
-                 "      AND config_preferences.name = nvt_preferences.name) = 0;",
+                 " LEFT JOIN config_preferences"
+                 "      ON config_preferences.config = %llu AND config_preferences.name = nvt_preferences.name"
+                 " WHERE config_preferences.id IS NULL AND nvt_preferences.name %s",
                  config,
                  quoted_section,
+                 config,
                  strcmp (quoted_section, "SERVER_PREFS") == 0
-                  ? "NOT LIKE '%:%:%:%'" : "LIKE '%:%:%:%'",
-                 config);
+                  ? "NOT LIKE '%:%:%:%'" : "LIKE '%:%:%:%'");
   g_free (quoted_section);
 }
 


### PR DESCRIPTION
**What**:
Changes the old SQL query from the init_preferences_iterator function to improve the query performance.
I've changed a "WHERE" clause with similar JOIN functionality.

**Why**:

I noticed that after the NVT sync (update NVT's cache etc.) this query was taking a lot of time (in some cases 6+ minutes in my VM) to complete and for this reason the whole process was slow.

EXPLAIN ANALYZE Results
![Selection_023](https://user-images.githubusercontent.com/2433615/146562633-e8afbf20-170e-4480-948c-c9d986aaaa27.png)


**How did you test it**:
- I verified the query with direct queries in the database for different config records and it returns the same results as the old one.
- I rebuilt the code and I run the gvm & I synced the nvts
- _**Maybe it needs more tests**_

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
