### PR TITLE
Rebuild NVTs in shadow tables

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -1919,7 +1919,7 @@ nvt_selector_iterator_type (iterator_t*);
 /* NVT preferences. */
 
 void
-manage_nvt_preference_add (const char*, const char*);
+manage_nvt_preference_add (const char*, const char*, int);
 
 void
 manage_nvt_preferences_enable ();

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -40,7 +40,7 @@
 
 
 /* Headers */
-int
+int
 check_db_extensions ();
 
 

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -1748,6 +1748,62 @@ create_view_vulns ()
 #undef VULNS_RESULTS_WHERE
 
 /**
+ * @brief Create NVT related tables.
+ */
+void
+create_tables_nvt (const gchar *suffix)
+{
+  sql ("CREATE TABLE IF NOT EXISTS vt_refs%s"
+       " (id SERIAL PRIMARY KEY,"
+       "  vt_oid text NOT NULL,"
+       "  type text NOT NULL,"
+       "  ref_id text NOT NULL,"
+       "  ref_text text);",
+       suffix);
+
+  sql ("CREATE TABLE IF NOT EXISTS vt_severities%s"
+       " (id SERIAL PRIMARY KEY,"
+       "  vt_oid text NOT NULL,"
+       "  type text NOT NULL,"
+       "  origin text,"
+       "  date integer,"
+       "  score double precision,"
+       "  value text);",
+       suffix);
+
+  sql ("CREATE TABLE IF NOT EXISTS nvt_preferences%s"
+       " (id SERIAL PRIMARY KEY,"
+       "  name text UNIQUE NOT NULL,"
+       "  value text);",
+       suffix);
+
+  sql ("CREATE TABLE IF NOT EXISTS nvts%s"
+       " (id SERIAL PRIMARY KEY,"
+       "  uuid text UNIQUE NOT NULL,"
+       "  oid text UNIQUE NOT NULL,"
+       "  name text,"
+       "  comment text,"
+       "  summary text,"
+       "  insight text,"
+       "  affected text,"
+       "  impact text,"
+       "  cve text,"
+       "  tag text,"
+       "  category text,"
+       "  family text,"
+       "  cvss_base text,"
+       "  creation_time integer,"
+       "  modification_time integer,"
+       "  solution text,"
+       "  solution_type text,"
+       "  solution_method text,"
+       "  detection text,"
+       "  qod integer,"
+       "  qod_type text);",
+       suffix);
+}
+
+/**
  * @brief Create all tables.
  */
 void
@@ -2565,50 +2621,7 @@ create_tables ()
        "  name text,"
        "  value text);");
 
-  sql ("CREATE TABLE IF NOT EXISTS vt_refs"
-       " (id SERIAL PRIMARY KEY,"
-       "  vt_oid text NOT NULL,"
-       "  type text NOT NULL,"
-       "  ref_id text NOT NULL,"
-       "  ref_text text);");
-
-  sql ("CREATE TABLE IF NOT EXISTS vt_severities"
-       " (id SERIAL PRIMARY KEY,"
-       "  vt_oid text NOT NULL,"
-       "  type text NOT NULL,"
-       "  origin text,"
-       "  date integer,"
-       "  score double precision,"
-       "  value text);");
-
-  sql ("CREATE TABLE IF NOT EXISTS nvt_preferences"
-       " (id SERIAL PRIMARY KEY,"
-       "  name text UNIQUE NOT NULL,"
-       "  value text);");
-
-  sql ("CREATE TABLE IF NOT EXISTS nvts"
-       " (id SERIAL PRIMARY KEY,"
-       "  uuid text UNIQUE NOT NULL,"
-       "  oid text UNIQUE NOT NULL,"
-       "  name text,"
-       "  comment text,"
-       "  summary text,"
-       "  insight text,"
-       "  affected text,"
-       "  impact text,"
-       "  cve text,"
-       "  tag text,"
-       "  category text,"
-       "  family text,"
-       "  cvss_base text,"
-       "  creation_time integer,"
-       "  modification_time integer,"
-       "  solution text,"
-       "  solution_type text,"
-       "  solution_method text,"
-       "  detection text,"
-       "  qod integer,"
-       "  qod_type text);");
+  create_tables_nvt ("");
 
   sql ("CREATE TABLE IF NOT EXISTS notes"
        " (id SERIAL PRIMARY KEY,"

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -1694,25 +1694,29 @@ check_config_families ()
 /**
  * @brief Add/replace an NVT preference.
  *
- * @param[in]  name    The name of the preference.
- * @param[in]  value   The value of the preference.
+ * @param[in]  name     The name of the preference.
+ * @param[in]  value    The value of the preference.
+ * @param[in]  rebuild  Whether a rebuild is happening.
  */
 void
-manage_nvt_preference_add (const char* name, const char* value)
+manage_nvt_preference_add (const char* name, const char* value, int rebuild)
 {
   gchar* quoted_name = sql_quote (name);
   gchar* quoted_value = sql_quote (value);
 
   if (strcmp (name, "port_range"))
     {
-      if (sql_int ("SELECT EXISTS"
-                   "  (SELECT * FROM nvt_preferences"
-                   "   WHERE name = '%s')",
-                   quoted_name))
-        sql ("DELETE FROM nvt_preferences WHERE name = '%s';", quoted_name);
+      if (rebuild == 0) {
+        if (sql_int ("SELECT EXISTS"
+                     "  (SELECT * FROM nvt_preferences"
+                     "   WHERE name = '%s')",
+                     quoted_name))
+          sql ("DELETE FROM nvt_preferences WHERE name = '%s';", quoted_name);
+      }
 
-      sql ("INSERT into nvt_preferences (name, value)"
+      sql ("INSERT into nvt_preferences%s (name, value)"
            " VALUES ('%s', '%s');",
+           rebuild ? "_rebuild" : "",
            quoted_name, quoted_value);
     }
 


### PR DESCRIPTION
## What

When rebuilding the NVTs, first fill shadow tables with the NVT data, then swap them with the real tables.

## Why

This prevents the rebuild from blocking write access to the db for long periods.

Reproduced by forcing a rebuild, and then running a task in GSA while the rebuild was doing the db part of the rebuild.  With main GSA hangs waiting for db access, with this PR it worked.

## References

GEA-49


