### PR TITLE
Skip SQL statements to speed up rebuild

### DIFF
--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -351,7 +351,7 @@ insert_nvt (const nvti_t *nvti, int truncate)
   gchar *qod_str, *qod_type, *cve;
   gchar *quoted_name, *quoted_summary, *quoted_insight, *quoted_affected;
   gchar *quoted_impact, *quoted_detection, *quoted_cve, *quoted_tag;
-  gchar *quoted_cvss_base, *quoted_qod_type, *quoted_family;
+  gchar *quoted_qod_type, *quoted_family;
   gchar *quoted_solution, *quoted_solution_type, *quoted_solution_method;
   int qod;
   double highest;
@@ -379,8 +379,6 @@ insert_nvt (const nvti_t *nvti, int truncate)
 
   quoted_tag = sql_quote (nvti_tag (nvti) ?  nvti_tag (nvti) : "");
 
-  quoted_cvss_base = sql_quote (nvti_cvss_base (nvti) ? nvti_cvss_base (nvti) : "");
-
   qod_str = nvti_qod (nvti);
   qod_type = nvti_qod_type (nvti);
 
@@ -405,17 +403,13 @@ insert_nvt (const nvti_t *nvti, int truncate)
        " creation_time, modification_time, uuid, solution_type,"
        " solution_method, solution, detection, qod, qod_type)"
        " VALUES ('%s', '%s', '%s', '%s', '%s', '%s', '%s',"
-       " '%s', %i, '%s', '%s', %i, %i, '%s', '%s', '%s', '%s', '%s', %d, '%s');",
+       " '%s', %i, '%s', %0.1f, %i, %i, '%s', '%s', '%s', '%s', '%s', %d, '%s');",
        nvti_oid (nvti), quoted_name, quoted_summary, quoted_insight,
        quoted_affected, quoted_impact, quoted_cve, quoted_tag,
-       nvti_category (nvti), quoted_family, quoted_cvss_base,
+       nvti_category (nvti), quoted_family, highest,
        nvti_creation_time (nvti), nvti_modification_time (nvti),
        nvti_oid (nvti), quoted_solution_type, quoted_solution_method,
        quoted_solution, quoted_detection, qod, quoted_qod_type);
-
-  sql ("UPDATE nvts SET cvss_base = %0.1f WHERE oid = '%s';",
-       highest,
-       nvti_oid (nvti));
 
   g_free (quoted_name);
   g_free (quoted_summary);
@@ -424,7 +418,6 @@ insert_nvt (const nvti_t *nvti, int truncate)
   g_free (quoted_impact);
   g_free (quoted_cve);
   g_free (quoted_tag);
-  g_free (quoted_cvss_base);
   g_free (quoted_family);
   g_free (quoted_solution);
   g_free (quoted_solution_type);

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -309,8 +309,9 @@ insert_nvt (const nvti_t *nvti, int truncate)
 
   quoted_family = sql_quote (nvti_family (nvti) ? nvti_family (nvti) : "");
 
-  if (sql_int ("SELECT EXISTS (SELECT * FROM nvts WHERE oid = '%s');",
-               nvti_oid (nvti)))
+  if ((truncate == 0)
+      && sql_int ("SELECT EXISTS (SELECT * FROM nvts WHERE oid = '%s');",
+                  nvti_oid (nvti)))
     sql ("DELETE FROM nvts WHERE oid = '%s';", nvti_oid (nvti));
 
   sql ("INSERT into nvts (oid, name, summary, insight, affected,"
@@ -326,7 +327,8 @@ insert_nvt (const nvti_t *nvti, int truncate)
        nvti_oid (nvti), quoted_solution_type, quoted_solution_method,
        quoted_solution, quoted_detection, qod, quoted_qod_type);
 
-  sql ("DELETE FROM vt_refs where vt_oid = '%s';", nvti_oid (nvti));
+  if (truncate == 0)
+    sql ("DELETE FROM vt_refs where vt_oid = '%s';", nvti_oid (nvti));
 
   for (i = 0; i < nvti_vtref_len (nvti); i++)
     {
@@ -347,7 +349,8 @@ insert_nvt (const nvti_t *nvti, int truncate)
       g_free (quoted_text);
     }
 
-  sql ("DELETE FROM vt_severities where vt_oid = '%s';", nvti_oid (nvti));
+  if (truncate == 0)
+    sql ("DELETE FROM vt_severities where vt_oid = '%s';", nvti_oid (nvti));
 
   highest = 0;
 
@@ -1559,8 +1562,9 @@ update_nvts_from_vts (entity_t *get_vts_response,
           sql_rollback ();
           return -1;
         }
-      sql ("DELETE FROM nvt_preferences WHERE name LIKE '%s:%%';",
-           nvti_oid (nvti));
+      if (truncate == 0)
+        sql ("DELETE FROM nvt_preferences WHERE name LIKE '%s:%%';",
+             nvti_oid (nvti));
       insert_nvt_preferences_list (preferences);
       g_list_free_full (preferences, g_free);
 

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -340,6 +340,8 @@ insert_vt_severities (const nvti_t *nvti, int truncate)
 /**
  * @brief Insert an NVT.
  *
+ * Always called within a transaction.
+ *
  * @param[in]  nvti       NVT Information.
  * @param[in]  truncate   True if NVT tables were truncated.
  */
@@ -394,6 +396,10 @@ insert_nvt (const nvti_t *nvti, int truncate)
                   nvti_oid (nvti)))
     sql ("DELETE FROM nvts WHERE oid = '%s';", nvti_oid (nvti));
 
+  insert_vt_refs(nvti, truncate);
+
+  highest = insert_vt_severities(nvti, truncate);
+
   sql ("INSERT into nvts (oid, name, summary, insight, affected,"
        " impact, cve, tag, category, family, cvss_base,"
        " creation_time, modification_time, uuid, solution_type,"
@@ -406,10 +412,6 @@ insert_nvt (const nvti_t *nvti, int truncate)
        nvti_creation_time (nvti), nvti_modification_time (nvti),
        nvti_oid (nvti), quoted_solution_type, quoted_solution_method,
        quoted_solution, quoted_detection, qod, quoted_qod_type);
-
-  insert_vt_refs(nvti, truncate);
-
-  highest = insert_vt_severities(nvti, truncate);
 
   sql ("UPDATE nvts SET cvss_base = %0.1f WHERE oid = '%s';",
        highest,


### PR DESCRIPTION
## What

Speed up the NVT rebuild by skipping SQL calls.  The calls were either redundant due to the initial truncates, or they could be merged into a previous statement.

Saves about 20-30% of the rebuild time for me.

## Why

The rebuild blocks tasks from writing their results, so a faster rebuild means less blocking in the UI.

Also much easier to find rebuild related problems if the rebuild can be repeated quickly.

## References

GEA-49
