### PR TITLE
Fix: Use edge gvm-libs container image for gvmd build image in main

### DIFF
--- a/.docker/build.Dockerfile
+++ b/.docker/build.Dockerfile
@@ -1,5 +1,5 @@
 # Define ARG we use through the build
-ARG VERSION=unstable
+ARG VERSION=edge
 
 # We want gvm-libs to be ready so we use the build docker image of gvm-libs
 FROM greenbone/gvm-libs:$VERSION


### PR DESCRIPTION
## What

Use edge gvm-libs container image for gvmd build image in main

## Why

The latest gvm-libs image from the main branch is published with the edge tag since some time. Therefore fix creating the gvmd-build container by using the edge tag.