### PR TITLE
Fix: Fixed infinite loop at the end of scans.

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -48006,7 +48006,10 @@ hosts_set_identifiers (report_t report)
           GString *select;
 
           if (report_host_noticeable (report, ip) == 0)
-            continue;
+            {
+              host_index++;
+              continue;
+            }
 
           quoted_host_name = sql_quote (ip);
 


### PR DESCRIPTION

## What
When the scan progress of a scan was at 100% some times the processing of the data in gvmd got into an infinite loop. That problem is fixed now.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This is a bug-fix.
<!-- Describe why are these changes necessary? -->

## References
GEA-273
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


