### PR TITLE
Ensure pcre 2 compatibility

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -6206,7 +6206,7 @@ manage_read_info (gchar *type, gchar *uid, gchar *name, gchar **result)
 int
 validate_username (const gchar * name)
 {
-  if (g_regex_match_simple ("^[[:alnum:]-_.]+$", name, 0, 0))
+  if (g_regex_match_simple ("^[[:alnum:]_.-]+$", name, 0, 0))
     return 0;
   else
     return 1;

--- a/src/manage_configs.c
+++ b/src/manage_configs.c
@@ -318,7 +318,7 @@ should_sync_config_from_path (const char *path, gboolean rebuild,
 
   split = g_regex_split_simple
            (/* Full-and-Fast--daba56c8-73ec-11df-a475-002264764cea.xml */
-            "^.*([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{12}).xml$",
+            "^.*([0-9a-f]{8})\\-([0-9a-f]{4})\\-([0-9a-f]{4})\\-([0-9a-f]{4})\\-([0-9a-f]{12}).xml$",
             path, 0, 0);
 
   if (split == NULL || g_strv_length (split) != 7)

--- a/src/manage_port_lists.c
+++ b/src/manage_port_lists.c
@@ -253,7 +253,7 @@ should_sync_port_list_from_path (const char *path, gboolean rebuild,
 
   split = g_regex_split_simple
            (/* Full-and-Fast--daba56c8-73ec-11df-a475-002264764cea.xml */
-            "^.*([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{12}).xml$",
+            "^.*([0-9a-f]{8})\\-([0-9a-f]{4})\\-([0-9a-f]{4})\\-([0-9a-f]{4})\\-([0-9a-f]{12}).xml$",
             path, 0, 0);
 
   if (split == NULL || g_strv_length (split) != 7)

--- a/src/manage_report_formats.c
+++ b/src/manage_report_formats.c
@@ -613,7 +613,7 @@ should_sync_report_format_from_path (const char *path,
 
   split = g_regex_split_simple
            (/* Full-and-Fast--daba56c8-73ec-11df-a475-002264764cea.xml */
-            "^.*([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{12}).xml$",
+            "^.*([0-9a-f]{8})\\-([0-9a-f]{4})\\-([0-9a-f]{4})\\-([0-9a-f]{4})\\-([0-9a-f]{12}).xml$",
             path, 0, 0);
 
   if (split == NULL || g_strv_length (split) != 7)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -7001,7 +7001,7 @@ validate_tippingpoint_data (alert_method_t method, const gchar *name,
 
       if (strcmp (name, "tp_sms_hostname") == 0)
         {
-          if (g_regex_match_simple ("^[0-9A-Za-z][0-9A-Za-z.-]*$",
+          if (g_regex_match_simple ("^[0-9A-Za-z][0-9A-Za-z.\\-]*$",
                                     *data, 0, 0)
               == FALSE)
             {
@@ -50012,8 +50012,8 @@ modify_setting (const gchar *uuid, const gchar *name,
            */
           languages_regex
             = g_regex_new ("^(Browser Language|"
-                           "([a-z]{2,3})(_[A-Z]{2})?(@[[:alnum:]_-]+)?"
-                           "(:([a-z]{2,3})(_[A-Z]{2})?(@[[:alnum:]_-]+)?)*)$",
+                           "([a-z]{2,3})(_[A-Z]{2})?(@[[:alnum:]_\\-]+)?"
+                           "(:([a-z]{2,3})(_[A-Z]{2})?(@[[:alnum:]_\\-]+)?)*)$",
                            0, 0, NULL);
           match = g_regex_match (languages_regex, value, 0, NULL);
           g_regex_unref (languages_regex);
@@ -50597,7 +50597,7 @@ setting_verify (const gchar *uuid, const gchar *value, const gchar *user)
   if (strcmp (uuid, SETTING_UUID_LSC_DEB_MAINTAINER) == 0)
     {
       if (g_regex_match_simple
-            ("^([[:alnum:]-_]*@[[:alnum:]-_][[:alnum:]-_.]*)?$",
+            ("^([[:alnum:]\\-_]*@[[:alnum:]\\-_][[:alnum:]\\-_.]*)?$",
             value, 0, 0) == FALSE)
         return 1;
     }

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -2470,7 +2470,7 @@ validate_param_value (report_format_t report_format,
       case REPORT_FORMAT_PARAM_TYPE_REPORT_FORMAT_LIST:
         {
           if (g_regex_match_simple
-                ("^(?:[[:alnum:]-_]+)?(?:,(?:[[:alnum:]-_])+)*$", value, 0, 0)
+                ("^(?:[[:alnum:]\\-_]+)?(?:,(?:[[:alnum:]\\-_])+)*$", value, 0, 0)
               == FALSE)
             return 1;
           else

--- a/src/utils.c
+++ b/src/utils.c
@@ -337,7 +337,7 @@ parse_iso_time_tz (const char *text_time, const char *fallback_tz)
   epoch_time = 0;
 
   if (regex == NULL)
-    regex = g_regex_new ("^([0-9]{4}-[0-9]{2}-[0-9]{2})"
+    regex = g_regex_new ("^([0-9]{4}\\-[0-9]{2}\\-[0-9]{2})"
                          "[T ]([0-9]{2}:[0-9]{2})"
                          "(:[0-9]{2})?(?:\\.[0-9]+)?"
                          "(Z|[+-][0-9]{2}:?[0-9]{2})?$",


### PR DESCRIPTION
**What**:

Ensure our used regular expressions are pcre 2 compatible to fix support of glib2.0 >= 2.73.2

Fixes #1866
Related to https://github.com/greenbone/gsad/issues/86

DEVOPS-426

**Why**:

glib changed their internal regexp library to use pcre 2 in a minor release (!) with version 2.73.2. This breaks some of our regular expressions.

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
