### PR TITLE
Fix: Ensure iso_time uses user TZ when tz_override is empty

### DIFF
--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -569,7 +569,7 @@ manage_create_sql_functions ()
        "   user_zone text;"
        " BEGIN"
        "   user_zone :="
-       "     coalesce ((SELECT current_setting ('gvmd.tz_override')),"
+       "     coalesce (NULLIF((SELECT current_setting ('gvmd.tz_override')), ''),"
        "               (SELECT timezone FROM users"
        "                WHERE id = gvmd_user ()));"
        " RETURN iso_time (seconds, user_zone);"


### PR DESCRIPTION
## What

In pl/pgsql function `iso_time`, convert `gvmd.tz_override` to NULL when it is the empty string.

## Why

This ensures that the user's timezone setting is used (instead of always UTC).

This has two effects:

1. GET commands now correctly return fields like CREATION_TIME in the user's timezone.

`time o m m '<get_info type="nvt" filter="sort-reverse=created rows=10 first=1000"/>' > /tmp/info`
After:
```<creation_time>2023-03-31T11:52:43+02:00</creation_time>```
Before:
```<creation_time>2023-03-31T09:52:43Z</creation_time>```

2. `iso_time` is much faster

`SELECT iso_time (creation_time), iso_time (modification_time) FROM nvts ORDER BY creation_time DESC LIMIT 10 OFFSET 85940;`
Before: 11s
After: 3s

In particular this means the GSA SecInfo > NVTs page is much faster when using the pager arrows (going to the end page was 11s and is now 4s for me). 

Why is it faster? The broken `coalesce` was causing the empty string to be passed as zone to `iso_time(seconds, zone)`. I think this was causing the exception to be thrown (and caught), slowing things down. 
