### PR TITLE
Add hostname to CVE scan report

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -2990,9 +2990,19 @@ cve_scan_host (task_t task, report_t report, gvm_host_t *gvm_host)
 
           if (prognosis_report_host)
             {
+              gchar *hostname;
+
               /* Complete the report_host. */
 
               report_host_set_end_time (prognosis_report_host, time (NULL));
+
+              hostname = report_host_hostname (report_host);
+              if (hostname) {
+                insert_report_host_detail (report, ip, "cve", "",
+                                           "CVE Scanner", "hostname", hostname);
+                g_free(hostname);
+              }
+
               insert_report_host_detail (report, ip, "cve", "",
                                          "CVE Scanner", "CVE Scan", "1");
               update_report_modification_time (report);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -28867,7 +28867,7 @@ report_host_ip (const char *host)
  *
  * @param[in]  report_host  Report host.
  *
- * @return Newly allocated UUID if available, else NULL.
+ * @return Newly allocated hostname if available, else NULL.
  */
 gchar*
 report_host_hostname (report_host_t report_host)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -28861,6 +28861,25 @@ report_host_ip (const char *host)
 }
 
 /**
+ * @brief Get the hostname of a report_host.
+ *
+ * The most recent host detail takes preference.
+ *
+ * @param[in]  report_host  Report host.
+ *
+ * @return Newly allocated UUID if available, else NULL.
+ */
+gchar*
+report_host_hostname (report_host_t report_host)
+{
+  return sql_string ("SELECT value FROM report_host_details"
+                     " WHERE report_host = %llu"
+                     " AND name = 'hostname'"
+                     " ORDER BY id DESC LIMIT 1;",
+                     report_host);
+}
+
+/**
  * @brief Check if a report host is alive and has at least one result.
  *
  * @param[in]  report  Report.

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -295,6 +295,8 @@ host_nthlast_report_host (const char *, report_host_t *, int);
 char*
 report_host_ip (const char *);
 
+gchar *report_host_hostname (report_host_t);
+
 void trim_report (report_t);
 
 int delete_report_internal (report_t);


### PR DESCRIPTION
## What

In the CVE scan, add a hostname host detail to the report at the end of each host "scan".  The hostname comes from the same host details used to calculate the CVE info.

## Why

To display hostnames in CVE reports.

## References

GEA-12

