### PR TITLE
Use case-insensitive comparison for CPEs in CVE scanner.

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -20112,7 +20112,7 @@ init_host_prognosis_iterator (iterator_t* iterator, report_host_t report_host)
                  " FROM scap.cves, scap.cpes, scap.affected_products,"
                  "      report_host_details"
                  " WHERE report_host_details.report_host = %llu"
-                 " AND cpes.name = report_host_details.value"
+                 " AND LOWER(cpes.name) = LOWER(report_host_details.value)"
                  " AND report_host_details.name = 'App'"
                  " AND cpes.id=affected_products.cpe"
                  " AND cves.id=affected_products.cve"


### PR DESCRIPTION

## What
Because some CVEs where not found because of a different notation (with capital letters / without capital letters) the comparison for the CPEs in the CVE scanner is now made case-insensitive.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This is a bug-fix
<!-- Describe why are these changes necessary? -->

## References
GEA-8
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


