### PR TITLE
Enabled certificates generation before gvmd start

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -68,6 +68,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Loading scap and cert data
 # xml-twig-tools
 
+# Required for set up certificates for GVM
+# gnutls-bin
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     dpkg \
@@ -76,6 +79,7 @@ RUN apt-get update && \
     gosu \
     gnupg \
     gpgsm \
+    gnutls-bin \
     libbsd0 \
     libgpgme11 \
     libical3 \
@@ -110,6 +114,7 @@ RUN addgroup --gid 1001 --system gvmd && \
 RUN mkdir -p /run/gvmd && \
     mkdir -p /var/lib/gvm && \
     mkdir -p /var/log/gvm && \
+    gvm-manage-certs -a && \
     chown -R gvmd:gvmd /etc/gvm && \
     chown -R gvmd:gvmd /run/gvmd && \
     chown -R gvmd:gvmd /var/lib/gvm && \

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -114,7 +114,6 @@ RUN addgroup --gid 1001 --system gvmd && \
 RUN mkdir -p /run/gvmd && \
     mkdir -p /var/lib/gvm && \
     mkdir -p /var/log/gvm && \
-    gvm-manage-certs -a && \
     chown -R gvmd:gvmd /etc/gvm && \
     chown -R gvmd:gvmd /run/gvmd && \
     chown -R gvmd:gvmd /var/lib/gvm && \

--- a/.docker/start-gvmd.sh
+++ b/.docker/start-gvmd.sh
@@ -26,7 +26,7 @@
 
 if [ -n "$GVM_CERTS" ] && [ "$GVM_CERTS" = true ]; then
 	echo "Generating certs"
-    gvm-manage-certs -a
+	gvm-manage-certs -a
 fi
 
 # check for psql connection

--- a/.docker/start-gvmd.sh
+++ b/.docker/start-gvmd.sh
@@ -24,6 +24,11 @@
 [ -z "$GVMD_USER" ] && GVMD_USER="gvmd"
 [ -z "$PGRES_DATA"] && PGRES_DATA="/var/lib/postgresql"
 
+if [ -n "$GVM_CERTS" ] && [ "$GVM_CERTS" = true ]; then
+	echo "Generating certs"
+    gvm-manage-certs -a
+fi
+
 # check for psql connection
 FILE=$PGRES_DATA/started
 until test -f "$FILE"; do


### PR DESCRIPTION
## What

Added `gnutls-bin` package in order to use `gvm-manage-certs`

## Why

Without certificate generation gvmd will not start with `-a` and `-p` params

## References

This post  is somehow related but it's not using docker. https://forum.greenbone.net/t/configuring-gvmd-for-external-access-tls/13912


I only edited Dockerfile in the main branch. Let me know if it should be modified in other branches too.

