### PR TITLE
Change: Adjust building the build container image for semver releases

### DIFF
--- a/.docker/build.Dockerfile
+++ b/.docker/build.Dockerfile
@@ -1,5 +1,5 @@
 # Define ARG we use through the build
-ARG VERSION=edge
+ARG VERSION=stable
 
 # We want gvm-libs to be ready so we use the build docker image of gvm-libs
 FROM greenbone/gvm-libs:$VERSION

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -2,13 +2,15 @@ name: Build Container Image Builds
 
 on:
   push:
-    branches: [ main, stable, oldstable ]
+    branches:
+      - main
     tags: ["v*"]
     paths:
       - .github/workflows/build-container.yml
       - .docker/build.Dockerfile
   pull_request:
-    branches: [ main, stable, oldstable ]
+    branches:
+      - main
     paths:
       - .github/workflows/build-container.yml
       - .docker/build.Dockerfile
@@ -25,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - uses: greenbone/actions/is-latest-tag@v2
+        id: latest
       - name: Setup container meta information
         id: meta
         uses: docker/metadata-action@v4
@@ -35,15 +39,20 @@ jobs:
             org.opencontainers.image.base.name=debian/stable-slim
           flavor: latest=false # no latest container tag for git tags
           tags: |
-            # create container tag for git tags
-            type=ref,event=tag
+            # use version, major.minor and major  for tags
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+            # use edge for default branch
+            type=edge
+
+            # set label for non-published pull request builds
             type=ref,event=pr
-            # use latest for stable branch
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'stable') }}
-            type=raw,value=stable,enable=${{ github.ref == format('refs/heads/{0}', 'stable') }}
-            type=raw,value=oldstable,enable=${{ github.ref == format('refs/heads/{0}', 'oldstable') }}
-            # use unstable for main branch
-            type=raw,value=unstable,enable={{is_default_branch}}
+
+            # when a new git tag is created set stable and a latest tags
+            type=raw,value=latest,enable=${{ steps.latest.outputs.is-latest-tag == 'true' }}
+            type=raw,value=stable,enable=${{ steps.latest.outputs.is-latest-tag == 'true' }}
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2


### PR DESCRIPTION
## What

Adjust building the build container image for semver releases

## Why

The gvmd repository will use semver in future as the scanner repos do now too. Therefore adjust the workflow for building and uploading the gvmd build image.

## References

Required before merging https://github.com/greenbone/gvmd/pull/2005
Requires https://github.com/greenbone/gvmd/pull/2008
GEA-195
