### PR TITLE
Allow overriding community feed base URL and ensure FEED_VERSION is set

### DIFF
--- a/tools/greenbone-feed-sync.in
+++ b/tools/greenbone-feed-sync.in
@@ -56,7 +56,10 @@ RSYNC_CHMOD="--perms --chmod=Fugo+r,Fug+w,Dugo-s,Dugo+rx,Dug+w"
 
 # RSYNC_COMMUNITY_BASE_URL defines the base rsync URL for the community feed
 # not including the feed type (data or vulnerability) and version.
-RSYNC_COMMUNITY_BASE_URL="rsync://feed.community.greenbone.net/community"
+if [ -z "$RSYNC_COMMUNITY_BASE_URL" ]
+then
+  RSYNC_COMMUNITY_BASE_URL="rsync://feed.community.greenbone.net/community"
+fi
 
 # RSYNC_COMMUNITY_DATA_URL defines the rsync URL for the community data feed.
 RSYNC_COMMUNITY_DATA_URL="${RSYNC_COMMUNITY_BASE_URL}/data-feed/@GMP_VERSION_FEED@/"

--- a/tools/greenbone-feed-sync.in
+++ b/tools/greenbone-feed-sync.in
@@ -345,6 +345,8 @@ is_feed_current () {
   if [ -r $TIMESTAMP ]
   then
     FEED_VERSION=`cat $TIMESTAMP`
+  else
+    FEED_VERSION=0
   fi
 
   if [ -z "$FEED_VERSION" ]


### PR DESCRIPTION
**What**:
If RSYNC_COMMUNITY_BASE_URL is set as an environment variable its value
will be used by the sync script instead of the default one.

The is_feed_current function will now always set the FEED_VERSION even
if the timestamp file does not exist.

**Why**:

<!-- Why are these changes necessary? -->

**How did you test it**:

Running the sync script with RSYNC_COMMUNITY_BASE_URL set as an env variable for all feed types and the following scenarios for already downloaded feed data: no feed data, outdated feed data and current feed data.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
