### PR TITLE
Change: Clarify use of port / location in GMP doc

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -835,7 +835,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </ele>
     <ele>
       <name>port</name>
-      <summary>Port to which note applies</summary>
+      <summary>Port (location) to which note applies</summary>
       <pattern>
         text
       </pattern>
@@ -1192,7 +1192,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </ele>
     <ele>
       <name>port</name>
-      <summary>Port to which override applies</summary>
+      <summary>Port (location) to which override applies</summary>
       <pattern>
         text
       </pattern>
@@ -1507,7 +1507,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </ele>
     <ele>
       <name>port</name>
-      <summary>The port on the host</summary>
+      <summary>The port (location) on the host</summary>
       <pattern>text</pattern>
     </ele>
     <ele>
@@ -2852,7 +2852,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </ele>
           <ele>
             <name>port</name>
-            <summary>The port of the error message</summary>
+            <summary>The port (location) of the error message</summary>
             <pattern><t>port</t></pattern>
           </ele>
           <ele>
@@ -4024,7 +4024,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </ele>
     <ele>
       <name>port</name>
-      <summary>Port to which note applies</summary>
+      <summary>Port (location) to which note applies</summary>
       <pattern>
         text
       </pattern>
@@ -4180,7 +4180,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </ele>
     <ele>
       <name>port</name>
-      <summary>Port to which override applies</summary>
+      <summary>Port (location) to which override applies</summary>
       <pattern>
         text
       </pattern>
@@ -12398,7 +12398,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <column>
             <name>port</name>
             <type>text</type>
-            <summary>Port the Note applies to</summary>
+            <summary>Port (location) the Note applies to</summary>
           </column>
           <column>
             <name>active</name>
@@ -13451,7 +13451,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <column>
             <name>port</name>
             <type>text</type>
-            <summary>Port the Override applies to</summary>
+            <summary>Port (location) the Override applies to</summary>
           </column>
           <column>
             <name>threat</name>
@@ -23971,7 +23971,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </ele>
     <ele>
       <name>port</name>
-      <summary>Port to which note applies</summary>
+      <summary>Port (location) to which note applies</summary>
       <pattern>
         text
       </pattern>
@@ -24111,7 +24111,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </ele>
     <ele>
       <name>port</name>
-      <summary>Port to which override applies</summary>
+      <summary>Port (location) to which override applies</summary>
       <pattern>
         text
       </pattern>


### PR DESCRIPTION
## What
The GMP doc is amended to make it clearer where "port" is used synonymously with "location" as used in GSA.

## Why
The use of the two words was causing some confusion for users.

## References
GEA-221
DOC-482


