### PR TITLE
Fix: q'n'd provide greenbone-nvt-sync for gvmd

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -92,6 +92,8 @@ RUN apt-get update && \
 COPY --from=build /install/ /
 COPY .docker/start-gvmd.sh /usr/local/bin/start-gvmd
 COPY .docker/entrypoint.sh /usr/local/bin/entrypoint
+# quick fix for stable only v21.x.x fix is already in next major release
+COPY --from=greenbone/openvas-scanner:stable /usr/local/bin/greenbone-nvt-sync /usr/local/bin/greenbone-nvt-sync
 
 RUN addgroup --gid 1001 --system gvmd \
     && adduser --no-create-home --shell /bin/false --disabled-password \


### PR DESCRIPTION
This fix provides the greenbone-nvt-sync script that is not part of the gvmd docker image - but should be there as gvmd is require it for feed version updates.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
