### PR TITLE
Clean up old SQL functions now included in pg-gvm

### DIFF
--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -2986,6 +2986,39 @@ db_extension_available (const char *name)
 }
 
 /**
+ * @brief Clean up old SQL functions now incliuded in the pg-gvm extension.
+ */
+void
+cleanup_old_sql_functions ()
+{
+  if (sql_int("SELECT count(*) FROM pg_extension WHERE extname = 'pg-gvm'"))
+    {
+      g_message ("%s: pg-gvm already installed, skipping function cleanup",
+               __func__);
+      return;
+    }
+
+  g_message ("%s: cleaning up SQL functions now included in pg-gvm extension",
+               __func__);
+
+  sql ("DROP FUNCTION IF EXISTS"
+       " hosts_contains (text, text) CASCADE;");
+
+  sql ("DROP FUNCTION IF EXISTS"
+       " max_hosts (text, text) CASCADE;");
+
+  sql ("DROP FUNCTION IF EXISTS"
+       " next_time_ical (text, bigint, text) CASCADE;");
+
+  sql ("DROP FUNCTION IF EXISTS"
+       " next_time_ical (text, bigint, text, integer) CASCADE;");
+
+  sql ("DROP FUNCTION IF EXISTS"
+       " regexp (text, text) CASCADE;");
+
+}
+
+/**
  * @brief Ensure all extensions are installed.
  *
  * @return 0 success, 1 extension missing.
@@ -3002,6 +3035,10 @@ check_db_extensions ()
       // Switch to superuser role and try to install extensions.
       sql ("SET ROLE \"%s\";", DB_SUPERUSER_ROLE);
       
+      // Clean up old functions now in pg-gvm
+      cleanup_old_sql_functions ();
+
+      // Install the extensions
       sql ("CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\"");
       sql ("CREATE EXTENSION IF NOT EXISTS \"pgcrypto\"");
       sql ("CREATE EXTENSION IF NOT EXISTS \"pg-gvm\"");

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -3015,7 +3015,7 @@ cleanup_old_sql_functions ()
 {
   if (sql_int("SELECT count(*) FROM pg_extension WHERE extname = 'pg-gvm'"))
     {
-      g_message ("%s: pg-gvm already installed, skipping function cleanup",
+      g_debug ("%s: pg-gvm already installed, skipping function cleanup",
                __func__);
       return;
     }

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -1210,7 +1210,7 @@ manage_create_sql_functions ()
                TASK_STATUS_DONE);
         }
 
-      /* result_nvt column (in OVERRIDES_SQL) was added in version 189.           */
+
       /* if (current_db_version >= 189)                                           */
       /* column date in table reports was renamed to creation_time in version 245 */
       if (current_db_version >= 245)
@@ -1229,6 +1229,28 @@ manage_create_sql_functions ()
                "                                   WHERE task = $1"
                "                                   AND scan_run_status = %u"
                "                                   ORDER BY creation_time DESC"
+               "                                   LIMIT 1 OFFSET 0), $2, $3))"
+               "         END;"
+               "$$ LANGUAGE SQL;",
+               TASK_STATUS_DONE);
+        }
+      /* result_nvt column (in OVERRIDES_SQL) was added in version 189. */
+      else if (current_db_version >= 189)
+        {
+          sql ("CREATE OR REPLACE FUNCTION task_severity (integer,"  // task
+               "                                          integer,"  // overrides
+               "                                          integer)"  // min_qod
+               " RETURNS double precision AS $$"
+               /* Calculate the severity of a task. */
+               "  SELECT CASE"
+               "         WHEN (SELECT target = 0"
+               "               FROM tasks WHERE id = $1)"
+               "         THEN CAST (NULL AS double precision)"
+               "         ELSE"
+               "         (SELECT report_severity ((SELECT id FROM reports"
+               "                                   WHERE task = $1"
+               "                                   AND scan_run_status = %u"
+               "                                   ORDER BY date DESC"
                "                                   LIMIT 1 OFFSET 0), $2, $3))"
                "         END;"
                "$$ LANGUAGE SQL;",


### PR DESCRIPTION
**What**:
If the extension pg-gvm is not installed yet, gvmd will try to remove the functions now included in the extension before installing the extension.

**Why**:

This is needed because with PostgreSQL 13.8 the extension can no longer simply overwrite the functions.
(T3-364)

**How did you test it**:
Created a database with gvmd 21.04 and migrated it with gvmd main.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
