### PR TITLE
Truncate NVTs inside the transaction that adds NVTs

### DIFF
--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -309,8 +309,9 @@ insert_nvt (const nvti_t *nvti, int truncate)
 
   quoted_family = sql_quote (nvti_family (nvti) ? nvti_family (nvti) : "");
 
-  if (sql_int ("SELECT EXISTS (SELECT * FROM nvts WHERE oid = '%s');",
-               nvti_oid (nvti)))
+  if ((truncate == 0)
+      && sql_int ("SELECT EXISTS (SELECT * FROM nvts WHERE oid = '%s');",
+                  nvti_oid (nvti)))
     sql ("DELETE FROM nvts WHERE oid = '%s';", nvti_oid (nvti));
 
   sql ("INSERT into nvts (oid, name, summary, insight, affected,"
@@ -326,7 +327,8 @@ insert_nvt (const nvti_t *nvti, int truncate)
        nvti_oid (nvti), quoted_solution_type, quoted_solution_method,
        quoted_solution, quoted_detection, qod, quoted_qod_type);
 
-  sql ("DELETE FROM vt_refs where vt_oid = '%s';", nvti_oid (nvti));
+  if (truncate == 0)
+    sql ("DELETE FROM vt_refs where vt_oid = '%s';", nvti_oid (nvti));
 
   for (i = 0; i < nvti_vtref_len (nvti); i++)
     {
@@ -347,7 +349,8 @@ insert_nvt (const nvti_t *nvti, int truncate)
       g_free (quoted_text);
     }
 
-  sql ("DELETE FROM vt_severities where vt_oid = '%s';", nvti_oid (nvti));
+  if (truncate == 0)
+    sql ("DELETE FROM vt_severities where vt_oid = '%s';", nvti_oid (nvti));
 
   highest = 0;
 
@@ -1559,8 +1562,9 @@ update_nvts_from_vts (entity_t *get_vts_response,
           sql_rollback ();
           return -1;
         }
-      sql ("DELETE FROM nvt_preferences WHERE name LIKE '%s:%%';",
-           nvti_oid (nvti));
+      if (truncate == 0)
+        sql ("DELETE FROM nvt_preferences WHERE name LIKE '%s:%%';",
+             nvti_oid (nvti));
       insert_nvt_preferences_list (preferences);
       g_list_free_full (preferences, g_free);
 

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -261,9 +261,10 @@ find_nvt (const char* oid, nvt_t* nvt)
  * @brief Insert an NVT.
  *
  * @param[in]  nvti       NVT Information.
+ * @param[in]  truncate   True if NVT tables were truncated.
  */
 static void
