### PR TITLE
Fix: task status overwrite when a task is stopped and quickly restarted (not resumed)

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -1703,7 +1703,7 @@ get_osp_scan_status (const char *scan_id, const char *host, int port,
  * @param[in]   scan_id   The UUID of the scan on the scanner.
  *
  * @return 0 if success, -1 if error, -2 if scan was stopped,
- *         -3 if the scan was interrupted.
+ *         -3 if the scan was interrupted, -4 already stopped.
  */
 static int
 handle_osp_scan (task_t task, report_t report, const char *scan_id)
@@ -1735,7 +1735,7 @@ handle_osp_scan (task_t task, report_t report, const char *scan_id)
       if (run_status == TASK_STATUS_STOPPED
           || run_status == TASK_STATUS_STOP_REQUESTED)
         {
-          rc = -2;
+          rc = -4;
           break;
         }
 


### PR DESCRIPTION
**What**:
Fix: task status overwrite when a task is stopped and quickly restarted (not resumed)

Jira: SC-505

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The still stopping task will overwrite the recentrly started task (the same task, different reports). This produces that the task is set in the DB as stopped, while it was actually started in ospd-openvas. The task will run in the background.
<!-- Why are these changes necessary? -->

**How did you test it**:
start a task, stop it, and start it again as quick as possible. Without the patch the task is stopped in gvmd but runs in background. With the patch, the it works as expected.


<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
