### PR TITLE
fork_cve_scan_handler() cleanup

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -3089,9 +3089,12 @@ fork_cve_scan_handler (task_t task, target_t target)
         set_report_scan_run_status (global_current_report,
                                     TASK_STATUS_INTERRUPTED);
         global_current_report = (report_t) 0;
+        current_scanner_task = 0;
         return -9;
       default:
         /* Parent, successfully forked. */
+        global_current_report = 0;
+        current_scanner_task = 0;
         g_debug ("%s: %i forked %i", __func__, getpid (), pid);
         return 0;
     }


### PR DESCRIPTION
## What

Added to fork_cve_scan_handler() parent process cleanup so it matches the fork_osp_scan_handler()

## Why

This fixed an issue I was having where CVE scans were leaving a stale global_current_report value, i.e. they weren't zeroing it out. This caused subsequent requests handled by the same gvmd process to fail.

## References

Closes #1979 
