### PR TITLE
Added the appliance_status response field to the get_license command.

### DIFF
--- a/src/gmp_license.c
+++ b/src/gmp_license.c
@@ -181,13 +181,15 @@ get_license_run (gmp_parser_t *gmp_parser,
   int ret;
 
   gchar *license_status;
+  gchar *appliance_status;
   theia_license_t *license_data;
 
   license_status = NULL;
   license_data = NULL;
 
   ret = manage_get_license (&license_status,
-                            &license_data);
+                            &license_data,
+                            &appliance_status);
 
   switch (ret)
     {
@@ -200,10 +202,12 @@ get_license_run (gmp_parser_t *gmp_parser,
                              "<get_license_response status=\"%s\""
                              " status_text=\"%s\">"
                              "<license>"
-                             "<status>%s</status>",
+                             "<status>%s</status>"
+                             "<appliance_status>%s</appliance_status>",
                              STATUS_OK,
                              STATUS_OK_TEXT,
-                             license_status);
+                             license_status,
+                             appliance_status ? appliance_status : "");
 
           if (license_data)
             {
@@ -245,6 +249,7 @@ get_license_run (gmp_parser_t *gmp_parser,
     }
 
   g_free (license_status);
+  g_free (appliance_status);
 
 #ifdef HAS_LIBTHEIA
   theia_license_free (license_data);

--- a/src/manage_license.c
+++ b/src/manage_license.c
@@ -167,6 +167,8 @@ manage_update_license_file (const char *new_license,
   return 0;
 }
 
+#ifdef HAS_LIBTHEIA
+
 /**
  * @brief Get the current appliance status
  *
@@ -193,6 +195,8 @@ get_appliance_status(theia_got_license_info_t *gli)
 
   return app_status;
 }
+
+#endif // HAS_LIBTHEIA
 
 /**
  * @brief Get the current license information.

--- a/src/manage_license.c
+++ b/src/manage_license.c
@@ -26,7 +26,7 @@
 #include "manage_acl.h"
 #include "manage_license.h"
 #include "utils.h"
-#include "sql.h"
+#include "manage_sql.h"
 
 #undef G_LOG_DOMAIN
 /**
@@ -182,8 +182,7 @@ get_appliance_status(theia_got_license_info_t *gli)
   gchar *comm_app;
   gchar *app_status;
 
-  comm_app = sql_string ("SELECT value from public.meta"
-                         " where name = 'community_appliance';");
+  comm_app = get_community_appliance_value ();
 
   if (comm_app && atoi (comm_app))
     app_status = g_strdup("community");

--- a/src/manage_license.h
+++ b/src/manage_license.h
@@ -37,4 +37,4 @@ int
 manage_update_license_file (const char *, gboolean *, char **);
 
 int
-manage_get_license (char **, theia_license_t **);
+manage_get_license (gchar **, theia_license_t **, gchar**);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -55493,6 +55493,18 @@ delete_permissions_cache_for_user (user_t user)
   sql ("DELETE FROM permissions_get_tasks WHERE \"user\" = %llu;", user);
 }
 
+/**
+ * @brief Get the community appliance value
+ *
+ * @return community appliance value or NULL if not available or on error
+ */
+gchar *
+get_community_appliance_value ()
+{
+  return (sql_string ("SELECT value from public.meta"
+                      " where name = 'community_appliance';"));
+}
+
 
 /* Optimize. */
 

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -480,4 +480,8 @@ config_family_entire_and_growing (config_t, const char*);
 void
 reports_clear_count_cache_dynamic ();
 
+
+gchar *
+get_community_appliance_value ();
+
 #endif /* not _GVMD_MANAGE_SQL_H */

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -12632,11 +12632,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <summary>The license information</summary>
         <pattern>
           <e>status</e>
+          <e>appliance_status</e>
           <e>content</e>
         </pattern>
         <ele>
           <name>status</name>
           <summary>Status of the license</summary>
+          <pattern>text</pattern>
+        </ele>
+        <ele>
+          <name>appliance_status</name>
+          <summary>Status of the appliance</summary>
           <pattern>text</pattern>
         </ele>
         <ele>
@@ -12776,6 +12782,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <get_license_response status="200" status_text="OK">
           <license>
             <status>active</status>
+            <appliance_status>commercial_active</appliance_status>
             <content>
               <meta>
                 <id>4711</id>


### PR DESCRIPTION
**What**:
Added the appliance_status response field to the get_license
command, so that the notification about license choices can
be handled.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
This is a small part of the new license feature.
Addresses AP-1942.
<!-- Why are these changes necessary? -->

**How did you test it**:
Ran the get license command in various constellations in GSA and
checked the response via the developer tools.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
