### PR TITLE
Add: Feed data objects can now be deprecated

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -11773,6 +11773,12 @@ handle_get_configs (gmp_parser_t *gmp_parser, GError **error)
         }
       SEND_GET_COMMON (config, &get_configs_data->get, &configs);
 
+      if (resource_id_deprecated ("config",
+                                  get_iterator_uuid (&configs)))
+        {
+          SENDF_TO_CLIENT_OR_FAIL ("<deprecated>1</deprecated>");
+        }
+
       /** @todo This should really be an nvt_selector_t. */
       selector = config_iterator_nvt_selector (&configs);
       config = get_iterator_resource (&configs);
@@ -14046,6 +14052,12 @@ handle_get_port_lists (gmp_parser_t *gmp_parser, GError **error)
       SEND_GET_COMMON (port_list, &get_port_lists_data->get,
                         &port_lists);
 
+      if (resource_id_deprecated ("port_list",
+                                  get_iterator_uuid (&port_lists)))
+        {
+          SENDF_TO_CLIENT_OR_FAIL ("<deprecated>1</deprecated>");
+        }
+
       SENDF_TO_CLIENT_OR_FAIL ("<port_count>"
                                "<all>%i</all>"
                                "<tcp>%i</tcp>"
@@ -14925,6 +14937,12 @@ handle_get_report_formats (gmp_parser_t *gmp_parser, GError **error)
                  (get_iterator_resource (&report_formats))
               : report_format_predefined
                  (get_iterator_resource (&report_formats)));
