### PR TITLE
[CMake] Do not install run(-time) dir(ectory)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,8 +294,6 @@ add_subdirectory (doc)
 
 install (DIRECTORY DESTINATION ${GVMD_STATE_DIR})
 
-install (DIRECTORY DESTINATION ${GVMD_RUN_DIR})
-
 install (FILES ${CMAKE_BINARY_DIR}/src/gvmd_log.conf
          DESTINATION ${GVM_SYSCONF_DIR})
 


### PR DESCRIPTION
Installing the empty GVMD_RUN_DIR serves no purpose. The run(-time)
directories of services should be dynamically created and not
statically installed. And gvmd's systemd service file ensures that the
PIDFile is created, which is the only content of gsad's run
directory. And even if there would be further content, then systemd's
RuntimeDirectory directive should be used instead.

The bottom line is: in no case should run-time directories be
installed, they are to be created at *run-time*.

See also the equivalent commit for gsad:
https://github.com/greenbone/gsad/commit/6a48b05ae7bb0864944fb4c9a73b53ca11388adc