### PR TITLE
Change: Implement new check to find WID-SEC advisories in the xml

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -5336,7 +5336,8 @@ get_cve_filename (char *item_id)
 /**
  * @brief Compute the filename where a given CERT-Bund Advisory can be found.
  *
- * @param[in] item_id   CERT-Bund identifier without version ("CB-K??/????").
+ * @param[in] item_id   CERT-Bund identifier without version 
+                        ("CB-K??/????" or "WID-SEC-????-????")
  *
  * @return A dynamically allocated string (to be g_free'd) containing the
  *         path to the desired file or NULL on error.
@@ -5349,6 +5350,11 @@ get_cert_bund_adv_filename (char *item_id)
   if (sscanf (item_id, "CB-K%d-%*s", &year) == 1)
     {
       return g_strdup_printf (CERT_BUND_ADV_FILENAME_FMT, year);
+    }
+  if (sscanf (item_id, "WID-SEC-%d-%*s", &year) == 1 )
+    {
+      // new year format is YYYY thus subtract 2000 from the int
+      return g_strdup_printf (CERT_BUND_ADV_FILENAME_FMT, year - 2000);
     }
   return NULL;
 }


### PR DESCRIPTION
**What**:

* Add a check to find the WID-SEC advisories in the xml, by adding the WID-SEC advisory id format into the check

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

* We need this to be able to show WID-SEC advisories in GSA after release

<!-- Why are these changes necessary? -->

**How did you test it**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
