### PR TITLE
Speed up nvt_preference_count

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 254)
+set (GVMD_DATABASE_VERSION 255)
 
 set (GVMD_SCAP_DATABASE_VERSION 20)
 

--- a/src/manage.h
+++ b/src/manage.h
@@ -1924,7 +1924,8 @@ nvt_selector_iterator_type (iterator_t*);
 /* NVT preferences. */
 
 void
-manage_nvt_preference_add (const char*, const char*, int);
+manage_nvt_preference_add (const char*, const char*, const char*, const char*,
+                           const char*, const char*, int);
 
 void
 manage_nvt_preferences_enable ();

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -1774,6 +1774,10 @@ create_tables_nvt (const gchar *suffix)
   sql ("CREATE TABLE IF NOT EXISTS nvt_preferences%s"
        " (id SERIAL PRIMARY KEY,"
        "  name text UNIQUE NOT NULL,"
+       "  pref_nvt text,"
+       "  pref_id integer,"
+       "  pref_type text,"
+       "  pref_name text,"
        "  value text);",
        suffix);
 

--- a/src/manage_preferences.c
+++ b/src/manage_preferences.c
@@ -80,6 +80,7 @@ preference_free (preference_t *preference)
     {
       free (preference->id);
       free (preference->name);
+      free (preference->pref_name);
       free (preference->type);
       free (preference->value);
       free (preference->nvt_name);

--- a/src/manage_preferences.h
+++ b/src/manage_preferences.h
@@ -31,7 +31,8 @@
  */
 typedef struct
 {
-  char *name;          ///< Name of preference.
+  char *name;          ///< Full name of preference, including OID etc.
+  char *pref_name;     ///< Name of preference.
   char *id;            ///< ID of preference.
   char *type;          ///< Type of preference (radio, password, ...).
   char *value;         ///< Value of preference.

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -1940,10 +1940,8 @@ nvt_preference_count (const char *oid)
 {
   gchar *quoted_oid = sql_quote (oid);
   int ret = sql_int ("SELECT COUNT(*) FROM nvt_preferences"
-                     " WHERE name != '%s:0:entry:Timeout'"
-                     "   AND name %s '%s:%%';",
-                     quoted_oid,
-                     sql_ilike_op (),
+                     " WHERE NOT (pref_type = 'entry' AND pref_name = 'Timeout')"
+                     "   AND pref_nvt = '%s';",
                      quoted_oid);
   g_free (quoted_oid);
   return ret;

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -1699,13 +1699,22 @@ check_config_families ()
  * @param[in]  rebuild  Whether a rebuild is happening.
  */
 void
-manage_nvt_preference_add (const char* name, const char* value, int rebuild)
+manage_nvt_preference_add (const char *name, const char *value,
+                           const char *oid, const char *id,
+                           const char *type, const char *pref_name,
+                           int rebuild)
 {
-  gchar* quoted_name = sql_quote (name);
-  gchar* quoted_value = sql_quote (value);
-
   if (strcmp (name, "port_range"))
     {
+      gchar *quoted_name, *quoted_value, *quoted_oid, *quoted_type;
+      gchar *quoted_pref_name;
+
+      quoted_name = sql_quote (name);
+      quoted_value = sql_quote (value);
+      quoted_oid = sql_quote (oid);
+      quoted_type = sql_quote (type);
+      quoted_pref_name = sql_quote (pref_name);
+
       if (rebuild == 0) {
         if (sql_int ("SELECT EXISTS"
                      "  (SELECT * FROM nvt_preferences"
@@ -1714,14 +1723,19 @@ manage_nvt_preference_add (const char* name, const char* value, int rebuild)
           sql ("DELETE FROM nvt_preferences WHERE name = '%s';", quoted_name);
       }
 
-      sql ("INSERT into nvt_preferences%s (name, value)"
-           " VALUES ('%s', '%s');",
+      sql ("INSERT into nvt_preferences%s"
+           " (name, value, pref_nvt, pref_id, pref_type, pref_name)"
+           " VALUES ('%s', '%s', '%s', %i, '%s', '%s');",
            rebuild ? "_rebuild" : "",
-           quoted_name, quoted_value);
-    }
+           quoted_name, quoted_value, quoted_oid, atoi (id), quoted_type,
+           quoted_pref_name);
 
-  g_free (quoted_name);
-  g_free (quoted_value);
+      g_free (quoted_name);
+      g_free (quoted_value);
+      g_free (quoted_oid);
+      g_free (quoted_type);
+      g_free (quoted_pref_name);
+    }
 }
 
 /**

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1374,6 +1374,7 @@ update_preferences_from_vt (element_t vt, const gchar *oid, GList **preferences)
 
               blank_control_chars (full_name);
               preference = g_malloc0 (sizeof (preference_t));
+              preference->free_strings = 1;
               preference->name = full_name;
               if (def)
                 preference->value = element_text (def);
@@ -1769,7 +1770,7 @@ update_nvts_from_vts (element_t *get_vts_response,
              rebuild ? "_rebuild" : "",
              nvti_oid (nvti));
       insert_nvt_preferences_list (preferences, rebuild);
-      g_list_free_full (preferences, g_free);
+      g_list_free_full (preferences, (GDestroyNotify) preference_free);
 
       nvti_free (nvti);
       vt = element_next (vt);

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1255,7 +1255,10 @@ insert_nvt_preference (gpointer nvt_preference, gpointer rebuild)
     return;
 
   preference = (preference_t*) nvt_preference;
-  manage_nvt_preference_add (preference->name, preference->value, GPOINTER_TO_INT (rebuild));
+  manage_nvt_preference_add (preference->name, preference->value,
+                             preference->nvt_oid, preference->id,
+                             preference->type, preference->pref_name,
+                             GPOINTER_TO_INT (rebuild));
 }
 
 /**
@@ -1368,7 +1371,6 @@ update_preferences_from_vt (element_t vt, const gchar *oid, GList **preferences)
                                            id,
                                            type,
                                            text);
-              g_free (text);
 
               blank_control_chars (full_name);
               preference = g_malloc0 (sizeof (preference_t));
@@ -1377,6 +1379,10 @@ update_preferences_from_vt (element_t vt, const gchar *oid, GList **preferences)
                 preference->value = element_text (def);
               else
                 preference->value = g_strdup ("");
+              preference->nvt_oid = g_strdup (oid);
+              preference->id = g_strdup (id);
+              preference->type = g_strdup (type);
+              preference->pref_name = text;
               *preferences = g_list_prepend (*preferences, preference);
             }
 


### PR DESCRIPTION
## What

Add more detailed columns to nvt_preferences, and use them to do an equal comparison instead of a LIKE in nvt_preference_count.

`time o m m '<get_nvts details="1" timeout="1" family="Databases" preferences_config_id="55385e2f-cd85-4a4a-954a-c89495aca669" preference_count="1" sort_field="nvts.name" sort_order="ascending"/>' > /tmp/nvts`

Before PR:  5s
After PR: 3.1s

## Why

The GSA Edit Config Family dialog is slow.  This saves a couple seconds.

## References

Similar to greenbone/gvmd/pull/1980
