### PR TITLE
Add: Added an option to ignore the pagination for alert reports.

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -12031,6 +12031,7 @@ generate_alert_filter_get (alert_t alert, const get_data_t *base_get_data,
                            get_data_t **alert_filter_get,
                            filter_t *filter_return)
 {
+  char *ignore_pagination;
   char *filt_id;
   filter_t filter;
 
@@ -12069,6 +12070,14 @@ generate_alert_filter_get (alert_t alert, const get_data_t *base_get_data,
     }
   else
     (*alert_filter_get) = NULL;
+
+  ignore_pagination = alert_data (alert, "method",
+                                  "composer_ignore_pagination");
+  if (ignore_pagination)
+    {
+      (*alert_filter_get)->ignore_pagination = atoi (ignore_pagination);
+      g_free (ignore_pagination);
+    }
 
   /* Adjust filter for report composer.
    *


### PR DESCRIPTION
## What
The option Pagination was added to the "Compose Content for Scan Report" dialog for alerts. The default of this option is ignore, so that all results are included in the report regardless of the number of rows specified in the filter selected in the dialog.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This is an improvement that belongs to a bug-fix.
<!-- Describe why are these changes necessary? -->

## References
GEA-124
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


