### PR TITLE
Fix: Handle undefined direction in alerts

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -14322,7 +14322,10 @@ condition_met (task_t task, report_t report, alert_t alert,
                     {
                       /* Same as "increased". */
                       if (cmp >= count)
-                        return 1;
+                        {
+                          free (filter_id);
+                          return 1;
+                        }
                     }
                   else if (((strcasecmp (direction, "changed") == 0)
                             && (abs (cmp) >= count))
@@ -14341,7 +14344,16 @@ condition_met (task_t task, report_t report, alert_t alert,
                   g_debug ("direction: %s", direction);
                   g_debug ("last_count: %i", last_count);
                   g_debug ("second_last_count NULL");
-                  if (((strcasecmp (direction, "changed") == 0)
+                  if (direction == NULL)
+                    {
+                      /* Same as "increased". */
+                      if (last_count > 0)
+                        {
+                          free (filter_id);
+                          return 1;
+                        }
+                    }
+                  else if (((strcasecmp (direction, "changed") == 0)
                        || (strcasecmp (direction, "increased") == 0))
                       && (last_count > 0))
                     {


### PR DESCRIPTION
## What
In alerts with the "Filter count changed" condition, the check now always falls back to checking if the count increased if the "direction" condition data is not defined.

## Why
Without the fix having it undefined could cause a segmentation fault.

## References
GEA-146
