### PR TITLE
Use result of g_string_free when arg 2 is FALSE

### DIFF
--- a/src/lsc_crypt.c
+++ b/src/lsc_crypt.c
@@ -679,9 +679,8 @@ lsc_crypt_encrypt_hashtable (lsc_crypt_ctx_t ctx, GHashTable *data)
         }
     }
 
-  plaintext = stringbuf->str;
   plaintextlen = stringbuf->len;
-  g_string_free (stringbuf, FALSE);
+  plaintext = g_string_free (stringbuf, FALSE);
   g_assert (plaintextlen);
 
   ciphertext = do_encrypt (ctx, plaintext, plaintextlen);
@@ -751,9 +750,8 @@ lsc_crypt_encrypt (lsc_crypt_ctx_t ctx, const char *first_name, ...)
   while ((name = va_arg (arg_ptr, const char *)))
     ;
   va_end (arg_ptr);
-  plaintext = stringbuf->str;
   plaintextlen = stringbuf->len;
-  g_string_free (stringbuf, FALSE);
+  plaintext = g_string_free (stringbuf, FALSE);
   g_assert (plaintextlen);
 
   ciphertext = do_encrypt (ctx, plaintext, plaintextlen);

--- a/src/manage.c
+++ b/src/manage.c
@@ -476,8 +476,7 @@ get_certificate_info (const gchar* certificate, gssize certificate_len,
               g_string_append_printf (string, "%02x", buffer[i]);
             }
 
-          *md5_fingerprint = string->str;
-          g_string_free (string, FALSE);
+          *md5_fingerprint = g_string_free (string, FALSE);
         }
 
       if (sha256_fingerprint)
@@ -497,8 +496,7 @@ get_certificate_info (const gchar* certificate, gssize certificate_len,
               g_string_append_printf (string, "%02X", buffer[i]);
             }
 
-          *sha256_fingerprint = string->str;
-          g_string_free (string, FALSE);
+          *sha256_fingerprint = g_string_free (string, FALSE);
         }
 
       if (subject)
@@ -541,8 +539,7 @@ get_certificate_info (const gchar* certificate, gssize certificate_len,
               g_string_append_printf (string, "%02X", buffer[i]);
             }
 
-          *serial = string->str;
-          g_string_free (string, FALSE);
+          *serial = g_string_free (string, FALSE);
         }
 
       gnutls_x509_crt_deinit (gnutls_cert);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -2140,8 +2140,7 @@ manage_report_filter_controls (const gchar *filter, int *first, int *max,
             }
           point++;
         }
-      *search_phrase = g_strchomp (phrase->str);
-      g_string_free (phrase, FALSE);
+      *search_phrase = g_strchomp (g_string_free (phrase, FALSE));
     }
 
   if (result_hosts_only)


### PR DESCRIPTION
## What

Always use the return from g_string_free when stealing the string.

## Why

Prevents warnings with glib 2.76.

## References

Similar to /greenbone/gsad/pull/153


