### PR TITLE
Change: Add nsis package to container image for windows credentials

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -38,6 +38,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 # dpkg
 # fakeroot
 
+# Windows Executable (.exe) credential installer
+# nsis
+
 # signature verification
 # gnupg
 
@@ -68,6 +71,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     dpkg \
     fakeroot \
+    nsis \
     gosu \
     gnupg \
     gpgsm \


### PR DESCRIPTION
## What

Add nsis package to container image for windows credentials

## Why

Currently creating windows credential installers doesn't work in the community containers because the nsis package is missing.

## References

DEVOPS-608


