### PR TITLE
Add some startup delay for gvmd in container

### DIFF
--- a/.docker/start-gvmd.sh
+++ b/.docker/start-gvmd.sh
@@ -5,6 +5,9 @@
 [ -z "$GVMD_ARGS" ] && GVMD_ARGS="--listen-mode=666"
 [ -z "$GVMD_USER" ] && GVMD_USER="gvmd"
 
+echo "waiting 10 seconds for postgres startup"
+sleep 10
+
 # check for psql connection
 until psql -U "$GVMD_USER" -d gvmd -c "SELECT 'connected' as connection"; do
 	echo "waiting 1 second to retry psql connection"


### PR DESCRIPTION
**What**:

Add a 10 seconds startup delay for gvmd in container

**Why**:

For the stable image postgres seems to need some additional time to startup
while already listening for new connections. Therefore our do loops seems to not suffice here.

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