-insert_nvt (const nvti_t *nvti)
+insert_nvt (const nvti_t *nvti, int truncate)
 {
   gchar *qod_str, *qod_type, *cve;
   gchar *quoted_name, *quoted_summary, *quoted_insight, *quoted_affected;
@@ -1482,12 +1483,14 @@ nvti_from_vt (entity_t vt)
  *
  * @param[in]  get_vts_response      OSP GET_VTS response.
  * @param[in]  scanner_feed_version  Version of feed from scanner.
+ * @param[in]  truncate              Whether to truncate the NVT tables first.
  *
  * @return 0 success, 1 VT integrity check failed, -1 error
  */
 static int
 update_nvts_from_vts (entity_t *get_vts_response,
-                      const gchar *scanner_feed_version)
+                      const gchar *scanner_feed_version,
+                      int truncate)
 {
   entity_t vts, vt;
   entities_t children;
@@ -1512,11 +1515,15 @@ update_nvts_from_vts (entity_t *get_vts_response,
 
   sql_begin_immediate ();
 
-  if (sql_int ("SELECT coalesce ((SELECT CAST (value AS INTEGER)"
-               "                  FROM meta"
-               "                  WHERE name = 'checked_preferences'),"
-               "                 0);")
-      == 0)
+  if (truncate) {
+    sql ("TRUNCATE nvts;");
+    sql ("TRUNCATE nvt_preferences;");
+  }
+  else if (sql_int ("SELECT coalesce ((SELECT CAST (value AS INTEGER)"
+                    "                  FROM meta"
+                    "                  WHERE name = 'checked_preferences'),"
+                    "                 0);")
+           == 0)
     /* We're in the first NVT sync after migrating preference names.
      *
      * If a preference was removed from an NVT then the preference will be in
@@ -1544,7 +1551,7 @@ update_nvts_from_vts (entity_t *get_vts_response,
       else
         count_modified_vts += 1;
 
-      insert_nvt (nvti);
+      insert_nvt (nvti, truncate);
 
       preferences = NULL;
       if (update_preferences_from_vt (vt, nvti_oid (nvti), &preferences))
@@ -1788,12 +1795,13 @@ DEF_ACCESS (nvt_severity_iterator_value, 4);
  * @param[in]  update_socket         Socket to use to contact scanner.
  * @param[in]  db_feed_version       Feed version from meta table.
  * @param[in]  scanner_feed_version  Feed version from scanner.
+ * @param[in]  truncate              Whether to truncate the NVT tables first.
  *
  * @return 0 success, 1 VT integrity check failed, -1 error.
  */
 static int
 update_nvt_cache_osp (const gchar *update_socket, gchar *db_feed_version,
-                      gchar *scanner_feed_version)
+                      gchar *scanner_feed_version, int truncate)
 {
   osp_connection_t *connection;
   GSList *scanner_prefs;
@@ -1802,7 +1810,8 @@ update_nvt_cache_osp (const gchar *update_socket, gchar *db_feed_version,
   time_t old_nvts_last_modified;
   int ret;
 
-  if (db_feed_version == NULL
+  if (truncate
+      || db_feed_version == NULL
       || strcmp (db_feed_version, "") == 0
       || strcmp (db_feed_version, "0") == 0)
     old_nvts_last_modified = 0;
@@ -1834,7 +1843,7 @@ update_nvt_cache_osp (const gchar *update_socket, gchar *db_feed_version,
   g_free (get_vts_opts.filter);
 
   osp_connection_close (connection);
-  ret = update_nvts_from_vts (&vts, scanner_feed_version);
+  ret = update_nvts_from_vts (&vts, scanner_feed_version, truncate);
   free_entity (vts);
   if (ret)
     return ret;
@@ -2068,7 +2077,7 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
               sql_int ("SELECT count (*) FROM nvts;"));
 
       ret = update_nvt_cache_osp (update_socket, db_feed_version,
-                                  scanner_feed_version);
+                                  scanner_feed_version, 0);
 
       g_free (db_feed_version);
       g_free (scanner_feed_version);
@@ -2145,13 +2154,9 @@ update_or_rebuild_nvts (int update)
   osp_connection_close (connection);
 
   if (update == 0)
-    {
-      sql ("TRUNCATE nvts;");
-      sql ("TRUNCATE nvt_preferences;");
-      set_nvts_feed_version ("0");
-    }
+    set_nvts_feed_version ("0");
 
-  ret = update_nvt_cache_osp (osp_update_socket, NULL, scanner_feed_version);
+  ret = update_nvt_cache_osp (osp_update_socket, NULL, scanner_feed_version, update == 0);
   if (ret)
     {
       return -1;

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1810,6 +1810,8 @@ update_nvt_cache_osp (const gchar *update_socket, gchar *db_feed_version,
     old_nvts_last_modified
       = (time_t) sql_int64_0 ("SELECT max(modification_time) FROM nvts");
 
+  /* Update NVTs. */
+
   connection = osp_connection_new (update_socket, 0, NULL, NULL, NULL);
   if (!connection)
     {
@@ -1838,6 +1840,7 @@ update_nvt_cache_osp (const gchar *update_socket, gchar *db_feed_version,
     return ret;
 
   /* Update scanner preferences */
+
   connection = osp_connection_new (update_socket, 0, NULL, NULL, NULL);
   if (!connection)
     {


### PR DESCRIPTION
## What

When rebuilding the db NVTs, truncate the NVT tables inside the transaction that adds the NVTs back to the db (instead of truncating them before the transaction).

At the same time use the truncation flag to skip some DELETE operations, as we know the tables were empty.

## Why

Moving the TRUNCATEs means that clients will use the existing nvt data until the transaction completes, instead of the empty NVT tables.  Specifically this means that when there is a NVT rebuild happening due to a hash value mismatch, then PDF reports in GSA will still have NVT names.

Skipping the DELETEs improves speed.

## References

GEA-49