### PR TITLE
Add missing \ref Doxygen call

### DIFF
--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -193,7 +193,7 @@
 /**
  * @brief Maximum number of frames in backtrace.
  *
- * For debugging backtrace in \ref handle_sigabrt and handle_sigsegv.
+ * For debugging backtrace in \ref handle_sigabrt and \ref handle_sigsegv.
  */
 #define BA_SIZE 100
 


### PR DESCRIPTION
Minor update to #1773, AFAICT each function call needs to have the `\ref` prepended in Doxygen.

Also needs the "backport-to-stable" as #1773 got backported into that branch via #1774