### PR TITLE
Add: GET_NVTS attribute skip_tags

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -7883,7 +7883,7 @@ send_nvt (iterator_t *nvts, int details, int preferences, int pref_count,
   gchar *msg;
 
   msg = get_nvt_xml (nvts, details, pref_count, preferences, timeout, config,
-                     0, skip_cert_refs, skip_cert_refs);
+                     0, skip_cert_refs, skip_tags);
   if (send_to_client (msg, write_to_client, write_to_client_data))
     {
       g_free (msg);

--- a/src/manage.h
+++ b/src/manage.h
@@ -1998,7 +1998,7 @@ void
 xml_append_nvt_refs (GString *, const char *, int *);
 
 gchar*
-get_nvt_xml (iterator_t*, int, int, int, const char*, config_t, int, int);
+get_nvt_xml (iterator_t*, int, int, int, const char*, config_t, int, int, int);
 
 char*
 task_preference_value (task_t, const char *);

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -13252,6 +13252,11 @@ END:VCALENDAR
         <type>boolean</type>
       </attrib>
       <attrib>
+        <name>skip_tags</name>
+        <summary>Whether to exclude user tags</summary>
+        <type>boolean</type>
+      </attrib>
+      <attrib>
         <name>timeout</name>
         <summary>Whether to include the special timeout preference</summary>
         <type>boolean</type>


### PR DESCRIPTION
## What

Add attribute skip_tags to GMP GET_NVTS.

Off
`time o m m '<get_nvts skip_tags="0" skip_cert_refs="1" details="1" timeout="1" family="General" preferences_config_id="55385e2f-cd85-4a4a-954a-c89495aca669" preference_count="1" sort_field="nvts.name" sort_order="ascending"/>' > /tmp/nvts`
  13s,10s,16s,10s

On
`time o m m '<get_nvts skip_tags="1" skip_cert_refs="1" details="1" timeout="1" family="General" preferences_config_id="55385e2f-cd85-4a4a-954a-c89495aca669" preference_count="1" sort_field="nvts.name" sort_order="ascending"/>' > /tmp/nvts`
  9s,11s,12s,10s

## Why

Allows GSA to request less info for the Edit Config Family dialog. Also saves some db querying on gvmd side.