### PR TITLE
Removed the "#ifndef NDEBUG" to get a backtrace in case of a signal in gvmd-journal.

### DIFF
--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -965,7 +965,6 @@ cleanup ()
   if (is_parent == 1) pidfile_remove (GVMD_PID_PATH);
 }
 
-#ifndef NDEBUG
 #include <execinfo.h>
 
 /**
@@ -974,7 +973,6 @@ cleanup ()
  * For debugging backtrace in \ref handle_sigabrt.
  */
 #define BA_SIZE 100
-#endif
 
 /**
  * @brief Handle a SIGABRT signal.
@@ -989,7 +987,6 @@ handle_sigabrt (int given_signal)
   if (in_sigabrt) _exit (EXIT_FAILURE);
   in_sigabrt = 1;
 
-#ifndef NDEBUG
   void *frames[BA_SIZE];
   int frame_count, index;
   char **frames_text;
@@ -1005,7 +1002,6 @@ handle_sigabrt (int given_signal)
   for (index = 0; index < frame_count; index++)
     g_debug ("BACKTRACE: %s", frames_text[index]);
   free (frames_text);
-#endif
 
   manage_cleanup_process_error (given_signal);
   cleanup ();
@@ -1035,7 +1031,6 @@ handle_termination_signal (int signal)
 static void
 handle_sigsegv (/* unused */ int given_signal)
 {
-#ifndef NDEBUG
   void *frames[BA_SIZE];
   int frame_count, index;
   char **frames_text;
@@ -1051,7 +1046,6 @@ handle_sigsegv (/* unused */ int given_signal)
   for (index = 0; index < frame_count; index++)
     g_debug ("BACKTRACE: %s", frames_text[index]);
   free (frames_text);
-#endif
 
   manage_cleanup_process_error (given_signal);
 

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -90,6 +90,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <execinfo.h>
 
 #include <gvm/base/pidfile.h>
 #include <gvm/base/pwpolicy.h>
@@ -188,6 +189,13 @@
  * @brief Default broker address
  */
 #define DEFAULT_BROKER_ADDRESS "localhost:1883"
+
+/**
+ * @brief Maximum number of frames in backtrace.
+ *
+ * For debugging backtrace in \ref handle_sigabrt and handle_sigsegv.
+ */
+#define BA_SIZE 100
 
 /**
  * @brief Interval in seconds to check whether client connection was closed.
@@ -964,15 +972,6 @@ cleanup ()
   /* Delete pidfile if this process is the parent. */
   if (is_parent == 1) pidfile_remove (GVMD_PID_PATH);
 }
-
-#include <execinfo.h>
-
-/**
- * @brief Maximum number of frames in backtrace.
- *
- * For debugging backtrace in \ref handle_sigabrt.
- */
-#define BA_SIZE 100
 
 /**
  * @brief Handle a SIGABRT signal.


### PR DESCRIPTION

**What**:
The backtrace functionality in gvmd.c was, because of the
surrounding "#ifndef NDEBUG" statement, only activated on
development systems. Now that statement is removed to also
get the backtrace (eventually listed in the gvmd-journal)
on GOS-systems of the customer.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
This is part of a bug-fix.
Addresses AP-1871
<!-- Why are these changes necessary? -->

**How did you test it**:
This can only be tested on a newly built GOS-System.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
