### PR TITLE
Change: Install old sync scripts, but deprecate them

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /source
 RUN mkdir /build && \
     mkdir /install && \
     cd /build && \
-    cmake -DCMAKE_BUILD_TYPE=Release /source && \
+    cmake -DINSTALL_OLD_SYNC_SCRIPT=OFF -DCMAKE_BUILD_TYPE=Release /source && \
     make DESTDIR=/install install
 
 FROM greenbone/gvm-libs:${GVM_LIBS_VERSION}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,12 @@ endif (NOT CMAKE_BUILD_TYPE)
 
 OPTION (ENABLE_COVERAGE "Enable support for coverage analysis" OFF)
 OPTION (DEBUG_FUNCTION_NAMES "Print function names on entry and exit" OFF)
+
 # the shell based scripts got replaced by https://github.com/greenbone/greenbone-feed-sync/
-OPTION (INSTALL_OLD_SYNC_SCRIPTS "Install shell based feed sync scripts" OFF)
+OPTION (INSTALL_OLD_SYNC_SCRIPTS "Install shell based feed sync scripts" ON)
+if (INSTALL_OLD_SYNC_SCRIPTS)
+  message (DEPRECATION "The version of greenbone-feed-sync included in gvmd is deprecated in favor of the newer Python version (https://github.com/greenbone/greenbone-feed-sync/) and will be removed in the next major version.")
+endif (INSTALL_OLD_SYNC_SCRIPTS)
 
 ## Retrieve git revision (at configure time)
 include (GetGit)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -265,7 +265,18 @@ The UUIDs of all created users can be found using
 ## Keeping the feeds up-to-date
 
 The `gvmd Data`, `SCAP` and `CERT` Feeds should be kept up-to-date by calling the
-`greenbone-feed-sync` script regularely (e.g. via a cron entry):
+`greenbone-feed-sync` script regularly (e.g. via a cron entry).
+
+There are currently two synchronization methods available: The older
+shell-based one included in the gvmd repository and a newer Python-based one
+that also handles the VT synchronization.
+
+### Legacy shell script
+
+The legacy feed sync script is deprecated but still installed by default for
+backward compatibility.
+
+This script has to be run for each type of data:
 
     greenbone-feed-sync --type GVMD_DATA
     greenbone-feed-sync --type SCAP
@@ -274,6 +285,21 @@ The `gvmd Data`, `SCAP` and `CERT` Feeds should be kept up-to-date by calling th
 Please note: The `CERT` feed sync depends on data provided by the `SCAP` feed
 and should be called after syncing the latter.
 You will need the `rsync` tool for a successful synchronization.
+
+If the installation of the shell script has been disabled, it can be enabled
+again with the CMake option `-DINSTALL_OLD_SYNC_SCRIPTS=ON`.
+
+### Python-based sync script
+
+The currently recommended way of synchronizing the gvmd data feeds is the
+Python tool "greenbone-feed-sync".
+
+It can be found at https://github.com/greenbone/greenbone-feed-sync together
+with instruction for its installation and usage.
+
+To avoid conflicts with the shell script included in the gvmd repository,
+gvmd should be built with the CMake option `-DINSTALL_OLD_SYNC_SCRIPTS=OFF`
+if the Python tool is to be used.
 
 
 ## Configure the default OSPD scanner socket path


### PR DESCRIPTION
## What
The old sync scripts are installed by default for backward compatibility but also marked as deprecated.

The installation instructions are updated to mention the new sync tool and CMake option to disable to old scripts.

## Why
This makes the behavior and documentation of gvmd more consistent with that in openvas-scanner.

## References
GEA-169
Corresponding change in openvas-scanner: greenbone/openvas-scanner/pull/1393
