### PR TITLE
Fix: Remove extra "gvmd: " from process titles

### DIFF
--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -600,7 +600,7 @@ accept_and_maybe_fork (int server_socket, sigset_t *sigmask_current)
           init_sentry ();
           is_parent = 0;
 
-          setproctitle ("gvmd: Serving client");
+          setproctitle ("Serving client");
 
           /* Restore the sigmask that was blanked for pselect. */
           pthread_sigmask (SIG_SETMASK, sigmask_current, NULL);
@@ -736,7 +736,7 @@ fork_connection_internal (gvm_connection_t *client_connection,
         /* Child.  Serve the scheduler GMP, then exit. */
 
         init_sentry ();
-        setproctitle ("gvmd: Serving GMP internally");
+        setproctitle ("Serving GMP internally");
 
         parent_client_socket = sockets[0];
 
@@ -834,7 +834,7 @@ fork_connection_internal (gvm_connection_t *client_connection,
 
         g_debug ("%s: %i forked %i", __func__, getpid (), pid);
 
-        setproctitle ("gvmd: Requesting GMP internally");
+        setproctitle ("Requesting GMP internally");
 
         /* This process is returned as the child of
          * fork_connection_for_scheduler so that the returned parent can wait
@@ -1105,7 +1105,7 @@ handle_sigabrt_simple (int signal)
 static int
 update_nvt_cache_osp (const gchar *update_socket)
 {
-  setproctitle ("gvmd: OSP: Updating NVT cache");
+  setproctitle ("OSP: Updating NVT cache");
 
   return manage_update_nvts_osp (update_socket);
 }
@@ -1121,7 +1121,7 @@ update_nvt_cache_osp (const gchar *update_socket)
 static int
 update_nvt_cache_retry ()
 {
-  setproctitle ("gvmd: Reloading NVTs");
+  setproctitle ("Reloading NVTs");
 
   /* Don't ignore SIGCHLD, in order to wait for child process. */
   setup_signal_handler (SIGCHLD, SIG_DFL, 0);
@@ -1216,7 +1216,7 @@ fork_update_nvt_cache ()
         /* Child.   */
 
         init_sentry ();
-        setproctitle ("gvmd: Updating NVT cache");
+        setproctitle ("Updating NVT cache");
 
         /* Clean up the process. */
 
@@ -1327,7 +1327,7 @@ fork_feed_sync ()
         /* Child.   */
 
         init_sentry ();
-        setproctitle ("gvmd: Synchronizing feed data");
+        setproctitle ("Synchronizing feed data");
 
         /* Clean up the process. */
 
@@ -2379,7 +2379,7 @@ gvmd (int argc, char** argv, char *env[])
   /* Set process title. */
 
   setproctitle_init (argc, argv, env);
-  setproctitle ("gvmd: Initializing");
+  setproctitle ("Initializing");
 
   /* Setup initial signal handlers. */
 
@@ -2574,7 +2574,7 @@ gvmd (int argc, char** argv, char *env[])
           return EXIT_FAILURE;
         }
 
-      setproctitle ("gvmd: Migrating database");
+      setproctitle ("Migrating database");
 
       g_info ("   Migrating database.");
 
@@ -2659,7 +2659,7 @@ gvmd (int argc, char** argv, char *env[])
     {
       int ret;
 
-      setproctitle ("gvmd: Optimizing");
+      setproctitle ("Optimizing");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2675,7 +2675,7 @@ gvmd (int argc, char** argv, char *env[])
     {
       int ret;
 
-      setproctitle ("gvmd: --rebuild");
+      setproctitle ("--rebuild");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2697,7 +2697,7 @@ gvmd (int argc, char** argv, char *env[])
       
       error_msg = NULL;
 
-      setproctitle ("gvmd: --rebuild-gvmd-data");
+      setproctitle ("--rebuild-gvmd-data");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2722,7 +2722,7 @@ gvmd (int argc, char** argv, char *env[])
     {
       int ret;
 
-      setproctitle ("gvmd: --rebuild-scap");
+      setproctitle ("--rebuild-scap");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2741,7 +2741,7 @@ gvmd (int argc, char** argv, char *env[])
     {
       int ret;
 
-      setproctitle ("gvmd: --dump-vt-verification");
+      setproctitle ("--dump-vt-verification");
   
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2764,7 +2764,7 @@ gvmd (int argc, char** argv, char *env[])
 
       /* Create the scanner and then exit. */
 
-      setproctitle ("gvmd: Creating scanner");
+      setproctitle ("Creating scanner");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2816,7 +2816,7 @@ gvmd (int argc, char** argv, char *env[])
 
       /* Modify the scanner and then exit. */
 
-      setproctitle ("gvmd: Modifying scanner");
+      setproctitle ("Modifying scanner");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2860,7 +2860,7 @@ gvmd (int argc, char** argv, char *env[])
     {
       int ret;
 
-      setproctitle ("gvmd: Checking alerts");
+      setproctitle ("Checking alerts");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2875,7 +2875,7 @@ gvmd (int argc, char** argv, char *env[])
   if (create_encryption_key)
     {
       int ret;
-      setproctitle ("gvmd: Creating encryption key");
+      setproctitle ("Creating encryption key");
       
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2890,7 +2890,7 @@ gvmd (int argc, char** argv, char *env[])
   if (set_encryption_key)
     {
       int ret;
-      setproctitle ("gvmd: Setting encryption key");
+      setproctitle ("Setting encryption key");
       
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2907,7 +2907,7 @@ gvmd (int argc, char** argv, char *env[])
     {
       int ret;
 
-      setproctitle ("gvmd: Creating user");
+      setproctitle ("Creating user");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2924,7 +2924,7 @@ gvmd (int argc, char** argv, char *env[])
     {
       int ret;
 
-      setproctitle ("gvmd: Deleting user");
+      setproctitle ("Deleting user");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2940,7 +2940,7 @@ gvmd (int argc, char** argv, char *env[])
     {
       int ret;
 
-      setproctitle ("gvmd: Getting roles");
+      setproctitle ("Getting roles");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2956,7 +2956,7 @@ gvmd (int argc, char** argv, char *env[])
     {
       int ret;
 
-      setproctitle ("gvmd: Getting users");
+      setproctitle ("Getting users");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2972,7 +2972,7 @@ gvmd (int argc, char** argv, char *env[])
     {
       int ret;
 
-      setproctitle ("gvmd: Getting scanners");
+      setproctitle ("Getting scanners");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -2988,7 +2988,7 @@ gvmd (int argc, char** argv, char *env[])
     {
       int ret;
 
-      setproctitle ("gvmd: Deleting scanner");
+      setproctitle ("Deleting scanner");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -3004,7 +3004,7 @@ gvmd (int argc, char** argv, char *env[])
     {
       int ret;
 
-      setproctitle ("gvmd: Verifying scanner");
+      setproctitle ("Verifying scanner");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -3020,7 +3020,7 @@ gvmd (int argc, char** argv, char *env[])
     {
       int ret;
 
-      setproctitle ("gvmd: Modifying user password");
+      setproctitle ("Modifying user password");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -3036,7 +3036,7 @@ gvmd (int argc, char** argv, char *env[])
     {
       int ret;
 
-      setproctitle ("gvmd: Modifying setting");
+      setproctitle ("Modifying setting");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -3053,7 +3053,7 @@ gvmd (int argc, char** argv, char *env[])
     {
       int ret;
 
-      setproctitle ("gvmd: Encrypting all credentials");
+      setproctitle ("Encrypting all credentials");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -3069,7 +3069,7 @@ gvmd (int argc, char** argv, char *env[])
     {
       int ret;
 
-      setproctitle ("gvmd: Decrypting all credentials");
+      setproctitle ("Decrypting all credentials");
 
       if (option_lock (&lockfile_checking))
         return EXIT_FAILURE;
@@ -3320,7 +3320,7 @@ gvmd (int argc, char** argv, char *env[])
 
   /* Enter the main forever-loop. */
 
-  setproctitle ("gvmd: Waiting for incoming connections");
+  setproctitle ("Waiting for incoming connections");
   serve_and_schedule ();
 
   gvm_close_sentry ();

--- a/src/manage.c
+++ b/src/manage.c
@@ -2865,7 +2865,7 @@ fork_osp_scan_handler (task_t task, target_t target, int from,
       exit (-1);
     }
 
-  setproctitle ("gvmd: OSP: Handling scan %s", report_id);
+  setproctitle ("OSP: Handling scan %s", report_id);
 
   rc = handle_osp_scan (task, global_current_report, report_id);
   g_free (report_id);
@@ -3217,7 +3217,7 @@ fork_cve_scan_handler (task_t task, target_t target)
 
   set_task_run_status (task, TASK_STATUS_RUNNING);
 
-  setproctitle ("gvmd: CVE: Handling scan %s", report_id);
+  setproctitle ("CVE: Handling scan %s", report_id);
   g_free (report_id);
 
   hosts = target_hosts (target);
@@ -4764,7 +4764,7 @@ scheduled_task_start (scheduled_task_t *scheduled_task,
 
           /* Parent.  Wait for child, to check return. */
 
-          setproctitle ("gvmd: scheduler: waiting for %i", pid);
+          setproctitle ("scheduler: waiting for %i", pid);
 
           g_debug ("%s: %i fork_connectioned %i",
                    __func__, getpid (), pid);
@@ -4865,7 +4865,7 @@ scheduled_task_start (scheduled_task_t *scheduled_task,
 
   /* Start the task. */
 
-  setproctitle ("gvmd: scheduler: starting %s", scheduled_task->task_uuid);
+  setproctitle ("scheduler: starting %s", scheduled_task->task_uuid);
 
   auth_opts = gmp_authenticate_info_opts_defaults;
   auth_opts.username = scheduled_task->owner_name;
@@ -4956,7 +4956,7 @@ scheduled_task_stop (scheduled_task_t *scheduled_task,
 
   /* Stop the task. */
 
-  setproctitle ("gvmd: scheduler: stopping %s",
+  setproctitle ("scheduler: stopping %s",
             scheduled_task->task_uuid);
 
   auth_opts = gmp_authenticate_info_opts_defaults;

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -9633,7 +9633,7 @@ alert_script_exec (const char *alert_id, const char *command_args,
                 init_sentry ();
                 cleanup_manage_process (FALSE);
 
-                setproctitle ("gvmd: Running alert script");
+                setproctitle ("Running alert script");
 
                 if (setgroups (0,NULL))
                   {
@@ -10446,7 +10446,7 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
                 init_sentry ();
                 cleanup_manage_process (FALSE);
 
-                setproctitle ("gvmd: Sending to Sourcefire");
+                setproctitle ("Sending to Sourcefire");
 
                 if (setgroups (0,NULL))
                   {
@@ -10775,7 +10775,7 @@ send_to_verinice (const char *url, const char *username, const char *password,
               {
                 /* Child.  Drop privileges, run command, exit. */
                 init_sentry ();
-                setproctitle ("gvmd: Sending to Verinice");
+                setproctitle ("Sending to Verinice");
 
                 cleanup_manage_process (FALSE);
 
@@ -20905,7 +20905,7 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
         }
     }
 
-  setproctitle ("gvmd: Importing results");
+  setproctitle ("Importing results");
 
   /* Add the results. */
 

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -3416,7 +3416,7 @@ run_report_format_script (gchar *report_format_id,
               /* Child.  Drop privileges, run command, exit. */
 
               init_sentry ();
-              setproctitle ("gvmd: Generating report");
+              setproctitle ("Generating report");
 
               cleanup_manage_process (FALSE);
 

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -3228,7 +3228,7 @@ manage_sync_cert (sigset_t *sigmask_current)
 {
   sync_secinfo (sigmask_current,
                 sync_cert,
-                "gvmd: Syncing CERT");
+                "Syncing CERT");
 }
 
 
@@ -3426,7 +3426,7 @@ update_scap_end ()
   sql ("ANALYZE scap.affected_products;");
 
   g_info ("%s: Updating SCAP info succeeded", __func__);
-  setproctitle ("gvmd: Syncing SCAP: done");
+  setproctitle ("Syncing SCAP: done");
 
   return 0;
 }
@@ -3473,7 +3473,7 @@ try_load_csv ()
       /* Add the indexes and constraints, now that the data is ready. */
 
       g_debug ("%s: add indexes", __func__);
-      setproctitle ("gvmd: Syncing SCAP: Adding indexes");
+      setproctitle ("Syncing SCAP: Adding indexes");
 
       if (manage_db_init_indexes ("scap"))
         {
@@ -3482,7 +3482,7 @@ try_load_csv ()
         }
 
       g_debug ("%s: add constraints", __func__);
-      setproctitle ("gvmd: Syncing SCAP: Adding constraints");
+      setproctitle ("Syncing SCAP: Adding constraints");
 
       if (manage_db_add_constraints ("scap"))
         {
@@ -3535,7 +3535,7 @@ update_scap (gboolean reset_scap_db)
 
           if (last_scap_update == last_feed_update)
             {
-              setproctitle ("gvmd: Syncing SCAP: done");
+              setproctitle ("Syncing SCAP: done");
               return 0;
             }
 
@@ -3564,7 +3564,7 @@ update_scap (gboolean reset_scap_db)
   /* Add the indexes and constraints. */
 
   g_debug ("%s: add indexes", __func__);
-  setproctitle ("gvmd: Syncing SCAP: Adding indexes");
+  setproctitle ("Syncing SCAP: Adding indexes");
 
   if (manage_db_init_indexes ("scap"))
     {
@@ -3585,13 +3585,13 @@ update_scap (gboolean reset_scap_db)
   g_info ("%s: Updating data from feed", __func__);
 
   g_debug ("%s: update cpes", __func__);
-  setproctitle ("gvmd: Syncing SCAP: Updating CPEs");
+  setproctitle ("Syncing SCAP: Updating CPEs");
 
   if (update_scap_cpes () == -1)
     return -1;
 
   g_debug ("%s: update cves", __func__);
-  setproctitle ("gvmd: Syncing SCAP: Updating CVEs");
+  setproctitle ("Syncing SCAP: Updating CVEs");
 
   if (update_scap_cves () == -1)
     return -1;
@@ -3602,12 +3602,12 @@ update_scap (gboolean reset_scap_db)
   /* Do calculations that need all data. */
 
   g_debug ("%s: update max cvss", __func__);
-  setproctitle ("gvmd: Syncing SCAP: Updating max CVSS");
+  setproctitle ("Syncing SCAP: Updating max CVSS");
 
   update_scap_cvss ();
 
   g_debug ("%s: update placeholders", __func__);
-  setproctitle ("gvmd: Syncing SCAP: Updating placeholders");
+  setproctitle ("Syncing SCAP: Updating placeholders");
 
   update_scap_placeholders ();
 
@@ -3635,7 +3635,7 @@ manage_sync_scap (sigset_t *sigmask_current)
 {
   sync_secinfo (sigmask_current,
                 sync_scap,
-                "gvmd: Syncing SCAP");
+                "Syncing SCAP");
 }
 
 /**


### PR DESCRIPTION
## What
The "gvmd: " prefix is removed from the text passed to calls to setproctitle.

## Why
The function will add a prefix of the executable name on its own, so it now no longer adds a superfluous one.

## References
GEA-240