### PR TITLE
Change: Make installing feed sync scripts optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,8 @@ endif (NOT CMAKE_BUILD_TYPE)
 
 OPTION (ENABLE_COVERAGE "Enable support for coverage analysis" OFF)
 OPTION (DEBUG_FUNCTION_NAMES "Print function names on entry and exit" OFF)
+# the shell based scripts got replaced by https://github.com/greenbone/greenbone-feed-sync/
+OPTION (INSTALL_OLD_SYNC_SCRIPTS "Install shell based feed sync scripts" OFF)
 
 ## Retrieve git revision (at configure time)
 include (GetGit)
@@ -394,20 +396,22 @@ install (FILES tools/cert_bund_getbyname.xsl tools/dfn_cert_getbyname.xsl
          DESTINATION ${GVM_CERT_RES_DIR}
          PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
 
-install (FILES ${CMAKE_BINARY_DIR}/tools/greenbone-feed-sync
-         DESTINATION ${SBINDIR}
-         PERMISSIONS OWNER_EXECUTE OWNER_READ OWNER_WRITE
-                     GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+if (INSTALL_OLD_SYNC_SCRIPTS)
+  install (FILES ${CMAKE_BINARY_DIR}/tools/greenbone-feed-sync
+          DESTINATION ${SBINDIR}
+          PERMISSIONS OWNER_EXECUTE OWNER_READ OWNER_WRITE
+                      GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 
-install (FILES ${CMAKE_BINARY_DIR}/tools/greenbone-scapdata-sync
-         DESTINATION ${SBINDIR}
-         PERMISSIONS OWNER_EXECUTE OWNER_READ OWNER_WRITE
-                     GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+  install (FILES ${CMAKE_BINARY_DIR}/tools/greenbone-scapdata-sync
+          DESTINATION ${SBINDIR}
+          PERMISSIONS OWNER_EXECUTE OWNER_READ OWNER_WRITE
+                      GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 
-install (FILES ${CMAKE_BINARY_DIR}/tools/greenbone-certdata-sync
-         DESTINATION ${SBINDIR}
-         PERMISSIONS OWNER_EXECUTE OWNER_READ OWNER_WRITE
-                     GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+  install (FILES ${CMAKE_BINARY_DIR}/tools/greenbone-certdata-sync
+          DESTINATION ${SBINDIR}
+          PERMISSIONS OWNER_EXECUTE OWNER_READ OWNER_WRITE
+                      GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+endif (INSTALL_OLD_SYNC_SCRIPTS)
 
 install (FILES ${CMAKE_SOURCE_DIR}/tools/gvm-lsc-deb-creator
                ${CMAKE_SOURCE_DIR}/tools/gvm-lsc-exe-creator

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -106,33 +106,18 @@ endif (NOT XSLTPROC_EXECUTABLE)
 
 if (XMLTOMAN_EXECUTABLE)
   add_custom_target (man COMMENT "Building manual page..."
-    DEPENDS gvmd.8 greenbone-certdata-sync.8 greenbone-scapdata-sync.8)
+    DEPENDS gvmd.8)
 
   add_custom_command (OUTPUT gvmd.8
 					  COMMAND sh
 					  ARGS -c \"${XMLTOMAN_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/gvmd.8.xml > ${CMAKE_CURRENT_BINARY_DIR}/gvmd.8\;\"
 					  DEPENDS gvmd.8.xml)
 
-  add_custom_command (OUTPUT greenbone-certdata-sync.8
-					  COMMAND sh
-					  ARGS -c \"${XMLTOMAN_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/greenbone-certdata-sync.8.xml > ${CMAKE_CURRENT_BINARY_DIR}/greenbone-certdata-sync.8\;\"
-					  DEPENDS greenbone-certdata-sync.8.xml)
-
-  add_custom_command (OUTPUT greenbone-scapdata-sync.8
-					  COMMAND sh
-					  ARGS -c \"${XMLTOMAN_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/greenbone-scapdata-sync.8.xml > ${CMAKE_CURRENT_BINARY_DIR}/greenbone-scapdata-sync.8\;\"
-					  DEPENDS greenbone-scapdata-sync.8.xml)
 else (XMLTOMAN_EXECUTABLE)
   message (STATUS "WARNING: xmltoman is required to generate manpage.")
   add_custom_command (OUTPUT gvmd.8
                       COMMAND echo "[Error: xmltoman required to see manpage here]"
 					          > gvmd.8)
-  add_custom_command (OUTPUT greenbone-certdata-sync.8
-                      COMMAND echo "[Error: xmltoman required to see manpage here]"
-					          > greenbone-certdata-sync.8)
-  add_custom_command (OUTPUT greenbone-scapdata-sync.8
-                      COMMAND echo "[Error: xmltoman required to see manpage here]"
-					          > greenbone-scapdata-sync.8)
 endif (XMLTOMAN_EXECUTABLE)
 
 if (XMLMANTOHTML_EXECUTABLE)
@@ -158,6 +143,6 @@ if (XSLTPROC_EXECUTABLE)
     COMPONENT doc)
 endif (XSLTPROC_EXECUTABLE)
 
-install (FILES gvmd.8 greenbone-certdata-sync.8 greenbone-scapdata-sync.8
+install (FILES gvmd.8
   DESTINATION share/man/man8/
   COMPONENT doc)


### PR DESCRIPTION
## What

There is a [new Python based `greenbone-feed-sync` script](https://github.com/greenbone/greenbone-feed-sync/) that is a drop in replacement for the shell based script provided by gvmd. This PR introduces a new `cmake` option `INSTALL_OLD_SYNC_SCRIPTS` to make installing the old sync scripts optional. By default the scripts aren't installed anymore.

## Why

Users should switch to the new sync script as soon as possible. Therefore don't install it anymore in the next release by default.

## References

Replaces https://github.com/greenbone/gvmd/pull/1912

DEVOPS-516

## Checklist

Build the stable container with and without `INSTALL_OLD_SYNC_SCRIPTS`.

