### PR TITLE
Change: Deprecate old sync script, update INSTALL.md

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ OPTION (ENABLE_COVERAGE "Enable support for coverage analysis" OFF)
 OPTION (DEBUG_FUNCTION_NAMES "Print function names on entry and exit" OFF)
 # the shell based scripts got replaced by https://github.com/greenbone/greenbone-feed-sync/
 OPTION (INSTALL_OLD_SYNC_SCRIPTS "Install shell based feed sync scripts" OFF)
+if (INSTALL_OLD_SYNC_SCRIPTS)
+  message (DEPRECATION "The version of greenbone-feed-sync included in gvmd is deprecated in favor of the newer Python version (https://github.com/greenbone/greenbone-feed-sync/) and will be removed in the next major version.")
+endif (INSTALL_OLD_SYNC_SCRIPTS)
 
 ## Retrieve git revision (at configure time)
 include (GetGit)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -265,7 +265,31 @@ The UUIDs of all created users can be found using
 ## Keeping the feeds up-to-date
 
 The `gvmd Data`, `SCAP` and `CERT` Feeds should be kept up-to-date by calling the
-`greenbone-feed-sync` script regularely (e.g. via a cron entry):
+`greenbone-feed-sync` script regularly (e.g. via a cron entry).
+
+There are currently two synchronization methods available: The older
+shell-based one included in the gvmd repository and a newer Python-based one
+that also handles the VT synchronization.
+
+### Python-based sync tool
+
+The currently recommended way of synchronizing the gvmd data feeds is the
+Python tool "greenbone-feed-sync", which can be found at
+https://github.com/greenbone/greenbone-feed-sync together with instruction
+for its installation and usage.
+
+When upgrading to the new synchronization tool, the old script should be
+removed to avoid conflicts as both are named "greenbone-feed-sync".
+
+### Legacy shell script
+
+The legacy feed sync script is deprecated and will be removed in the next major
+release of gvmd.
+
+Therefore, installation of it is now disabled by default but can be enabled for
+backward compatibility with the CMake option `-DINSTALL_OLD_SYNC_SCRIPTS=ON`.
+
+The legacy script has to be run for each type of data:
 
     greenbone-feed-sync --type GVMD_DATA
     greenbone-feed-sync --type SCAP
@@ -274,7 +298,6 @@ The `gvmd Data`, `SCAP` and `CERT` Feeds should be kept up-to-date by calling th
 Please note: The `CERT` feed sync depends on data provided by the `SCAP` feed
 and should be called after syncing the latter.
 You will need the `rsync` tool for a successful synchronization.
-
 
 ## Configure the default OSPD scanner socket path
 


### PR DESCRIPTION
## What
The old sync scripts can still be installed for backward compatibility but are now marked as deprecated.

The installation instructions are updated to mention the new sync tool and CMake option to re-enable to old scripts.

## Why
To make the status of the old feed sync more clear and give directions to the new method.

## References
GEA-169
Corresponding change in openvas-scanner: greenbone/openvas-scanner/pull/1393



