### PR TITLE
Change: Use score -99 for missing severity in CVEs

### DIFF
--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -2529,7 +2529,7 @@ insert_cve_from_entry (element_t entry, element_t last_modified,
     }
 
   if (score == NULL)
-    severity_dbl = 0;
+    severity_dbl = SEVERITY_MISSING;
   else
     severity_dbl = atof (element_text (score));
 


### PR DESCRIPTION
## What
When a CVE entry in the nvdcve file has no cvss score, it is stored with the score SEVERITY_MISSING (-99.0) instead of 0.0.


## Why
This allows distinguishing them from CVEs that explicitly have a score of 0.0 assigned.

## References
GEA-224


