### PR TITLE
Speed up GET_TARGETS

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -32101,40 +32101,45 @@ modify_target (const char *target_id, const char *name, const char *hosts,
    {                                                           \
      "(SELECT name FROM credentials"                           \
      " WHERE credentials.id"                                   \
-     "       = target_credential (targets.id, 0,"              \
-     "                            CAST ('ssh' AS text)))",     \
+     "       = (SELECT credential FROM targets_login_data"     \
+     "          WHERE target = targets.id"                     \
+     "          AND type = CAST ('ssh' AS text)))",            \
      "ssh_credential",                                         \
      KEYWORD_TYPE_STRING                                       \
    },                                                          \
    {                                                           \
      "(SELECT name FROM credentials"                           \
      " WHERE credentials.id"                                   \
-     "       = target_credential (targets.id, 0,"              \
-     "                            CAST ('smb' AS text)))",     \
+     "       = (SELECT credential FROM targets_login_data"     \
+     "          WHERE target = targets.id"                     \
+     "          AND type = CAST ('smb' AS text)))",            \
      "smb_credential",                                         \
      KEYWORD_TYPE_STRING                                       \
    },                                                          \
    {                                                           \
      "(SELECT name FROM credentials"                           \
      " WHERE credentials.id"                                   \
-     "       = target_credential (targets.id, 0,"              \
-     "                            CAST ('esxi' AS text)))",    \
+     "       = (SELECT credential FROM targets_login_data"     \
+     "          WHERE target = targets.id"                     \
+     "          AND type = CAST ('esxi' AS text)))",           \
      "esxi_credential",                                        \
      KEYWORD_TYPE_STRING                                       \
    },                                                          \
    {                                                           \
      "(SELECT name FROM credentials"                           \
      " WHERE credentials.id"                                   \
-     "       = target_credential (targets.id, 0,"              \
-     "                            CAST ('snmp' AS text)))",    \
+     "       = (SELECT credential FROM targets_login_data"     \
+     "          WHERE target = targets.id"                     \
+     "          AND type = CAST ('snmp' AS text)))",           \
      "snmp_credential",                                        \
      KEYWORD_TYPE_STRING                                       \
    },                                                          \
    {                                                           \
      "(SELECT name FROM credentials"                           \
      " WHERE credentials.id"                                   \
-     "       = target_credential (targets.id, 0,"              \
-     "                            CAST ('elevate' AS text)))", \
+     "       = (SELECT credential FROM targets_login_data"     \
+     "          WHERE target = targets.id"                     \
+     "          AND type = CAST ('elevate' AS text)))",        \
      "ssh_elevate_credential",                                 \
      KEYWORD_TYPE_STRING                                       \
    },                                                          \

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -32054,13 +32054,17 @@ modify_target (const char *target_id, const char *name, const char *hosts,
  {                                                             \
    GET_ITERATOR_COLUMNS (targets),                             \
    { "hosts", NULL, KEYWORD_TYPE_STRING },                     \
-   { "target_credential (id, 0, CAST ('ssh' AS text))",        \
+   { "(SELECT credential FROM targets_login_data"              \
+     " WHERE target = targets.id"                              \
+     " AND type = CAST ('ssh' AS text))",                      \
      NULL,                                                     \
      KEYWORD_TYPE_INTEGER },                                   \
    { "target_login_port (id, 0, CAST ('ssh' AS text))",        \
      "ssh_port",                                               \
      KEYWORD_TYPE_INTEGER },                                   \
-   { "target_credential (id, 0, CAST ('smb' AS text))",        \
+   { "(SELECT credential FROM targets_login_data"              \
+     " WHERE target = targets.id"                              \
+     " AND type = CAST ('smb' AS text))",                      \
      NULL,                                                     \
      KEYWORD_TYPE_INTEGER },                                   \
    { "port_list", NULL, KEYWORD_TYPE_INTEGER },                \
@@ -32083,15 +32087,21 @@ modify_target (const char *target_id, const char *name, const char *hosts,
    { "reverse_lookup_only", NULL, KEYWORD_TYPE_INTEGER },      \
    { "reverse_lookup_unify", NULL, KEYWORD_TYPE_INTEGER },     \
    { "alive_test", NULL, KEYWORD_TYPE_INTEGER },               \
-   { "target_credential (id, 0, CAST ('esxi' AS text))",       \
+   { "(SELECT credential FROM targets_login_data"              \
+     " WHERE target = targets.id"                              \
+     " AND type = CAST ('esxi' AS text))",                     \
      NULL,                                                     \
      KEYWORD_TYPE_INTEGER },                                   \
    { "0", NULL, KEYWORD_TYPE_INTEGER },                        \
-   { "target_credential (id, 0, CAST ('snmp' AS text))",       \
+   { "(SELECT credential FROM targets_login_data"              \
+     " WHERE target = targets.id"                              \
+     " AND type = CAST ('snmp' AS text))",                     \
      NULL,                                                     \
      KEYWORD_TYPE_INTEGER },                                   \
    { "0", NULL, KEYWORD_TYPE_INTEGER },                        \
-   { "target_credential (id, 0, CAST ('elevate' AS text))",    \
+   { "(SELECT credential FROM targets_login_data"              \
+     " WHERE target = targets.id"                              \
+     " AND type = CAST ('elevate' AS text))",                  \
      NULL,                                                     \
      KEYWORD_TYPE_INTEGER },                                   \
    { "0", NULL, KEYWORD_TYPE_INTEGER },                        \


### PR DESCRIPTION
## What

Move statement from SQL function into iterator column definition, so Postgres can do better optimisation.

With a db containing 1669 targets and 1055 credentials:

    time o m m '<get_targets filter="first=1 rows=-1"/>'
Before PR: 5m33s
After PR: 1.7s

Note that the trash case is fairly fast already, because it has fewer columns.

## Why

Speeds up GET_TARGETS for the GSA Edit Task dialog.

## References

Closes greenbone/gvmd/issues/1624.



