### PR TITLE
Remove stray header

### DIFF
--- a/src/sql.h
+++ b/src/sql.h
@@ -94,9 +94,6 @@ sql_error (char *sql, ...);
 int
 sql_giveup (char *sql, ...);
 
-void
-sql_quiet (char *sql, ...);
-
 double
 sql_double (char *sql, ...);
 


### PR DESCRIPTION
## What

Remove stray header.

## Why

Function removed in 2018.

## References

Removed by #236.
