### PR TITLE
Disable table_driven_lsc in policies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 249)
+set (GVMD_DATABASE_VERSION 250)
 
 set (GVMD_SCAP_DATABASE_VERSION 19)
 

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -2897,6 +2897,19 @@ copy_config (const char* name, const char* comment, const char *config_id,
        quoted_config_selector);
   g_free (quoted_config_selector);
 
+  /* Workaround to disable notus checks in compliance policies */
+
+  sql ("INSERT INTO config_preferences (config, type, name, value)"
+       " SELECT id, 'SERVER_PREFS', 'table_driven_lsc', '0'"
+       "    FROM configs"
+       "   WHERE configs.id = %llu"
+       "     AND usage_type='policy'"
+       "     AND configs.id NOT IN"
+       "          (SELECT config FROM config_preferences"
+       "           WHERE name = 'table_driven_lsc'"
+       "           AND type = 'SERVER_PREFS');",
+       new);
+
   sql_commit ();
   if (new_config) *new_config = new;
   return 0;

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -2546,6 +2546,19 @@ create_config_internal (int check_access, const char *config_id,
 
   update_config_caches (*config);
 
+  /* Workaround to disable notus checks in compliance policies */
+
+  sql ("INSERT INTO config_preferences (config, type, name, value)"
+       " SELECT id, 'SERVER_PREFS', 'table_driven_lsc', '0'"
+       "    FROM configs"
+       "   WHERE configs.id = %llu"
+       "     AND usage_type='policy'"
+       "     AND configs.id NOT IN"
+       "          (SELECT config FROM config_preferences"
+       "           WHERE name = 'table_driven_lsc'"
+       "           AND type = 'SERVER_PREFS');",
+       *config);
+
   sql_commit ();
   *name = candidate_name;
   return 0;
@@ -4414,6 +4427,19 @@ update_config (config_t config, const gchar *name,
       sql_rollback ();
       return;
     }
+
+  /* Workaround to disable notus checks in compliance policies */
+
+  sql ("INSERT INTO config_preferences (config, type, name, value)"
+       " SELECT id, 'SERVER_PREFS', 'table_driven_lsc', '0'"
+       "    FROM configs"
+       "   WHERE configs.id = %llu"
+       "     AND usage_type='policy'"
+       "     AND configs.id NOT IN"
+       "          (SELECT config FROM config_preferences"
+       "           WHERE name = 'table_driven_lsc'"
+       "           AND type = 'SERVER_PREFS');",
+       config);
 
   sql_commit ();
 }


### PR DESCRIPTION
**What**:
The migration to version 250 sets the table_driven_lsc scanner
preference to 0 for all existing policies.

When creating a policy by importing it manually or via the feed the
scanner preference `table_driven_lsc` will be set to 0 to disable
notus scans.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
This disables notus LSCs in compliance scans where their results are not
wanted.

(AP-1993, Part of AP-1988)
<!-- Why are these changes necessary? -->

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
