### PR TITLE
switch to setproctitle

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,7 @@ pkg_check_modules (LIBGVM_OSP REQUIRED libgvm_osp>=22.4)
 pkg_check_modules (LIBGVM_GMP REQUIRED libgvm_gmp>=22.4)
 pkg_check_modules (GNUTLS REQUIRED gnutls>=3.2.15)
 pkg_check_modules (GLIB REQUIRED glib-2.0>=2.42)
+pkg_check_modules (LIBBSD REQUIRED libbsd)
 pkg_check_modules (LIBICAL REQUIRED libical>=1.00)
 
 message (STATUS "Looking for PostgreSQL...")
@@ -95,7 +96,7 @@ endif (WITH_LIBTHEIA)
 
 include_directories (${LIBGVM_GMP_INCLUDE_DIRS}
                      ${LIBGVM_BASE_INCLUDE_DIRS} ${LIBGVM_UTIL_INCLUDE_DIRS}
-                     ${LIBGVM_OSP_INCLUDE_DIRS}  ${GLIB_INCLUDE_DIRS})
+                     ${LIBGVM_OSP_INCLUDE_DIRS}  ${LIBBSD_INCLUDE_DIRS} ${GLIB_INCLUDE_DIRS})
 
 add_library (gvm-pg-server SHARED
              manage_pg_server.c manage_utils.c)
