### PR TITLE
New options to set a new credential encryption key + Fixes for --encrypt-all-credentials

### DIFF
--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -22,6 +22,9 @@ Check SecInfo alerts.
 \fB--client-watch-interval=\fINUMBER\fB\f1
 Check if client connection was closed every NUMBER seconds. 0 to disable. Defaults to 1 second.
 .TP
+\fB--create-encryption-key\f1
+Create a new credential encryption key, set it as the new default and exit. With no other options given, a 4096 bit RSA key is created. 
+.TP
 \fB--create-scanner=\fISCANNER\fB\f1
 Create global scanner SCANNER and exit.
 .TP
@@ -57,6 +60,12 @@ Do not restrict passwords to the policy.
 .TP
 \fB--disable-scheduling\f1
 Disable task scheduling.
+.TP
+\fB--encryption-key-length=\fILENGTH\fB\f1
+Set key length to LENGTH bits when creating a new RSA credential encryption key. Defaults to 4096. 
+.TP
+\fB--encryption-key-type=\fITYPE\fB\f1
+Use the key type TYPE when creating a new credential encryption key. Currently only RSA is supported. 
 .TP
 \fB--encrypt-all-credentials\f1
 (Re-)Encrypt all credentials.

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -75,6 +75,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </optdesc>
     </option>
     <option>
+      <p><opt>--create-encryption-key</opt></p>
+      <optdesc>
+        <p>
+          Create a new credential encryption key, set it as the new default
+           and exit.
+          With no other options given, a 4096 bit RSA key is created.
+        </p>
+      </optdesc>
+    </option>
+    <option>
       <p><opt>--create-scanner=<arg>SCANNER</arg></opt></p>
       <optdesc>
         <p>Create global scanner SCANNER and exit.</p>
@@ -144,6 +154,24 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <p><opt>--disable-scheduling</opt></p>
       <optdesc>
         <p>Disable task scheduling.</p>
+      </optdesc>
+    </option>
+    <option>
+      <p><opt>--encryption-key-length=<arg>LENGTH</arg></opt></p>
+      <optdesc>
+        <p>
+          Set key length to LENGTH bits when creating a new RSA
+          credential encryption key. Defaults to 4096.
+        </p>
+      </optdesc>
+    </option>
+    <option>
+      <p><opt>--encryption-key-type=<arg>TYPE</arg></opt></p>
+      <optdesc>
+        <p>
+          Use the key type TYPE when creating a new credential
+          encryption key. Currently only RSA is supported.
+        </p>
       </optdesc>
     </option>
     <option>

--- a/doc/gvmd.html
+++ b/doc/gvmd.html
@@ -57,6 +57,14 @@
       
     
     
+      <p><b>--create-encryption-key</b></p>
+      
+        <p>Create a new credential encryption key, set it as the new default
+           and exit. With no other options given, a 4096 bit RSA key is
+           created.</p>
+      
+    
+    
       <p><b>--create-scanner=<em>SCANNER</em></b></p>
       
         <p>Create global scanner SCANNER and exit.</p>
@@ -114,6 +122,20 @@
       <p><b>--disable-scheduling</b></p>
       
         <p>Disable task scheduling.</p>
+      
+    
+    
+      <p><b>--encryption-key-length=<em>LENGTH</em></b></p>
+      
+        <p>Set key length to LENGTH bits when creating a new RSA credential
+        encryption key. Defaults to 4096.</p>
+      
+    
+    
+      <p><b>--encryption-key-type=<em>TYPE</em></b></p>
+      
+        <p>Use the key type TYPE when creating a new credential encryption key.
+           Currently only RSA is supported.</p>
       
     
     

--- a/src/lsc_crypt.c
+++ b/src/lsc_crypt.c
@@ -42,15 +42,6 @@
 #define G_LOG_DOMAIN "md  crypt"
 
 /**
- * @brief The name of the encryption key.
- *
- * Note that the code will use the "=" prefix flag to indicate an
- * exact search.  Thus when creating the key it should not have a
- * comment or email address part.
- */
-#define ENCRYPTION_KEY_UID "GVM Credential Encryption"
-
-/**
  * @brief The maximum size of an encrypted value
  *
  * To avoid excessive memory allocations we put a limit on the size of
@@ -94,7 +85,14 @@ struct lsc_crypt_ctx_s
   char *plaintext;             ///< Text to be encrypted.
   size_t plaintextlen;         ///< Length of text.
   struct namelist_s *namelist; ///< Info describing PLAINTEXT.
+  gchar *enckey_uid;           ///< Encryption key UID to use.
 };
+
+
+/* Key generation parameters  */
+gchar *enckey_type = NULL;
+
+int enckey_length = 0;
 
 
 /* Simple helper functions  */
