### PR TITLE
Add: Certificate info for TippingPoint SMS alerts

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -11142,6 +11142,69 @@ handle_get_alerts (gmp_parser_t *gmp_parser, GError **error)
                   g_free (username);
                 }
             }
+          else if (strcmp (name, "tp_sms_tls_certificate") == 0)
+            {
+              const char *certificate = alert_data_iterator_data (&data);
+              time_t activation_time, expiration_time;
+              gchar *md5_fingerprint, *sha256_fingerprint;
+              gchar *subject, *issuer, *serial;
+
+              if (certificate && strcmp (certificate, "")
+                  && get_certificate_info ((gchar*)certificate,
+                                           strlen (certificate),
+                                           &activation_time,
+                                           &expiration_time,
+                                           &md5_fingerprint,
+                                           &sha256_fingerprint,
+                                           &subject,
+                                           &issuer,
+                                           &serial,
+                                           NULL) == 0)
+                {
+                  gchar *activation_time_str, *expiration_time_str;
+
+                  activation_time_str = certificate_iso_time (activation_time);
+                  expiration_time_str = certificate_iso_time (expiration_time);
+
+                  SENDF_TO_CLIENT_OR_FAIL (
+                    "<data>"
+                    "<name>%s</name>"
+                    "<certificate_info>"
+                    "<activation_time>%s</activation_time>"
+                    "<expiration_time>%s</expiration_time>"
+                    "<md5_fingerprint>%s</md5_fingerprint>"
+                    "<sha256_fingerprint>%s</sha256_fingerprint>"
+                    "<subject>%s</subject>"
+                    "<issuer>%s</issuer>"
+                    "<serial>%s</serial>"
+                    "</certificate_info>"
+                    "%s"
+                    "</data>",
+                    name,
+                    activation_time_str,
+                    expiration_time_str,
+                    md5_fingerprint,
+                    sha256_fingerprint,
+                    subject,
+                    issuer,
+                    serial,
+                    certificate);
+                }
+              else
+                {
+                  SENDF_TO_CLIENT_OR_FAIL ("<data>"
+                                           "<name>%s</name>"
+                                           "%s"
+                                           "</data>",
+                                           name,
+                                           certificate);
+                }
+              g_free (md5_fingerprint);
+              g_free (sha256_fingerprint);
+              g_free (subject);
+              g_free (issuer);
+              g_free (serial);
+            }
           else
             {
               SENDF_TO_CLIENT_OR_FAIL ("<data>"

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -8768,6 +8768,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               text
               <e>name</e>
               <o><e>credential</e></o>
+              <o><e>certificate_info</e></o>
             </pattern>
             <ele>
               <name>name</name>
@@ -8798,6 +8799,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <summary>The username of the credential</summary>
                 <pattern><t>name</t></pattern>
               </ele>
+            </ele>
+            <ele>
+              <name>certificate_info</name>
+              <summary>Certificate info if the data is a TLS certificate</summary>
+              <type>certificate_info</type>
             </ele>
           </ele>
         </ele>


### PR DESCRIPTION
## What
The get_alerts command now returns additional certificate info for the TLS certificate method data of TippingPoint SMS alerts.

## Why
This makes it easier to verify that the correct certificate has been set for the alert.

## References
GEA-180
