### PR TITLE
Add: Set required contents read permission on cc workflow

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   pull-requests: write
+  contents: read
 
 jobs:
   conventional-commits:


### PR DESCRIPTION
## What

Set required contents read permission on cc workflow

## Why

To check for available conventional commits the workflow need to be able to read the contents of the repository. For public repos this isn't strictly required but maybe it elevates the permission for PRs from externals.

