### PR TITLE
Add: Add Note/Override excerpt size setting

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -8026,7 +8026,8 @@ buffer_notes_xml (GString *buffer, iterator_t *notes, int include_notes_details,
       if (include_notes_details == 0)
         {
           const char *text = note_iterator_text (notes);
-          gchar *excerpt = utf8_substring (text, 0, 60);
+          gchar *excerpt = utf8_substring (text, 0,
+                                           setting_excerpt_size_int ());
           /* This must match send_get_common. */
           buffer_xml_append_printf (buffer,
                                     "<owner><name>%s</name></owner>"
@@ -8288,7 +8289,8 @@ buffer_overrides_xml (GString *buffer, iterator_t *overrides,
       if (include_overrides_details == 0)
         {
           const char *text = override_iterator_text (overrides);
-          gchar *excerpt = utf8_substring (text, 0, 60);
+          gchar *excerpt = utf8_substring (text, 0,
+                                           setting_excerpt_size_int ());
           /* This must match send_get_common. */
           buffer_xml_append_printf (buffer,
                                     "<owner><name>%s</name></owner>"

--- a/src/manage.h
+++ b/src/manage.h
@@ -1167,6 +1167,13 @@ result_detection_reference (result_t, report_t, const char *, const char *,
  */
 #define MIN_QOD_DEFAULT 70
 
+/** 
+ * @brief Default size to limit note and override text to in reports.
+ */
+#define EXCERPT_SIZE_DEFAULT 300
+
+
+
 void
 reports_clear_count_cache_for_override (override_t, int);
 
@@ -3298,6 +3305,9 @@ setting_is_default_ca_cert (const gchar *);
 
 char *
 setting_filter (const char *);
+
+int
+setting_excerpt_size_int ();
 
 void
 init_setting_iterator (iterator_t *, const char *, const char *, int, int, int,

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -113,6 +113,11 @@
 #define SETTING_UUID_MAX_ROWS_PER_PAGE "76374a7a-0569-11e6-b6da-28d24461215b"
 
 /**
+ * @brief UUID of 'Note/Override Excerpt Size' setting.
+ */
+#define SETTING_UUID_EXCERPT_SIZE "9246a0f6-c6ad-44bc-86c2-557a527c8fb3"
+
+/**
  * @brief UUID of 'Default CA Cert' setting.
  */
 #define SETTING_UUID_DEFAULT_CA_CERT "9ac801ea-39f8-11e6-bbaa-28d24461215b"


### PR DESCRIPTION
## What
A new setting for the size limit of Note and Override text shown in results has been added and set to a default of 300.

## Why
This allows using more descriptive text for notes and overrides than with the old hardcoded limit of 60 characters.

## References
GEA-86
