### PR TITLE
Change: Set task status to processing during report asset creation

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -21284,15 +21284,16 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
 
   current_scanner_task = task;
   global_current_report = report;
-  set_task_run_status (task, TASK_STATUS_DONE);
-  current_scanner_task = 0;
-  global_current_report = 0;
+  set_task_run_status (task, TASK_STATUS_PROCESSING);
 
   if (in_assets_int)
     {
       create_asset_report (*report_id, "");
     }
 
+  set_task_run_status (task, TASK_STATUS_DONE);
+  current_scanner_task = 0;
+  global_current_report = 0;
   gvm_close_sentry ();
   exit (EXIT_SUCCESS);
   return 0;


### PR DESCRIPTION
## What

Set task status to processing during report asset creation.

## Why

If a report is uploaded to a container task it will appear done (with the "Container" status in GSA) once it is in the phase of processing the assets. This can be misleading, especially if the processing takes a long time, as is the case for uploading multiple larger reports.

## References

GEA-353