@@ -166,6 +164,31 @@ get32 (const void *buffer)
 
 /* Local functions. */
 
+static gchar*
+generate_parms_string (const char *enckey_uid)
+{
+  gchar *parms_string = NULL;
+
+  if (enckey_type == NULL || strcasecmp (enckey_type, "RSA") == 0)
+    {
+      parms_string = g_strdup_printf (
+          "<GnupgKeyParms format=\"internal\">\n"
+          "Key-Type: RSA\n"
+          "Key-Length: %d\n"
+          "Key-Usage: encrypt\n"
+          "Name-Real: %s\n"
+          "Expire-Date: 0\n"
+          "%%no-protection\n"
+          "%%no-ask-passphrase\n"
+          "</GnupgKeyParms>\n",
+          (enckey_length > 0) ? enckey_length 
+                              : DEFAULT_ENCRYPTION_RSA_KEY_LENGTH,
+          enckey_uid
+        );
+    }
+  return parms_string;
+}
+
 
 /**
  * @brief Create the credential encryption key
@@ -179,16 +202,14 @@ get32 (const void *buffer)
 static int
 create_the_key (lsc_crypt_ctx_t ctx)
 {
-  const char parms[] =
-    "<GnupgKeyParms format=\"internal\">\n"
-    "Key-Type: RSA\n"
-    "Key-Length: 2048\n"
-    "Key-Usage: encrypt\n"
-    "Name-Real: " ENCRYPTION_KEY_UID "\n"
-    "Expire-Date: 0\n"
-    "%no-protection\n"
-    "%no-ask-passphrase\n"
-    "</GnupgKeyParms>\n";
+  if (ctx->enckey_uid == NULL || strcmp (ctx->enckey_uid, "") == 0)
+    {
+      log_gpgme (G_LOG_LEVEL_WARNING, 0,
+                 "encryption context has no key UID set");
+      return -1;
+    }
+
+  gchar *parms = generate_parms_string (ctx->enckey_uid);
   gpg_error_t err;
 
   log_gpgme (G_LOG_LEVEL_INFO, 0, "starting key generation ...");
@@ -196,11 +217,11 @@ create_the_key (lsc_crypt_ctx_t ctx)
   if (err)
     {
       log_gpgme(G_LOG_LEVEL_WARNING, err, "error creating OpenPGP key '%s'",
-                ENCRYPTION_KEY_UID);
+                ctx->enckey_uid);
       return -1;
     }
   log_gpgme (G_LOG_LEVEL_INFO, 0,
-             "OpenPGP key '%s' has been generated", ENCRYPTION_KEY_UID);
+             "OpenPGP key '%s' has been generated", ctx->enckey_uid);
   return 0;
 }
 
@@ -222,16 +243,25 @@ find_the_key (lsc_crypt_ctx_t ctx, gboolean no_create)
   gpg_error_t err;
   int nfound, any_skipped;
   gpgme_key_t found, key;
+  gchar *enckey_filter;
 
+  if (ctx->enckey_uid == NULL || strcmp (ctx->enckey_uid, "") == 0)
+    {
+      log_gpgme (G_LOG_LEVEL_WARNING, 0,
+                 "encryption context has no key UID set");
+      return NULL;
+    }
  again:
   /* Search for the public key.  Note that the "=" prefix flag enables
      an exact search.  */
-  err = gpgme_op_keylist_start (ctx->encctx, "="ENCRYPTION_KEY_UID, 0);
+  enckey_filter = g_strdup_printf("=%s", ctx->enckey_uid);
+  err = gpgme_op_keylist_start (ctx->encctx, enckey_filter, 0);
+  g_free (enckey_filter);
   if (err)
     {
       log_gpgme (G_LOG_LEVEL_WARNING, err,
                  "error starting search for OpenPGP key '%s'",
-                 ENCRYPTION_KEY_UID);
+                 ctx->enckey_uid);
       return NULL;
     }
 
