### PR TITLE
[gvmd.service] Drop Group= directive

### DIFF
--- a/config/gvmd.service.in
+++ b/config/gvmd.service.in
@@ -8,7 +8,6 @@ ConditionKernelCommandLine=!recovery
 [Service]
 Type=forking
 User=gvm
-Group=gvm
 PIDFile=${GVMD_PID_PATH}
 RuntimeDirectory=gvmd
 RuntimeDirectoryMode=2775


### PR DESCRIPTION
Specifying the Group is typically never required, as systemd's default
behavior to use the user's primary group is what you want anyways. And
to make the service file more readable, unnecessary directives should
be removed. So this removes the Group= directive.

See also the equivalent commit in gsad:
https://github.com/greenbone/gsad/commit/9961b1e3e95dc49b6546fbbab5c57a3da30a762d