### PR TITLE
Add: Add extra information to report TLS certificates

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -26945,6 +26945,194 @@ print_report_host_details_xml (report_host_t report_host, FILE *stream,
 }
 
 /**
+ * @brief Print the XML for a report host's TLS certificates to a file stream.
+ * @param[in]  report_host  The report host to get certificates from.
+ * @param[in]  host_ip      The IP address of the report host.
+ * @param[in]  stream       File stream to write to.
+ *
+ * @return 0 on success, -1 error.
+ */
+static int
+print_report_host_tls_certificates_xml (report_host_t report_host, 
+                                        const char *host_ip,
+                                        FILE *stream)
+{
+
+  iterator_t tls_certs;
+  time_t activation_time, expiration_time;
+  gchar *md5_fingerprint, *sha256_fingerprint, *subject, *issuer, *serial;
+  gnutls_x509_crt_fmt_t certificate_format;
+
+  if (report_host == 0
+      || strcmp (host_ip, "") == 0)
+    return -1;
+
+  init_iterator (&tls_certs,
+                "SELECT rhd.value, rhd.name, rhd.source_name"
+                " FROM report_host_details AS rhd"
+                " WHERE rhd.report_host = %llu"
+                "   AND (source_description = 'SSL/TLS Certificate'"
+                "        OR source_description = 'SSL Certificate')",
+                report_host);
+  
+  while (next (&tls_certs)) 
+    {
+      const char *certificate_prefixed, *certificate_b64;
+      gsize certificate_size;
+      unsigned char *certificate;
+      const char *scanner_fpr_prefixed, *scanner_fpr;
+      gchar *quoted_scanner_fpr;
+      char *ssldetails;       
+      iterator_t ports;
+      gboolean valid;
+      time_t now;
+
+      certificate_prefixed = iterator_string (&tls_certs, 0);
+      certificate_b64 = g_strrstr (certificate_prefixed, ":") + 1;
+
+      certificate = g_base64_decode (certificate_b64, &certificate_size);
+
+      scanner_fpr_prefixed = iterator_string (&tls_certs, 1);
+      scanner_fpr = g_strrstr (scanner_fpr_prefixed, ":") + 1;
+
+      quoted_scanner_fpr = sql_quote (scanner_fpr);
+
+      activation_time = -1;
+      expiration_time = -1;
+      md5_fingerprint = NULL;
+      sha256_fingerprint = NULL;
+      subject = NULL;
+      issuer = NULL;
+      serial = NULL;
+      certificate_format = 0;
+
+      get_certificate_info ((gchar*)certificate,
+                            certificate_size,
+                            &activation_time,
+                            &expiration_time,
+                            &md5_fingerprint,
+                            &sha256_fingerprint,
+                            &subject,
+                            &issuer,
+                            &serial,
+                            &certificate_format);
+
+      if (sha256_fingerprint == NULL)
+        sha256_fingerprint = g_strdup (scanner_fpr);
+
+      ssldetails
+        = sql_string ("SELECT rhd.value"
+                      " FROM report_host_details AS rhd"
+                      " WHERE report_host = %llu"
+                      "   AND name = 'SSLDetails:%s'"
+                      " LIMIT 1;",
+                      report_host,
+                      quoted_scanner_fpr);
+
+      if (ssldetails)
+        parse_ssldetails (ssldetails,
+                          &activation_time,
+                          &expiration_time,
+                          &issuer,
+                          &serial);
+      else
+        g_warning ("%s: No SSLDetails found for fingerprint %s",
+                   __func__,
+                   scanner_fpr);
+
+      free (ssldetails);
+
+      now = time (NULL);
+
+      if((expiration_time >= now || expiration_time == -1) 
+         && (activation_time <= now || activation_time == -1))
+        {
+          valid = TRUE;
+        }
+      else
+        {
+          valid = FALSE;
+        }
+      char *hostname = sql_string ("SELECT value FROM report_host_details"
+                                   " WHERE report_host = %llu"
+                                   "   AND name = 'hostname'",
+                                   report_host);
+
+      PRINT (stream,
+        "<tls_certificate>"
+        "<name>%s</name>"
+        "<certificate format=\"%s\">%s</certificate>"
+        "<sha256_fingerprint>%s</sha256_fingerprint>"
+        "<md5_fingerprint>%s</md5_fingerprint>"
+        "<valid>%d</valid>"
+        "<activation_time>%s</activation_time>"
+        "<expiration_time>%s</expiration_time>"
+        "<subject_dn>%s</subject_dn>"
+        "<issuer_dn>%s</issuer_dn>"
+        "<serial>%s</serial>"
+        "<host><ip>%s</ip><hostname>%s</hostname></host>",
+        scanner_fpr,
+        tls_certificate_format_str (certificate_format),
+        certificate_b64,
+        sha256_fingerprint,
+        md5_fingerprint,
+        valid,
+        certificate_iso_time (activation_time),
+        certificate_iso_time (expiration_time),
+        subject,
+        issuer,
+        serial,
+        host_ip,
+        hostname ? hostname : "");
+
+
+      g_free (certificate);
+      g_free (md5_fingerprint);
+      g_free (sha256_fingerprint);
+      g_free (subject);
+      g_free (issuer);
+      g_free (serial);
+
+      free (hostname);
+    
+      init_iterator (&ports,
+                  "SELECT value FROM report_host_details"
+                  " WHERE report_host = %llu"
+                  "   AND name = 'SSLInfo'"
+                  "   AND value LIKE '%%:%%:%s'",
+                  report_host,
+                  quoted_scanner_fpr);
+     
+      PRINT (stream, "<ports>");
+
+      while (next (&ports))
+        {
+          const char *value;
+          gchar *port;
+
+          value = iterator_string (&ports, 0);
+          port = g_strndup (value, g_strrstr (value, ":") - value - 1);
+
+          PRINT (stream, "<port>%s</port>", port);
+
+          g_free (port);
+        }
+
+      PRINT (stream, "</ports>");
+
+      PRINT (stream, "</tls_certificate>");
+      
+      g_free (quoted_scanner_fpr);
+      cleanup_iterator (&ports);   
+    
+    }
+    cleanup_iterator (&tls_certs);
+
+  return 0;
+}
+
+
+/**
  * @brief Write report error message to file stream.
  *
  * @param[in]   stream      Stream to write to.
@@ -29574,7 +29762,6 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
             }
           cleanup_iterator (&hosts);
         }
-      array_free (result_hosts);
     }
   else if (get->details)
     {
@@ -29678,6 +29865,66 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
   g_hash_table_destroy (f_host_infos);
   g_hash_table_destroy (f_host_logs);
   g_hash_table_destroy (f_host_false_positives);
+
+
+  /* Print TLS certificates */
+
+   if (get->details && result_hosts_only)
+    {
+      gchar *result_host;
+      int index = 0;
+      PRINT (out, "<tls_certificates>");
+      while ((result_host = g_ptr_array_index (result_hosts, index++)))
+        {
+          gboolean present;
+          iterator_t hosts;
+          init_report_host_iterator (&hosts, report, result_host, 0);
+          present = next (&hosts);
+          if (present)
+            {
+              report_host_t report_host = host_iterator_report_host(&hosts);
+
+              if (print_report_host_tls_certificates_xml(report_host, 
+                                                         result_host,
+                                                         out))
+                {
+                  fclose (out);
+                  cleanup_iterator (&hosts);
+                  tz_revert (zone, tz, old_tz_override);
+                  return -1;
+                }
+            }
+          cleanup_iterator (&hosts);
+        }
+      PRINT (out, "</tls_certificates>");
+      array_free (result_hosts);
+    }
+  else if (get->details)
+    {
+      const char *host;
+      iterator_t hosts;
+      init_report_host_iterator (&hosts, report, NULL, 0);
+      
+      PRINT (out, "<tls_certificates>");
+      
+      while (next (&hosts))
+        {
+          report_host_t report_host = host_iterator_report_host(&hosts);
+          host = host_iterator_host (&hosts);
+
+          if (print_report_host_tls_certificates_xml(report_host, 
+                                                     host,
+                                                     out))
+            {
+              fclose (out);
+              cleanup_iterator (&hosts);
+              tz_revert (zone, tz, old_tz_override);
+              return -1;
+            }
+        }
+      cleanup_iterator (&hosts);
+      PRINT (out, "</tls_certificates>");
+    }
 
   end_time = scan_end_time (report);
   PRINT (out,

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -26968,12 +26968,12 @@ print_report_host_tls_certificates_xml (report_host_t report_host,
     return -1;
 
   init_iterator (&tls_certs,
-                "SELECT rhd.value, rhd.name, rhd.source_name"
-                " FROM report_host_details AS rhd"
-                " WHERE rhd.report_host = %llu"
-                "   AND (source_description = 'SSL/TLS Certificate'"
-                "        OR source_description = 'SSL Certificate')",
-                report_host);
+                 "SELECT rhd.value, rhd.name, rhd.source_name"
+                 " FROM report_host_details AS rhd"
+                 " WHERE rhd.report_host = %llu"
+                 "   AND (source_description = 'SSL/TLS Certificate'"
+                 "        OR source_description = 'SSL Certificate')",
+                 report_host);
   
   while (next (&tls_certs)) 
     {
@@ -27096,12 +27096,12 @@ print_report_host_tls_certificates_xml (report_host_t report_host,
       free (hostname);
     
       init_iterator (&ports,
-                  "SELECT value FROM report_host_details"
-                  " WHERE report_host = %llu"
-                  "   AND name = 'SSLInfo'"
-                  "   AND value LIKE '%%:%%:%s'",
-                  report_host,
-                  quoted_scanner_fpr);
+                     "SELECT value FROM report_host_details"
+                     " WHERE report_host = %llu"
+                     "   AND name = 'SSLInfo'"
+                     "   AND value LIKE '%%:%%:%s'",
+                     report_host,
+                     quoted_scanner_fpr);
      
       PRINT (stream, "<ports>");
 

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -1946,6 +1946,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <e>apps</e>
             <e>ssl_certs</e>
             <any><e>host</e></any>
+            <e>tls_certificates</e>
             <e>timestamp</e>
             <e>scan_start</e>
             <e>scan_end</e>
@@ -2811,6 +2812,124 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <name>extra</name>
             <summary>Extra info (NVT CVSS for closed CVE results)</summary>
             <pattern>text</pattern>
+          </ele>
+        </ele>
+      </ele>
+      <ele>
+        <name>tls_certificates</name>
+        <summary>List of TLS certificates found with the scan</summary>
+        <pattern>
+          <any><e>tls_certificate</e></any>
+        </pattern>
+        <ele>
+          <name>tls_certificate</name>
+          <summary>TLS certificate found with the scan</summary>
+          <pattern>
+            <e>name</e>
+            <e>certificate</e>
+            <e>sha256_fingerprint</e>
+            <e>md5_fingerprint</e>
+            <e>valid</e>
+            <e>activation_time</e>
+            <e>expiration_time</e>
+            <e>subject_dn</e>
+            <e>issuer_dn</e>
+            <e>serial</e>
+            <e>host</e>
+            <e>ports</e>
+          </pattern>
+          <ele>
+            <name>name</name>
+            <summary>The name of the TLS certificate</summary>
+            <pattern>text</pattern>
+          </ele>
+          <ele>
+            <name>certificate</name>
+            <summary>The Base64 encoded certificate data</summary>
+            <pattern>
+              <attrib>
+                <name>format</name>
+                <summary>The format of the certificate</summary>
+                <type>
+                  <alts>
+                    <alt>DER</alt>
+                    <alt>PEM</alt>
+                    <alt>unknown</alt>
+                  </alts>
+                </type>
+                <required>1</required>
+              </attrib>
+            </pattern>
+          </ele>
+          <ele>
+            <name>sha256_fingerprint</name>
+            <summary>The SHA256 fingerprint of the certificate</summary>
+            <pattern>text</pattern>
+          </ele>
+          <ele>
+            <name>md5_fingerprint</name>
+            <summary>The MD5 fingerprint of the certificate</summary>
+            <pattern>text</pattern>
+          </ele>
+          <ele>
+            <name>valid</name>
+            <summary>Whether the certificate is currently valid</summary>
+            <pattern><t>boolean</t></pattern>
+          </ele>
+          <ele>
+            <name>activation_time</name>
+            <summary>Time before which the certificate is not valid</summary>
+            <pattern><t>iso_time</t></pattern>
+          </ele>
+          <ele>
+            <name>expiration_time</name>
+            <summary>Time after which the certificate is not valid</summary>
+            <pattern><t>iso_time</t></pattern>
+          </ele>
+          <ele>
+            <name>subject_dn</name>
+            <summary>Distinguished name (DN) of the certificate subject</summary>
+            <pattern>text</pattern>
+          </ele>
+          <ele>
+            <name>issuer_dn</name>
+            <summary>Distinguished name (DN) of the certificate issuer</summary>
+            <pattern>text</pattern>
+          </ele>
+          <ele>
+            <name>serial</name>
+            <summary>Hexadecimal serial number of the certificate</summary>
+            <pattern>text</pattern>
+          </ele>
+          <ele>
+            <name>host</name>
+            <summary>Host where the certificate was found</summary>
+            <pattern>
+              <e>ip</e>
+              <e>hostname</e>
+            </pattern>
+            <ele>
+              <name>ip</name>
+              <summary>IP address of the host</summary>
+              <pattern>text</pattern>
+            </ele>
+            <ele>
+              <name>hostname</name>
+              <summary>If available, the hostname from host details</summary>
+              <pattern>text</pattern>
+            </ele>
+          </ele>
+          <ele>
+            <name>ports</name>
+            <summary>List of ports where the certificate was found</summary>
+            <pattern>
+              <any><e>port</e></any>
+            </pattern>
+            <ele>
+              <name>port</name>
+              <summary>Port where the certificate was found</summary>
+              <pattern><t>integer</t></pattern>
+            </ele>           
           </ele>
         </ele>
       </ele>


### PR DESCRIPTION

## What
A new element <tls_certificates> is added to the report XML to collect all TLS certificates.

## Why
Extra information (subject_dn, sha256_fingerprint, md5_fingerprint, valid) is required to show details for report TLS certificates in GSA.

## References
GEA-308


