### PR TITLE
Disable table_driven_lsc in policies via migration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 249)
+set (GVMD_DATABASE_VERSION 250)
 
 set (GVMD_SCAP_DATABASE_VERSION 19)
 


### PR DESCRIPTION
**What**:
The migration to version 250 sets the table_driven_lsc scanner
preference to 0 for all existing policies.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
This disables notus LSCs in compliance scans where their results are not
wanted.
(AP-1993, Part of AP-1988)
<!-- Why are these changes necessary? -->

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
