### PR TITLE
Add: create_credential error case for type

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -19886,6 +19886,11 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                  (XML_ERROR_SYNTAX ("create_credential",
                                     "Erroneous certificate"));
                 break;
+              case 18:
+                SEND_TO_CLIENT_OR_FAIL
+                 (XML_ERROR_SYNTAX ("create_credential",
+                                    "Cannot determine type for new credential"));
+                break;
               case 99:
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("create_credential",

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -34457,7 +34457,8 @@ validate_credential_username_for_format (const gchar *username,
  *         11 community missing, 12 auth algorithm missing,
  *         14 privacy algorithm missing,
  *         15 invalid auth algorithm, 16 invalid privacy algorithm,
- *         17 invalid certificate, 99 permission denied, -1 error.
+ *         17 invalid certificate, 18 cannot determine type,
+ *         99 permission denied, -1 error.
  */
 int
 create_credential (const char* name, const char* comment, const char* login,
@@ -34534,7 +34535,7 @@ create_credential (const char* name, const char* comment, const char* login,
   else
     {
       g_warning ("%s: Cannot determine type of new credential", __func__);
-      return -1;
+      return 18;
     }
 
   /* Validate credential data */


### PR DESCRIPTION
## What

When create_credential fails to determine the type, return a specific error instead of just internal error.

## Why

This caught me out when I was missing the type field, and a little more of a clue would have helped. (The command is too complex to just say that the type field is missing.)

Test with something like:
`o m m "<create_credential><name>eg3</name><password>eg</password></create_credential>"`

... which should look like this:
`o m m "<create_credential><name>eg3</name><password>eg</password><type>pw</type></create_credential>"`

