### PR TITLE
Changed the order of options in tar command.

### DIFF
--- a/tools/gvm-lsc-deb-creator
+++ b/tools/gvm-lsc-deb-creator
@@ -161,7 +161,7 @@ COPYRIGHT_FILE="${DOC_DATA_DIR}/copyright"
 
 # Create data archive
 cd "${DATA_DIR}"
-tar -C "${DATA_DIR}" -acfz "../data.tar.gz" "${HOME_SUBDIR}" "${DOC_SUBDIR}"
+tar -C "${DATA_DIR}" -z -cf "../data.tar.gz" "${HOME_SUBDIR}" "${DOC_SUBDIR}"
 
 
 #


### PR DESCRIPTION
## What
Changed the order of options in tar command in lsc-gvm-deb-creator, because the option "z" must not be the last option. The option "a" was omitted because it means to use the archive suffix to determine the compression program but the "z" option already says to use gzip.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This is a bug-fix.
<!-- Describe why are these changes necessary? -->

## References
Addresses issue GEA-45.
<!-- Add links to issue tickets, etc. -->

## Checklist
Tested manually on local development system.
<!-- Remove this section if not applicable to your changes -->

- [x] Tests


