### PR TITLE
Change: Improve log message for getting the feed version

### DIFF
--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1960,7 +1960,7 @@ osp_scanner_feed_version (const gchar *update_socket)
   if (osp_get_vts_version (connection, &scanner_feed_version, &error))
     {
       if (error && strcmp (error, "OSPd OpenVAS is still starting") == 0)
-        g_info ("%s: failed to get scanner_feed_version. %s",
+        g_info ("%s: No feed version available yet. %s",
                 __func__, error);
       else
         g_warning ("%s: failed to get scanner_feed_version. %s",


### PR DESCRIPTION
**What**:

Rework the message to a less harsh tone. Nothing has failed yet. Just
ospd-openvas is not ready because it is still reading the vt data for
example.

**Why**:

When starting up a new setup the message is logged very often and due to its tone it may indicate that something is wrong which actually isn't. Therefore improve the message to just give some information message.

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
