### PR TITLE
Docs: remove reference to old option

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -508,9 +508,12 @@ Look for the current key and remember its keyid. Then:
     gpg --homedir /var/lib/gvm/gvmd/gnupg --edit-key KEYID
 
 At the prompt enter `disable` followed by `save` and `quit`.
-Then create a new key and re-encrypt all passwords:
+Then start gvmd to create a new key:
 
-    gvmd --create-credentials-encryption-key
+    gvmd
+
+and finally re-encrypt all passwords:
+
     gvmd --encrypt-all-credentials
 
 No encryption: If for backward compatibility reasons encrypted credentials


### PR DESCRIPTION
## What

Remove ref to `--create-credentials-encryption-key`, and mention that gvmd must be started.

Note that if gvmd is already running then `--encrypt-all-credentials` will skip the automatic key creation, so the INSTALL just says to start gvmd before running `--encrypt-all-credentials`.

## Why

Option was removed.

## References

Option removed in 10f0632cca096965a0261928fc1dc04a90ebe0dc.

Closes greenbone/gvmd/issues/463

