### PR TITLE
Fix: check uuid before passing to credentials_setup

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -17464,6 +17464,10 @@ authenticate (credentials_t* credentials)
           g_free (quoted_name);
           g_free (quoted_method);
 
+          if (credentials->uuid == NULL)
+            /* Can happen if user is deleted while logged in to GSA. */
+            return 1;
+          
           if (credentials_setup (credentials))
             {
               free (credentials->uuid);


### PR DESCRIPTION
## What

Check if uuid is NULL before passing it to `credentials_setup`.

## Why

An assertion failure was happening because `credentials_setup` expects uuid to exist, but uuid may be NULL if a user is deleted while logged in to GSA.

To reproduce
1. gvmd --create-user m
2. login to GSA
3. gvmd --delete-user m
4. click somewhere in GSA menu
5. see assertion failure in gvmd output.
