### PR TITLE
Change: Use new feed dir structure in sync scripts

### DIFF
--- a/tools/greenbone-feed-sync.in
+++ b/tools/greenbone-feed-sync.in
@@ -54,6 +54,19 @@ RSYNC_COMPRESS="--compress-level=9"
 # RSYNC_CHMOD specifies the permissions to chmod the files to.
 RSYNC_CHMOD="--perms --chmod=Fugo+r,Fug+w,Dugo-s,Dugo+rx,Dug+w"
 
+# RSYNC_COMMUNITY_BASE_URL defines the base rsync URL for the community feed
+# not including the feed type (data or vulnerability) and version.
+RSYNC_COMMUNITY_BASE_URL="rsync://feed.community.greenbone.net/"
+
+# RSYNC_COMMUNITY_DATA_URL defines the rsync URL for the community data feed.
+RSYNC_COMMUNITY_DATA_URL="${RSYNC_COMMUNITY_BASE_URL}/data-feed/@GMP_VERSION_FEED@/"
+
+# RSYNC_COMMUNITY_CERT_URL defines the rsync URL for the community SCAP feed.
+RSYNC_COMMUNITY_CERT_URL="${RSYNC_COMMUNITY_BASE_URL}/vulnerability-feed/@GMP_VERSION_FEED@/cert-data/"
+
+# RSYNC_COMMUNITY_SCAP_URL defines the rsync URL for the community SCAP feed.
+RSYNC_COMMUNITY_SCAP_URL="${RSYNC_COMMUNITY_BASE_URL}/vulnerability-feed/@GMP_VERSION_FEED@/scap-data/"
+
 # PORT controls the outgoing TCP port for updates. If PAT/Port-Translation is
 # not used, this should be "24". For some application layer firewalls or gates
 # the value 22 (Standard SSH) is useful. Only change if you know what you are
