### PR TITLE
Fix GMP doc for get_assets command

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -9096,7 +9096,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </column>
           <column>
             <name>ip</name>
-            <type>ip</type>
+            <type>text</type>
             <summary>IP address</summary>
           </column>
         </filter_keywords>
@@ -9151,6 +9151,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <alt>os</alt>
           </alts>
         </type>
+      </attrib>
+      <attrib>
+        <name>details</name>
+        <summary>Whether to include additional information (e.g., tags)</summary>
+        <type>boolean</type>
       </attrib>
     </pattern>
     <response>


### PR DESCRIPTION
**What**:
The type of the ip filter column has been changed to "text" and the
missing "details" attribute of the command has been added.

**Why**:
AP-1635

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
