### PR TITLE
increase max email attachment size

### DIFF
--- a/.docker/start-gvmd.sh
+++ b/.docker/start-gvmd.sh
@@ -20,7 +20,7 @@
 
 [ -z "$USER" ] && USER="admin"
 [ -z "$PASSWORD" ] && PASSWORD="admin"
-[ -z "$GVMD_ARGS" ] && GVMD_ARGS="--listen-mode=666"
+[ -z "$GVMD_ARGS" ] && GVMD_ARGS="--listen-mode=666 --max-email-attachment-size=20971520"
 [ -z "$GVMD_USER" ] && GVMD_USER="gvmd"
 [ -z "$PGRES_DATA"] && PGRES_DATA="/var/lib/postgresql"
 


### PR DESCRIPTION
## What

With the docker container now allowing sendmail if the attachment is bigger than 1 MB the email being sent will notify that the attachment is too big to be attached.

My change uses the GVMD arguments to increase the attachment size
Added the flag and rerun container with the flag. email sent ok.

## Why

in order to be able to send bigger PDF reports




