### PR TITLE
Add task last_/first_report_created filters

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -14610,7 +14610,8 @@ append_to_task_string (task_t task, const char* field, const char* value)
    "last_report", "threat", "trend", "severity", "schedule", "next_due",      \
    "first", "last", "false_positive", "log", "low", "medium", "high",         \
    "hosts", "result_hosts", "fp_per_host", "log_per_host", "low_per_host",    \
-   "medium_per_host", "high_per_host", "target", "usage_type", NULL }
+   "medium_per_host", "high_per_host", "target", "usage_type",                \
+   "first_report_created", "last_report_created", NULL }
 
 /**
  * @brief Task iterator columns.
@@ -14823,7 +14824,23 @@ append_to_task_string (task_t task, const char* field, const char* value)
      "(SELECT name FROM targets WHERE id = target)",                         \
      "target",                                                               \
      KEYWORD_TYPE_STRING                                                     \
-   }
+   },                                                                        \
+   {                                                                         \
+     "(SELECT creation_time FROM reports WHERE task = tasks.id"              \
+     /* TODO 1 == TASK_STATUS_DONE */                                        \
+     " AND scan_run_status = 1"                                              \
+     " ORDER BY creation_time ASC LIMIT 1)",                                 \
+     "first_report_created",                                                 \
+     KEYWORD_TYPE_INTEGER                                                    \
+   },                                                                        \
+   {                                                                         \
+     "(SELECT creation_time FROM reports WHERE task = tasks.id"              \
+     /* TODO 1 == TASK_STATUS_DONE */                                        \
+     " AND scan_run_status = 1"                                              \
+     " ORDER BY creation_time DESC LIMIT 1)",                                \
+     "last_report_created",                                                  \
+     KEYWORD_TYPE_INTEGER                                                    \
+   }                                                                         \
 
 /**
  * @brief Task iterator WHERE columns.

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -19559,14 +19559,24 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <summary>Time the task is next due to run</summary>
           </column>
           <column>
-            <name>first</name>
+            <name>first_report_created</name>
             <type>iso_time</type>
             <summary>Timestamp of the first report</summary>
           </column>
           <column>
-            <name>last</name>
+            <name>last_report_created</name>
             <type>iso_time</type>
             <summary>Timestamp of the last finished report</summary>
+          </column>
+          <column>
+            <name>first</name>
+            <type>iso_time</type>
+            <summary>Timestamp of the first report (deprecated, use first_report_created)</summary>
+          </column>
+          <column>
+            <name>last</name>
+            <type>iso_time</type>
+            <summary>Timestamp of the last finished report (deprecated, use last_report_created)</summary>
           </column>
           <column>
             <name>false_positive</name>


### PR DESCRIPTION
**What**:
The filter columns first_report_created, last_report_created are added to get_tasks.

**Why**:
These are alternatives to the "first" and "last" columns added because
the name "first" conflicts with the pagination offset keyword.
(T3-226)

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] PR merge commit message adjusted
