### PR TITLE
Use gvm-libs:edge as base for the gvmd production image in main

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -1,4 +1,5 @@
 ARG VERSION=unstable
+ARG GVM_LIBS_VERSION=edge
 ARG DEBIAN_FRONTEND=noninteractive
 
 FROM greenbone/gvmd-build:${VERSION} as builder
@@ -12,7 +13,7 @@ RUN mkdir /build && \
     cmake -DCMAKE_BUILD_TYPE=Release /source && \
     make DESTDIR=/install install
 
-FROM greenbone/gvm-libs:${VERSION}
+FROM greenbone/gvm-libs:${GVM_LIBS_VERSION}
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION


## What

Use gvm-libs:edge as base for the gvmd production image in main

## Why

Building the gvmd container image in the main branch requires a gvm-libs container image from its main branch.


