### PR TITLE
Fixing 0-byte credential creator issue

### DIFF
--- a/tools/gvm-lsc-deb-creator
+++ b/tools/gvm-lsc-deb-creator
@@ -162,9 +162,7 @@ COPYRIGHT_FILE="${DOC_DATA_DIR}/copyright"
 } > "${COPYRIGHT_FILE}"
 
 # Create data archive
-cd "${DATA_DIR}"
-tar -C "${DATA_DIR}" -z -cf "../data.tar.gz" "${HOME_SUBDIR}" "${DOC_SUBDIR}"
-
+tar -P -z -cf "${TEMP_DIR}/data.tar.gz" "${PACKAGE_BASE_DIR}/${HOME_DATA_SUBDIR}" "${PACKAGE_BASE_DIR}/${DOC_DATA_SUBDIR}"
 
 #
 # Create control files

--- a/tools/gvm-lsc-deb-creator
+++ b/tools/gvm-lsc-deb-creator
@@ -1,4 +1,28 @@
 #!/bin/bash
+# Copyright (C) 2018-2022 Greenbone AG
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# This script generates a Debian package that creates a user for GVM
+# local security checks.
+
+#
+# Variables
+#
+
 # Command line parameters
 USERNAME="$1"
 PUBKEY_FILE="$2"
@@ -88,6 +112,14 @@ then
   exit 1
 fi
 
+#
+# Set up error handling
+#
+handle_error() {
+  echo "DEB package generation failed" >&2
+  exit 1
+}
+trap handle_error ERR
 
 #
 # Create data files

--- a/tools/gvm-lsc-deb-creator
+++ b/tools/gvm-lsc-deb-creator
@@ -1,28 +1,4 @@
 #!/bin/bash
-# Copyright (C) 2018-2022 Greenbone AG
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-# This script generates a Debian package that creates a user for GVM
-# local security checks.
-
-#
-# Variables
-#
-
 # Command line parameters
 USERNAME="$1"
 PUBKEY_FILE="$2"
@@ -112,14 +88,6 @@ then
   exit 1
 fi
 
-#
-# Set up error handling
-#
-handle_error() {
-  echo "DEB package generation failed" >&2
-  exit 1
-}
-trap handle_error ERR
 
 #
 # Create data files

--- a/tools/gvm-lsc-rpm-creator
+++ b/tools/gvm-lsc-rpm-creator
@@ -130,6 +130,8 @@ SPEC_FILE="${SPEC_DIR}/${PACKAGE_NAME_VERSION}.spec"
   echo "BuildArch: noarch"
   # Put output in current directory
   echo "%define _rpmdir %(pwd)"
+  # Set _topdir
+  echo "%define _topdir ${TEMP_DIR}"
 
   # Create description section
   echo "%description"

--- a/tools/template.nsis
+++ b/tools/template.nsis
@@ -65,9 +65,9 @@ Section
   ; Create user and add it to the Administrators group
   DetailPrint `Creating user ${__USERNAME__}`
   SetDetailsPrint none
-  ExecWait `cmd /C net user ${__USERNAME__} "${__PASSWORD__}" /add /active:yes`
+  ExecWait 'cmd /C net user ${__USERNAME__} "${__PASSWORD__}" /add /active:yes'
   SetDetailsPrint both
-  ExecWait `cmd /C net localgroup $ADMINGROUPNAME %COMPUTERNAME%\${__USERNAME__} /add`
+  ExecWait 'cmd /C net localgroup $ADMINGROUPNAME %COMPUTERNAME%\${__USERNAME__} /add'
 
   ; Remove temporary files for localized admin group names
   Delete $TEMPVBSFILE
@@ -81,7 +81,7 @@ SectionEnd
 ; Uninstaller section
 Section Uninstall
 
-  ExecWait "net user ${__USERNAME__} /delete"
+  ExecWait 'net user ${__USERNAME__} /delete'
 
   ; Display message that everything seems to be fine
   MessageBox MB_OK "A user has been removed. You can now safely remove the uninstaller from your Desktop."


### PR DESCRIPTION
## What

The credential creator packages for .deb, .rpm, and .exe created 0-byte packages.

## Why

To allow Greenbone to effectively create the credential packages for authenticated scans.

## References

None.

## Checklist

- [ *] These solutions have been tested on Ubuntu, CentOS, and Kali Linux distros.


