### PR TITLE
Fixed the number of results in triggered alerts.

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -13977,6 +13977,14 @@ handle_get_preferences (gmp_parser_t *gmp_parser, GError **error)
   set_client_state (CLIENT_AUTHENTIC);
 }
 
+/**
+ * @brief Init some data of the get_data_t structure of an alert.
+ *
+ * @param[in]  alert_id   Id of the alert the get_data_t structure
+ *                        belongs to.
+ * @param[in]  get        The get_data_t structure where some components
+ *                        are to be initialized
+ */
 static void
 init_alert_get_data(const char *alert_id, get_data_t *get)
 {

--- a/src/manage.h
+++ b/src/manage.h
@@ -638,6 +638,9 @@ event_name (event_t);
 gchar*
 event_description (event_t, const void *, const char *);
 
+alert_method_t
+alert_method (alert_t alert);
+
 const char*
 alert_method_name (alert_method_t);
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -12580,7 +12580,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
                    * anyway, to make it easier for the compiler to see. */
                   filter = 0;
                   ret = report_content_for_alert
-                          (alert, 0, task, get,
+                          (alert, report, task, get,
                            "notice_report_format",
                            NULL,
                            /* TXT fallback */
@@ -12660,7 +12660,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
                    * anyway, to make it easier for the compiler to see. */
                   filter = 0;
                   ret = report_content_for_alert
-                          (alert, 0, task, get,
+                          (alert, report, task, get,
                            "notice_attach_format",
                            NULL,
                            /* TXT fallback */

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -8047,7 +8047,7 @@ alert_condition (alert_t alert)
  *
  * @return Method.
  */
-static alert_method_t
+alert_method_t
 alert_method (alert_t alert)
 {
   return sql_int ("SELECT method FROM alerts WHERE id = %llu;",
@@ -28602,7 +28602,6 @@ manage_send_report (report_t report, report_t delta_report,
       alert_t alert = 0;
       alert_condition_t condition;
       alert_method_t method;
-      get_data_t get_copy;
 
       if (find_alert_with_permission (alert_id, &alert, "get_alerts"))
         return -1;
@@ -28610,20 +28609,12 @@ manage_send_report (report_t report, report_t delta_report,
       if (alert == 0)
         return 1;
 
-      get_copy = *get;
       condition = alert_condition (alert);
       method = alert_method (alert);
-      if (method == ALERT_METHOD_EMAIL)
-        {
-          get_copy.filter = g_strdup_printf ("notes=1 overrides=1"
-                                             " sort-reverse=severity rows=1000");
-	  get_copy.ignore_pagination = 0;
-	}
 
       ret = escalate_2 (alert, task, report, EVENT_TASK_RUN_STATUS_CHANGED,
                         (void*) TASK_STATUS_DONE, method, condition,
-                        &get_copy, notes_details, overrides_details, NULL);
-      g_free(get_copy.filter);
+                        get, notes_details, overrides_details, NULL);
       if (ret == -3)
         return -4;
       if (ret == -1)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -28623,6 +28623,7 @@ manage_send_report (report_t report, report_t delta_report,
       ret = escalate_2 (alert, task, report, EVENT_TASK_RUN_STATUS_CHANGED,
                         (void*) TASK_STATUS_DONE, method, condition,
                         &get_copy, notes_details, overrides_details, NULL);
+      g_free(get_copy.filter);
       if (ret == -3)
         return -4;
       if (ret == -1)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -28602,6 +28602,7 @@ manage_send_report (report_t report, report_t delta_report,
       alert_t alert = 0;
       alert_condition_t condition;
       alert_method_t method;
+      get_data_t get_copy;
 
       if (find_alert_with_permission (alert_id, &alert, "get_alerts"))
         return -1;
@@ -28609,12 +28610,19 @@ manage_send_report (report_t report, report_t delta_report,
       if (alert == 0)
         return 1;
 
+      get_copy = *get;
       condition = alert_condition (alert);
       method = alert_method (alert);
+      if (method == ALERT_METHOD_EMAIL)
+        {
+          get_copy.filter = g_strdup_printf ("notes=1 overrides=1"
+                                             " sort-reverse=severity rows=1000");
+	  get_copy.ignore_pagination = 0;
+	}
 
       ret = escalate_2 (alert, task, report, EVENT_TASK_RUN_STATUS_CHANGED,
                         (void*) TASK_STATUS_DONE, method, condition,
-                        get, notes_details, overrides_details, NULL);
+                        &get_copy, notes_details, overrides_details, NULL);
       if (ret == -3)
         return -4;
       if (ret == -1)


### PR DESCRIPTION
Fixed the number of results in triggered alerts.

**What**:
Now the number of results for automatically triggered alerts and manually triggered alerts are the same.

In addition now the selected report (not always the latest report) is used when manually triggering an alert.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
This is a bug-fix. Addresses T4-420 and T4-411.
<!-- Why are these changes necessary? -->

**How did you test it**:

<!--
Manually tested on my development system.
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