@@ -276,13 +306,17 @@ find_the_key (lsc_crypt_ctx_t ctx, gboolean no_create)
     }
   else if (!found)
     {
-      static int genkey_tried;
+      static GHashTable *genkey_tried_uids = NULL;
+      if (genkey_tried_uids == NULL)
+        genkey_tried_uids = g_hash_table_new (g_str_hash, g_str_equal);
 
       /* Try to create the key if we have not seen any matching key at
          all and if this is the first time in this process' lifetime.  */
-      if (!any_skipped && !genkey_tried && !no_create)
+      if (!any_skipped
+          && !no_create
+          && !g_hash_table_contains (genkey_tried_uids, ctx->enckey_uid))
         {
-          genkey_tried = 1;
+          g_hash_table_add (genkey_tried_uids, g_strdup (ctx->enckey_uid));
           if (!create_the_key (ctx))
             goto again; /* Created - search again.  */
         }
@@ -296,7 +330,7 @@ find_the_key (lsc_crypt_ctx_t ctx, gboolean no_create)
     {
       log_gpgme (G_LOG_LEVEL_MESSAGE, err,
                  "error searching for OpenPGP key '%s'",
-                 ENCRYPTION_KEY_UID);
+                 ctx->enckey_uid);
       gpgme_key_unref (found);
       found = NULL;
     }
