### PR TITLE
Fix handling of SSH keys in modify_credential

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -317,6 +317,20 @@ truncate_private_key (const gchar* private_key)
         }
     }
 
+  if (key_start == NULL)
+    {
+      key_start = strstr (private_key, "-----BEGIN OPENSSH PRIVATE KEY-----");
+      if (key_start)
+        {
+          key_end = strstr (key_start, "-----END OPENSSH PRIVATE KEY-----");
+
+          if (key_end)
+            key_end += strlen ("-----END OPENSSH PRIVATE KEY-----");
+          else
+            return NULL;
+        }
+    }
+
   if (key_end && key_end[0] == '\n')
     key_end++;
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -34465,7 +34465,7 @@ modify_credential (const char *credential_id,
         {
           if (key_private_to_use || password)
             {
-              if (check_private_key (key_private_truncated
+              if (check_private_key (key_private_to_use
                                       ? key_private_to_use
                                       : credential_iterator_private_key
                                          (&iterator),
@@ -34481,7 +34481,7 @@ modify_credential (const char *credential_id,
 
               set_credential_private_key
                 (credential,
-                 key_private_truncated
+                 key_private_to_use
                   ? key_private_to_use
                   : credential_iterator_private_key (&iterator),
                  password


### PR DESCRIPTION
**What**:
If the private key header and footer are not recognized by
truncate_private_key, the original key is now used as intended instead
of reverting to the old private key.
Also, the truncate_private_key function will now work with
"-----BEGIN OPENSSH PRIVATE KEY-----" and the corresponding footer.

**Why**:
This fixes not being able to modify credentials with SSH keys using
"-----BEGIN OPENSSH PRIVATE KEY-----" (AP-1990).

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
