### PR TITLE
Add: New cleanup-tls-certificate-encoding optimize option

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -437,6 +437,11 @@ supported values for `<name>` are:
   This cleans up id sequences that are likely to run out due to regular feed
   updates like the ids for config preferences.
 
+- `cleanup-tls-certificate-encoding`
+
+  This cleans up TLS certificates where the subject or issuer DN is not
+  valid UTF-8.
+
 - `migrate-relay-sensors`
 
   If relays are active, this can be used to make sure all sensor type

--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -137,7 +137,7 @@ Modify user's password and exit.
 Modify user's password and exit.
 .TP
 \fB--optimize=\fINAME\fB\f1
-Run an optimization: vacuum, add-feed-permissions, analyze, cleanup-config-prefs, cleanup-feed-permissions, cleanup-port-names, cleanup-report-formats, cleanup-result-nvts, cleanup-result-severities, cleanup-schedule-times, cleanup-sequences, migrate-relay-sensors, rebuild-report-cache or update-report-cache.
+Run an optimization: vacuum, add-feed-permissions, analyze, cleanup-config-prefs, cleanup-feed-permissions, cleanup-port-names, cleanup-report-formats, cleanup-result-nvts, cleanup-result-severities, cleanup-schedule-times, cleanup-sequences, cleanup-tls-certificate-encoding, migrate-relay-sensors, rebuild-report-cache or update-report-cache.
 .TP
 \fB--osp-vt-update=\fISCANNER-SOCKET\fB\f1
 Unix socket for OSP NVT update. Defaults to the path of the 'OpenVAS Default' scanner if it is an absolute path.

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -324,8 +324,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
            cleanup-config-prefs, cleanup-feed-permissions,
            cleanup-port-names, cleanup-report-formats, cleanup-result-nvts,
            cleanup-result-severities, cleanup-schedule-times, cleanup-sequences,
-           migrate-relay-sensors, rebuild-report-cache
-           or update-report-cache.</p>
+           cleanup-tls-certificate-encoding, migrate-relay-sensors,
+           rebuild-report-cache or update-report-cache.</p>
       </optdesc>
     </option>
     <option>

--- a/doc/gvmd.html
+++ b/doc/gvmd.html
@@ -278,8 +278,8 @@
            cleanup-config-prefs, cleanup-feed-permissions,
            cleanup-port-names, cleanup-report-formats, cleanup-result-nvts,
            cleanup-result-severities, cleanup-schedule-times, cleanup-sequences,
-           migrate-relay-sensors, rebuild-report-cache
-           or update-report-cache.</p>
+           cleanup-tls-certificate-encoding, migrate-relay-sensors,
+           rebuild-report-cache or update-report-cache.</p>
       
     
     

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -2101,7 +2101,8 @@ gvmd (int argc, char** argv, char *env[])
           " cleanup-config-prefs, cleanup-feed-permissions,"
           " cleanup-port-names, cleanup-report-formats, cleanup-result-encoding,"
           " cleanup-result-nvts, cleanup-result-severities,"
-          " cleanup-schedule-times, cleanup-sequences, migrate-relay-sensors,"
+          " cleanup-schedule-times, cleanup-sequences,"
+          " cleanup-tls-certificate-encoding, migrate-relay-sensors,"
           " rebuild-report-cache or update-report-cache.",
           "<name>" },
         { "osp-vt-update", '\0', 0, G_OPTION_ARG_STRING,

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -56836,6 +56836,22 @@ manage_optimize (GSList *log_config, const db_conn_info_t *database,
                                           " Cleaned up id sequences.");
         }
     }
+  else if (strcasecmp (name, "cleanup-tls-certificate-encoding") == 0)
+    {
+      int changes;
+      sql_begin_immediate ();
+
+      g_debug ("%s: Cleaning up encoding of TLS certificate DNs",
+               __func__);
+
+      changes = cleanup_tls_certificate_encoding ();
+
+      sql_commit ();
+
+      success_text = g_strdup_printf ("Optimized: Cleaned up encoding"
+                                      " of %d TLS certificate(s).",
+                                      changes);
+    }
   else if (strcasecmp (name, "migrate-relay-sensors") == 0)
     {
       if (get_relay_mapper_path ())

--- a/src/manage_sql_tls_certificates.c
+++ b/src/manage_sql_tls_certificates.c
@@ -1713,3 +1713,49 @@ tls_certificate_host_asset_id (const char *host_ip, const char *origin_id)
                     host_ip,
                     origin_id);
 }
+
+/**
+ * @brief Clean up DNs of TLS Certificates that are not valid UTF-8.
+ * 
+ * @return The number of TLS certificates updated.
+ */
+int
+cleanup_tls_certificate_encoding ()
+{
+  int changes = 0;
+  iterator_t iterator;
+  
+  init_iterator (&iterator,
+                 "SELECT id, subject_dn, issuer_dn"
+                 " FROM tls_certificates"
+                 " WHERE subject_dn ~ '[\\x80-\\xFF]'"
+                 "   OR issuer_dn ~ '[\\x80-\\xFF]'");
+  
+  while (next (&iterator))
+    {
+      tls_certificate_t tls_certificate;
+      const char *subject_dn, *issuer_dn;
+  
+      tls_certificate = iterator_int64 (&iterator, 0);
+      subject_dn = iterator_string (&iterator, 1);
+      issuer_dn = iterator_string (&iterator, 2);
+
+      if (g_utf8_validate (subject_dn, -1, NULL) == FALSE
+          || g_utf8_validate (issuer_dn, -1, NULL) == FALSE)
+        {
+          gchar *quoted_subject_dn = sql_ascii_escape_and_quote (subject_dn);
+          gchar *quoted_issuer_dn = sql_ascii_escape_and_quote (issuer_dn);
+          
+          sql ("UPDATE tls_certificates"
+               " SET subject_dn = '%s', issuer_dn = '%s'"
+               " WHERE id = %llu",
+               quoted_subject_dn, quoted_issuer_dn, tls_certificate);
+          changes ++;
+
+          g_free (quoted_subject_dn);
+          g_free (quoted_issuer_dn);
+        }
+    }
+  cleanup_iterator (&iterator);
+  return changes;
+}

--- a/src/manage_sql_tls_certificates.h
+++ b/src/manage_sql_tls_certificates.h
@@ -52,4 +52,7 @@ add_tls_certificates_from_report_host (report_host_t,
                                        const char*,
                                        const char*);
 
+int
+cleanup_tls_certificate_encoding ();
+
 #endif /* not _GVMD_MANAGE_SQL_TLS_CERTIFICATES_H */


### PR DESCRIPTION
## What
The --optimize command line parameter now has the option "cleanup-tls-certificate-encoding", which cleans up TLS certificates where the subject or issuer DN is not valid UTF-8.

## Why
This can be used to fix old database where certificates with invalid DNs were imported before escaping was added.

## References
GEA-3
