### PR TITLE
Change: Show false positives in reports list by default

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -14275,7 +14275,7 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
       /* Setup result filter from overrides. */
       get_reports_data->get.filter
         = g_strdup_printf ("apply_overrides=%i min_qod=%i levels=%s",
-                           overrides, min_qod, levels);
+                           overrides, min_qod, levels ? levels : "hmlgdf");
       g_free (levels);
     }
 

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -14248,7 +14248,7 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
       || (strlen (get_reports_data->report_get.id) == 0))
     {
       int overrides, min_qod;
-      gchar *filter;
+      gchar *filter, *levels;
       get_data_t * get;
 
       /* For simplicity, use a fixed result filter when filtering
@@ -14269,12 +14269,14 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
       g_free (get_reports_data->get.filter);
       overrides = filter_term_apply_overrides (filter ? filter : get->filter);
       min_qod = filter_term_min_qod (filter ? filter : get->filter);
+      levels = filter_term_value (filter ? filter : get->filter, "levels");
       g_free (filter);
 
       /* Setup result filter from overrides. */
       get_reports_data->get.filter
-        = g_strdup_printf ("apply_overrides=%i min_qod=%i",
-                           overrides, min_qod);
+        = g_strdup_printf ("apply_overrides=%i min_qod=%i levels=%s",
+                           overrides, min_qod, levels);
+      g_free (levels);
     }
 
   ret = init_report_iterator (&reports, &get_reports_data->report_get);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -27435,7 +27435,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
 
   max_results = manage_max_rows (max_results);
 
-  levels = levels ? levels : g_strdup ("hmlgd");
+  levels = levels ? levels : g_strdup ("hmlgdf");
 
   if (task && task_uuid (task, &tsk_uuid))
     {


### PR DESCRIPTION
## What
When no results filter is given for get_reports, include false positive results by default and use the levels keyword from the reports filter if available.

## Why
This was changed because the previous behavior was confusing for users.

## References
GEA-79
