### PR TITLE
Add: Add option to set port for SCP alert method

### DIFF
--- a/src/alert_methods/SCP/alert
+++ b/src/alert_methods/SCP/alert
@@ -20,11 +20,12 @@
 
 USERNAME=$1
 HOST=$2
-DEST=$3
-KNOWN_HOSTS=$4
-PRIVATE_KEY_FILE=$5
-PASSWORD_FILE=$6
-REPORT_FILE=$7
+PORT=$3
+DEST=$4
+KNOWN_HOSTS=$5
+PRIVATE_KEY_FILE=$6
+PASSWORD_FILE=$7
+REPORT_FILE=$8
 
 KNOWN_HOSTS_FILE=`mktemp` || exit 1
 echo $KNOWN_HOSTS > $KNOWN_HOSTS_FILE
@@ -55,9 +56,9 @@ DEST_ESC=`shell_esc "$DEST"`
 
 if [ -z "$PRIVATE_KEY_FILE" ]
 then
-  timeout $TIMEOUT sshpass -f ${PASSWORD_FILE} scp -o HashKnownHosts=no -o UserKnownHostsFile="${KNOWN_HOSTS_FILE} ~/.ssh/known_hosts ~/.ssh/known_hosts2 /etc/ssh/ssh_known_hosts" "${REPORT_FILE}" "${USERNAME}@${HOST}:${DEST_ESC}" 2>$ERROR_FILE
+  timeout $TIMEOUT sshpass -f ${PASSWORD_FILE} scp -P "$PORT" -o HashKnownHosts=no -o UserKnownHostsFile="${KNOWN_HOSTS_FILE} ~/.ssh/known_hosts ~/.ssh/known_hosts2 /etc/ssh/ssh_known_hosts" "${REPORT_FILE}" "${USERNAME}@${HOST}:${DEST_ESC}" 2>$ERROR_FILE
 else
-  timeout $TIMEOUT sshpass -f ${PASSWORD_FILE} -P "passphrase" scp -i "$PRIVATE_KEY_FILE" -o PasswordAuthentication=no -o HashKnownHosts=no -o UserKnownHostsFile="${KNOWN_HOSTS_FILE} ~/.ssh/known_hosts ~/.ssh/known_hosts2 /etc/ssh/ssh_known_hosts" "${REPORT_FILE}" "${USERNAME}@${HOST}:${DEST_ESC}" 2>$ERROR_FILE
+  timeout $TIMEOUT sshpass -f ${PASSWORD_FILE} -P "passphrase" scp -P "$PORT" -i "$PRIVATE_KEY_FILE" -o PasswordAuthentication=no -o HashKnownHosts=no -o UserKnownHostsFile="${KNOWN_HOSTS_FILE} ~/.ssh/known_hosts ~/.ssh/known_hosts2 /etc/ssh/ssh_known_hosts" "${REPORT_FILE}" "${USERNAME}@${HOST}:${DEST_ESC}" 2>$ERROR_FILE
 fi
 
 EXIT_CODE=$?

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -19387,6 +19387,12 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                                         "Error in SCP host"));
                     log_event_fail ("alert", "Alert", NULL, "created");
                     break;
+                  case 16:
+                    SEND_TO_CLIENT_OR_FAIL
+                     (XML_ERROR_SYNTAX ("create_alert",
+                                        "Error in SCP port"));
+                    log_event_fail ("alert", "Alert", NULL, "created");
+                    break;
                   case 17:
                     SEND_TO_CLIENT_OR_FAIL
                      (XML_ERROR_SYNTAX ("create_alert",
@@ -22462,6 +22468,12 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("modify_alert",
                                     "Error in SCP host"));
+                log_event_fail ("alert", "Alert", NULL, "modify");
+                break;
+              case 16:
+                SEND_TO_CLIENT_OR_FAIL
+                 (XML_ERROR_SYNTAX ("modify_alert",
+                                    "Error in SCP port"));
                 log_event_fail ("alert", "Alert", NULL, "modify");
                 break;
               case 17:


### PR DESCRIPTION
## What
The option to set the port used by the SCP alert method with the "scp_port" method data is added.

## Why
This allows using a host with a non-default SSH port as the destination.

## References
GEA-280
