### PR TITLE
Corrected the used index in an iterator access function.

### DIFF
--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -3255,7 +3255,7 @@ config_iterator_nvts_growing (iterator_t* iterator)
  * @return The usage type of the config, or NULL if iteration is complete.
  *         Freed by cleanup_iterator.
  */
-DEF_ACCESS (config_iterator_usage_type, GET_ITERATOR_COLUMN_COUNT + 8);
+DEF_ACCESS (config_iterator_usage_type, GET_ITERATOR_COLUMN_COUNT + 6);
 
 /**
  * @brief Get predefined status from a config iterator.


### PR DESCRIPTION
## What
Because the iterator access function "config_iterator_usage_type(...)" always returned NULL instead of the correct value, the used index in that function had to be corrected.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This is a bug-fix.
<!-- Describe why are these changes necessary? -->

## References
GEA-204
AP-1919
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist
Tested manually in my local development environment.
<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


