### PR TITLE
Change: Use (old)stable for release Docker images

### DIFF
--- a/.docker/build.Dockerfile
+++ b/.docker/build.Dockerfile
@@ -1,8 +1,8 @@
 # Define ARG we use through the build
-ARG VERSION=oldstable
+ARG GVM_LIBS_VERSION=oldstable
 
 # We want gvm-libs to be ready so we use the build docker image of gvm-libs
-FROM greenbone/gvm-libs:$VERSION
+FROM greenbone/gvm-libs:$GVM_LIBS_VERSION
 
 # This will make apt-get install without question
 ARG DEBIAN_FRONTEND=noninteractive

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -53,6 +53,14 @@ jobs:
             # when a new git tag is created set stable and a latest tags
             type=raw,value=latest,enable=${{ steps.latest.outputs.is-latest-tag == 'true' }}
             type=raw,value=stable,enable=${{ steps.latest.outputs.is-latest-tag == 'true' }}
+      - name: Set container build options
+        id: container-opts
+        run: |
+          if [[ "${{ github.ref_type }}" = 'tag' ]]; then
+            echo "gvm-libs-version=oldstable" >> $GITHUB_OUTPUT
+          else
+            echo "gvm-libs-version=oldstable-edge" >> $GITHUB_OUTPUT
+          fi
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
@@ -69,6 +77,8 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
+          build-args: |
+            GVM_LIBS_VERSION=${{ steps.container-opts.outputs.gvm-libs-version }}
           file: .docker/build.Dockerfile
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -43,6 +43,16 @@ jobs:
             # when a new git tag is created set stable and a latest tags
             type=raw,value=latest,enable=${{ steps.latest.outputs.is-latest-tag == 'true' }}
             type=raw,value=stable,enable=${{ steps.latest.outputs.is-latest-tag == 'true' }}
+      - name: Set container build options
+        id: container-opts
+        run: |
+          if [[ "${{ github.ref_type }}" = 'tag' ]]; then
+            echo "version=stable" >> $GITHUB_OUTPUT
+            echo "gvm-libs-version=oldstable" >> $GITHUB_OUTPUT
+          else
+            echo "version=edge" >> $GITHUB_OUTPUT
+            echo "gvm-libs-version=oldstable-edge" >> $GITHUB_OUTPUT
+          fi
       - name: Login to Docker Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
@@ -58,6 +68,9 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' && (github.ref_type == 'tag' || github.ref_name == 'main') }}
+          build-args: |
+            VERSION=${{ steps.container-opts.outputs.version }}
+            GVM_LIBS_VERSION=${{ steps.container-opts.outputs.gvm-libs-version }}
           file: .docker/prod.Dockerfile
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## What
When building Docker images for release tags, use the oldstable gvm-libs image and stable build image.
Otherwise use the oldstable-edge gvm-libs and edge build image.

## Why

<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->
