### PR TITLE
Install top-level rnc.xsl for RNC and HTML formats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,6 +305,10 @@ install (FILES ${CMAKE_SOURCE_DIR}/src/pwpolicy.conf
 # Schema formats.
 
 install (FILES src/schema_formats/rnc.xsl
+         DESTINATION ${GVMD_DATA_DIR}/global_schema_formats/
+         PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
+
+install (FILES src/schema_formats/rnc.xsl
                src/schema_formats/HTML/HTML.xsl
          DESTINATION ${GVMD_DATA_DIR}/global_schema_formats/02052818-dab6-11df-9be4-002264764cea/
          PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)


### PR DESCRIPTION
## What

Install rnc.xsl into GVMD_DATA_DIR/global_schema_formats/.

## Why

The XSL in the RNC and HTML schema formats refers to ../rnc.xsl, so that file needs to exist.

To reproduce, run something like
`o m m '<help format="HTML"/>'`
Before the patch the response was `<help_response status="500" status_text="Internal error" />`

Note that `make doc-gmp` also uses the RNC and HTML XSL.  This already was working because `make doc-gmp` runs the XSL commands in the source directories, so ../rnc.xsl exists.

## References

Looks like the problem was introduced in greenbone/gvmd/pull/1556.


