### PR TITLE
Add: New options to get all hosts with a given OS

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -11417,10 +11417,12 @@ handle_get_assets (gmp_parser_t *gmp_parser, GError **error)
           g_string_append_printf (result,
                                   "<title>%s</title>"
                                   "<installs>%i</installs>"
+                                  "<all_installs>%i</all_installs>"
                                   "<hosts>"
                                   "%i",
                                   asset_os_iterator_title (&assets),
                                   asset_os_iterator_installs (&assets),
+                                  asset_os_iterator_all_installs (&assets),
                                   asset_os_iterator_installs (&assets));
           init_os_host_iterator (&os_hosts,
                                   get_iterator_resource (&assets));

--- a/src/manage.h
+++ b/src/manage.h
@@ -2245,6 +2245,9 @@ const char*
 asset_os_iterator_average_severity (iterator_t *);
 
 int
+asset_os_iterator_all_installs (iterator_t *);
+
+int
 asset_os_count (const get_data_t *);
 
 int

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -9074,6 +9074,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </filter_keywords>
         <filter_keywords>
           <condition>type is "host"</condition>
+          <option>
+            <name>os_id</name>
+            <type>UUID</type>
+            <summary>
+              UUID of an OS asset that was detected on the hosts but
+              does not have to be the best match
+            </summary>
+          </option>
+          <column>
+            <name>best_os_cpe</name>
+            <type>text</type>
+            <summary>CPE-ID of best matching OS</summary>
+          </column>
           <column>
             <name>severity</name>
             <type>severity</type>
@@ -9082,7 +9095,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <column>
             <name>os</name>
             <type>text</type>
-            <summary>Best matching OS</summary>
+            <summary>Best matching OS, either name or CPE-ID</summary>
           </column>
           <column>
             <name>oss</name>
@@ -9103,6 +9116,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <filter_keywords>
           <condition>type is "os"</condition>
           <column>
+            <name>all_hosts</name>
+            <type>integer</type>
+            <summary>
+              Number of all hosts using the asset, even if the OS
+              is not the best match
+            </summary>
+          </column>
+          <column>
             <name>title</name>
             <type>text</type>
             <summary>CPE title of the asset</summary>
@@ -9110,7 +9131,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <column>
             <name>hosts</name>
             <type>integer</type>
-            <summary>Number of hosts using the asset</summary>
+            <summary>Number of hosts using the asset as best OS match</summary>
           </column>
           <column>
             <name>latest_severity</name>
@@ -9418,6 +9439,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <pattern>
             <e>title</e>
             <e>installs</e>
+            <e>all_installs</e>
             <e>latest_severity</e>
             <e>highest_severity</e>
             <e>average_severity</e>
@@ -9431,7 +9453,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <ele>
 <!-- FIX hosts/host_count? -->
             <name>installs</name>
-            <summary>Number of hosts on which OS has been detected</summary>
+            <summary>
+              Number of hosts on which OS has been detected as the best match
+            </summary>
+            <pattern>integer</pattern>
+          </ele>
+          <ele>
+            <name>all_installs</name>
+            <summary>
+              Number of hosts on which OS has been detected,
+              not necessarily as the best match
+            </summary>
             <pattern>integer</pattern>
           </ele>
           <ele>
@@ -9469,7 +9501,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </ele>
           <ele>
             <name>hosts</name>
-            <summary>Hosts on which this OS has been detected</summary>
+            <summary>
+              Hosts on which this OS has been detected as the best match
+            </summary>
             <pattern>
               <e>asset</e>
             </pattern>


### PR DESCRIPTION
## What
This adds new filter keywords for the get_assets GMP command to find all hosts with a given OS, not just the ones where the OS is the best match.
Another new filter column is also added specifically for the CPE-ID of the best matching OS of a host.
Also, a new all_hosts element and filter column are added to OS assets containing the number of all hosts with the OS.

## Why
This allows finding out where OS assets are still in use by hosts and making the filtered hosts pages more and counts shown in GSA more consistent.

## References
GEA-117