@@ -476,19 +510,35 @@ do_decrypt (lsc_crypt_ctx_t ctx, const char *cipherstring,
 /* API */
 
 /**
+ * @brief Sets the parameters for creating a new encryption key
+ *
+ * @param[in]  type   Type of the 
+ * @param[in]  length 
+ */
+int
+lsc_crypt_enckey_parms_init (const char *type, int length)
+{
+  g_free (enckey_type);
+  enckey_type = type ? g_strdup (type) : NULL;
+  enckey_length = length;
+  return 0;
+}
+
+/**
  * @brief Return a new context for LSC encryption
  *
  * @return A new context object to be released with \ref
  *         lsc_crypt_release.
  */
 lsc_crypt_ctx_t
-lsc_crypt_new ()
+lsc_crypt_new (const char *enckey_uid)
 {
   char * path = g_build_filename (GVMD_STATE_DIR, "gnupg", NULL);
   lsc_crypt_ctx_t ctx;
 
   ctx = g_malloc0 (sizeof *ctx);
   ctx->encctx = gvm_init_gpgme_ctx_from_dir (path);
+  ctx->enckey_uid = enckey_uid ? g_strdup (enckey_uid) : NULL;
   g_free (path);
   if (!ctx->encctx)
     {
@@ -542,6 +592,38 @@ lsc_crypt_flush (lsc_crypt_ctx_t ctx)
   g_free (ctx->plaintext);
   ctx->plaintext = NULL;
 }
+
+/**
+ * @brief Checks if the encryption key defined by the context already exists
+ *
+ * @param[in] ctx        The context
+ * 
+ * @return Whether the key exists
+ */
+gboolean
+lsc_crypt_enckey_exists (lsc_crypt_ctx_t ctx)
+{
+  gpgme_key_t key = find_the_key (ctx, TRUE);
+  return key != NULL;
+}
+
+/**
+ * @brief Creates the key for the given context if it does not already exists
+ *
+ * @param[in] ctx        The context
+ *
+ * @return 0 on success, 1 key already exits, -1 on other error.
+ */
+int
+lsc_crypt_create_enckey (lsc_crypt_ctx_t ctx)
+{
+  if (lsc_crypt_enckey_exists (ctx))
+    return 1;
+  if (create_the_key (ctx))
+    return -1;
+  return 0;
+}
+
 
 
 /**

--- a/src/lsc_crypt.h
+++ b/src/lsc_crypt.h
@@ -70,6 +70,8 @@ gboolean lsc_crypt_enckey_exists (lsc_crypt_ctx_t);
 
 int lsc_crypt_create_enckey (lsc_crypt_ctx_t ctx);
 
+char *lsc_crypt_encrypt_hashtable (lsc_crypt_ctx_t, GHashTable*);
+
 char *lsc_crypt_encrypt (lsc_crypt_ctx_t,
                          const char *, ...) G_GNUC_NULL_TERMINATED;
 

--- a/src/lsc_crypt.h
+++ b/src/lsc_crypt.h
@@ -26,6 +26,30 @@
 
 #include <glib.h>
 
+/// @brief Default length for RSA encryption keys
+#define DEFAULT_ENCRYPTION_RSA_KEY_LENGTH 4096
+
+/**
+ * @brief The name of the old encryption key.
+ *
+ * Note that the code will use the "=" prefix flag to indicate an
+ * exact search.  Thus when creating the key it should not have a
+ * comment or email address part.
+ */
+#define OLD_ENCRYPTION_KEY_UID "GVM Credential Encryption"
+
+/**
+ * @brief Template for the name of the encryption key.
+ *
+ * It must contain a single %s that will be replaced with the current 
+ * date and time.
+ *
+ * Note that the code will use the "=" prefix flag to indicate an
+ * exact search.  Thus when creating the key it should not have a
+ * comment or email address part.
+ */
+#define ENCRYPTION_KEY_UID_TEMPLATE "GVM Credential Encryption - %s"
+
 /* (Defined in gvmd.c) */
 extern int disable_encrypted_credentials;
 
@@ -33,12 +57,18 @@ extern int disable_encrypted_credentials;
 struct lsc_crypt_ctx_s;
 typedef struct lsc_crypt_ctx_s *lsc_crypt_ctx_t;
 
-lsc_crypt_ctx_t lsc_crypt_new ();
+int lsc_crypt_enckey_parms_init (const char *, int);
+
+lsc_crypt_ctx_t lsc_crypt_new (const char*);
 void lsc_crypt_release (lsc_crypt_ctx_t);
 
 int lsc_crypt_create_key ();
 
 void lsc_crypt_flush (lsc_crypt_ctx_t);
+
+gboolean lsc_crypt_enckey_exists (lsc_crypt_ctx_t);
+
+int lsc_crypt_create_enckey (lsc_crypt_ctx_t ctx);
 
 char *lsc_crypt_encrypt (lsc_crypt_ctx_t,
                          const char *, ...) G_GNUC_NULL_TERMINATED;

--- a/src/manage.h
+++ b/src/manage.h
@@ -3486,6 +3486,12 @@ manage_get_ldap_info (int *, gchar **, gchar **, int *, gchar **, int *);
 void
 manage_set_ldap_info (int, gchar *, gchar *, int, gchar *, int);
 
+char *
+get_radius_key (gboolean *);
+
+void
+set_radius_key (const char*, gboolean);
+
 void
 manage_get_radius_info (int *, char **, char **);
 

--- a/src/manage.h
+++ b/src/manage.h
@@ -201,6 +201,7 @@ authenticate (credentials_t*);
 
 void
 logout_user ();
+
 
 /* Database. */
 
@@ -233,6 +234,21 @@ manage_encrypt_all_credentials (GSList *, const db_conn_info_t *);
 
 int
 manage_decrypt_all_credentials (GSList *, const db_conn_info_t *);
+
+int
+manage_create_encryption_key (GSList *log_config,
+                              const db_conn_info_t *database);
+
+int
+manage_set_encryption_key (GSList *log_config,
+                           const db_conn_info_t *database,
+                           const char*);
+
+char *
+current_encryption_key_uid (gboolean);
+
+void
+set_current_encryption_key_uid (const char *new_uid);
 
 void
 manage_session_set_timezone (const char *);

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -2971,7 +2971,7 @@ migrate_250_to_251 ()
       char *secret;
       char *quoted;
       lsc_crypt_ctx_t crypt_ctx;
-      crypt_ctx = lsc_crypt_new ();
+      crypt_ctx = lsc_crypt_new (OLD_ENCRYPTION_KEY_UID);
 
       sql ("DELETE FROM meta WHERE name LIKE 'radius_key';");
       secret = lsc_crypt_encrypt (crypt_ctx, "secret_key", secret_key, NULL);


### PR DESCRIPTION
## What
This adds new command line options to create a new credential encryption
key, select an existing ones by UID and change parameters for new keys
(currently only the RSA key length).

The function for encrypting or decrypting all credentials now also
handles the fields "community" and "privacy_password".

The RADIUS key is now also covered by the options for enabling / disabling
credential encryption.

## Why
This makes it simpler to implement new recommendation regarding the
secure key length and adds interfaces for supporting other key types
like elliptic curve based ones.

## References
GEA-193


