### PR TITLE
Ensure everything gets written after client EOF is read

### DIFF
--- a/src/gmpd.c
+++ b/src/gmpd.c
@@ -378,9 +378,6 @@ gmpd_send_to_client (const char* msg, void* write_to_client_data)
       switch (write_to_client (write_to_client_data))
         {
           case  0:      /* Wrote everything in to_client. */
-            // FIX
-            //if (close_connection)
-            //  goto client_free;
             break;
           case -1:      /* Error. */
             g_debug ("   %s full (%i < %zu); client write failed",

--- a/src/gmpd.c
+++ b/src/gmpd.c
@@ -78,6 +78,11 @@ buffer_size_t from_client_start = 0;
 buffer_size_t from_client_end = 0;
 
 /**
+ * @brief Flag for serve_gmp and gmpd_send_to_client.
+ */
+static int close_connection = 0;
+
+/**
  * @brief Initialise the GMP library for the GMP daemon.
  *
  * @param[in]  log_config      Log configuration
@@ -373,6 +378,9 @@ gmpd_send_to_client (const char* msg, void* write_to_client_data)
       switch (write_to_client (write_to_client_data))
         {
           case  0:      /* Wrote everything in to_client. */
+            // FIX
+            //if (close_connection)
+            //  goto client_free;
             break;
           case -1:      /* Error. */
             g_debug ("   %s full (%i < %zu); client write failed",
@@ -455,9 +463,12 @@ int
 serve_gmp (gvm_connection_t *client_connection, const db_conn_info_t *database,
            gchar **disable)
 {
-  int nfds, rc = 0;
+  int nfds, rc;
 
   g_debug ("   Serving GMP");
+
+  rc = 0;
+  close_connection = 0;
 
   /* Initialise the XML parser and the manage library. */
   init_gmp_process (database,
@@ -542,7 +553,8 @@ serve_gmp (gvm_connection_t *client_connection, const db_conn_info_t *database,
         }
 
       /* Read any data from the client. */
-      if (client_connection->socket > 0
+      if (close_connection == 0
+          && client_connection->socket > 0
           && FD_ISSET (client_connection->socket, &readfds))
         {
           buffer_size_t initial_start = from_client_end;
@@ -561,11 +573,9 @@ serve_gmp (gvm_connection_t *client_connection, const db_conn_info_t *database,
                 g_debug ("   EOF reading from client");
                 if (client_connection->socket > 0
                     && FD_ISSET (client_connection->socket, &writefds))
-                  /* Write rest of to_client to client, so that the client gets
-                   * any buffered output and the response to the error. */
-                  write_to_client (client_connection);
-                rc = 0;
-                goto client_free;
+                  /* Stop reading, but process rest of input and output. */
+                  close_connection = 1;
+                break;
               default:       /* Programming error. */
                 assert (0);
             }
@@ -613,6 +623,8 @@ serve_gmp (gvm_connection_t *client_connection, const db_conn_info_t *database,
           switch (write_to_client (client_connection))
             {
               case  0:      /* Wrote everything in to_client. */
+                if (close_connection)
+                  goto client_free;
                 break;
               case -1:      /* Error. */
                 rc = -1;


### PR DESCRIPTION
## What

When EOF is read from a GMP client, stay in the select loop until everything has been written to the client.

## Why

The gvmd process may need to run through the select loop multiple times if the client has a read buffer that is smaller than the response.

To reproduce, run something like:
`echo "<authenticate><credentials><username>$1</username><password>$2</password></credentials></authenticate><help format=\"XML\"/>" | socat -t5000 GOPEN:$SOCKET -`
Before the patch only a partial response would be received.
