### PR TITLE
Encrypting and decrypting of the RADIUS server secret key.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 250)
+set (GVMD_DATABASE_VERSION 251)
 
 set (GVMD_SCAP_DATABASE_VERSION 19)
 

--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -87,7 +87,7 @@ set(PostgreSQL_ROOT_DIR_MESSAGE "Set the PostgreSQL_ROOT system variable to wher
 
 
 set(PostgreSQL_KNOWN_VERSIONS ${PostgreSQL_ADDITIONAL_VERSIONS}
-    "13" "12" "11" "10" "9.6" "9.5" "9.4" "9.3" "9.2" "9.1" "9.0" "8.4" "8.3" "8.2" "8.1" "8.0")
+    "14" "13" "12" "11" "10" "9.6" "9.5" "9.4" "9.3" "9.2" "9.1" "9.0" "8.4" "8.3" "8.2" "8.1" "8.0")
 
 # Define additional search paths for root directories.
 set( PostgreSQL_ROOT_DIRECTORIES

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -18664,7 +18664,8 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                 "<value>%s</value>"
                 "</auth_conf_setting>"
                 "</group>",
-                radius_enabled ? "true" : "false", radius_host, radius_key);
+                radius_enabled ? "true" : "false", radius_host,
+                "ThisIsAPlaceholderSecretKey!");
               g_free (radius_host);
               g_free (radius_key);
             }

--- a/src/lsc_crypt.c
+++ b/src/lsc_crypt.c
@@ -634,7 +634,7 @@ lsc_crypt_encrypt (lsc_crypt_ctx_t ctx, const char *first_name, ...)
  *         has not been called.  If no value is available NULL is
  *         returned.
  */
-const char *
+char *
 lsc_crypt_decrypt (lsc_crypt_ctx_t ctx, const char *ciphertext,
                    const char *name)
 {

--- a/src/lsc_crypt.h
+++ b/src/lsc_crypt.h
@@ -43,7 +43,7 @@ void lsc_crypt_flush (lsc_crypt_ctx_t);
 char *lsc_crypt_encrypt (lsc_crypt_ctx_t,
                          const char *, ...) G_GNUC_NULL_TERMINATED;
 
-const char *lsc_crypt_decrypt (lsc_crypt_ctx_t, const char *, const char *);
+char *lsc_crypt_decrypt (lsc_crypt_ctx_t, const char *, const char *);
 const char *lsc_crypt_get_password (lsc_crypt_ctx_t, const char *);
 const char *lsc_crypt_get_private_key (lsc_crypt_ctx_t, const char *);
 

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -2942,6 +2942,55 @@ migrate_249_to_250 ()
   return 0;
 }
 
+/**
+ * @brief Migrate the database from version 250 to version 251.
+ *
+ * @return 0 success, -1 error.
+ */
+int
+migrate_250_to_251 ()
+{
+  sql_begin_immediate ();
+
+  /* Ensure that the database is currently version 249. */
+
+  if (manage_db_version () != 250)
+    {
+      sql_rollback ();
+      return -1;
+    }
+
+  /* Update the database. */
+
+  char *secret_key = NULL;
+
+  secret_key = sql_string ("SELECT value FROM meta WHERE name = 'radius_key';");
+
+  if (secret_key)
+    {
+      char *secret;
+      char *quoted;
+      lsc_crypt_ctx_t crypt_ctx;
+      crypt_ctx = lsc_crypt_new ();
+
+      sql ("DELETE FROM meta WHERE name LIKE 'radius_key';");
+      secret = lsc_crypt_encrypt (crypt_ctx, "secret_key", secret_key, NULL);
+      quoted = sql_quote (secret);
+      sql ("INSERT INTO meta (name, value) VALUES ('radius_key', '%s');", quoted);
+      g_free (secret);
+      g_free (quoted);
+      g_free (secret_key);
+    }
+
+  /* Set the database version to 251. */
+
+  set_db_version (251);
+
+  sql_commit ();
+
+  return 0;
+}
+
 #undef UPDATE_DASHBOARD_SETTINGS
 
 /**
@@ -2998,6 +3047,7 @@ static migrator_t database_migrators[] = {
   {248, migrate_247_to_248},
   {249, migrate_248_to_249},
   {250, migrate_249_to_250},
+  {251, migrate_250_to_251},
   /* End marker. */
   {-1, NULL}};
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -53295,6 +53295,8 @@ manage_set_ldap_info (int enabled, gchar *host, gchar *authdn,
 void
 manage_get_radius_info (int *enabled, char **host, char **key)
 {
+  char *secret;
+
   if (enabled)
     *enabled = radius_auth_enabled ();
 
@@ -53302,9 +53304,15 @@ manage_get_radius_info (int *enabled, char **host, char **key)
   if (!*host)
     *host = g_strdup ("127.0.0.1");
 
-  *key = sql_string ("SELECT value FROM meta WHERE name = 'radius_key';");
-  if (!*key)
-    *key = g_strdup ("testing123");
+  secret = sql_string ("SELECT value FROM meta WHERE name = 'radius_key';");
+  if (!secret)
+    *key = g_strdup ("ThisIsAPlaceholderSecretKey!");
+  else
+    {
+      lsc_crypt_ctx_t crypt_ctx;
+      crypt_ctx = lsc_crypt_new ();
+      *key = lsc_crypt_decrypt (crypt_ctx, secret, "secret_key");
+    }
 }
 
 /**
@@ -53337,12 +53345,18 @@ manage_set_radius_info (int enabled, gchar *host, gchar *key)
       g_free (quoted);
     }
 
-  if (key)
+  if (key && strcmp (key, "ThisIsAPlaceholderSecretKey!"))
     {
+      char *secret;
+      lsc_crypt_ctx_t crypt_ctx;
+      crypt_ctx = lsc_crypt_new ();
+
       sql ("DELETE FROM meta WHERE name LIKE 'radius_key';");
-      quoted = sql_quote (key);
+      secret = lsc_crypt_encrypt (crypt_ctx, "secret_key", key, NULL);
+      quoted = sql_quote (secret);
       sql ("INSERT INTO meta (name, value) VALUES ('radius_key', '%s');",
            quoted);
+      g_free (secret);
       g_free (quoted);
     }
 


### PR DESCRIPTION
Now the RADIUS server secret key is encrypted and no longer stored in the database as plain text. The key is also no longer send to GSA in the response, instead a placeholder is send.

**What**:

<!--
Now the RADIUS server secret key is encrypted and no longer stored in the database as plain text.
The key is also no longer send to GSA in the response, instead a placeholder is send.
-->

**Why**:

This is a bug-fix.
Addresses T4-123.
<!-- Why are these changes necessary? -->

**How did you test it**:
Tested manually on the local development system.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
