### PR TITLE
Fix pattern match for migrating preferences

### DIFF
--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -3069,25 +3069,29 @@ migrate_253_to_254_alter (int trash)
   sql ("ALTER TABLE config_preferences%s ADD COLUMN pref_nvt text;",
        trash ? "_trash" : "");
   sql ("UPDATE config_preferences%s"
-       " SET pref_nvt = substring (name, '^([^:]*)');",
+       " SET pref_nvt = substring (name, '^([^:]*)')"
+       " WHERE name LIKE '%%:%%';",
        trash ? "_trash" : "");
 
   sql ("ALTER TABLE config_preferences%s ADD COLUMN pref_id integer;",
        trash ? "_trash" : "");
   sql ("UPDATE config_preferences%s"
-       " SET pref_id = CAST (substring (name, '^[^:]*:([^:]*)') AS integer);",
+       " SET pref_id = CAST (substring (name, '^[^:]*:([^:]*)') AS integer)"
+       " WHERE name LIKE '%%:%%';",
        trash ? "_trash" : "");
 
   sql ("ALTER table config_preferences%s ADD COLUMN pref_type text;",
        trash ? "_trash" : "");
   sql ("UPDATE config_preferences%s"
-       " SET pref_type = substring (name, '^[^:]*:[^:]*:([^:]*):');",
+       " SET pref_type = substring (name, '^[^:]*:[^:]*:([^:]*):')"
+       " WHERE name LIKE '%%:%%';",
        trash ? "_trash" : "");
 
   sql ("ALTER table config_preferences%s ADD COLUMN pref_name text;",
        trash ? "_trash" : "");
   sql ("UPDATE config_preferences%s"
-       " SET pref_name = substring (name, '^[^:]*:[^:]*:[^:]*:(.*)');",
+       " SET pref_name = substring (name, '^[^:]*:[^:]*:[^:]*:(.*)')"
+       " WHERE name LIKE '%%:%%';",
        trash ? "_trash" : "");
 }
 
@@ -3146,22 +3150,22 @@ migrate_254_to_255 ()
   sql ("ALTER TABLE nvt_preferences ADD COLUMN pref_nvt text;");
   sql ("UPDATE nvt_preferences"
        " SET pref_nvt = substring (name, '^([^:]*)')"
-       " WHERE name LIKE '%:%';");
+       " WHERE name LIKE '%%:%%';");
 
   sql ("ALTER TABLE nvt_preferences ADD COLUMN pref_id integer;");
   sql ("UPDATE nvt_preferences"
        " SET pref_id = CAST (substring (name, '^[^:]*:([^:]*)') AS integer)"
-       " WHERE name LIKE '%:%';");
+       " WHERE name LIKE '%%:%%';");
 
   sql ("ALTER table nvt_preferences ADD COLUMN pref_type text;");
   sql ("UPDATE nvt_preferences"
        " SET pref_type = substring (name, '^[^:]*:[^:]*:([^:]*):')"
-       " WHERE name LIKE '%:%';");
+       " WHERE name LIKE '%%:%%';");
 
   sql ("ALTER table nvt_preferences ADD COLUMN pref_name text;");
   sql ("UPDATE nvt_preferences"
        " SET pref_name = substring (name, '^[^:]*:[^:]*:[^:]*:(.*)')"
-       " WHERE name LIKE '%:%';");
+       " WHERE name LIKE '%%:%%';");
 
   /* Set the database version to 255. */
 


### PR DESCRIPTION
## What
Migrating the config preferences now only tries to process ones containing a colon.
Also, the format string for the NVT preferences migration is adusted to ensure percent signs are correct.

## Why
This addresses problems when migrating the database.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


