### PR TITLE
Fix iCal next time calculation, use new SQL func

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -5147,7 +5147,7 @@ manage_schedule (manage_connection_forker_t fork_connection,
                  task_schedule_iterator_task (&schedules));
         set_task_schedule_next_time
          (task_schedule_iterator_task (&schedules),
-          icalendar_next_time_from_string (icalendar, zone, 0));
+          icalendar_next_time_from_string (icalendar, time(NULL), zone, 0));
 
         /* Skip this task if it was already added to the starts list
          * to avoid conflicts between multiple users with permissions. */

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -18228,7 +18228,9 @@ set_task_schedule (task_t task, schedule_t schedule, int periods)
   sql ("UPDATE tasks"
        " SET schedule = %llu,"
        " schedule_periods = %i,"
-       " schedule_next_time = (SELECT next_time_ical (icalendar, timezone)"
+       " schedule_next_time = (SELECT next_time_ical (icalendar,"
+       "                                              m_now()::bigint,"
+       "                                              timezone)"
        "                       FROM schedules"
        "                       WHERE id = %llu),"
        " modification_time = m_now ()"
@@ -18262,7 +18264,9 @@ set_task_schedule_uuid (const gchar *task_id, schedule_t schedule, int periods)
   sql ("UPDATE tasks"
        " SET schedule = %llu,"
        "%s"
-       " schedule_next_time = (SELECT next_time_ical (icalendar, timezone)"
+       " schedule_next_time = (SELECT next_time_ical (icalendar,"
+       "                                              m_now()::bigint,"
+       "                                              timezone)"
        "                       FROM schedules"
        "                       WHERE id = %llu),"
        " modification_time = m_now ()"
@@ -18740,7 +18744,7 @@ update_duration_schedule_periods (task_t task)
   duration_expired_element
    = /* The task has started, so assume that the start time was the last
       * most recent start of the period. */
-     " AND (SELECT next_time_ical (icalendar, timezone, -1)"
+     " AND (SELECT next_time_ical (icalendar, m_now()::bigint, timezone, -1)"
      "             + duration"
      "      FROM schedules"
      "      WHERE schedules.id = schedule)"
@@ -29706,16 +29710,18 @@ cleanup_schedule_times ()
 {
   sql ("UPDATE tasks"
         " SET schedule_next_time"
-        "   = (SELECT next_time_ical (icalendar, timezone)"
+        "   = (SELECT next_time_ical (icalendar, m_now()::bigint, timezone)"
         "      FROM schedules"
         "      WHERE schedules.id = tasks.schedule)"
         " WHERE schedule_next_time != 0"
         "   AND schedule_next_time"
-        "         = (SELECT next_time_ical (icalendar, timezone)"
+        "         = (SELECT next_time_ical (icalendar, m_now()::bigint,"
+        "                                   timezone)"
         "              FROM schedules"
         "             WHERE schedules.id = tasks.schedule)"
         "   AND schedule_next_time"
-        "         != (SELECT next_time_ical (icalendar, timezone)"
+        "         != (SELECT next_time_ical (icalendar, m_now()::bigint,"
+        "                                    timezone)"
         "              FROM schedules"
         "             WHERE schedules.id = tasks.schedule);");
 
@@ -40765,7 +40771,7 @@ schedule_info (schedule_t schedule, int trash, gchar **icalendar, gchar **zone)
    { "duration", NULL, KEYWORD_TYPE_INTEGER },                             \
    { "timezone", NULL, KEYWORD_TYPE_STRING },                              \
    { "icalendar", NULL, KEYWORD_TYPE_STRING },                             \
-   { "next_time_ical (icalendar, timezone)",                               \
+   { "next_time_ical (icalendar, m_now()::bigint, timezone)",              \
      "next_run",                                                           \
      KEYWORD_TYPE_INTEGER },                                               \
    { "first_time", "first_run", KEYWORD_TYPE_INTEGER },                    \
@@ -41061,7 +41067,8 @@ task_schedule_iterator_stop_due (iterator_t* iterator)
 
           now = time (NULL);
 
-          start = icalendar_next_time_from_string (icalendar, zone, -1);
+          start = icalendar_next_time_from_string (icalendar, time(NULL), zone,
+                                                   -1);
           if ((start + duration) < now)
             return TRUE;
         }
@@ -41331,6 +41338,7 @@ modify_schedule (const char *schedule_id, const char *name, const char *comment,
   // Update scheduled next times for tasks
 
   new_next_time = icalendar_next_time_from_vcalendar (ical_component,
+                                                      time(NULL),
                                                       real_timezone, 0);
 
   sql ("UPDATE tasks SET schedule_next_time = %ld"

--- a/src/manage_utils.c
+++ b/src/manage_utils.c
@@ -1148,7 +1148,7 @@ icalendar_next_time_from_recurrence (struct icalrecurrencetype recurrence,
       /* Iterate over rule-based recurrences up to first time after
        * reference time */
       while (icaltime_is_null_time (recur_time) == FALSE
-             && icaltime_compare (recur_time, reference_time) < 0)
+             && icaltime_compare (recur_time, reference_time) <= 0)
         {
           if (icalendar_time_matches_array (recur_time, exdates) == FALSE)
             prev_time = recur_time;
@@ -1199,8 +1199,10 @@ icalendar_next_time_from_recurrence (struct icalrecurrencetype recurrence,
  * @brief  Get the next or previous due time from a VCALENDAR component.
  * The VCALENDAR must have simplified with icalendar_from_string for this to
  *  work reliably.
+ * The reference time is usually the current time.
  *
  * @param[in]  vcalendar       The VCALENDAR component to get the time from.
+ * @param[in]  reference_time  The reference time for calculating the next time.
  * @param[in]  default_tzid    Timezone id to use if none is set in the iCal.
  * @param[in]  periods_offset  0 for next, -1 for previous from/before now.
  *
@@ -1208,11 +1210,12 @@ icalendar_next_time_from_recurrence (struct icalrecurrencetype recurrence,
  */
 time_t
 icalendar_next_time_from_vcalendar (icalcomponent *vcalendar,
+                                    time_t reference_time,
                                     const char *default_tzid,
                                     int periods_offset)
 {
   icalcomponent *vevent;
-  icaltimetype dtstart, dtstart_with_tz, ical_now;
+  icaltimetype dtstart, dtstart_with_tz, ical_reference_time;
   icaltimezone *tz;
   icalproperty *rrule_prop;
   struct icalrecurrencetype recurrence;
@@ -1253,12 +1256,12 @@ icalendar_next_time_from_vcalendar (icalcomponent *vcalendar,
   icaltime_set_timezone (&dtstart_with_tz, tz);
 
   // Get current time
-  ical_now = icaltime_current_time_with_zone (tz);
+  ical_reference_time = icaltime_from_timet_with_zone (reference_time, 0, tz);
   // Set timezone explicitly because icaltime_current_time_with_zone doesn't.
-  icaltime_set_timezone (&ical_now, tz);
-  if (ical_now.zone == NULL)
+  icaltime_set_timezone (&ical_reference_time, tz);
+  if (ical_reference_time.zone == NULL)
     {
-      ical_now.zone = tz;
+      ical_reference_time.zone = tz;
     }
 
   // Get EXDATEs and RDATEs
@@ -1275,7 +1278,7 @@ icalendar_next_time_from_vcalendar (icalcomponent *vcalendar,
   // Calculate next time.
   next_time = icalendar_next_time_from_recurrence (recurrence,
                                                    dtstart_with_tz,
-                                                   ical_now, tz,
+                                                   ical_reference_time, tz,
                                                    exdates, rdates,
                                                    periods_offset);
 
@@ -1290,8 +1293,10 @@ icalendar_next_time_from_vcalendar (icalcomponent *vcalendar,
  * @brief  Get the next or previous due time from a VCALENDAR string.
  * The string must be a VCALENDAR simplified with icalendar_from_string for
  *  this to work reliably.
+ * The reference time is usually the current time.
  *
  * @param[in]  ical_string     The VCALENDAR string to get the time from.
+ * @param[in]  reference_time  The reference time for calculating the next time.
  * @param[in]  default_tzid    Timezone id to use if none is set in the iCal.
  * @param[in]  periods_offset  0 for next, -1 for previous from/before now.
  *
@@ -1299,6 +1304,7 @@ icalendar_next_time_from_vcalendar (icalcomponent *vcalendar,
  */
 time_t
 icalendar_next_time_from_string (const char *ical_string,
+                                 time_t reference_time,
                                  const char *default_tzid,
                                  int periods_offset)
 {
@@ -1306,7 +1312,9 @@ icalendar_next_time_from_string (const char *ical_string,
   icalcomponent *ical_parsed;
 
   ical_parsed = icalcomponent_new_from_string (ical_string);
-  next_time = icalendar_next_time_from_vcalendar (ical_parsed, default_tzid,
+  next_time = icalendar_next_time_from_vcalendar (ical_parsed,
+                                                  reference_time,
+                                                  default_tzid,
                                                   periods_offset);
   icalcomponent_free (ical_parsed);
   return next_time;

--- a/src/manage_utils.h
+++ b/src/manage_utils.h
@@ -87,10 +87,10 @@ icalendar_approximate_rrule_from_vcalendar (icalcomponent *, time_t *, time_t *,
                                             int *);
 
 time_t
-icalendar_next_time_from_vcalendar (icalcomponent *, const char *, int);
+icalendar_next_time_from_vcalendar (icalcomponent *, time_t, const char *, int);
 
 time_t
-icalendar_next_time_from_string (const char *, const char *, int);
+icalendar_next_time_from_string (const char *, time_t, const char *, int);
 
 int
 icalendar_duration_from_vcalendar (icalcomponent *);


### PR DESCRIPTION
**What**:
The iCalendar helper functions and next_time_ical SQL extension function
now have a new parameter for the reference time, which should be the
current time.
The functions now no longer return the current/reference time as the
next time when it is the same as a recurrence time.

**Why**:
This allows using a consistent reference time throughout queries that
take a longer time to run.
The recurrence time issue could cause unwanted effects like scheduled
tasks being started twice for the same scheduled time.

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
