### PR TITLE
Change: Allow overriding LOG_CMD for sync script

### DIFF
--- a/tools/greenbone-feed-sync.in
+++ b/tools/greenbone-feed-sync.in
@@ -21,10 +21,58 @@
 # case a GSF access key is present) or else from the Greenbone
 # Community Feed.
 
-log_notice () {
-  $LOG_CMD -p daemon.notice "$1"
+########## LOG FUNCTIONS
+########## =============
+
+# LOG_CMD defines the command to use for logging. To have logger log to syslog
+# only, remove "-s" here.
+if [ -z "$LOG_CMD" ]
+then
+  LOG_CMD="logger -t $SCRIPT_NAME -s"
+fi
+
+TEST_LOGGER=$(logger -s "" 2>/dev/null)
+HAS_LOGGER=$?
+
+log_debug () {
+  if [ $HAS_LOGGER -eq 0 ]; then
+    $LOG_CMD -p daemon.debug "$1"
+  else
+    echo "$1"
+  fi
 }
 
+log_info () {
+  if [ $HAS_LOGGER -eq 0 ]; then
+    $LOG_CMD -p daemon.info "$1"
+  else
+    echo "$1"
+  fi
+}
+
+log_warning () {
+  if [ $HAS_LOGGER -eq 0 ]; then
+    $LOG_CMD -p daemon.warning "$1"
+  else
+    echo "$1"
+  fi
+}
+
+log_err () {
+  if [ $HAS_LOGGER -eq 0 ]; then
+    $LOG_CMD -p daemon.err "$1"
+  else
+    echo "$1" >&2
+  fi
+}
+
+log_notice () {
+  if [ $HAS_LOGGER -eq 0 ]; then
+    $LOG_CMD -p daemon.notice "$1"
+  else
+    echo "$1"
+  fi
+}
 
 ########## SETTINGS
 ########## ========
@@ -63,13 +111,6 @@ PORT=24
 # SCRIPT_NAME is the name the scripts will use to identify itself and to mark
 # log messages.
 SCRIPT_NAME="greenbone-feed-sync"
-
-# LOG_CMD defines the command to use for logging. To have logger log to syslog
-# only, remove "-s" here.
-if [ -z "$LOG_CMD" ]
-then
-  LOG_CMD="logger -t $SCRIPT_NAME -s"
-fi
 
 
 # LOCK_FILE is the name of the file used to lock the feed during sync or update.
@@ -140,22 +181,6 @@ FEED_TYPES_SUPPORTED="CERT, SCAP or GVMD_DATA"
 
 ########## FUNCTIONS
 ########## =========
-
-log_debug () {
-  $LOG_CMD -p daemon.debug "$1"
-}
-
-log_info () {
-  $LOG_CMD -p daemon.info "$1"
-}
-
-log_warning () {
-  $LOG_CMD -p daemon.warning "$1"
-}
-
-log_err () {
-  $LOG_CMD -p daemon.err "$1"
-}
 
 init_feed_type () {
   if [ -z "$FEED_TYPE" ]

--- a/tools/greenbone-feed-sync.in
+++ b/tools/greenbone-feed-sync.in
@@ -64,9 +64,13 @@ PORT=24
 # log messages.
 SCRIPT_NAME="greenbone-feed-sync"
 
-# LOG_CMD defines the command to use for logging. To have logger log to stderr
-# as well as syslog, add "-s" here.
-LOG_CMD="logger -t $SCRIPT_NAME"
+# LOG_CMD defines the command to use for logging. To have logger log to syslog
+# only, remove "-s" here.
+if [ -z "$LOG_CMD" ]
+then
+  LOG_CMD="logger -t $SCRIPT_NAME -s"
+fi
+
 
 # LOCK_FILE is the name of the file used to lock the feed during sync or update.
 if [ -z "$LOCK_FILE" ]


### PR DESCRIPTION
**What**:

Allow to override the LOG_CMD for greenbone-feed-sync
and log to stderror by default too. Also fix logging if syslog
is not available.

**Why**:

When nothing it logged to stderr it is very difficult to guess what's going wrong here.

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
