### PR TITLE
Change: Improve message used when db is wrong version

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -26825,8 +26825,8 @@ extern buffer_size_t from_client_end;
  *                              daemon layer, or NULL.
  * @param[in]  skip_db_check    Skip DB check.
  *
- * @return 0 success, -1 error, -2 database is wrong version,
- *         -4 max_ips_per_target out of range.
+ * @return 0 success, -1 error, -2 database is too old,
+ *         -4 max_ips_per_target out of range, -5 database is too new.
  */
 int
 init_gmp (GSList *log_config, const db_conn_info_t *database,

--- a/src/gmpd.c
+++ b/src/gmpd.c
@@ -95,8 +95,8 @@ static int close_connection = 0;
  *                              daemon layer, or NULL.
  * @param[in]  skip_db_check    Skip DB check.
  *
- * @return 0 success, -1 error, -2 database is wrong version,
- *         -4 max_ips_per_target out of range.
+ * @return 0 success, -1 error, -2 database is too old,
+ *         -4 max_ips_per_target out of range, -5 database is too new.
  */
 int
 init_gmpd (GSList *log_config, const db_conn_info_t *database,

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -3142,6 +3142,19 @@ gvmd (int argc, char** argv, char *env[])
         break;
       case -2:
         g_critical ("%s: database is wrong version", __func__);
+        g_critical ("%s: Your database is too old for this version of gvmd.",
+                    __func__);
+        g_critical ("%s: Please migrate to the current data model.", __func__);
+        g_critical ("%s: Use a command like this: gvmd --migrate", __func__);
+        log_config_free ();
+        gvm_close_sentry ();
+        exit (EXIT_FAILURE);
+        break;
+      case -5:
+        g_critical ("%s: database is wrong version", __func__);
+        g_critical ("%s: Your database is too new for this version of gvmd.",
+                    __func__);
+        g_critical ("%s: Please upgrade gvmd to a newer version.", __func__);
         log_config_free ();
         gvm_close_sentry ();
         exit (EXIT_FAILURE);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -922,8 +922,9 @@ cert_check_time ()
  * @param[in]  log_config  Log configuration.
  * @param[in]  database    Database.
  *
- * @return 0 success, -1 error, -2 database is wrong version,
- *         -3 database needs to be initialised from server.
+ * @return 0 success, -1 error, -2 database is too old,
+ *         -3 database needs to be initialised from server,
+ *         -5 database is too new.
  */
 int
 manage_option_setup (GSList *log_config, const db_conn_info_t *database)
@@ -945,6 +946,14 @@ manage_option_setup (GSList *log_config, const db_conn_info_t *database)
         break;
       case -2:
         fprintf (stderr, "Database is wrong version.\n");
+        fprintf (stderr, "Your database is too old for this version of gvmd.\n");
+        fprintf (stderr, "Please migrate to the current data model.\n");
+        fprintf (stderr, "Use a command like this: gvmd --migrate\n");
+        return ret;
+      case -5:
+        fprintf (stderr, "Database is wrong version.\n");
+        fprintf (stderr, "Your database is too new for this version of gvmd.\n");
+        fprintf (stderr, "Please upgrade gvmd to a newer version.\n");
         return ret;
       case -3:
         fprintf (stderr, "Database must be initialised.\n");
@@ -6246,8 +6255,8 @@ encrypt_all_auth_settings (gboolean decrypt_flag)
  * @param[in] database      Location of manage database.
  *
  * @return 0 success, -1 error,
- *         -2 database is wrong version, -3 database needs to be initialised
- *         from server.
+ *         -2 database is too old, -3 database needs to be initialised
+ *         from server, -5 database is too new.
  */
 int
 manage_encrypt_all_credentials (GSList *log_config,
@@ -6287,8 +6296,8 @@ manage_encrypt_all_credentials (GSList *log_config,
  * @param[in] database      Location of manage database.
  *
  * @return 0 success, -1 error,
- *         -2 database is wrong version, -3 database needs to be initialised
- *         from server.
+ *         -2 database is too old, -3 database needs to be initialised
+ *         from server, -5 database is too new.
  */
 int
 manage_decrypt_all_credentials (GSList *log_config,
@@ -6627,8 +6636,8 @@ check_alerts ()
  * @param[in]  database    Location of manage database.
  *
  * @return 0 success, -1 error,
- *         -2 database is wrong version, -3 database needs to be initialised
- *         from server.
+ *         -2 database is too old, -3 database needs to be initialised
+ *         from server, -5 database is too new.
  */
 int
 manage_check_alerts (GSList *log_config, const db_conn_info_t *database)
@@ -15979,7 +15988,7 @@ add_role_permission_resource (const gchar *role_id, const gchar *permission,
 /**
  * @brief Ensure that the databases are the right versions.
  *
- * @return 0 success, -1 error, -2 database is wrong version.
+ * @return 0 success, -1 error, -2 database is too old, -5 database is too new.
  */
 static int
 check_db_versions ()
@@ -15996,14 +16005,20 @@ check_db_versions ()
       if (strcmp (database_version,
                   G_STRINGIFY (GVMD_DATABASE_VERSION)))
         {
+          int existing;
+
           g_message ("%s: database version of database: %s",
                      __func__,
                      database_version);
           g_message ("%s: database version supported by manager: %s",
                      __func__,
                      G_STRINGIFY (GVMD_DATABASE_VERSION));
+
+          existing = atoi (database_version);
+
           g_free (database_version);
-          return -2;
+
+          return GVMD_DATABASE_VERSION > existing ? -2 : -5;
         }
       g_free (database_version);
     }
@@ -16013,15 +16028,22 @@ check_db_versions ()
   scap_db_version = manage_scap_db_version ();
   if (scap_db_version == -1)
     g_message ("No SCAP database found");
-  else if (scap_db_version != manage_scap_db_supported_version ())
+  else
     {
-      g_message ("%s: database version of SCAP database: %i",
-                 __func__,
-                 scap_db_version);
-      g_message ("%s: SCAP database version supported by manager: %s",
-                 __func__,
-                 G_STRINGIFY (GVMD_SCAP_DATABASE_VERSION));
-      return -2;
+      int supported;
+      
+      supported = manage_scap_db_supported_version ();
+      if (scap_db_version != supported)
+        {
+          g_message ("%s: database version of SCAP database: %i",
+                     __func__,
+                     scap_db_version);
+          g_message ("%s: SCAP database version supported by manager: %s",
+                     __func__,
+                     G_STRINGIFY (GVMD_SCAP_DATABASE_VERSION));
+
+          return supported > scap_db_version ? -2 : -5;
+        }
     }
 
   /* Check CERT database version. */
@@ -16029,15 +16051,22 @@ check_db_versions ()
   cert_db_version = manage_cert_db_version ();
   if (cert_db_version == -1)
     g_message ("No CERT database found");
-  else if (cert_db_version != manage_cert_db_supported_version ())
+  else
     {
-      g_message ("%s: database version of CERT database: %i",
-                 __func__,
-                 cert_db_version);
-      g_message ("%s: CERT database version supported by manager: %s",
-                 __func__,
-                 G_STRINGIFY (GVMD_CERT_DATABASE_VERSION));
-      return -2;
+      int supported;
+
+      supported = manage_cert_db_supported_version ();
+      if (cert_db_version != supported)
+        {
+          g_message ("%s: database version of CERT database: %i",
+                     __func__,
+                     cert_db_version);
+          g_message ("%s: CERT database version supported by manager: %s",
+                     __func__,
+                     G_STRINGIFY (GVMD_CERT_DATABASE_VERSION));
+
+          return supported > cert_db_version ? -2 : -5;
+        }
     }
   return 0;
 }
@@ -16700,8 +16729,8 @@ cleanup_tables ()
  * @param[in]  skip_db_check       Skip DB check.
  * @param[in]  check_encryption_key  Check encryption key if doing DB check.
  *
- * @return 0 success, -1 error, -2 database is wrong version,
- *         -4 max_ips_per_target out of range.
+ * @return 0 success, -1 error, -2 database is too old,
+ *         -4 max_ips_per_target out of range, -5 database is too new.
  */
 static int
 init_manage_internal (GSList *log_config,
@@ -16856,8 +16885,9 @@ init_manage_internal (GSList *log_config,
  *                                 with GMP when an alert occurs.
  * @param[in]  skip_db_check       Skip DB check.
  *
- * @return 0 success, -1 error, -2 database is wrong version, -3 database needs
- *         to be initialised from server, -4 max_ips_per_target out of range.
+ * @return 0 success, -1 error, -2 database is too old, -3 database needs
+ *         to be initialised from server, -4 max_ips_per_target out of range,
+ *         -5 database is too new.
  */
 int
 init_manage (GSList *log_config, const db_conn_info_t *database,
@@ -16889,8 +16919,9 @@ init_manage (GSList *log_config, const db_conn_info_t *database,
  * @param[in]  database        Location of database.
  * @param[in]  max_ips_per_target  Max number of IPs per target.
  *
- * @return 0 success, -1 error, -2 database is wrong version, -3 database needs
- *         to be initialised from server, -4 max_ips_per_target out of range.
+ * @return 0 success, -1 error, -2 database is too old, -3 database needs
+ *         to be initialised from server, -4 max_ips_per_target out of range,
+ *         -5 database is too new.
  */
 int
 init_manage_helper (GSList *log_config, const db_conn_info_t *database,
@@ -39879,8 +39910,8 @@ DEF_ACCESS (override_iterator_new_severity, GET_ITERATOR_COLUMN_COUNT + 15);
  * @param[in]  key_pub_path     Certificate path.
  * @param[in]  key_priv_path    Private key path.
  *
- * @return 0 success, -1 error, -2 database is wrong version, -3 database needs
- *         to be initialised from server.
+ * @return 0 success, -1 error, -2 database is too old, -3 database needs
+ *         to be initialised from server, -5 database is too new.
  */
 int
 manage_create_scanner (GSList *log_config, const db_conn_info_t *database,
@@ -40063,8 +40094,8 @@ manage_create_scanner (GSList *log_config, const db_conn_info_t *database,
  * @param[in]  uuid        UUID of scanner.
  *
  * @return 0 success, 2 failed to find scanner, 3 scanner can't be deleted,
- *         -1 error.  -2 database is wrong version, -3 database needs to be
- *         initialised from server.
+ *         -1 error.  -2 database is too old, -3 database needs to be
+ *         initialised from server, -5 database is too new.
  */
 int
 manage_delete_scanner (GSList *log_config, const db_conn_info_t *database,
@@ -40135,8 +40166,8 @@ manage_delete_scanner (GSList *log_config, const db_conn_info_t *database,
  *
  * @return 0 success, , 1 failed to find scanner, 2 scanner with new name
  *         exists, 3 scanner_id required, 4 invalid value, 99 permission
- *         denied, -1 error, -2 database is wrong version, -3 database needs
- *         to be initialised from server.
+ *         denied, -1 error, -2 database is too old, -3 database needs
+ *         to be initialised from server, -5 database is too new.
  */
 int
 manage_modify_scanner (GSList *log_config, const db_conn_info_t *database,
@@ -40361,8 +40392,8 @@ manage_modify_scanner (GSList *log_config, const db_conn_info_t *database,
  * @param[in]  uuid        UUID of scanner.
  *
  * @return 0 success, 1 failed to find scanner, 2 failed to verify scanner,
- *         -1 error.  -2 database is wrong version, -3 database needs to be
- *         initialised from server.
+ *         -1 error, -2 database is too old, -3 database needs to be
+ *         initialised from server, -5 database is too new.
  */
 int
 manage_verify_scanner (GSList *log_config, const db_conn_info_t *database,
@@ -52446,8 +52477,8 @@ manage_default_ca_cert ()
  * @param[in]  role_name   Role of user.  Admin if NULL.
  *
  * @return 0 success, -1 error,
- *         -2 database is wrong version, -3 database needs to be initialised
- *         from server.
+ *         -2 database is too old, -3 database needs to be initialised
+ *         from server, -5 database is too new.
  */
 int
 manage_create_user (GSList *log_config, const db_conn_info_t *database,
@@ -52540,8 +52571,8 @@ manage_create_user (GSList *log_config, const db_conn_info_t *database,
  * @param[in]  inheritor_name  Name of user that inherits user's resources.
  *
  * @return 0 success, 2 failed to find user, 4 user has active tasks, -1 error.
- *         -2 database is wrong version, -3 database needs to be initialised
- *         from server.
+ *         -2 database is too old, -3 database needs to be initialised
+ *         from server, -5 database is too new.
  */
 int
 manage_delete_user (GSList *log_config, const db_conn_info_t *database,
@@ -57488,8 +57519,8 @@ delete_permissions_cache_for_user (user_t user)
  * @param[in]  name        Name of optimization.
  *
  * @return 0 success, 1 error in name, -1 error,
- *         -2 database is wrong version, -3 database needs to be initialised
- *         from server.
+ *         -2 database is too old, -3 database needs to be initialised
+ *         from server, -5 database is too new.
  */
 int
 manage_optimize (GSList *log_config, const db_conn_info_t *database,

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -2390,7 +2390,7 @@ manage_sync_nvts (int (*fork_update_nvt_cache) ())
  * @param[in]  update  0 rebuild, else update.
  *
  * @return 0 success, -1 error, -1 no osp update socket, -2 could not connect
- *         to osp update socket -3 failed to get scanner version
+ *         to osp update socket, -3 failed to get scanner version
  */
 int
 update_or_rebuild_nvts (int update)
@@ -2456,8 +2456,9 @@ update_or_rebuild_nvts (int update)
  * @param[in]  database    Location of manage database.
  *
  * @return 0 success, 1 VT integrity check failed, -1 error,
- *         -2 database is wrong version,
- *         -3 database needs to be initialised from server, -5 sync active.
+ *         -2 database is too old,
+ *         -3 database needs to be initialised from server,
+ *         -5 database is too new, -6 sync active.
  */
 int
 manage_rebuild (GSList *log_config, const db_conn_info_t *database)
@@ -2471,7 +2472,7 @@ manage_rebuild (GSList *log_config, const db_conn_info_t *database)
     {
       case 1:
         printf ("A feed sync is already running.\n");
-        return -5;
+        return -6;
       case -1:
         printf ("Error getting sync lock.\n");
         return -1;
@@ -2525,8 +2526,9 @@ manage_rebuild (GSList *log_config, const db_conn_info_t *database)
  * @param[in]  log_config  Log configuration.
  * @param[in]  database    Location of manage database.
  *
- * @return 0 success, -1 error, -2 database is wrong version,
- *         -3 database needs to be initialised from server, -5 sync active.
+ * @return 0 success, -1 error, -2 database is too old,
+ *         -3 database needs to be initialised from server,
+ *         -5 database is too new, -6 sync active.
  */
 int
 manage_dump_vt_verification (GSList *log_config,
@@ -2540,7 +2542,7 @@ manage_dump_vt_verification (GSList *log_config,
     {
       case 1:
         printf ("A feed sync is already running.\n");
-        return -5;
+        return -6;
       case -1:
         printf ("Error getting sync lock.\n");
         return -1;


### PR DESCRIPTION
## What

Be more descriptive in error messages when database is wrong version.

To test, run SQL like `update meta set value = 9999 where name = 'database_version';` and `update scap.meta set value = 3 where name = 'database_version';`

## Why

Makes it easier to understand what action is needed. 

## References

Closes #1271 
