### PR TITLE
Change: Drop results_autofp on NVTs rebuild

### DIFF
--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1637,6 +1637,7 @@ update_nvts_from_vts (entity_t *get_vts_response,
     }
 
   if (rebuild) {
+    sql ("DROP VIEW IF EXISTS results_autofp;");
     sql ("DROP VIEW vulns;");
     sql ("DROP TABLE nvts, nvt_preferences, vt_refs, vt_severities;");
 


### PR DESCRIPTION
## What
Drop results_autofp on NVTs rebuild.

## Why
If the view is left from older versions of gvmd, it will be removed on rebuild so it does not prevent replacing the nvts table.

## References
GEA-49

