### PR TITLE
Fix: Include requested reports in task_running_report

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -17884,8 +17884,10 @@ task_running_report (task_t task)
       return (unsigned int) sql_int ("SELECT max(id) FROM reports"
                                      " WHERE task = %llu AND end_time IS NULL"
                                      " AND (scan_run_status = %u "
+                                     " OR scan_run_status = %u "
                                      " OR scan_run_status = %u);",
                                      task,
+                                     TASK_STATUS_REQUESTED,
                                      TASK_STATUS_RUNNING,
                                      TASK_STATUS_QUEUED);
     }


### PR DESCRIPTION
## What
When getting the currently running report in the task_running_report function, reports with the status "Requested" are now also included.

## Why
This addresses a problem with starting scheduled task manually.

## References
GEA-12

