### PR TITLE
Fix running `gvmd --migrate`

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -570,7 +570,7 @@ lock_internal (lockfile_t *lockfile, const gchar *lockfile_name,
   if (name_is_full_path)
     full_name = g_strdup (lockfile_name);
   else
-    full_name = g_build_filename (GVMD_RUN_DIR, lockfile_name, NULL);
+    full_name = g_build_filename (GVMD_STATE_DIR, lockfile_name, NULL);
 
   old_umask = umask (0);
   fd = open (full_name, O_RDWR | O_CREAT,


### PR DESCRIPTION


## What

Fix running `gvmd --migrate`

## Why

Create lock function based files in the GVM_STATE_DIR and not in the GVM_RUN_DIR. The GVM_RUN_DIR is only available when `gvmd` is actually running. This is not the case when a database migration is needed. In that case GVM_RUN_DIR does not exist and the `gvm-create-functions` lock file can't be created. But that lock file is required to run `gvmd --migrate` and without the migration `gvmd` wont start as a service.