### PR TITLE
Add: Mail transport agent to enable email notifications in docker

### DIFF
--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -18,4 +18,5 @@
 
 #!/bin/bash
 
+. setup-mta
 exec gosu gvmd "$@"

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -84,6 +84,8 @@ RUN apt-get update && \
     libgpgme11 \
     libical3 \
     libpq5 \
+    msmtp \
+    msmtp-mta \
     openssh-client \
     postgresql-client-13 \
     postgresql-client-common \
@@ -107,6 +109,7 @@ COPY --from=builder /install/ /
 
 COPY .docker/start-gvmd.sh /usr/local/bin/start-gvmd
 COPY .docker/entrypoint.sh /usr/local/bin/entrypoint
+COPY .docker/setup-mta.sh /usr/local/bin/setup-mta
 
 RUN addgroup --gid 1001 --system gvmd && \
     adduser --no-create-home --shell /bin/false --disabled-password --uid 1001 --system --group gvmd

--- a/.docker/setup-mta.sh
+++ b/.docker/setup-mta.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Make any changes only when MTA_HOST has been set
+if [ -n MTA_HOST ]; then
+    echo "setting up configuration file for mail agent"
+    CONFIG="/etc/msmtprc"
+    echo "host $MTA_HOST" > $CONFIG
+    [ -n MTA_PORT ] && echo "port $MTA_PORT" >> $CONFIG
+    [ -n MTA_TLS ] && echo "tls $MTA_TLS" >> $CONFIG
+    [ -n MTA_STARTTLS ] && echo "tls_starttls $MTA_STARTTLS" >> $CONFIG
+    [ -n MTA_AUTH ] && echo "auth $MTA_AUTH" >> $CONFIG
+    [ -n MTA_USER ] && echo "user $MTA_USER" >> $CONFIG
+    [ -n MTA_FROM ] && echo "from $MTA_FROM" >> $CONFIG
+    [ -n MTA_PASSWORD ] && echo "password $MTA_PASSWORD" >> $CONFIG
+    [ -n MTA_LOGFILE ] && echo "logfile $MTA_LOGFILE" >> $CONFIG
+    chown gvmd:mail $CONFIG
+    chmod 750 $CONFIG
+fi


### PR DESCRIPTION
This adds the `msmtp` and `msmtp-mta` packages to achieve ability of sending email notifications from docker container. Default `gvmd` image has no MTA but tries to send emails via local mailer (and always fails for sure).

With msmtp user can send emails to a single preferred SMTP server.

## What

This PR adds mstmp and msmtp-mta packages and configuration script into docker image to setup msmtp with environment variables. Tested with Google mail provider and local enterprise mail relay without authorization.

Container image will become bigger for about 260 kB (740 kB unpacked).

## Why

At the time containerized GVMD can not send alerts and notifications via email.

## References

As someone [said in the Greenbone Forum](https://forum.greenbone.net/t/alerts-not-working/13025) it is worth to add sending email ability into container.


