### PR TITLE
Add column hash_value to the tables results and report_host_details

### DIFF
--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -2489,7 +2489,8 @@ create_tables ()
        "  owner integer REFERENCES users (id) ON DELETE RESTRICT,"
        "  date integer,"
        "  hostname text,"
-       "  path text);");
+       "  path text,"
+       "  hash_value text);");
 
   sql ("CREATE TABLE IF NOT EXISTS results_trash"
        " (id SERIAL PRIMARY KEY,"
@@ -2619,7 +2620,8 @@ create_tables ()
        "  source_name text,"
        "  source_description text,"
        "  name text,"
-       "  value text);");
+       "  value text,"
+       "  hash_value text);");
 
   create_tables_nvt ("");
 


### PR DESCRIPTION
## What
Add column `hash_value` to the tables `results` and `report_host_details`
Closes #1990

## Why

The column `hash_value` is added to the `results` and `report_host_details` tables when the gvmd DB is migrated [from the version 251 to version 252](https://github.com/greenbone/gvmd/commit/574b4322f7d404334f5969f453ceda23bde2c890#diff-fbbcd795488f75705d5496e59b231a81de3799d912c338d588adfd444961eb80R3005) and [from the version 252 to version 253](https://github.com/greenbone/gvmd/commit/4d809184e560b3f69d99db400d5b0e61bbe4e4d9#diff-fbbcd795488f75705d5496e59b231a81de3799d912c338d588adfd444961eb80R3036) accordingly, but is not created when the tables are newly created, this makes `gvmd` failed to save scan results.

## Checklist
- [x] Tests