@@ -169,9 +182,7 @@ init_feed_type () {
     SCRIPT_ID="CERTSYNC"
 
     if [ -z "$COMMUNITY_CERT_RSYNC_FEED" ]; then
-      COMMUNITY_RSYNC_FEED="rsync://feed.community.greenbone.net:/cert-data"
-      # An alternative syntax which might work if the above doesn't:
-      # COMMUNITY_RSYNC_FEED="rsync@feed.community.greenbone.net::cert-data"
+      COMMUNITY_RSYNC_FEED="$RSYNC_COMMUNITY_CERT_URL"
     else
       COMMUNITY_RSYNC_FEED="$COMMUNITY_CERT_RSYNC_FEED"
     fi
@@ -197,9 +208,7 @@ init_feed_type () {
     SCRIPT_ID="SCAPSYNC"
 
     if [ -z "$COMMUNITY_SCAP_RSYNC_FEED" ]; then
-      COMMUNITY_RSYNC_FEED="rsync://feed.community.greenbone.net:/scap-data"
-      # An alternative syntax which might work if the above doesn't:
-      # COMMUNITY_RSYNC_FEED="rsync@feed.community.greenbone.net::scap-data"
+      COMMUNITY_RSYNC_FEED="$RSYNC_COMMUNITY_SCAP_URL"
     else
       COMMUNITY_RSYNC_FEED="$COMMUNITY_SCAP_RSYNC_FEED"
     fi
@@ -225,9 +234,7 @@ init_feed_type () {
     SCRIPT_ID="GVMD_DATA_SYNC"
 
     if [ -z "$COMMUNITY_GVMD_DATA_RSYNC_FEED" ]; then
-      COMMUNITY_RSYNC_FEED="rsync://feed.community.greenbone.net:/data-objects/gvmd/"
-      # An alternative syntax which might work if the above doesn't:
-      # COMMUNITY_RSYNC_FEED="rsync@feed.community.greenbone.net::data-objects/gvmd/"
+      COMMUNITY_RSYNC_FEED="$RSYNC_COMMUNITY_DATA_URL"
     else
       COMMUNITY_RSYNC_FEED="$COMMUNITY_GVMD_DATA_RSYNC_FEED"
     fi

--- a/tools/greenbone-feed-sync.in
+++ b/tools/greenbone-feed-sync.in
@@ -67,6 +67,30 @@ RSYNC_COMMUNITY_CERT_URL="${RSYNC_COMMUNITY_BASE_URL}/vulnerability-feed/@GMP_VE
 # RSYNC_COMMUNITY_SCAP_URL defines the rsync URL for the community SCAP feed.
 RSYNC_COMMUNITY_SCAP_URL="${RSYNC_COMMUNITY_BASE_URL}/vulnerability-feed/@GMP_VERSION_FEED@/scap-data/"
 
+# If ENTERPRISE_FEED_HOST_OVERRIDE is set to a non-empty string,
+#  the hostname of the enterprise feed server will overridden with it.
+# Otherwise the server hostname from the feed access key will be used.
+if [ -z "$ENTERPRISE_FEED_HOST_OVERRIDE" ]
+then
+  ENTERPRISE_FEED_HOST_OVERRIDE=""
+fi
+
+# ENTERPRISE_FEED_BASE_PATH defines the common base path for the feed data
+#  on the enterprise feed server.
+ENTERPRISE_FEED_BASE_PATH="/"
+
+# ENTERPRISE_FEED_DATA_PATH defines the path of the gvmd data feed
+#  on the enterprise feed server.
+ENTERPRISE_FEED_DATA_PATH="$ENTERPRISE_FEED_BASE_PATH/data-feed/@GMP_VERSION_FEED@/"
+
+# ENTERPRISE_FEED_DATA_PATH defines the path of the CERT feed
+#  on the enterprise feed server.
+ENTERPRISE_FEED_CERT_PATH="$ENTERPRISE_FEED_BASE_PATH/vulnerability-feed/@GMP_VERSION_FEED@/cert-data/"
+
+# ENTERPRISE_FEED_DATA_PATH defines the path of the SCAP feed
+#  on the enterprise feed server.
+ENTERPRISE_FEED_SCAP_PATH="$ENTERPRISE_FEED_BASE_PATH/vulnerability-feed/@GMP_VERSION_FEED@/scap-data/"
+
 # PORT controls the outgoing TCP port for updates. If PAT/Port-Translation is
 # not used, this should be "24". For some application layer firewalls or gates
 # the value 22 (Standard SSH) is useful. Only change if you know what you are
@@ -187,7 +211,7 @@ init_feed_type () {
       COMMUNITY_RSYNC_FEED="$COMMUNITY_CERT_RSYNC_FEED"
     fi
 
-    GSF_RSYNC_PATH="/cert-data"
+    GSF_RSYNC_PATH="$ENTERPRISE_FEED_CERT_PATH"
 
     if [ -e $ACCESSKEY ]; then
       if [ -z "$FEED_NAME" ]; then
@@ -213,7 +237,7 @@ init_feed_type () {
       COMMUNITY_RSYNC_FEED="$COMMUNITY_SCAP_RSYNC_FEED"
     fi
 
-    GSF_RSYNC_PATH="/scap-data"
+    GSF_RSYNC_PATH="$ENTERPRISE_FEED_SCAP_PATH"
 
     if [ -e $ACCESSKEY ]; then
       if [ -z "$FEED_NAME" ]; then
@@ -239,7 +263,7 @@ init_feed_type () {
       COMMUNITY_RSYNC_FEED="$COMMUNITY_GVMD_DATA_RSYNC_FEED"
     fi
 
-    GSF_RSYNC_PATH="/data-objects/gvmd/"
+    GSF_RSYNC_PATH="$ENTERPRISE_FEED_DATA_PATH"
 
     if [ -e $ACCESSKEY ]; then
       if [ -z "$FEED_NAME" ]; then
@@ -350,7 +374,13 @@ is_feed_current () {
   if [ -e $ACCESSKEY ]
   then
     read feeduser < $ACCESSKEY
-    custid_at_host=`head -1 $ACCESSKEY | cut -d : -f 1`
+    if [ -z "$ENTERPRISE_FEED_HOST_OVERRIDE" ]
+    then
+      custid_at_host=`head -1 $ACCESSKEY | cut -d : -f 1`
+    else
+      custid=`head -1 $ACCESSKEY | cut -d @ -f 1`
+      custid_at_host="${custid}@${ENTERPRISE_FEED_HOST_OVERRIDE}"
+    fi
 
     if [ -z "$feeduser" ] || [ -z "$custid_at_host" ]
     then
@@ -480,7 +510,13 @@ sync_feed_data(){
 
     mkdir -p "$FEED_DIR"
     read feeduser < $ACCESSKEY
-    custid_at_host=`head -1 $ACCESSKEY | cut -d : -f 1`
+    if [ -z "$ENTERPRISE_FEED_HOST_OVERRIDE" ]
+    then
+      custid_at_host=`head -1 $ACCESSKEY | cut -d : -f 1`
+    else
+      custid=`head -1 $ACCESSKEY | cut -d @ -f 1`
+      custid_at_host="${custid}@${ENTERPRISE_FEED_HOST_OVERRIDE}"
+    fi
 
     if [ -z "$feeduser" ] || [ -z "$custid_at_host" ]
     then


### PR DESCRIPTION
**What**:
The sync script is adapted to a new feed server directory structure and will only download the feed
content for the current version.

**Why**:
There will be new community and enterprise feed servers for versions 22.04 and newer
that will use a new directory structure.

**How did you test it**:
By setting up a local rsync server using the new structure and changing the base URL.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
