### PR TITLE
Change: Use gvm-libs:oldstable images

### DIFF
--- a/.docker/build.Dockerfile
+++ b/.docker/build.Dockerfile
@@ -1,5 +1,5 @@
 # Define ARG we use through the build
-ARG VERSION=stable
+ARG VERSION=oldstable
 
 # We want gvm-libs to be ready so we use the build docker image of gvm-libs
 FROM greenbone/gvm-libs:$VERSION

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -1,5 +1,5 @@
 ARG VERSION=edge
-ARG GVM_LIBS_VERSION=stable
+ARG GVM_LIBS_VERSION=oldstable
 ARG DEBIAN_FRONTEND=noninteractive
 
 FROM greenbone/gvmd-build:${VERSION} as builder

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -36,7 +36,7 @@ jobs:
           images: ${{ github.repository }}-build
           labels: |
             org.opencontainers.image.vendor=Greenbone
-            org.opencontainers.image.base.name=debian/stable-slim
+            org.opencontainers.image.base.name=greenbone/gvm-libs
           flavor: latest=false # no latest container tag for git tags
           tags: |
             # use version, major.minor and major  for tags

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -26,7 +26,7 @@ jobs:
           images: ${{ github.repository }}
           labels: |
             org.opencontainers.image.vendor=Greenbone
-            org.opencontainers.image.base.name=debian/stable-slim
+            org.opencontainers.image.base.name=greenbone/gvm-libs
           flavor: latest=false # no latest container tag for git tags
           tags: |
             # use version, major.minor and major  for tags


### PR DESCRIPTION
## What
Use gvm-libs:oldstable images as base for the build and production images

## Why
The oldstable tag of gvm-libs is used for compatibility of the debian package dependencies.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->
