### PR TITLE
Small changes to get the model change needed info passed to GSA.

### DIFF
--- a/src/gmp_license.c
+++ b/src/gmp_license.c
@@ -412,8 +412,9 @@ modify_license_run (gmp_parser_t *gmp_parser,
       case 0:
         SENDF_TO_CLIENT_OR_FAIL
          ("<modify_license_response status=\"%s\""
-          " status_text=\"%s\""
-          " model_change_needed=\"%d\"/>",
+          " status_text=\"%s\">"
+          " <status_details>%d</status_details>"
+          " </modify_license_response>",
           STATUS_OK,
           STATUS_OK_TEXT,
           model_change_needed ? 1 : 0);

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -23848,12 +23848,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <type>text</type>
           <required>1</required>
         </attrib>
-        <attrib>
-          <name>model_change_needed</name>
-          <summary>Whether a model change is necessary or not</summary>
-          <type>boolean</type>
-          <required>1</required>
-        </attrib>
       </pattern>
     </response>
     <example>
@@ -23864,7 +23858,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </modify_license>
       </request>
       <response>
-        <modify_license_response status="200" status_text="OK" model_change_needed="1">
+        <modify_license_response status="200" status_text="OK">
         </modify_license_response>
       </response>
     </example>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -23848,6 +23848,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <type>text</type>
           <required>1</required>
         </attrib>
+        <attrib>
+          <name>status_details</name>
+          <summary>Whether a model change is needed</summary>
+          <type>boolean</type>
+          <required>1</required>
+        </attrib>
       </pattern>
     </response>
     <example>
@@ -23859,6 +23865,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </request>
       <response>
         <modify_license_response status="200" status_text="OK">
+        <status_details>1</status_details>
         </modify_license_response>
       </response>
     </example>


### PR DESCRIPTION
**What**:
Replaced the attribute "model_change_needed=%d" in the response XML
by the XML element "<status_details>%d</status_details>", because this
element is already passed to GSA. So no changes are needed in gsad
here anymore.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
This is a part of AP-1891.
<!-- Why are these changes necessary? -->

**How did you test it**:
Tested in GSA with the developer tools (F12)
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
