### PR TITLE
Fix: Use right case for NVT timeout preference

### DIFF
--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -1762,7 +1762,7 @@ init_nvt_preference_iterator (iterator_t* iterator, const char *oid)
                      " AND name != 'nasl_no_signature_check'"
                      " AND name != 'network_targets'"
                      " AND name != 'ntp_save_sessions'"
-                     " AND name != '%s:0:entry:Timeout'"
+                     " AND name != '%s:0:entry:timeout'"
                      " AND name NOT %s 'server_info_%%'"
                      /* Task preferences. */
                      " AND name != 'max_checks'"
@@ -1782,7 +1782,7 @@ init_nvt_preference_iterator (iterator_t* iterator, const char *oid)
                    " AND name != 'nasl_no_signature_check'"
                    " AND name != 'network_targets'"
                    " AND name != 'ntp_save_sessions'"
-                   " AND name NOT %s '%%:0:entry:Timeout'"
+                   " AND name NOT %s '%%:0:entry:timeout'"
                    " AND name NOT %s 'server_info_%%'"
                    /* Task preferences. */
                    " AND name != 'max_checks'"

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1210,7 +1210,7 @@ char *
 nvt_default_timeout (const char* oid)
 {
   return sql_string ("SELECT value FROM nvt_preferences"
-                     " WHERE name = '%s:0:entry:Timeout'",
+                     " WHERE name = '%s:0:entry:timeout'",
                      oid);
 }
 


### PR DESCRIPTION
## What

Use lowercase "timeout" when matching the timeout preference in `init_nvt_preference_iterator` and `nvt_default_timeout`.

## Why

OSP uses lowercase for this preference.  The capitalization is left over from OTP.

To reproduce, in GSA edit a config, edit the family "Product detection" and then edit the NVT "Eggdrop detection" (OID 1.3.6.1.4.1.25623.1.0.100206).  Before the PR there was an extra Timeout preference, and the special Timeout preference in the top row was missing the default value (3600).

## References

The timeout prefs in the db were updated to lowercase in 2019 in b594763 as part of greenbone/gvmd/pull/744.

