### PR TITLE
Fix: Handle missing report getting task severity

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -18861,13 +18861,12 @@ task_severity_double (task_t task, int overrides, int min_qod, int offset)
       || task_target (task) == 0 /* Container task. */)
     return SEVERITY_MISSING;
 
-  sql_int64 (&report,
-             "SELECT id FROM reports"
-             "           WHERE reports.task = %llu"
-             "           AND reports.scan_run_status = %u"
-             "           ORDER BY reports.creation_time DESC"
-             "           LIMIT 1 OFFSET %d",
-             task, TASK_STATUS_DONE, offset);
+  report = sql_int64_0 ("SELECT id FROM reports"
+                        "           WHERE reports.task = %llu"
+                        "           AND reports.scan_run_status = %u"
+                        "           ORDER BY reports.creation_time DESC"
+                        "           LIMIT 1 OFFSET %d",
+                        task, TASK_STATUS_DONE, offset);
 
   return report_severity (report, overrides, min_qod);
 }
@@ -24693,6 +24692,9 @@ report_severity (report_t report, int overrides, int min_qod)
 {
   double severity;
   iterator_t iterator;
+
+  if (report == 0)
+    return SEVERITY_MISSING;
 
   init_iterator (&iterator,
                  "SELECT max(severity)"


### PR DESCRIPTION
## What
The task_severity_double function now no longer tries to get the severity from an undefined report if no report matches the criteria. Instead it passes the report row id 0 to report_severity, which will always return SEVERITY_MISSING in this case.

## Why
This fixes the check for the "Severity changed" alert condition not working correctly if the task has no second report for comparison.

## References
GEA-246


