### PR TITLE
Fix: Require gvm-libs 22.7 for credentials excerpt_size

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,7 +26,7 @@ find_package (Threads)
 ## list and throw an error, otherwise long install-cmake-install-cmake cycles
 ## might occur.
 
-pkg_check_modules (LIBGVM_BASE REQUIRED libgvm_base>=22.6)
+pkg_check_modules (LIBGVM_BASE REQUIRED libgvm_base>=22.7)
 pkg_check_modules (LIBGVM_UTIL REQUIRED libgvm_util>=22.6)
 pkg_check_modules (LIBGVM_OSP REQUIRED libgvm_osp>=22.6)
 pkg_check_modules (LIBGVM_GMP REQUIRED libgvm_gmp>=22.6)


### PR DESCRIPTION




## What

Require gvm-libs 22.7 for credentials excerpt_size

## Why
The credentials excerpt_size got introduced with https://github.com/greenbone/gvm-libs/commit/19d347c0 and was released with gvm-libs 22.7.0. Since https://github.com/greenbone/gvmd/commit/81b9aaaf8 it is used in gvmd. The change was released with gvmd 22.7.0.

## References
Closes #2073

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


