### PR TITLE
Change: Log client command errors only as debug message

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -26618,7 +26618,7 @@ process_gmp_client_input ()
             g_debug ("   client error: G_MARKUP_ERROR_UNKNOWN_ATTRIBUTE");
           else
             err = -1;
-          g_info ("   Failed to parse client XML: %s", error->message);
+          g_debug ("   Failed to parse client XML: %s", error->message);
           g_error_free (error);
         }
       else
@@ -26733,7 +26733,7 @@ process_gmp (gmp_parser_t *parser, const gchar *command, gchar **response)
             g_debug ("   client error: G_MARKUP_ERROR_UNKNOWN_ATTRIBUTE");
           else
             err = -1;
-          g_info ("   Failed to parse client XML: %s", error->message);
+          g_debug ("   Failed to parse client XML: %s", error->message);
           g_error_free (error);
         }
       else


### PR DESCRIPTION
**What**:

Log client command errors only as debug message

**Why**:

Using info could spam the log when an erroneous client is used. Also
when a client requests a disabled command like getting the license this
is logged as info currently which confused our community users.

Silence `md    gmp:   INFO:2022-08-18 13h37.13 UTC:1678:    Failed to parse client XML: Command Unavailable` message by default.

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] PR merge commit message adjusted
