### PR TITLE
Refactor: Add libbsd to docker images

### DIFF
--- a/.docker/build.Dockerfile
+++ b/.docker/build.Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
     xsltproc \
     libcgreen1-dev \
     lcov \
-	libbsd-dev \
+    libbsd-dev \
     libgpgme-dev && \
     rm -rf /var/lib/apt/lists/*
 

--- a/.docker/build.Dockerfile
+++ b/.docker/build.Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && \
     xsltproc \
     libcgreen1-dev \
     lcov \
+	libbsd-dev \
     libgpgme-dev && \
     rm -rf /var/lib/apt/lists/*
 

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && \
     libical-dev \
     postgresql-server-dev-13 \
     xml-twig-tools \
+	libbsd \
     xsltproc && \
     rm -rf /var/lib/apt/lists/*
 

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
     libical-dev \
     postgresql-server-dev-13 \
     xml-twig-tools \
-	libbsd \
+    libbsd \
     xsltproc && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
To enable a switch from gvm-libs proctitle-set to libbsd setproctitle
the build and production images need libbsd so that the pipeline goes
through on switch.

This is a preparation to reduce the depndency on gvm-libs.
