### PR TITLE
Add dependencies for "Build Documentation" workflow and run on PR

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -3,6 +3,8 @@ name: 'Build Documentation'
 on:
   push:
     branches: [ main, stable, oldstable ]
+  pull_request:
+    branches: [ main, stable, oldstable ]
 
 jobs:
   generate-doc-and-upload-coverage:
@@ -10,6 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     container: greenbone/doxygen
     steps:
+      - name: Install gvmd doc dependencies
+        run: |
+          apt update
+          apt install --no-install-recommends -y xmltoman xsltproc
+          rm -rf /var/lib/apt/lists/*
       - name: Run the c lang coverage action
         uses: greenbone/actions/doc-coverage-clang@v3
 


### PR DESCRIPTION
## What
Some missing dependencies have been added to the "Build XML documentation and upload coverage" job and the workflow is now run for any pull request on main, stable or oldstable to catch errors earlier.

## Why

<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


