### PR TITLE
adds a note about rsync in the INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -273,6 +273,7 @@ The `gvmd Data`, `SCAP` and `CERT` Feeds should be kept up-to-date by calling th
 
 Please note: The `CERT` feed sync depends on data provided by the `SCAP` feed
 and should be called after syncing the latter.
+You will need the `rsync` tool for a successful synchronization.
 
 
 ## Configure the default OSPD scanner socket path


### PR DESCRIPTION
**What**:

This adds a note about rsync in the INSTALLmd.

**Why**:

Unlike `greenbone-nvt-sync`, `greenbone-feed-sync` doesn't output any error in case the rsync is not in the system.
So you may not understand why feeds are not synchronized with no error.

I had been struggled with this behaviour for a couple of days.
This problem will be likely occurred in case that openvas-scanner and gvmd are installed in a different hosts.
(Its' my environment.)

After all I noticed that I can check the lack of rsync by executing the command with `--selftest` option.
But I could have noticed the cause of the problem soon if the rsync requirement is noted in INSTALL.md.

**How did you test it**:

**Checklist**:

- [ ] Tests N/A
- [ ] PR merge commit message adjusted
