### PR TITLE
Added check of uploaded certificate for TippingPoint SMS alerts.

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -7047,7 +7047,16 @@ validate_tippingpoint_data (alert_method_t method, const gchar *name,
 
       if (strcmp (name, "tp_sms_tls_certificate") == 0)
         {
-          // TODO: Check certificate, return 52 on failure
+          // Check certificate, return 52 on failure
+          int ret;
+          gnutls_x509_crt_fmt_t crt_fmt;
+
+          ret = get_certificate_info (*data, strlen(*data), NULL, NULL, NULL,
+                                      NULL, NULL, NULL, NULL, &crt_fmt);
+          if (ret || crt_fmt != GNUTLS_X509_FMT_PEM)
+            {
+              return 52;
+            }
         }
 
       if (strcmp (name, "tp_sms_tls_workaround") == 0)


### PR DESCRIPTION
## What
Now the uploaded certificate for a TippingPoint SMS alert is checked, if it is a valid X509 certificate in PEM format. This check takes place before the alert data is saved.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
The missing check caused bugs.
<!-- Describe why are these changes necessary? -->

## References
GEA-254
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist
Tested manually on my local development system.
<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