@@ -268,35 +269,35 @@ add_executable (gvmd
 
 target_link_libraries (gvmd m
                        ${GNUTLS_LDFLAGS} ${GPGME_LDFLAGS} ${CMAKE_THREAD_LIBS_INIT} ${LINKER_HARDENING_FLAGS} ${LINKER_DEBUG_FLAGS}
-                       ${PostgreSQL_LIBRARIES} ${GLIB_LDFLAGS} ${GTHREAD_LDFLAGS}
+                       ${PostgreSQL_LIBRARIES} ${LIBBSD_LDFLAGS} ${GLIB_LDFLAGS} ${GTHREAD_LDFLAGS}
                        ${LIBGVM_BASE_LDFLAGS} ${LIBGVM_UTIL_LDFLAGS} ${LIBGVM_OSP_LDFLAGS} ${LIBGVM_GMP_LDFLAGS}
                        ${LIBICAL_LDFLAGS} ${LINKER_HARDENING_FLAGS} ${OPT_THEIA_TGT})
 target_link_libraries (manage-test cgreen m
                        ${GNUTLS_LDFLAGS} ${GPGME_LDFLAGS} ${CMAKE_THREAD_LIBS_INIT} ${LINKER_HARDENING_FLAGS} ${LINKER_DEBUG_FLAGS}
-                       ${PostgreSQL_LIBRARIES} ${GLIB_LDFLAGS} ${GTHREAD_LDFLAGS}
+                       ${PostgreSQL_LIBRARIES} ${LIBBSD_LDFLAGS} ${GLIB_LDFLAGS} ${GTHREAD_LDFLAGS}
                        ${LIBGVM_BASE_LDFLAGS} ${LIBGVM_UTIL_LDFLAGS} ${LIBGVM_OSP_LDFLAGS} ${LIBGVM_GMP_LDFLAGS}
                        ${LIBICAL_LDFLAGS} ${LINKER_HARDENING_FLAGS} ${OPT_THEIA_TGT})
 target_link_libraries (manage-sql-test cgreen m
                        ${GNUTLS_LDFLAGS} ${GPGME_LDFLAGS} ${CMAKE_THREAD_LIBS_INIT} ${LINKER_HARDENING_FLAGS} ${LINKER_DEBUG_FLAGS}
-                       ${PostgreSQL_LIBRARIES} ${GLIB_LDFLAGS} ${GTHREAD_LDFLAGS}
+                       ${PostgreSQL_LIBRARIES} ${LIBBSD_LDFLAGS} ${GLIB_LDFLAGS} ${GTHREAD_LDFLAGS}
                        ${LIBGVM_BASE_LDFLAGS} ${LIBGVM_UTIL_LDFLAGS} ${LIBGVM_OSP_LDFLAGS} ${LIBGVM_GMP_LDFLAGS}
                        ${LIBICAL_LDFLAGS} ${LINKER_HARDENING_FLAGS} ${OPT_THEIA_TGT})
 target_link_libraries (manage-utils-test cgreen m
                        ${GNUTLS_LDFLAGS} ${GPGME_LDFLAGS} ${CMAKE_THREAD_LIBS_INIT} ${LINKER_HARDENING_FLAGS} ${LINKER_DEBUG_FLAGS}
-                       ${PostgreSQL_LIBRARIES} ${GLIB_LDFLAGS} ${GTHREAD_LDFLAGS}
+                       ${PostgreSQL_LIBRARIES} ${LIBBSD_LDFLAGS} ${GLIB_LDFLAGS} ${GTHREAD_LDFLAGS}
                        ${LIBGVM_BASE_LDFLAGS} ${LIBGVM_UTIL_LDFLAGS} ${LIBGVM_OSP_LDFLAGS} ${LIBGVM_GMP_LDFLAGS}
                        ${LIBICAL_LDFLAGS} ${LINKER_HARDENING_FLAGS} ${OPT_THEIA_TGT})
 target_link_libraries (gmp-tickets-test cgreen m
                        ${GNUTLS_LDFLAGS} ${GPGME_LDFLAGS} ${CMAKE_THREAD_LIBS_INIT} ${LINKER_HARDENING_FLAGS} ${LINKER_DEBUG_FLAGS}
-                       ${PostgreSQL_LIBRARIES} ${GLIB_LDFLAGS} ${GTHREAD_LDFLAGS}
+                       ${PostgreSQL_LIBRARIES} ${LIBBSD_LDFLAGS} ${GLIB_LDFLAGS} ${GTHREAD_LDFLAGS}
                        ${LIBGVM_BASE_LDFLAGS} ${LIBGVM_UTIL_LDFLAGS} ${LIBGVM_OSP_LDFLAGS} ${LIBGVM_GMP_LDFLAGS}
                        ${LIBICAL_LDFLAGS} ${LINKER_HARDENING_FLAGS} ${OPT_THEIA_TGT})
 target_link_libraries (utils-test cgreen m
                        ${GNUTLS_LDFLAGS} ${GPGME_LDFLAGS} ${CMAKE_THREAD_LIBS_INIT} ${LINKER_HARDENING_FLAGS} ${LINKER_DEBUG_FLAGS}
-                       ${PostgreSQL_LIBRARIES} ${GLIB_LDFLAGS} ${GTHREAD_LDFLAGS}
+                       ${PostgreSQL_LIBRARIES} ${LIBBSD_LDFLAGS} ${GLIB_LDFLAGS} ${GTHREAD_LDFLAGS}
                        ${LIBGVM_BASE_LDFLAGS} ${LIBGVM_UTIL_LDFLAGS} ${LIBGVM_OSP_LDFLAGS} ${LIBGVM_GMP_LDFLAGS}
                        ${LIBICAL_LDFLAGS} ${LINKER_HARDENING_FLAGS} ${OPT_THEIA_TGT})
-target_link_libraries (gvm-pg-server ${GLIB_LDFLAGS} ${GTHREAD_LDFLAGS} ${LIBGVM_BASE_LDFLAGS} ${LIBGVM_UTIL_LDFLAGS} ${LIBICAL_LDFLAGS} ${LINKER_HARDENING_FLAGS})
+target_link_libraries (gvm-pg-server ${LIBBSD_LDFLAGS} ${GLIB_LDFLAGS} ${GTHREAD_LDFLAGS} ${LIBGVM_BASE_LDFLAGS} ${LIBGVM_UTIL_LDFLAGS} ${LIBICAL_LDFLAGS} ${LINKER_HARDENING_FLAGS})
 
 set_target_properties (gvmd PROPERTIES LINKER_LANGUAGE C)
 set_target_properties (manage-test PROPERTIES LINKER_LANGUAGE C)

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -95,7 +95,7 @@
 #include <gvm/base/pidfile.h>
 #include <gvm/base/pwpolicy.h>
 #include <gvm/base/logging.h>
-#include <gvm/base/proctitle.h>
+#include <bsd/unistd.h>
 #include <gvm/base/gvm_sentry.h>
 #include <gvm/util/fileutils.h>
 #include <gvm/util/serverutils.h>
@@ -600,7 +600,7 @@ accept_and_maybe_fork (int server_socket, sigset_t *sigmask_current)
           init_sentry ();
           is_parent = 0;
 
-          proctitle_set ("gvmd: Serving client");
+          setproctitle ("gvmd: Serving client");
 
           /* Restore the sigmask that was blanked for pselect. */
           pthread_sigmask (SIG_SETMASK, sigmask_current, NULL);
@@ -736,7 +736,7 @@ fork_connection_internal (gvm_connection_t *client_connection,
         /* Child.  Serve the scheduler GMP, then exit. */
 
         init_sentry ();
-        proctitle_set ("gvmd: Serving GMP internally");
+        setproctitle ("gvmd: Serving GMP internally");
 
         parent_client_socket = sockets[0];
 
@@ -834,7 +834,7 @@ fork_connection_internal (gvm_connection_t *client_connection,
 
         g_debug ("%s: %i forked %i", __func__, getpid (), pid);
 
-        proctitle_set ("gvmd: Requesting GMP internally");
+        setproctitle ("gvmd: Requesting GMP internally");
 
         /* This process is returned as the child of
          * fork_connection_for_scheduler so that the returned parent can wait
@@ -1105,7 +1105,7 @@ handle_sigabrt_simple (int signal)
 static int
 update_nvt_cache_osp (const gchar *update_socket)
 {
-  proctitle_set ("gvmd: OSP: Updating NVT cache");
+  setproctitle ("gvmd: OSP: Updating NVT cache");
 
   return manage_update_nvts_osp (update_socket);
 }
@@ -1121,7 +1121,7 @@ update_nvt_cache_osp (const gchar *update_socket)
 static int
 update_nvt_cache_retry ()
 {
-  proctitle_set ("gvmd: Reloading NVTs");
+  setproctitle ("gvmd: Reloading NVTs");
 
   /* Don't ignore SIGCHLD, in order to wait for child process. */
   setup_signal_handler (SIGCHLD, SIG_DFL, 0);
@@ -1216,7 +1216,7 @@ fork_update_nvt_cache ()
         /* Child.   */
 
         init_sentry ();
-        proctitle_set ("gvmd: Updating NVT cache");
+        setproctitle ("gvmd: Updating NVT cache");
 
         /* Clean up the process. */
 
@@ -1327,7 +1327,7 @@ fork_feed_sync ()
         /* Child.   */
 
         init_sentry ();
-        proctitle_set ("gvmd: Synchronizing feed data");
+        setproctitle ("gvmd: Synchronizing feed data");
 
         /* Clean up the process. */
 
@@ -1818,7 +1818,7 @@ parse_authentication_goption_arg (const gchar *opt, const gchar *arg,
  * @return EXIT_SUCCESS on success, EXIT_FAILURE on failure.
  */
 int
-gvmd (int argc, char** argv)
+gvmd (int argc, char** argv, char *env[])
 {
   /* Process options. */
 
@@ -2326,8 +2326,8 @@ gvmd (int argc, char** argv)
 
   /* Set process title. */
 
-  proctitle_init (argc, argv);
-  proctitle_set ("gvmd: Initializing");
+  setproctitle_init (argc, argv, env);
+  setproctitle ("gvmd: Initializing");
 
   /* Setup initial signal handlers. */
 
@@ -2511,7 +2511,7 @@ gvmd (int argc, char** argv)
           return EXIT_FAILURE;
         }
 
-      proctitle_set ("gvmd: Migrating database");
+      setproctitle ("gvmd: Migrating database");
 
       g_info ("   Migrating database.");
 
@@ -2596,7 +2596,7 @@ gvmd (int argc, char** argv)
     {
       int ret;
 
-      proctitle_set ("gvmd: Optimizing");
+      setproctitle ("gvmd: Optimizing");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2612,7 +2612,7 @@ gvmd (int argc, char** argv)
     {
       int ret;
 
-      proctitle_set ("gvmd: --rebuild");
+      setproctitle ("gvmd: --rebuild");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2634,7 +2634,7 @@ gvmd (int argc, char** argv)
       
       error_msg = NULL;
 
-      proctitle_set ("gvmd: --rebuild-gvmd-data");
+      setproctitle ("gvmd: --rebuild-gvmd-data");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2659,7 +2659,7 @@ gvmd (int argc, char** argv)
     {
       int ret;
 
-      proctitle_set ("gvmd: --rebuild-scap");
+      setproctitle ("gvmd: --rebuild-scap");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2678,7 +2678,7 @@ gvmd (int argc, char** argv)
     {
       int ret;
 
-      proctitle_set ("gvmd: --dump-vt-verification");
+      setproctitle ("gvmd: --dump-vt-verification");
   
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2701,7 +2701,7 @@ gvmd (int argc, char** argv)
 
       /* Create the scanner and then exit. */
 
-      proctitle_set ("gvmd: Creating scanner");
+      setproctitle ("gvmd: Creating scanner");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2753,7 +2753,7 @@ gvmd (int argc, char** argv)
 
       /* Modify the scanner and then exit. */
 
-      proctitle_set ("gvmd: Modifying scanner");
+      setproctitle ("gvmd: Modifying scanner");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2797,7 +2797,7 @@ gvmd (int argc, char** argv)
     {
       int ret;
 
-      proctitle_set ("gvmd: Checking alerts");
+      setproctitle ("gvmd: Checking alerts");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2813,7 +2813,7 @@ gvmd (int argc, char** argv)
     {
       int ret;
 
-      proctitle_set ("gvmd: Creating user");
+      setproctitle ("gvmd: Creating user");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2830,7 +2830,7 @@ gvmd (int argc, char** argv)
     {
       int ret;
 
-      proctitle_set ("gvmd: Deleting user");
+      setproctitle ("gvmd: Deleting user");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2846,7 +2846,7 @@ gvmd (int argc, char** argv)
     {
       int ret;
 
-      proctitle_set ("gvmd: Getting roles");
+      setproctitle ("gvmd: Getting roles");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2862,7 +2862,7 @@ gvmd (int argc, char** argv)
     {
       int ret;
 
-      proctitle_set ("gvmd: Getting users");
+      setproctitle ("gvmd: Getting users");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2878,7 +2878,7 @@ gvmd (int argc, char** argv)
     {
       int ret;
 
-      proctitle_set ("gvmd: Getting scanners");
+      setproctitle ("gvmd: Getting scanners");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2894,7 +2894,7 @@ gvmd (int argc, char** argv)
     {
       int ret;
 
-      proctitle_set ("gvmd: Deleting scanner");
+      setproctitle ("gvmd: Deleting scanner");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2910,7 +2910,7 @@ gvmd (int argc, char** argv)
     {
       int ret;
 
-      proctitle_set ("gvmd: Verifying scanner");
+      setproctitle ("gvmd: Verifying scanner");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2926,7 +2926,7 @@ gvmd (int argc, char** argv)
     {
       int ret;
 
-      proctitle_set ("gvmd: Modifying user password");
+      setproctitle ("gvmd: Modifying user password");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2942,7 +2942,7 @@ gvmd (int argc, char** argv)
     {
       int ret;
 
-      proctitle_set ("gvmd: Modifying setting");
+      setproctitle ("gvmd: Modifying setting");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2959,7 +2959,7 @@ gvmd (int argc, char** argv)
     {
       int ret;
 
-      proctitle_set ("gvmd: Encrypting all credentials");
+      setproctitle ("gvmd: Encrypting all credentials");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2975,7 +2975,7 @@ gvmd (int argc, char** argv)
     {
       int ret;
 
-      proctitle_set ("gvmd: Decrypting all credentials");
+      setproctitle ("gvmd: Decrypting all credentials");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -3226,7 +3226,7 @@ gvmd (int argc, char** argv)
 
   /* Enter the main forever-loop. */
 
-  proctitle_set ("gvmd: Waiting for incoming connections");
+  setproctitle ("gvmd: Waiting for incoming connections");
   serve_and_schedule ();
 
   gvm_close_sentry ();

--- a/src/gvmd.h
+++ b/src/gvmd.h
@@ -25,6 +25,6 @@
 #define _GVMD_H
 
 int
-gvmd (int, char **);
+gvmd (int, char **, char **);
 
 #endif /* not _GVMD_H */

--- a/src/main.c
+++ b/src/main.c
@@ -34,7 +34,7 @@
  * @return EXIT_SUCCESS on success, EXIT_FAILURE on failure.
  */
 int
-main (int argc, char **argv)
+main (int argc, char **argv, char *env[])
 {
-  return gvmd (argc, argv);
+  return gvmd (argc, argv, env);
 }

--- a/src/manage.c
+++ b/src/manage.c
@@ -82,7 +82,7 @@
 
 #include <gvm/base/gvm_sentry.h>
 #include <gvm/base/hosts.h>
-#include <gvm/base/proctitle.h>
+#include <bsd/unistd.h>
 #include <gvm/osp/osp.h>
 #include <gvm/util/fileutils.h>
 #include <gvm/util/serverutils.h>
@@ -2651,7 +2651,7 @@ static int
 fork_osp_scan_handler (task_t task, target_t target, int from,
                        char **report_id_return)
 {
-  char *report_id, title[128], *error = NULL;
+  char *report_id, *error = NULL;
   int rc;
 
   assert (task);
@@ -2726,8 +2726,7 @@ fork_osp_scan_handler (task_t task, target_t target, int from,
       exit (-1);
     }
 
-  snprintf (title, sizeof (title), "gvmd: OSP: Handling scan %s", report_id);
-  proctitle_set (title);
+  setproctitle ("gvmd: OSP: Handling scan %s", report_id);
 
   rc = handle_osp_scan (task, global_current_report, report_id);
   g_free (report_id);
@@ -2996,7 +2995,7 @@ static int
 fork_cve_scan_handler (task_t task, target_t target)
 {
   int pid;
-  char *report_id, title[128], *hosts;
+  char *report_id, *hosts;
   gvm_hosts_t *gvm_hosts;
   gvm_host_t *gvm_host;
 
@@ -3046,9 +3045,8 @@ fork_cve_scan_handler (task_t task, target_t target)
 
   set_task_run_status (task, TASK_STATUS_RUNNING);
 
-  snprintf (title, sizeof (title), "gvmd: CVE: Handling scan %s", report_id);
+  setproctitle ("gvmd: CVE: Handling scan %s", report_id);
   g_free (report_id);
-  proctitle_set (title);
 
   hosts = target_hosts (target);
   if (hosts == NULL)
@@ -4536,7 +4534,6 @@ scheduled_task_start (scheduled_task_t *scheduled_task,
                       manage_connection_forker_t fork_connection,
                       sigset_t *sigmask_current)
 {
-  char title[128];
   int pid;
   gvm_connection_t connection;
   gmp_authenticate_info_opts_t auth_opts;
@@ -4594,10 +4591,7 @@ scheduled_task_start (scheduled_task_t *scheduled_task,
 
           /* Parent.  Wait for child, to check return. */
 
-          snprintf (title, sizeof (title),
-                    "gvmd: scheduler: waiting for %i",
-                    pid);
-          proctitle_set (title);
+          setproctitle ("gvmd: scheduler: waiting for %i", pid);
 
           g_debug ("%s: %i fork_connectioned %i",
                    __func__, getpid (), pid);
@@ -4698,10 +4692,7 @@ scheduled_task_start (scheduled_task_t *scheduled_task,
 
   /* Start the task. */
 
-  snprintf (title, sizeof (title),
-            "gvmd: scheduler: starting %s",
-            scheduled_task->task_uuid);
-  proctitle_set (title);
+  setproctitle ("gvmd: scheduler: starting %s", scheduled_task->task_uuid);
 
   auth_opts = gmp_authenticate_info_opts_defaults;
   auth_opts.username = scheduled_task->owner_name;
@@ -4767,7 +4758,6 @@ scheduled_task_stop (scheduled_task_t *scheduled_task,
                      manage_connection_forker_t fork_connection,
                      sigset_t *sigmask_current)
 {
-  char title[128];
   gvm_connection_t connection;
   gmp_authenticate_info_opts_t auth_opts;
 
@@ -4793,10 +4783,8 @@ scheduled_task_stop (scheduled_task_t *scheduled_task,
 
   /* Stop the task. */
 
-  snprintf (title, sizeof (title),
-            "gvmd: scheduler: stopping %s",
+  setproctitle ("gvmd: scheduler: stopping %s",
             scheduled_task->task_uuid);
-  proctitle_set (title);
 
   auth_opts = gmp_authenticate_info_opts_defaults;
   auth_opts.username = scheduled_task->owner_name;

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -71,7 +71,7 @@
 #include <gvm/base/hosts.h>
 #include <gvm/base/pwpolicy.h>
 #include <gvm/base/logging.h>
-#include <gvm/base/proctitle.h>
+#include <bsd/unistd.h>
 #include <gvm/util/fileutils.h>
 #include <gvm/util/gpgmeutils.h>
 #include <gvm/util/serverutils.h>
@@ -9398,7 +9398,7 @@ alert_script_exec (const char *alert_id, const char *command_args,
                 init_sentry ();
                 cleanup_manage_process (FALSE);
 
-                proctitle_set ("gvmd: Running alert script");
+                setproctitle ("gvmd: Running alert script");
 
                 if (setgroups (0,NULL))
                   {
@@ -10201,7 +10201,7 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
                 init_sentry ();
                 cleanup_manage_process (FALSE);
 
-                proctitle_set ("gvmd: Sending to Sourcefire");
+                setproctitle ("gvmd: Sending to Sourcefire");
 
                 if (setgroups (0,NULL))
                   {
@@ -10530,7 +10530,7 @@ send_to_verinice (const char *url, const char *username, const char *password,
               {
                 /* Child.  Drop privileges, run command, exit. */
                 init_sentry ();
-                proctitle_set ("gvmd: Sending to Verinice");
+                setproctitle ("gvmd: Sending to Verinice");
 
                 cleanup_manage_process (FALSE);
 
@@ -20481,7 +20481,7 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
         }
     }
 
-  proctitle_set ("gvmd: Importing results");
+  setproctitle ("gvmd: Importing results");
 
   /* Add the results. */
 

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -45,7 +45,7 @@
 #include <unistd.h>
 
 #include <gvm/base/gvm_sentry.h>
-#include <gvm/base/proctitle.h>
+#include <bsd/unistd.h>
 #include <gvm/util/uuidutils.h>
 #include <gvm/util/fileutils.h>
 
@@ -3416,7 +3416,7 @@ run_report_format_script (gchar *report_format_id,
               /* Child.  Drop privileges, run command, exit. */
 
               init_sentry ();
-              proctitle_set ("gvmd: Generating report");
+              setproctitle ("gvmd: Generating report");
 
               cleanup_manage_process (FALSE);
 

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -49,7 +49,7 @@
 #include <unistd.h>
 
 #include <gvm/base/gvm_sentry.h>
-#include <gvm/base/proctitle.h>
+#include <bsd/unistd.h>
 #include <gvm/util/fileutils.h>
 
 #undef G_LOG_DOMAIN
@@ -2731,7 +2731,7 @@ sync_secinfo (sigset_t *sigmask_current, int (*update) (void),
 
     }
 
-  proctitle_set (process_title);
+  setproctitle ("%s", process_title);
 
   if (update () == 0)
     {
@@ -3328,7 +3328,7 @@ update_scap_end ()
   sql ("ANALYZE scap.affected_products;");
 
   g_info ("%s: Updating SCAP info succeeded", __func__);
-  proctitle_set ("gvmd: Syncing SCAP: done");
+  setproctitle ("gvmd: Syncing SCAP: done");
 
   return 0;
 }
@@ -3375,7 +3375,7 @@ try_load_csv ()
       /* Add the indexes and constraints, now that the data is ready. */
 
       g_debug ("%s: add indexes", __func__);
-      proctitle_set ("gvmd: Syncing SCAP: Adding indexes");
+      setproctitle ("gvmd: Syncing SCAP: Adding indexes");
 
       if (manage_db_init_indexes ("scap"))
         {
@@ -3384,7 +3384,7 @@ try_load_csv ()
         }
 
       g_debug ("%s: add constraints", __func__);
-      proctitle_set ("gvmd: Syncing SCAP: Adding constraints");
+      setproctitle ("gvmd: Syncing SCAP: Adding constraints");
 
       if (manage_db_add_constraints ("scap"))
         {
@@ -3437,7 +3437,7 @@ update_scap (gboolean reset_scap_db)
 
           if (last_scap_update == last_feed_update)
             {
-              proctitle_set ("gvmd: Syncing SCAP: done");
+              setproctitle ("gvmd: Syncing SCAP: done");
               return 0;
             }
 
@@ -3466,7 +3466,7 @@ update_scap (gboolean reset_scap_db)
   /* Add the indexes and constraints. */
 
   g_debug ("%s: add indexes", __func__);
-  proctitle_set ("gvmd: Syncing SCAP: Adding indexes");
+  setproctitle ("gvmd: Syncing SCAP: Adding indexes");
 
   if (manage_db_init_indexes ("scap"))
     {
@@ -3487,13 +3487,13 @@ update_scap (gboolean reset_scap_db)
   g_info ("%s: Updating data from feed", __func__);
 
   g_debug ("%s: update cpes", __func__);
-  proctitle_set ("gvmd: Syncing SCAP: Updating CPEs");
+  setproctitle ("gvmd: Syncing SCAP: Updating CPEs");
 
   if (update_scap_cpes () == -1)
     return -1;
 
   g_debug ("%s: update cves", __func__);
-  proctitle_set ("gvmd: Syncing SCAP: Updating CVEs");
+  setproctitle ("gvmd: Syncing SCAP: Updating CVEs");
 
   if (update_scap_cves () == -1)
     return -1;
@@ -3504,12 +3504,12 @@ update_scap (gboolean reset_scap_db)
   /* Do calculations that need all data. */
 
   g_debug ("%s: update max cvss", __func__);
-  proctitle_set ("gvmd: Syncing SCAP: Updating max CVSS");
+  setproctitle ("gvmd: Syncing SCAP: Updating max CVSS");
 
   update_scap_cvss ();
 
   g_debug ("%s: update placeholders", __func__);
-  proctitle_set ("gvmd: Syncing SCAP: Updating placeholders");
+  setproctitle ("gvmd: Syncing SCAP: Updating placeholders");
 
   update_scap_placeholders ();
 


### PR DESCRIPTION
Refactor: move from gvm-lib proctitle-set to libbsd setproctitle

To be less dependenct on gvm-libs and have more robust way to set
proctitle this commit switches from gvm-libs proctitle-set to
setproctitle of libbsd.