### PR TITLE
Add error result and exit scan if VT list empty

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -2465,7 +2465,7 @@ launch_osp_openvas_task (task_t task, target_t target, const char *scan_id,
 
   if (empty) {
     if (error)
-      *error = g_strdup ("Exiting because VT list is empty");
+      *error = g_strdup ("Exiting because VT list is empty (e.g. feed not synced yet)");
     g_slist_free_full (osp_targets, (GDestroyNotify) osp_target_free);
     // Credentials are freed with target
     g_slist_free_full (vts, (GDestroyNotify) osp_vt_single_free);


### PR DESCRIPTION
## What

When starting an osp-openvas scan, if the VT list is empty then exit before contacting the scanner.  Also add an error to the report to give the user a hint.

## Why

If a task was started when the NVT tables were empty, then the task was going straight to "Interrupted", with no reason given.

Note that since #1926 it should be much more rare that the NVT tables are empty, because during rebuild these tables are now truncated inside the transaction that rebuilds them.  It is still possible to truncate them by hand, or to start gvmd and GSA before the NVTs are ready.

## References

GEA-49

