### PR TITLE
Batch INSERTs into vt_severities

### DIFF
--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1887,6 +1887,7 @@ gvmd (int argc, char** argv, char *env[])
   static gchar *feed_lock_path = NULL;
   static int feed_lock_timeout = 0;
   static int vt_ref_insert_size = VT_REF_INSERT_SIZE_DEFAULT;
+  static int vt_sev_insert_size = VT_SEV_INSERT_SIZE_DEFAULT;
   static gchar *vt_verification_collation = NULL;
 
   GString *full_disable_commands = g_string_new ("");
@@ -2216,6 +2217,11 @@ gvmd (int argc, char** argv, char *env[])
           "Max number of VT refs to insert per statement during VT update,"
           " 0 for unlimited, default: "
           G_STRINGIFY (VT_REF_INSERT_SIZE_DEFAULT), "<number>" },
+        { "vt-sev-insert-size", '\0', 0, G_OPTION_ARG_INT,
+          &vt_sev_insert_size,
+          "Max number of VT severities to insert per statement during VT update,"
+          " 0 for unlimited, default: "
+          G_STRINGIFY (VT_SEV_INSERT_SIZE_DEFAULT), "<number>" },
         { "vt-verification-collation", '\0', 0, G_OPTION_ARG_STRING,
           &vt_verification_collation,
           "Set collation for VT verification to <collation>, omit or leave"
@@ -2304,6 +2310,8 @@ gvmd (int argc, char** argv, char *env[])
   set_secinfo_commit_size (secinfo_commit_size);
 
   set_vt_ref_insert_size (vt_ref_insert_size);
+
+  set_vt_sev_insert_size (vt_sev_insert_size);
 
   /* Set VT verification collation override */
   set_vt_verification_collation (vt_verification_collation);

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -50,20 +50,6 @@
  */
 #define G_LOG_DOMAIN "md manage"
 
-/**
- * @brief Rows per statement when inserting VT refs for update/rebuild.
- *
- * There are about 500k vt_refs.
- */
-#define VT_REFS_BATCH_SIZE 50000
-
-/**
- * @brief Rows per statement when inserting VT severities for update/rebuild.
- *
- * There are about 80k vt_severities.
- */
-#define VT_SEVS_BATCH_SIZE 100000
-
 
 /* Headers from backend specific manage_xxx.c file. */
 
@@ -77,6 +63,11 @@ create_tables_nvt (const gchar *);
  * @brief Max number of rows inserted per statement.
  */
 static int vt_ref_insert_size = VT_REF_INSERT_SIZE_DEFAULT;
+
+/**
+ * @brief Max number of rows inserted per statement.
+ */
+static int vt_sev_insert_size = VT_SEV_INSERT_SIZE_DEFAULT;
 
 /**
  * @brief File socket for OSP NVT update.
@@ -153,6 +144,20 @@ set_vt_ref_insert_size (int new_size)
     vt_ref_insert_size = 0;
   else
     vt_ref_insert_size = new_size;
+}
+
+/**
+ * @brief Set the VT severity insert size.
+ *
+ * @param new_size  New size.
+ */
+void
+set_vt_sev_insert_size (int new_size)
+{
+  if (new_size < 0)
+    vt_sev_insert_size = 0;
+  else
+    vt_sev_insert_size = new_size;
 }
 
 /**
@@ -1766,7 +1771,7 @@ update_nvts_from_vts (element_t *get_vts_response,
     sql ("TRUNCATE nvt_preferences;");
 
   vt_refs_batch = batch_start (vt_ref_insert_size);
-  vt_sevs_batch = batch_start (VT_SEVS_BATCH_SIZE);
+  vt_sevs_batch = batch_start (vt_sev_insert_size);
   vt = element_first_child (vts);
   while (vt)
     {

--- a/src/manage_sql_nvts.h
+++ b/src/manage_sql_nvts.h
@@ -105,6 +105,16 @@
 void
 set_vt_ref_insert_size (int);
 
+/**
+ * @brief Default for vt_sev_insert_size.
+ *
+ * There are about 80k vt_severities.
+ */
+#define VT_SEV_INSERT_SIZE_DEFAULT 100000
+
+void
+set_vt_sev_insert_size (int);
+
 const char *
 get_osp_vt_update_socket ();
 


### PR DESCRIPTION
## What

During update/rebuild there was one INSERT statement per vt_severity.  Now there are 100k INSERT statements per vt_severity.

Configurable via command line argument --vt-sev-insert-size.  Note that there are about 80k vt_severities, so 100k means a single batch.

## Why

This saves some seconds during the NVT rebuild.

## References

Similar to greenbone/gvmd/pull/1988.
