### PR TITLE
Fix: Do not skip first delta result with ignore_pagination

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -28266,7 +28266,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
   if (delta && get->details)
     {
       if (print_report_delta_xml (out, &results, &delta_results, delta_states,
-                                  ignore_pagination ? 1 : first_result,
+                                  ignore_pagination ? 0 : first_result,
                                   ignore_pagination ? -1 : max_results,
                                   task, notes,
                                   notes_details, overrides, overrides_details,


### PR DESCRIPTION
## What
When getting a delta report with the ignore_pagination option, the first result is no longer erroneously skipped.

## Why

<!-- Describe why are these changes necessary? -->

## References
GEA-247