### PR TITLE
Add OS to CVE scan report

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -2990,7 +2990,7 @@ cve_scan_host (task_t task, report_t report, gvm_host_t *gvm_host)
 
           if (prognosis_report_host)
             {
-              gchar *hostname;
+              gchar *hostname, *best;
 
               /* Complete the report_host. */
 
@@ -3001,6 +3001,20 @@ cve_scan_host (task_t task, report_t report, gvm_host_t *gvm_host)
                 insert_report_host_detail (report, ip, "cve", "",
                                            "CVE Scanner", "hostname", hostname);
                 g_free(hostname);
+              }
+
+              best = report_host_best_os_cpe (report_host);
+              if (best) {
+                insert_report_host_detail (report, ip, "cve", "",
+                                           "CVE Scanner", "best_os_cpe", best);
+                g_free(best);
+              }
+
+              best = report_host_best_os_txt (report_host);
+              if (best) {
+                insert_report_host_detail (report, ip, "cve", "",
+                                           "CVE Scanner", "best_os_txt", best);
+                g_free(best);
               }
 
               insert_report_host_detail (report, ip, "cve", "",

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -28880,6 +28880,44 @@ report_host_hostname (report_host_t report_host)
 }
 
 /**
+ * @brief Get the best_os_cpe of a report_host.
+ *
+ * The most recent host detail takes preference.
+ *
+ * @param[in]  report_host  Report host.
+ *
+ * @return Newly allocated best_os_cpe if available, else NULL.
+ */
+gchar*
+report_host_best_os_cpe (report_host_t report_host)
+{
+  return sql_string ("SELECT value FROM report_host_details"
+                     " WHERE report_host = %llu"
+                     " AND name = 'best_os_cpe'"
+                     " ORDER BY id DESC LIMIT 1;",
+                     report_host);
+}
+
+/**
+ * @brief Get the best_os_txt of a report_host.
+ *
+ * The most recent host detail takes preference.
+ *
+ * @param[in]  report_host  Report host.
+ *
+ * @return Newly allocated best_os_txt if available, else NULL.
+ */
+gchar*
+report_host_best_os_txt (report_host_t report_host)
+{
+  return sql_string ("SELECT value FROM report_host_details"
+                     " WHERE report_host = %llu"
+                     " AND name = 'best_os_txt'"
+                     " ORDER BY id DESC LIMIT 1;",
+                     report_host);
+}
+
+/**
  * @brief Check if a report host is alive and has at least one result.
  *
  * @param[in]  report  Report.

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -297,6 +297,10 @@ report_host_ip (const char *);
 
 gchar *report_host_hostname (report_host_t);
 
+gchar *report_host_best_os_cpe (report_host_t);
+
+gchar *report_host_best_os_txt (report_host_t);
+
 void trim_report (report_t);
 
 int delete_report_internal (report_t);


### PR DESCRIPTION
## What

In the CVE scan, add OS host details to the report at the end of each host "scan".  The OS info comes from the same host details used to calculate the CVE info.

## Why

To display the OS icon in GSA CVE reports.

## References

Similar to #1918.