### PR TITLE
gvmd.service.in: drop EnvironmentFile which used stale DEFAULT_CONFIG…

### DIFF
--- a/config/gvmd.service.in
+++ b/config/gvmd.service.in
@@ -12,7 +12,6 @@ Group=gvm
 PIDFile=${GVMD_PID_PATH}
 RuntimeDirectory=gvmd
 RuntimeDirectoryMode=2775
-EnvironmentFile=${DEFAULT_CONFIG_DIR}/gvmd
 ExecStart=${SBINDIR}/gvmd --osp-vt-update=/run/ospd/ospd-openvas.sock --listen-group=gvm
 Restart=always
 TimeoutStopSec=10


### PR DESCRIPTION
The DEFAULT_CONFIG_DIR variable was removed with 0b775e3705f8 ("Use
better defaults for installation directories") but gvmd.service.in
still references it.

Fixes: 0b775e3705f8 ("Use better defaults for installation directories")