+
+          if (resource_id_deprecated ("report_format",
+                                      get_iterator_uuid (&report_formats)))
+            {
+              SENDF_TO_CLIENT_OR_FAIL ("<deprecated>1</deprecated>");
+            }
 
           if (get_report_formats_data->alerts)
             {

--- a/src/gmp_configs.c
+++ b/src/gmp_configs.c
@@ -182,6 +182,7 @@ attr_or_null (entity_t entity, const gchar *name)
  * @param[out] all_selector          True if ALL_SELECTOR was present.
  * @param[out] import_nvt_selectors  Address for selectors.
  * @param[out] import_preferences    Address for preferences.
+ * @param[out] deprecated            Address for deprecation status.
  *
  * @return 0 success, 1 preference did no exist, -1 preference without ID.
  */
@@ -190,7 +191,8 @@ parse_config_entity (entity_t config, const char **config_id, char **name,
                      char **comment, char **usage_type,
                      int *all_selector,
                      array_t **import_nvt_selectors,
-                     array_t **import_preferences)
+                     array_t **import_preferences,
+                     char **deprecated)
 {
   entity_t entity, preferences, nvt_selectors;
 
@@ -215,6 +217,14 @@ parse_config_entity (entity_t config, const char **config_id, char **name,
         *usage_type = entity_text (entity);
       else
         *usage_type = NULL;
+    }
+
+  if (deprecated)
+    {
+      *deprecated = NULL;
+      entity = entity_child (config, "deprecated");
+      if (entity)
+        *deprecated = entity_text (entity);
     }
 
   /* Collect NVT selectors. */
@@ -416,7 +426,7 @@ create_config_run (gmp_parser_t *gmp_parser, GError **error)
 
       if (parse_config_entity (config, NULL, &import_name, &comment,
                                NULL, &all_selector, &import_nvt_selectors,
-                               &import_preferences))
+                               &import_preferences, NULL))
         {
           SEND_TO_CLIENT_OR_FAIL
            (XML_ERROR_SYNTAX ("create_config",

--- a/src/gmp_configs.h
+++ b/src/gmp_configs.h
@@ -41,7 +41,7 @@ create_config_element_text (const gchar *, gsize);
 
 int
 parse_config_entity (entity_t, const char **, char **, char **,
-                     char **, int *, array_t **, array_t **);
+                     char **, int *, array_t **, array_t **, char **);
 
 /* modify_config */
 

--- a/src/gmp_port_lists.c
+++ b/src/gmp_port_lists.c
@@ -109,10 +109,12 @@ create_port_list_element_start (gmp_parser_t *gmp_parser, const gchar *name,
  * @param[out] name          Address for name.
  * @param[out] comment       Address for comment.
  * @param[out] ranges        Address for port ranges.
+ * @param[out] deprecated    Address for deprecation status.
  */
 void
 parse_port_list_entity (entity_t port_list, const char **port_list_id,
-                        char **name, char **comment, array_t **ranges)
+                        char **name, char **comment, array_t **ranges,
+                        char **deprecated)
 {
   entity_t entity, port_ranges;
 
@@ -128,6 +130,14 @@ parse_port_list_entity (entity_t port_list, const char **port_list_id,
   entity = entity_child (port_list, "comment");
   if (entity)
     *comment = entity_text (entity);
+
+  if (deprecated)
+    {
+      *deprecated = NULL;
+      entity = entity_child (port_list, "deprecated");
+      if (entity)
+        *deprecated = entity_text (entity);
+    }
 
   /* Collect port ranges. */
 
@@ -207,7 +217,7 @@ create_port_list_run (gmp_parser_t *gmp_parser, GError **error)
       /* Get the port_list data from the XML. */
 
       parse_port_list_entity (port_list, &port_list_id, &import_name,
-                              &comment, &ranges);
+                              &comment, &ranges, NULL);
 
       /* Check data, then create port list. */
 

--- a/src/gmp_port_lists.h
+++ b/src/gmp_port_lists.h
@@ -38,6 +38,7 @@ void
 create_port_list_element_text (const gchar *, gsize);
 
 void
-parse_port_list_entity (entity_t, const char **, char **, char **, array_t **);
+parse_port_list_entity (entity_t, const char **, char **, char **, array_t **,
+                        char **);
 
 #endif /* not _GVMD_GMP_PORT_LISTS_H */

--- a/src/gmp_report_formats.c
+++ b/src/gmp_report_formats.c
@@ -156,6 +156,7 @@ params_options_free (array_t *params_options)
  * @param[out] files             Address for files.
  * @param[out] params            Address for params.
  * @param[out] params_options    Address for param options.
+ * @param[out] deprecated        Address for deprecation status.
  */
 void
 parse_report_format_entity (entity_t report_format,
@@ -163,7 +164,8 @@ parse_report_format_entity (entity_t report_format,
                             char **content_type, char **extension,
                             char **summary, char **description,
                             char **signature, array_t **files,
-                            array_t **params, array_t **params_options)
+                            array_t **params, array_t **params_options,
+                            char **deprecated)
 {
   entity_t file, param_entity;
   entities_t children;
@@ -177,6 +179,8 @@ parse_report_format_entity (entity_t report_format,
   *summary = child_or_null (report_format, "summary");
   *description = child_or_null (report_format, "description");
   *signature = child_or_null (report_format, "signature");
+  if (deprecated)
+    *deprecated = child_or_null (report_format, "deprecated");
 
   *files = make_array ();
   *params = make_array ();
@@ -367,7 +371,7 @@ create_report_format_run (gmp_parser_t *gmp_parser, GError **error)
       parse_report_format_entity (report_format, &report_format_id,
                                   &import_name, &content_type, &extension,
                                   &summary, &description, &signature, &files,
-                                  &params, &params_options);
+                                  &params, &params_options, NULL);
 
       /* Check data, then create report format. */
 

--- a/src/gmp_report_formats.h
+++ b/src/gmp_report_formats.h
@@ -43,6 +43,6 @@ params_options_free (array_t *);
 void
 parse_report_format_entity (entity_t, const char **, char **, char **,
                             char **, char **, char **, char **,
-                            array_t **, array_t **, array_t **);
+                            array_t **, array_t **, array_t **, char **);
 
 #endif /* not _GVMD_GMP_REPORT_FORMATS_H */

--- a/src/manage.h
+++ b/src/manage.h
@@ -407,6 +407,12 @@ type_is_scap (const char*);
 int
 delete_resource (const char *, const char *, int);
 
+int
+resource_id_deprecated (const char *, const char *);
+
+void
+set_resource_id_deprecated (const char *, const char *, gboolean);
+
 
 /* Events and Alerts. */
 

--- a/src/manage_configs.c
+++ b/src/manage_configs.c
@@ -141,7 +141,7 @@ update_config_from_file (config_t config, const gchar *path)
 {
   entity_t entity;
   array_t *nvt_selectors, *preferences;
-  char *comment, *name, *usage_type;
+  char *comment, *name, *usage_type, *deprecated;
   const char *config_id;
   int all_selector;
 
@@ -156,7 +156,7 @@ update_config_from_file (config_t config, const gchar *path)
 
   switch (parse_config_entity (entity, &config_id, &name, &comment,
                                &usage_type, &all_selector, &nvt_selectors,
-                               &preferences))
+                               &preferences, &deprecated))
     {
       case 0:
         break;
@@ -174,7 +174,7 @@ update_config_from_file (config_t config, const gchar *path)
   /* Update the config. */
 
   update_config (config, name, comment, usage_type, all_selector,
-                 nvt_selectors, preferences);
+                 nvt_selectors, preferences, deprecated);
 
   /* Cleanup. */
 
@@ -197,7 +197,7 @@ create_config_from_file (const gchar *path)
 {
   entity_t config;
   array_t *nvt_selectors, *preferences;
-  char *created_name, *comment, *name, *usage_type;
+  char *created_name, *comment, *name, *usage_type, *deprecated;
   const char *config_id;
   config_t new_config;
   int all_selector;
@@ -213,7 +213,7 @@ create_config_from_file (const gchar *path)
 
   switch (parse_config_entity (config, &config_id, &name, &comment,
                                &usage_type, &all_selector, &nvt_selectors,
-                               &preferences))
+                               &preferences, &deprecated))
     {
       case 0:
         break;
@@ -226,6 +226,16 @@ create_config_from_file (const gchar *path)
         free_entity (config);
         g_warning ("%s: Failed to parse entity", __func__);
         return -1;
+    }
+
+  /* Handle deprecation status */
+
+  if (deprecated && atoi (deprecated))
+    {
+      g_debug ("Skipping import of deprecated config %s.",
+               config_id);
+      set_resource_id_deprecated ("config", config_id, TRUE);
+      return 0;
     }
 
   /* Create the config. */
@@ -329,6 +339,24 @@ should_sync_config_from_path (const char *path, gboolean rebuild,
   uuid = g_strdup_printf ("%s-%s-%s-%s-%s",
                           split[1], split[2], split[3], split[4], split[5]);
   g_strfreev (split);
+
+  if (resource_id_deprecated ("config", uuid))
+    {
+      find_config_no_acl (uuid, config);
+      
+      if (rebuild)
+        return 1;
+
+      full_path = g_build_filename (feed_dir_configs (), path, NULL);
+      if (deprecated_config_id_updated_in_feed (uuid, full_path))
+        {
+          g_free (full_path);
+          return 1;
+        }
+      g_free (full_path);
+      return 0;
+    }
+
   if (find_config_no_acl (uuid, config) == 0
       && *config)
     {
@@ -343,6 +371,7 @@ should_sync_config_from_path (const char *path, gboolean rebuild,
 
       if (config_updated_in_feed (*config, full_path))
         {
+          g_free (full_path);
           return 1;
         }
 

--- a/src/manage_configs.c
+++ b/src/manage_configs.c
@@ -345,14 +345,19 @@ should_sync_config_from_path (const char *path, gboolean rebuild,
       find_config_no_acl (uuid, config);
       
       if (rebuild)
-        return 1;
+        {
+          g_free (uuid);
+          return 1;
+        }
 
       full_path = g_build_filename (feed_dir_configs (), path, NULL);
       if (deprecated_config_id_updated_in_feed (uuid, full_path))
         {
+          g_free (uuid);
           g_free (full_path);
           return 1;
         }
+      g_free (uuid);
       g_free (full_path);
       return 0;
     }
@@ -361,7 +366,10 @@ should_sync_config_from_path (const char *path, gboolean rebuild,
       && *config)
     {
       if (rebuild)
-        return 1;
+        {
+          g_free (uuid);
+          return 1;
+        }
 
       full_path = g_build_filename (feed_dir_configs (), path, NULL);
 

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -1993,6 +1993,13 @@ create_tables ()
        "  type TEXT,"
        "  value TEXT);");
 
+  sql ("CREATE TABLE IF NOT EXISTS deprecated_feed_data"
+       " (id SERIAL PRIMARY KEY,"
+       "  type TEXT,"
+       "  uuid TEXT,"
+       "  modification_time INTEGER,"
+       "  UNIQUE (type, uuid));");
+
   sql ("CREATE TABLE IF NOT EXISTS filters"
        " (id SERIAL PRIMARY KEY,"
        "  uuid text UNIQUE NOT NULL,"

--- a/src/manage_port_lists.c
+++ b/src/manage_port_lists.c
@@ -282,14 +282,18 @@ should_sync_port_list_from_path (const char *path, gboolean rebuild,
       find_port_list_no_acl (uuid, port_list);
       
       if (rebuild)
-        return 1;
+        {
+          return 1;
+        }
 
       full_path = g_build_filename (feed_dir_port_lists (), path, NULL);
       if (deprecated_port_list_id_updated_in_feed (uuid, full_path))
         {
+          g_free (uuid);
           g_free (full_path);
           return 1;
         }
+      g_free (uuid);
       g_free (full_path);
       return 0;
     }
@@ -298,7 +302,10 @@ should_sync_port_list_from_path (const char *path, gboolean rebuild,
       && *port_list)
     {
       if (rebuild)
-        return 1;
+        {
+          g_free (uuid);
+          return 1;
+        }
 
       full_path = g_build_filename (feed_dir_port_lists (), path, NULL);
 

--- a/src/manage_port_lists.c
+++ b/src/manage_port_lists.c
@@ -115,7 +115,7 @@ create_port_list_from_file (const gchar *path)
 {
   entity_t port_list;
   array_t *ranges;
-  char *comment, *name;
+  char *comment, *name, *deprecated;
   const char *port_list_id;
   port_list_t new_port_list;
 
@@ -129,7 +129,17 @@ create_port_list_from_file (const gchar *path)
   /* Parse the data out of the entity. */
 
   parse_port_list_entity (port_list, &port_list_id, &name, &comment,
-                          &ranges);
+                          &ranges, &deprecated);
+
+  /* Handle deprecation status */
+
+  if (deprecated && atoi (deprecated))
+    {
+      g_debug ("Skipping import of deprecated port list %s.",
+               port_list_id);
+      set_resource_id_deprecated ("port_list", port_list_id, TRUE);
+      return 0;
+    }
 
   /* Create the port_list. */
 
@@ -207,7 +217,7 @@ update_port_list_from_file (port_list_t port_list, const gchar *path)
 {
   entity_t entity;
   array_t *ranges;
-  char *comment, *name;
+  char *comment, *name, *deprecated;
   const char *port_list_id;
 
   g_debug ("%s: updating %s", __func__, path);
@@ -219,11 +229,12 @@ update_port_list_from_file (port_list_t port_list, const gchar *path)
 
   /* Parse the data out of the entity. */
 
-  parse_port_list_entity (entity, &port_list_id, &name, &comment, &ranges);
+  parse_port_list_entity (entity, &port_list_id, &name, &comment, &ranges,
+                          &deprecated);
 
   /* Update the port list. */
 
-  update_port_list (port_list, name, comment, ranges);
+  update_port_list (port_list, name, comment, ranges, deprecated);
 
   /* Cleanup. */
 
@@ -265,6 +276,24 @@ should_sync_port_list_from_path (const char *path, gboolean rebuild,
   uuid = g_strdup_printf ("%s-%s-%s-%s-%s",
                           split[1], split[2], split[3], split[4], split[5]);
   g_strfreev (split);
+
+  if (resource_id_deprecated ("port_list", uuid))
+    {
+      find_port_list_no_acl (uuid, port_list);
+      
+      if (rebuild)
+        return 1;
+
+      full_path = g_build_filename (feed_dir_port_lists (), path, NULL);
+      if (deprecated_port_list_id_updated_in_feed (uuid, full_path))
+        {
+          g_free (full_path);
+          return 1;
+        }
+      g_free (full_path);
+      return 0;
+    }
+
   if (find_port_list_no_acl (uuid, port_list) == 0
       && *port_list)
     {
@@ -279,6 +308,7 @@ should_sync_port_list_from_path (const char *path, gboolean rebuild,
 
       if (port_list_updated_in_feed (*port_list, full_path))
         {
+          g_free (full_path);
           return 1;
         }
 

--- a/src/manage_report_formats.c
+++ b/src/manage_report_formats.c
@@ -643,7 +643,10 @@ should_sync_report_format_from_path (const char *path,
       find_report_format_no_acl (uuid, report_format);
       
       if (rebuild)
-        return 1;
+        {
+          g_free (uuid);
+          return 1;
+        }
 
       full_path = g_build_filename (feed_dir_report_formats (), path, NULL);
       if (deprecated_report_format_id_updated_in_feed (uuid, full_path))
@@ -651,6 +654,7 @@ should_sync_report_format_from_path (const char *path,
           g_free (full_path);
           return 1;
         }
+      g_free (uuid);
       g_free (full_path);
       return 0;
     }
@@ -659,7 +663,10 @@ should_sync_report_format_from_path (const char *path,
       && *report_format)
     {
       if (rebuild)
-        return 1;
+        {
+          g_free (uuid);
+          return 1;
+        }
 
       full_path = g_build_filename (feed_dir_report_formats (), path, NULL);
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -4749,6 +4749,63 @@ manage_trash_resource_name (const char *type, const char *uuid, char **name)
 }
 
 /**
+ * @brief Check if a resource has been marked as deprecated.
+ *
+ * @param[in]  type         Resource type.
+ * @param[in]  resource_id  UUID of the resource.
+ *
+ * @return 1 if deprecated, else 0.
+ */
+int
+resource_id_deprecated (const char *type, const char *resource_id)
+{
+  int ret;
+  gchar *quoted_type = sql_quote (type);
+  gchar *quoted_uuid = sql_quote (resource_id);
+
+  ret = sql_int ("SELECT count(*) FROM deprecated_feed_data"
+                 " WHERE type = '%s' AND uuid = '%s';",
+                 quoted_type, quoted_uuid);
+
+  g_free (quoted_type);
+  g_free (quoted_uuid);
+
+  return ret != 0;
+}
+
+/**
+ * @brief Mark whether resource as deprecated.
+ *
+ * @param[in]  type         Resource type.
+ * @param[in]  resource_id  UUID of the resource.
+ * @param[in]  deprecated   Whether the resource is deprecated.
+ */
+void
+set_resource_id_deprecated (const char *type, const char *resource_id,
+                            gboolean deprecated)
+{
+  gchar *quoted_type = sql_quote (type);
+  gchar *quoted_uuid = sql_quote (resource_id);
+
+  if (deprecated)
+    {
+      sql ("INSERT INTO deprecated_feed_data (type, uuid, modification_time)"
+           " VALUES ('%s', '%s', m_now ())"
+           " ON CONFLICT (uuid, type)"
+           " DO UPDATE SET modification_time = m_now ()",
+           quoted_type, quoted_uuid);
+    }
+  else
+    {
+      sql ("DELETE FROM deprecated_feed_data"
+           " WHERE type = '%s' AND uuid = '%s'",
+           quoted_type, quoted_uuid);
+    }
+  g_free (quoted_type);
+  g_free (quoted_uuid);
+}
+
+/**
  * @brief Get the UUID of a resource.
  *
  * @param[in]  type      Type.

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -4774,7 +4774,7 @@ resource_id_deprecated (const char *type, const char *resource_id)
 }
 
 /**
- * @brief Mark whether resource as deprecated.
+ * @brief Mark whether resource is deprecated.
  *
  * @param[in]  type         Resource type.
  * @param[in]  resource_id  UUID of the resource.

--- a/src/manage_sql_configs.h
+++ b/src/manage_sql_configs.h
@@ -89,9 +89,12 @@ migrate_predefined_configs ();
 int
 config_updated_in_feed (config_t, const gchar *);
 
+int
+deprecated_config_id_updated_in_feed (const char *, const gchar *);
+
 void
 update_config (config_t, const gchar *, const gchar *, const gchar *,
-               int, const array_t*, const array_t*);
+               int, const array_t*, const array_t*, const gchar *);
 
 void
 check_db_configs ();

--- a/src/manage_sql_port_lists.h
+++ b/src/manage_sql_port_lists.h
@@ -66,8 +66,12 @@ migrate_predefined_port_lists ();
 int
 port_list_updated_in_feed (port_list_t, const gchar *);
 
+int
+deprecated_port_list_id_updated_in_feed (const char *, const gchar *);
+
 void
-update_port_list (port_list_t, const gchar *, const gchar *, array_t *);
+update_port_list (port_list_t, const gchar *, const gchar *, array_t *,
+                  const gchar *);
 
 void
 check_db_port_lists ();

--- a/src/manage_sql_report_formats.h
+++ b/src/manage_sql_report_formats.h
@@ -71,10 +71,13 @@ void
 update_report_format (report_format_t, const gchar *, const gchar *,
                       const gchar *, const gchar *, const gchar *,
                       const gchar *, const gchar *, array_t *, array_t *,
-                      array_t *);
+                      array_t *, const gchar *);
 
 int
 report_format_updated_in_feed (report_format_t, const gchar *);
+
+int
+deprecated_report_format_id_updated_in_feed (const char*, const gchar *);
 
 int
 migrate_predefined_report_formats ();

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -7459,6 +7459,7 @@ END:VCALENDAR
           <o><e>preferences</e></o>
           <o><e>nvt_selectors</e></o>
           <e>predefined</e>
+          <o><e>deprecated</e></o>
         </pattern>
         <ele>
           <name>owner</name>
@@ -7836,6 +7837,11 @@ END:VCALENDAR
         <ele>
           <name>predefined</name>
           <summary>Whether the config was predefined by the feed</summary>
+          <pattern><t>boolean</t></pattern>
+        </ele>
+        <ele>
+          <name>deprecated</name>
+          <summary>Whether the config is deprecated</summary>
           <pattern><t>boolean</t></pattern>
         </ele>
       </ele>
@@ -14910,6 +14916,7 @@ END:VCALENDAR
           <o><e>port_ranges</e></o>
           <o><e>targets</e></o>
           <e>predefined</e>
+          <o><e>deprecated</e></o>
         </pattern>
         <ele>
           <name>owner</name>
@@ -15112,6 +15119,11 @@ END:VCALENDAR
         <ele>
           <name>predefined</name>
           <summary>Whether the port list was predefined by the feed</summary>
+          <pattern><t>boolean</t></pattern>
+        </ele>
+        <ele>
+          <name>deprecated</name>
+          <summary>Whether the port list is deprecated</summary>
           <pattern><t>boolean</t></pattern>
         </ele>
       </ele>
@@ -16522,6 +16534,7 @@ END:VCALENDAR
           <e>trust</e>
           <e>active</e>
           <e>predefined</e>
+          <o><e>deprecated</e></o>
           <any><e>param</e></any>
         </pattern>
         <ele>
@@ -16778,11 +16791,11 @@ END:VCALENDAR
               <required>1</required>
             </attrib>
             <e>time</e>
-			<alts>
-			  <alt>yes</alt>
-			  <alt>no</alt>
-			  <alt>unknown</alt>
-			</alts>
+            <alts>
+              <alt>yes</alt>
+              <alt>no</alt>
+              <alt>unknown</alt>
+            </alts>
           </pattern>
           <ele>
             <name>time</name>
@@ -16798,6 +16811,11 @@ END:VCALENDAR
         <ele>
           <name>predefined</name>
           <summary>Whether the report format was predefined by the feed</summary>
+          <pattern><t>boolean</t></pattern>
+        </ele>
+        <ele>
+          <name>deprecated</name>
+          <summary>Whether the report format is deprecated</summary>
           <pattern><t>boolean</t></pattern>
         </ele>
       </ele>


### PR DESCRIPTION
## What
The data objects in the feed (configs, port lists, report formats) can now be deprecated, which prevents them from being imported unless they already exist in the database. Existing data objects are will be marked with a new XML element to indicate they are deprecated.

## Why
This will be used to deprecate feed data objects that are no longer maintained.

## References
GEA-6

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


