### PR TITLE
Change: Split building build and production container images

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,26 +1,35 @@
-name: Container Image Builds
+name: Build Container Image Builds
 
 on:
   push:
     branches: [ main, stable, oldstable ]
     tags: ["v*"]
+    paths:
+      - .github/workflows/build-container.yml
+      - .docker/build.Dockerfile
   pull_request:
     branches: [ main, stable, oldstable ]
+    paths:
+      - .github/workflows/build-container.yml
+      - .docker/build.Dockerfile
   workflow_dispatch:
   repository_dispatch:
+  schedule:
+    # rebuild image every sunday
+    - cron: "0 0 * * 0"
 
 jobs:
-  images:
-    name: Production Images
+  build-images:
+    name: "Build Images"
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v3
       - name: Setup container meta information
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ github.repository }}
+          images: ${{ github.repository }}-build
           labels: |
             org.opencontainers.image.vendor=Greenbone
             org.opencontainers.image.base.name=debian/stable-slim
@@ -35,22 +44,30 @@ jobs:
             type=raw,value=oldstable,enable=${{ github.ref == format('refs/heads/{0}', 'oldstable') }}
             # use unstable for main branch
             type=raw,value=unstable,enable={{is_default_branch}}
-      - name: Login to Docker Registry
+      - name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - run: echo "Build and push ${{ steps.meta.outputs.tags }}"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Build and push Container image
+      - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
-          file: .docker/prod.Dockerfile
+          file: .docker/build.Dockerfile
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+      - name: Trigger libtheia container build
+        if: github.event_name != 'pull_request'
+        run: |
+          curl -X POST https://api.github.com/repos/greenbone/libtheia/actions/workflows/container.yml/dispatches \
+          -H "Accept: application/vnd.github.v3+json" \
+          -u greenbonebot:${{ secrets.GREENBONE_BOT_TOKEN }} \
+          -d '{"ref":"main"}'


### PR DESCRIPTION
**What**:

Split building build and production container images

**Why**:

The build image really rarely needs a rebuild. Therefore split this job
into an own workflow and only rebuild if the corresponding dockerfile
or workflow has changed.

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
