### PR TITLE
Add command line option --vt-sync-extra-days

### DIFF
--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -211,6 +211,9 @@ Verify scanner SCANNER-UUID and exit.
 \fB--version\f1
 Print version and exit.
 .TP
+\fB--vt-sync-extra-days=\fIN\fB\f1
+Also fetch VTs up to N days older than the feed timestamp when synchronizing the feed. 
+.TP
 \fB--vt-verification-collation=\fICOLLATION\fB\f1
 Set collation for VT verification to COLLATION, omit or leave empty to choose automatically. Should be 'ucs_default' if DB uses UTF-8 or 'C' for single-byte encodings. 
 .SH SIGNALS

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -472,6 +472,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </optdesc>
     </option>
     <option>
+      <p><opt>--vt-sync-extra-days=<arg>N</arg></opt></p>
+      <optdesc>
+        <p>
+          Also fetch VTs up to N days older than the feed timestamp
+          when synchronizing the feed.
+        </p>
+      </optdesc>
+    </option>
+    <option>
       <p><opt>--vt-verification-collation=<arg>COLLATION</arg></opt></p>
       <optdesc>
         <p>

--- a/doc/gvmd.html
+++ b/doc/gvmd.html
@@ -430,6 +430,12 @@
         <p>Print version and exit.</p>
       
     
+      <p><b>--vt-sync-extra-days=<em>N</em></b></p>
+      
+        <p>
+          Also fetch VTs up to N days older than the feed timestamp
+          when synchronizing the feed.
+        </p>
     
       <p><b>--vt-verification-collation=<em>COLLATION</em></b></p>
       

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1885,6 +1885,7 @@ gvmd (int argc, char** argv, char *env[])
   static gchar *broker_address = NULL;
   static gchar *feed_lock_path = NULL;
   static int feed_lock_timeout = 0;
+  static int vt_sync_extra_days = 0;
   static gchar *vt_verification_collation = NULL;
 
   GString *full_disable_commands = g_string_new ("");
@@ -2204,6 +2205,11 @@ gvmd (int argc, char** argv, char *env[])
           &print_version,
           "Print version and exit.",
           NULL },
+        { "vt-sync-extra-days", '\0', 0, G_OPTION_ARG_INT,
+          &vt_sync_extra_days,
+          "Also fetch VTs up to <N> days older than the feed timestamp"
+          " when synchronizing the feed",
+          "<N>" },
         { "vt-verification-collation", '\0', 0, G_OPTION_ARG_STRING,
           &vt_verification_collation,
           "Set collation for VT verification to <collation>, omit or leave"
@@ -2287,6 +2293,9 @@ gvmd (int argc, char** argv, char *env[])
   /* Set SecInfo update commit size */
 
   set_secinfo_commit_size (secinfo_commit_size);
+
+  /* Set extra days to fetch with VT feed sync */
+  set_vt_sync_extra_days (vt_sync_extra_days);
 
   /* Set VT verification collation override */
   set_vt_verification_collation (vt_verification_collation);

--- a/src/manage_sql_nvts.h
+++ b/src/manage_sql_nvts.h
@@ -104,6 +104,12 @@ void
 set_osp_vt_update_socket (const char *new_socket);
 
 int
+get_vt_sync_extra_days ();
+
+void
+set_vt_sync_extra_days (int);
+
+int
 check_osp_vt_update_socket ();
 
 void


### PR DESCRIPTION
**What**:
This option makes gvmd fetch VTs up to a set number of days older than
the last feed timestamp when updating the VTs.

**Why**:
This is a workaround to ensure VTs are reloaded if they are added to the feed a few days after their "last modification" time.
The new option should be set to the expected delay. (T3-115)

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] PR merge commit message adjusted
