### PR TITLE
Fix buffer overrun in buffer_aggregate_xml()

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -10113,7 +10113,7 @@ buffer_aggregate_xml (GString *xml, iterator_t* aggregate, const gchar* type,
                 = g_tree_lookup (subgroup_c_counts, subgroup_value);
               if (subgroup_c_count == NULL)
                 {
-                  subgroup_c_count = g_malloc0 (sizeof (long int*));
+                  subgroup_c_count = g_malloc0 (sizeof (long int));
                   g_tree_insert (subgroup_c_counts,
                                  g_strdup (subgroup_value),
                                  subgroup_c_count);
@@ -10297,7 +10297,7 @@ buffer_aggregate_xml (GString *xml, iterator_t* aggregate, const gchar* type,
 
               if (subgroup_c_sum == NULL)
                 {
-                  subgroup_c_sum = g_malloc (sizeof (double *));
+                  subgroup_c_sum = g_malloc (sizeof (double));
                   *subgroup_c_sum = 0;
 
                   g_tree_insert (c_sum_tree,


### PR DESCRIPTION
When compiling with gcc on 32 bit armhf:

    sizeof(double) == 8, sizeof(double *) == 4

If needing a buffer for double, allocating space for a pointer is insufficient and leads to a buffer overrun when assigning a value.

We shouldn't confound long int and long int* either.

Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>