### PR TITLE
Fix: Fix linking to gpgme

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,7 @@ pkg_check_modules (GNUTLS REQUIRED gnutls>=3.2.15)
 pkg_check_modules (GLIB REQUIRED glib-2.0>=2.42)
 pkg_check_modules (LIBBSD REQUIRED libbsd)
 pkg_check_modules (LIBICAL REQUIRED libical>=1.00)
+pkg_check_modules (GPGME REQUIRED gpgme)
 
 message (STATUS "Looking for PostgreSQL...")
 find_program (PG_CONFIG_EXECUTABLE pg_config DOC "pg_config")
@@ -70,19 +71,22 @@ else (NOT XSLTPROC_EXECUTABLE)
   message (STATUS "Looking for xsltproc... ${XSLTPROC_EXECUTABLE}")
 endif (NOT XSLTPROC_EXECUTABLE)
 
-message (STATUS "Looking for gpgme...")
-find_library (GPGME gpgme)
-if (NOT GPGME)
-  message (SEND_ERROR "The gpgme library is required.")
-else (NOT GPGME)
-  message (STATUS "Looking for gpgme... ${GPGME}")
-  execute_process (COMMAND gpgme-config --cflags
-    OUTPUT_VARIABLE GPGME_CFLAGS
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-  execute_process (COMMAND gpgme-config --libs
-    OUTPUT_VARIABLE GPGME_LDFLAGS
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-endif (NOT GPGME)
+if (NOT GPGME_FOUND)
+  # fallback for older gpgme versions without gpgme.pc file
+  message (STATUS "Looking for gpgme...")
+  find_library (GPGME gpgme)
+  if (NOT GPGME)
+    message (SEND_ERROR "The gpgme library is required.")
+  else (NOT GPGME)
+    message (STATUS "Looking for gpgme... ${GPGME}")
+    execute_process (COMMAND gpgme-config --cflags
+      OUTPUT_VARIABLE GPGME_CFLAGS
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process (COMMAND gpgme-config --libs
+      OUTPUT_VARIABLE GPGME_LDFLAGS
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+  endif (NOT GPGME)
+endif (NOT GPGME_FOUND)
 
 if (WITH_LIBTHEIA)
   find_package(Theia 1.0.0 REQUIRED)


### PR DESCRIPTION
## What

Fix linking to gpgme

## Why

Use pkg-config to search for gpgme linker flags. The gpgme-config tool is deprecated and removed in a newer gpgme version. The gpgme package comes already with a gpgme.pc file for pkg-config on Debian bullseye.

