### PR TITLE
Change: move GET iterator time conversion out of SQL

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -8045,7 +8045,7 @@ buffer_notes_xml (GString *buffer, iterator_t *notes, int include_notes_details,
 
           text = note_iterator_text (notes);
           excerpt = utf8_substring (text, 0, setting_excerpt_size_int ());
-          creation = get_iterator_creation_time (notes);
+          creation = get_iterator_creation_time (notes, NULL);
           modification = get_iterator_modification_time (notes);
 
           /* This must match send_get_common. */
@@ -8113,7 +8113,7 @@ buffer_notes_xml (GString *buffer, iterator_t *notes, int include_notes_details,
             }
 
           end_time = note_iterator_end_time (notes);
-          creation = get_iterator_creation_time (notes);
+          creation = get_iterator_creation_time (notes, NULL);
           modification = get_iterator_modification_time (notes);
 
           /* This must match send_get_common. */
@@ -8321,7 +8321,7 @@ buffer_overrides_xml (GString *buffer, iterator_t *overrides,
 
           text = override_iterator_text (overrides);
           excerpt = utf8_substring (text, 0, setting_excerpt_size_int ());
-          creation = get_iterator_creation_time (overrides);
+          creation = get_iterator_creation_time (overrides, NULL);
           modification = get_iterator_modification_time (overrides);
 
           /* This must match send_get_common. */
@@ -8402,7 +8402,7 @@ buffer_overrides_xml (GString *buffer, iterator_t *overrides,
             }
 
           end_time = override_iterator_end_time (overrides);
-          creation = get_iterator_creation_time (overrides);
+          creation = get_iterator_creation_time (overrides, NULL);
           modification = get_iterator_modification_time (overrides);
 
           /* This must match send_get_common. */
@@ -9236,17 +9236,15 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
                     const char *delta_state, iterator_t *delta_results,
                     int changed, int cert_loaded, int lean, int use_delta_fields)
 {
-
   const char *descr, *name, *comment;
   const char *severity, *original_severity, *original_level;
   const char *host, *hostname, *result_id, *port, *path, *asset_id, *qod, *qod_type;
   char *detect_oid, *detect_ref, *detect_cpe, *detect_loc, *detect_name;
   double severity_double;
-  gchar *nl_descr, *nl_descr_escaped;
+  gchar *nl_descr, *nl_descr_escaped, *creation_time, *user_zone;
   result_t result;
   report_t report;
   task_t selected_task;
-  gchar *creation_time;
   
   comment = get_iterator_comment (results);
   name = get_iterator_name (results);
@@ -9254,6 +9252,7 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
   port = result_iterator_port (results);
   asset_id = NULL;
 
+  manage_current_user_info (&user_zone);
   if (use_delta_fields)
     {
       descr = result_iterator_delta_description (results);
@@ -9282,7 +9281,7 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
       qod = result_iterator_qod (results);
       qod_type = result_iterator_qod_type (results);
       result = result_iterator_result (results);
-      creation_time = get_iterator_creation_time (results);
+      creation_time = get_iterator_creation_time (results, user_zone);
       result_id = get_iterator_uuid (results);
       path = result_iterator_path (results);
       report = result_iterator_report (results);
@@ -9290,7 +9289,7 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
       if (host)
         asset_id = result_iterator_asset_host_id (results);
     }
-
+  g_free (user_zone);
 
   if (descr)
     {
@@ -11575,7 +11574,7 @@ handle_get_assets (gmp_parser_t *gmp_parser, GError **error)
               else
                 name = NULL;
 
-              creation = get_iterator_creation_time (&identifiers);
+              creation = get_iterator_creation_time (&identifiers, NULL);
               modification = get_iterator_modification_time (&identifiers);
 
               xml_string_append (result,
@@ -14629,7 +14628,7 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
           task_t task;
           gchar *creation, *modification;
 
-          creation = get_iterator_creation_time (&reports);
+          creation = get_iterator_creation_time (&reports, NULL);
           modification = get_iterator_modification_time (&reports);
 
           /* Send the standard elements.  Should match send_get_common. */
@@ -17932,7 +17931,7 @@ handle_get_vulns (gmp_parser_t *gmp_parser, GError **error)
       time_t oldest, newest;
       gchar *creation, *modification;
 
-      creation = get_iterator_creation_time (&vulns);
+      creation = get_iterator_creation_time (&vulns, NULL);
       modification = get_iterator_modification_time (&vulns);
 
       count ++;

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -9264,7 +9264,7 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
       qod = result_iterator_delta_qod (results);
       qod_type = result_iterator_delta_qod_type (results);
       result = result_iterator_delta_result (results);
-      creation_time = (gchar *) result_iterator_delta_creation_time (results); // FIX
+      creation_time = result_iterator_delta_creation_time (results);
       result_id = result_iterator_delta_uuid (results);
       path = result_iterator_delta_path (results);
       report = result_iterator_delta_report (results);

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -8040,9 +8040,14 @@ buffer_notes_xml (GString *buffer, iterator_t *notes, int include_notes_details,
 
       if (include_notes_details == 0)
         {
-          const char *text = note_iterator_text (notes);
-          gchar *excerpt = utf8_substring (text, 0,
-                                           setting_excerpt_size_int ());
+          gchar *excerpt, *creation, *modification;
+          const char *text;
+
+          text = note_iterator_text (notes);
+          excerpt = utf8_substring (text, 0, setting_excerpt_size_int ());
+          creation = get_iterator_creation_time (notes);
+          modification = get_iterator_modification_time (notes);
+
           /* This must match send_get_common. */
           buffer_xml_append_printf (buffer,
                                     "<owner><name>%s</name></owner>"
@@ -8063,8 +8068,8 @@ buffer_notes_xml (GString *buffer, iterator_t *notes, int include_notes_details,
                                     note_iterator_nvt_oid (notes),
                                     note_iterator_nvt_name (notes),
                                     note_iterator_nvt_type (notes),
-                                    get_iterator_creation_time (notes),
-                                    get_iterator_modification_time (notes),
+                                    creation,
+                                    modification,
                                     note_iterator_active (notes),
                                     strlen (excerpt) < strlen (text),
                                     excerpt,
@@ -8072,6 +8077,8 @@ buffer_notes_xml (GString *buffer, iterator_t *notes, int include_notes_details,
                                       && (uuid_task == NULL))
                                      || (note_iterator_result (notes)
                                          && (uuid_result == NULL))));
+          g_free (creation);
+          g_free (modification);
 
           if (tag_count)
             {
@@ -8092,6 +8099,7 @@ buffer_notes_xml (GString *buffer, iterator_t *notes, int include_notes_details,
           int trash_task;
           time_t end_time;
           iterator_t tags;
+          gchar *creation, *modification;
 
           if (uuid_task)
             {
@@ -8105,6 +8113,8 @@ buffer_notes_xml (GString *buffer, iterator_t *notes, int include_notes_details,
             }
 
           end_time = note_iterator_end_time (notes);
+          creation = get_iterator_creation_time (notes);
+          modification = get_iterator_modification_time (notes);
 
           /* This must match send_get_common. */
           buffer_xml_append_printf
@@ -8132,8 +8142,8 @@ buffer_notes_xml (GString *buffer, iterator_t *notes, int include_notes_details,
             note_iterator_nvt_oid (notes),
             note_iterator_nvt_name (notes),
             note_iterator_nvt_type (notes),
-            get_iterator_creation_time (notes),
-            get_iterator_modification_time (notes),
+            creation,
+            modification,
             note_iterator_active (notes),
             end_time > 1 ? iso_time (&end_time) : "",
             note_iterator_text (notes),
@@ -8150,6 +8160,8 @@ buffer_notes_xml (GString *buffer, iterator_t *notes, int include_notes_details,
              || (note_iterator_result (notes) && (uuid_result == NULL))));
 
           free (name_task);
+          g_free (creation);
+          g_free (modification);
 
           if (include_result && uuid_result && note_iterator_result (notes))
             {
@@ -8304,9 +8316,14 @@ buffer_overrides_xml (GString *buffer, iterator_t *overrides,
 
       if (include_overrides_details == 0)
         {
-          const char *text = override_iterator_text (overrides);
-          gchar *excerpt = utf8_substring (text, 0,
-                                           setting_excerpt_size_int ());
+          gchar *excerpt, *creation, *modification;
+          const char *text;
+
+          text = override_iterator_text (overrides);
+          excerpt = utf8_substring (text, 0, setting_excerpt_size_int ());
+          creation = get_iterator_creation_time (overrides);
+          modification = get_iterator_modification_time (overrides);
+
           /* This must match send_get_common. */
           buffer_xml_append_printf (buffer,
                                     "<owner><name>%s</name></owner>"
@@ -8331,8 +8348,8 @@ buffer_overrides_xml (GString *buffer, iterator_t *overrides,
                                     override_iterator_nvt_oid (overrides),
                                     override_iterator_nvt_name (overrides),
                                     override_iterator_nvt_type (overrides),
-                                    get_iterator_creation_time (overrides),
-                                    get_iterator_modification_time (overrides),
+                                    creation,
+                                    modification,
                                     override_iterator_active (overrides),
                                     strlen (excerpt) < strlen (text),
                                     excerpt,
@@ -8348,6 +8365,9 @@ buffer_overrides_xml (GString *buffer, iterator_t *overrides,
                                       && (uuid_task == NULL))
                                      || (override_iterator_result (overrides)
                                          && (uuid_result == NULL))));
+
+          g_free (creation);
+          g_free (modification);
 
           if (tag_count)
             {
@@ -8368,6 +8388,7 @@ buffer_overrides_xml (GString *buffer, iterator_t *overrides,
           int trash_task;
           time_t end_time;
           iterator_t tags;
+          gchar *creation, *modification;
 
           if (uuid_task)
             {
@@ -8381,6 +8402,8 @@ buffer_overrides_xml (GString *buffer, iterator_t *overrides,
             }
 
           end_time = override_iterator_end_time (overrides);
+          creation = get_iterator_creation_time (overrides);
+          modification = get_iterator_modification_time (overrides);
 
           /* This must match send_get_common. */
           buffer_xml_append_printf
@@ -8411,8 +8434,8 @@ buffer_overrides_xml (GString *buffer, iterator_t *overrides,
             override_iterator_nvt_oid (overrides),
             override_iterator_nvt_name (overrides),
             override_iterator_nvt_type (overrides),
-            get_iterator_creation_time (overrides),
-            get_iterator_modification_time (overrides),
+            creation,
+            modification,
             override_iterator_active (overrides),
             end_time > 1 ? iso_time (&end_time) : "",
             override_iterator_text (overrides),
@@ -8433,6 +8456,8 @@ buffer_overrides_xml (GString *buffer, iterator_t *overrides,
              || (override_iterator_result (overrides) && (uuid_result == NULL))));
 
           free (name_task);
+          g_free (creation);
+          g_free (modification);
 
           if (include_result && uuid_result
               && override_iterator_result (overrides))
@@ -9212,7 +9237,7 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
                     int changed, int cert_loaded, int lean, int use_delta_fields)
 {
 
-  const char *descr, *name, *comment, *creation_time;
+  const char *descr, *name, *comment;
   const char *severity, *original_severity, *original_level;
   const char *host, *hostname, *result_id, *port, *path, *asset_id, *qod, *qod_type;
   char *detect_oid, *detect_ref, *detect_cpe, *detect_loc, *detect_name;
@@ -9221,6 +9246,7 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
   result_t result;
   report_t report;
   task_t selected_task;
+  gchar *creation_time;
   
   comment = get_iterator_comment (results);
   name = get_iterator_name (results);
@@ -9238,7 +9264,7 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
       qod = result_iterator_delta_qod (results);
       qod_type = result_iterator_delta_qod_type (results);
       result = result_iterator_delta_result (results);
-      creation_time = result_iterator_delta_creation_time (results);
+      creation_time = (gchar *) result_iterator_delta_creation_time (results); // FIX
       result_id = result_iterator_delta_uuid (results);
       path = result_iterator_delta_path (results);
       report = result_iterator_delta_report (results);
@@ -9323,9 +9349,12 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
                               comment);
 
   if (creation_time)
-    buffer_xml_append_printf (buffer,
-                              "<creation_time>%s</creation_time>",
-                              creation_time);
+    {
+      buffer_xml_append_printf (buffer,
+                                "<creation_time>%s</creation_time>",
+                                creation_time);
+      g_free (creation_time);
+    }
 
   if (include_details)
     {
@@ -11536,7 +11565,7 @@ handle_get_assets (gmp_parser_t *gmp_parser, GError **error)
           while (next (&identifiers))
             {
               const char *source_type;
-              gchar *name;
+              gchar *name, *creation, *modification;
 
               source_type = host_identifier_iterator_source_type
                               (&identifiers);
@@ -11545,6 +11574,9 @@ handle_get_assets (gmp_parser_t *gmp_parser, GError **error)
                                     (&identifiers));
               else
                 name = NULL;
+
+              creation = get_iterator_creation_time (&identifiers);
+              modification = get_iterator_modification_time (&identifiers);
 
               xml_string_append (result,
                                  "<identifier id=\"%s\">"
@@ -11561,8 +11593,8 @@ handle_get_assets (gmp_parser_t *gmp_parser, GError **error)
                                  get_iterator_uuid (&identifiers),
                                  get_iterator_name (&identifiers),
                                  host_identifier_iterator_value (&identifiers),
-                                 get_iterator_creation_time (&identifiers),
-                                 get_iterator_modification_time (&identifiers),
+                                 creation,
+                                 modification,
                                  host_identifier_iterator_source_id
                                   (&identifiers),
                                  source_type,
@@ -11573,6 +11605,8 @@ handle_get_assets (gmp_parser_t *gmp_parser, GError **error)
                                  name ? name : "");
 
               g_free (name);
+              g_free (creation);
+              g_free (modification);
 
               if (strcmp (get_iterator_name (&identifiers), "OS") == 0)
                 xml_string_append (result,
@@ -14593,6 +14627,10 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
       if (get_reports_data->alert_id == NULL)
         {
           task_t task;
+          gchar *creation, *modification;
+
+          creation = get_iterator_creation_time (&reports);
+          modification = get_iterator_modification_time (&reports);
 
           /* Send the standard elements.  Should match send_get_common. */
           buffer_xml_append_printf
@@ -14615,12 +14653,12 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
              get_iterator_comment (&reports)
               ? get_iterator_comment (&reports)
               : "",
-             get_iterator_creation_time (&reports)
-              ? get_iterator_creation_time (&reports)
-              : "",
-             get_iterator_modification_time (&reports)
-              ? get_iterator_modification_time (&reports)
-              : "");
+             creation ? creation : "",
+             modification ? creation : "");
+
+          g_free (creation);
+          g_free (modification);
+
           /* Send short task and report format info */
           report_task (report, &task);
           if (task)
@@ -17892,6 +17930,10 @@ handle_get_vulns (gmp_parser_t *gmp_parser, GError **error)
   while (next (&vulns))
     {
       time_t oldest, newest;
+      gchar *creation, *modification;
+
+      creation = get_iterator_creation_time (&vulns);
+      modification = get_iterator_modification_time (&vulns);
 
       count ++;
       SENDF_TO_CLIENT_OR_FAIL ("<vuln id=\"%s\">"
@@ -17904,10 +17946,13 @@ handle_get_vulns (gmp_parser_t *gmp_parser, GError **error)
                                get_iterator_uuid (&vulns),
                                get_iterator_name (&vulns),
                                vuln_iterator_type (&vulns),
-                               get_iterator_creation_time (&vulns),
-                               get_iterator_modification_time (&vulns),
+                               creation,
+                               modification,
                                vuln_iterator_severity (&vulns),
                                vuln_iterator_qod (&vulns));
+
+      g_free (creation);
+      g_free (modification);
 
       // results for the vulnerability
       oldest = vuln_iterator_oldest (&vulns);

--- a/src/gmp_get.c
+++ b/src/gmp_get.c
@@ -316,8 +316,12 @@ send_get_common (const char *type, get_data_t *get, iterator_t *iterator,
   const char *tag_type;
   iterator_t tags;
   int tag_count;
+  gchar *creation, *modification;
 
   buffer = g_string_new ("");
+
+  creation = get_iterator_creation_time (iterator);
+  modification = get_iterator_modification_time (iterator);
 
   buffer_xml_append_printf (buffer,
                             "<%s id=\"%s\">"
@@ -342,14 +346,13 @@ send_get_common (const char *type, get_data_t *get, iterator_t *iterator,
                             get_iterator_comment (iterator)
                             ? get_iterator_comment (iterator)
                             : "",
-                            get_iterator_creation_time (iterator)
-                            ? get_iterator_creation_time (iterator)
-                            : "",
-                            get_iterator_modification_time (iterator)
-                            ? get_iterator_modification_time (iterator)
-                            : "",
+                            creation ? creation : "",
+                            modification ? modification : "",
                             writable,
                             in_use);
+
+  g_free (creation);
+  g_free (modification);
 
   if (/* The user is the owner. */
       (current_credentials.username

--- a/src/gmp_get.c
+++ b/src/gmp_get.c
@@ -320,7 +320,7 @@ send_get_common (const char *type, get_data_t *get, iterator_t *iterator,
 
   buffer = g_string_new ("");
 
-  creation = get_iterator_creation_time (iterator);
+  creation = get_iterator_creation_time (iterator, NULL);
   modification = get_iterator_modification_time (iterator);
 
   buffer_xml_append_printf (buffer,

--- a/src/manage.c
+++ b/src/manage.c
@@ -5831,7 +5831,7 @@ get_nvt_xml (iterator_t *nvts, int details, int pref_count,
             }
 
           default_timeout = nvt_default_timeout (oid);
-          creation = get_iterator_creation_time (nvts);
+          creation = get_iterator_creation_time (nvts, NULL);
           modification = get_iterator_modification_time (nvts);
 
           g_string_append_printf (buffer,

--- a/src/manage.c
+++ b/src/manage.c
@@ -5771,6 +5771,7 @@ get_nvt_xml (iterator_t *nvts, int details, int pref_count,
         {
           char *default_timeout;
           GString *nvt_tags;
+          gchar *creation, *modification;
 
           DEF (tag);
 
@@ -5830,6 +5831,9 @@ get_nvt_xml (iterator_t *nvts, int details, int pref_count,
             }
 
           default_timeout = nvt_default_timeout (oid);
+          creation = get_iterator_creation_time (nvts);
+          modification = get_iterator_modification_time (nvts);
+
           g_string_append_printf (buffer,
                                   "<default_timeout>%s</default_timeout>"
                                   "<creation_time>%s</creation_time>"
@@ -5843,19 +5847,18 @@ get_nvt_xml (iterator_t *nvts, int details, int pref_count,
                                   "<refs>%s</refs>"
                                   "<tags>%s</tags>",
                                   default_timeout ? default_timeout : "",
-                                  get_iterator_creation_time (nvts)
-                                  ? get_iterator_creation_time (nvts)
-                                  : "",
-                                  get_iterator_modification_time (nvts)
-                                  ? get_iterator_modification_time (nvts)
-                                  : "",
+                                  creation ? creation : "",
+                                  modification ? modification : "",
                                   nvt_iterator_category (nvts),
                                   family_text,
                                   nvt_iterator_qod (nvts),
                                   nvt_iterator_qod_type (nvts),
                                   refs_str->str,
                                   nvt_tags->str);
+
           free (default_timeout);
+          g_free (creation);
+          g_free (modification);
 
           g_string_free (nvt_tags, 1);
         }

--- a/src/manage.h
+++ b/src/manage.h
@@ -3430,6 +3430,9 @@ manage_default_ca_cert ();
 
 /* Users. */
 
+user_t
+manage_current_user_info (gchar **);
+
 gboolean
 find_user_by_name_with_permission (const char *, user_t *, const char *);
 

--- a/src/manage.h
+++ b/src/manage.h
@@ -1563,7 +1563,7 @@ result_iterator_delta_qod_type (iterator_t*);
 gchar *
 result_iterator_delta_creation_time (iterator_t*);
 
-const char *
+gchar *
 result_iterator_delta_modification_time (iterator_t*);
 
 task_t

--- a/src/manage.h
+++ b/src/manage.h
@@ -1560,7 +1560,7 @@ result_iterator_delta_uuid (iterator_t*);
 const char *
 result_iterator_delta_qod_type (iterator_t*);
 
-const char *
+gchar *
 result_iterator_delta_creation_time (iterator_t*);
 
 const char *

--- a/src/manage_get.c
+++ b/src/manage_get.c
@@ -154,18 +154,46 @@ get_iterator_comment (iterator_t* iterator)
  *
  * @param[in]  iterator  Iterator.
  *
- * @return Creation time of the resource or NULL if iteration is complete.
+ * @return Creation time, or NULL if iteration is complete. Caller must free.
  */
-DEF_ACCESS (get_iterator_creation_time, 4);
+gchar *
+get_iterator_creation_time (iterator_t* iterator)
+{
+  time_t epoch;
+  char *iso;
+
+  if (iterator->done) return NULL;
+
+  epoch = iterator_int64 (iterator, 4);
+  iso = iso_time (&epoch);
+  if (iso)
+    // iso points to static memory.
+    return g_strdup (iso);
+  return g_strdup("ERR");
+}
 
 /**
  * @brief Get the modification time of the resource from a GET iterator.
  *
  * @param[in]  iterator  Iterator.
  *
- * @return Modification time of the resource or NULL if iteration is complete.
+ * @return Modification time, or NULL if iteration is complete. Caller must free.
  */
-DEF_ACCESS (get_iterator_modification_time, 5);
+gchar *
+get_iterator_modification_time (iterator_t* iterator)
+{
+  time_t epoch;
+  char *iso;
+
+  if (iterator->done) return NULL;
+
+  epoch = iterator_int64 (iterator, 5);
+  iso = iso_time (&epoch);
+  if (iso)
+    // iso points to static memory.
+    return g_strdup (iso);
+  return g_strdup("ERR");
+}
 
 /**
  * @brief Get the owner name of the resource from a GET iterator.

--- a/src/manage_get.c
+++ b/src/manage_get.c
@@ -157,7 +157,7 @@ get_iterator_comment (iterator_t* iterator)
  * @return Creation time, or NULL if iteration is complete. Caller must free.
  */
 gchar *
-get_iterator_creation_time (iterator_t* iterator)
+get_iterator_creation_time (iterator_t* iterator, const gchar *zone)
 {
   time_t epoch;
   char *iso;
@@ -165,7 +165,7 @@ get_iterator_creation_time (iterator_t* iterator)
   if (iterator->done) return NULL;
 
   epoch = iterator_int64 (iterator, 4);
-  iso = iso_time (&epoch);
+  iso = iso_time_tz (&epoch, zone, NULL);
   if (iso)
     // iso points to static memory.
     return g_strdup (iso);

--- a/src/manage_get.h
+++ b/src/manage_get.h
@@ -67,7 +67,7 @@ const char*
 get_iterator_comment (iterator_t*);
 
 gchar*
-get_iterator_creation_time (iterator_t*);
+get_iterator_creation_time (iterator_t*, const gchar*);
 
 gchar*
 get_iterator_modification_time (iterator_t*);

--- a/src/manage_get.h
+++ b/src/manage_get.h
@@ -66,10 +66,10 @@ get_iterator_name (iterator_t*);
 const char*
 get_iterator_comment (iterator_t*);
 
-const char*
+gchar*
 get_iterator_creation_time (iterator_t*);
 
-const char*
+gchar*
 get_iterator_modification_time (iterator_t*);
 
 const char*

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -22381,7 +22381,7 @@ where_qod (int min_qod)
     { "comparison.delta_qod", NULL, KEYWORD_TYPE_INTEGER },                   \
     { "comparison.delta_uuid", NULL, KEYWORD_TYPE_STRING },                   \
     { "delta_qod_type", NULL, KEYWORD_TYPE_STRING },                          \
-    { " iso_time (delta_date, opts.user_zone)",                               \
+    { "delta_date",                                                           \
       "delta_creation_time",                                                  \
       KEYWORD_TYPE_STRING },                                                  \
     { " iso_time (delta_date, opts.user_zone)",                               \
@@ -23798,13 +23798,22 @@ result_iterator_delta_qod_type (iterator_t* iterator)
  *
  * @param[in]  iterator  Iterator.
  *
- * @return delta creation time if any, else NULL.
+ * @return Time, or NULL if iteration is complete. Caller must free.
  */
-const char *
+gchar *
 result_iterator_delta_creation_time (iterator_t* iterator)
 {
-  if (iterator->done) return 0;
-  return iterator_string (iterator, RESULT_ITERATOR_DELTA_COLUMN_OFFSET + 6);
+  time_t epoch;
+  char *iso;
+
+  if (iterator->done) return NULL;
+
+  epoch = iterator_int64 (iterator, RESULT_ITERATOR_DELTA_COLUMN_OFFSET + 6);
+  iso = iso_time (&epoch);
+  if (iso)
+    // iso points to static memory.
+    return g_strdup (iso);
+  return g_strdup("ERR");
 }
 
 /**

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -21658,8 +21658,8 @@ report_add_results_array (report_t report, GArray *results)
    { "uuid", NULL, KEYWORD_TYPE_STRING },                                    \
    { "iso_time (creation_time)", "name", KEYWORD_TYPE_STRING },              \
    { "''", NULL, KEYWORD_TYPE_STRING },                                      \
-   { "creation_time", NULL, KEYWORD_TYPE_STRING },                           \
-   { "modification_time", NULL, KEYWORD_TYPE_STRING },                       \
+   { "creation_time", NULL, KEYWORD_TYPE_INTEGER },                          \
+   { "modification_time", NULL, KEYWORD_TYPE_INTEGER },                      \
    { "creation_time", "created", KEYWORD_TYPE_INTEGER },                     \
    { "modification_time", "modified", KEYWORD_TYPE_INTEGER },                \
    { "(SELECT name FROM users WHERE users.id = reports.owner)",              \
@@ -22383,10 +22383,10 @@ where_qod (int min_qod)
     { "delta_qod_type", NULL, KEYWORD_TYPE_STRING },                          \
     { "delta_date",                                                           \
       "delta_creation_time",                                                  \
-      KEYWORD_TYPE_STRING },                                                  \
+      KEYWORD_TYPE_INTEGER },                                                 \
     { "delta_date",                                                           \
       "delta_modification_time",                                              \
-      KEYWORD_TYPE_STRING },                                                  \
+      KEYWORD_TYPE_INTEGER },                                                 \
     { "delta_task", NULL, KEYWORD_TYPE_INTEGER },                             \
     { "delta_report", NULL, KEYWORD_TYPE_INTEGER },                           \
     { "(SELECT name FROM users WHERE users.id = results.owner)",              \
@@ -55064,8 +55064,8 @@ user_resources_in_use (user_t user,
    { "uuid", "uuid", KEYWORD_TYPE_STRING },                                  \
    { "name", "name", KEYWORD_TYPE_STRING },                                  \
    { "''", "comment", KEYWORD_TYPE_STRING },                                 \
-   { "creation_time", NULL, KEYWORD_TYPE_STRING },                           \
-   { "modification_time", NULL, KEYWORD_TYPE_STRING },                       \
+   { "creation_time", NULL, KEYWORD_TYPE_INTEGER },                          \
+   { "modification_time", NULL, KEYWORD_TYPE_INTEGER },                      \
    { "creation_time", "created", KEYWORD_TYPE_INTEGER },                     \
    { "modification_time", "modified", KEYWORD_TYPE_INTEGER },                \
    { "cast (null AS text)", "_owner", KEYWORD_TYPE_INTEGER },                \

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -22384,7 +22384,7 @@ where_qod (int min_qod)
     { "delta_date",                                                           \
       "delta_creation_time",                                                  \
       KEYWORD_TYPE_STRING },                                                  \
-    { " iso_time (delta_date, opts.user_zone)",                               \
+    { "delta_date",                                                           \
       "delta_modification_time",                                              \
       KEYWORD_TYPE_STRING },                                                  \
     { "delta_task", NULL, KEYWORD_TYPE_INTEGER },                             \
@@ -23821,13 +23821,22 @@ result_iterator_delta_creation_time (iterator_t* iterator)
  *
  * @param[in]  iterator  Iterator.
  *
- * @return delta modification time if any, else NULL.
+ * @return Time, or NULL if iteration is complete. Caller must free.
  */
-const char *
+gchar *
 result_iterator_delta_modification_time (iterator_t* iterator)
 {
-  if (iterator->done) return 0;
-  return iterator_string (iterator, RESULT_ITERATOR_DELTA_COLUMN_OFFSET + 7);
+  time_t epoch;
+  char *iso;
+
+  if (iterator->done) return NULL;
+
+  epoch = iterator_int64 (iterator, RESULT_ITERATOR_DELTA_COLUMN_OFFSET + 7);
+  iso = iso_time (&epoch);
+  if (iso)
+    // iso points to static memory.
+    return g_strdup (iso);
+  return g_strdup("ERR");
 }
 
 /**

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -21658,8 +21658,8 @@ report_add_results_array (report_t report, GArray *results)
    { "uuid", NULL, KEYWORD_TYPE_STRING },                                    \
    { "iso_time (creation_time)", "name", KEYWORD_TYPE_STRING },              \
    { "''", NULL, KEYWORD_TYPE_STRING },                                      \
-   { "iso_time (creation_time)", NULL, KEYWORD_TYPE_STRING },                \
-   { "iso_time (modification_time)", NULL, KEYWORD_TYPE_STRING },            \
+   { "creation_time", NULL, KEYWORD_TYPE_STRING },                           \
+   { "modification_time", NULL, KEYWORD_TYPE_STRING },                       \
    { "creation_time", "created", KEYWORD_TYPE_INTEGER },                     \
    { "modification_time", "modified", KEYWORD_TYPE_INTEGER },                \
    { "(SELECT name FROM users WHERE users.id = reports.owner)",              \
@@ -50006,8 +50006,8 @@ init_host_identifier_iterator (iterator_t* iterator, host_t host,
 
   if (host)
     init_iterator (iterator,
-                   "SELECT id, uuid, name, comment, iso_time (creation_time),"
-                   "       iso_time (modification_time), creation_time,"
+                   "SELECT id, uuid, name, comment, creation_time,"
+                   "       modification_time, creation_time,"
                    "       modification_time, owner, owner, value,"
                    "       source_type, source_id, source_data,"
                    "       (CASE WHEN source_type LIKE 'Report%%'"
@@ -50019,8 +50019,8 @@ init_host_identifier_iterator (iterator_t* iterator, host_t host,
                    " FROM host_identifiers"
                    " WHERE host = %llu"
                    " UNION"
-                   " SELECT id, uuid, name, comment, iso_time (creation_time),"
-                   "        iso_time (modification_time), creation_time,"
+                   " SELECT id, uuid, name, comment, creation_time,"
+                   "        modification_time, creation_time,"
                    "        modification_time, owner, owner,"
                    "        (SELECT name FROM oss WHERE id = os),"
                    "        source_type, source_id, source_data,"
@@ -50040,8 +50040,8 @@ init_host_identifier_iterator (iterator_t* iterator, host_t host,
                    ascending ? "ASC" : "DESC");
   else
     init_iterator (iterator,
-                   "SELECT id, uuid, name, comment, iso_time (creation_time),"
-                   "       iso_time (modification_time), creation_time,"
+                   "SELECT id, uuid, name, comment, creation_time,"
+                   "       modification_time, creation_time,"
                    "       modification_time, owner, owner, value,"
                    "       source_type, source_id, source_data, 0, '', ''"
                    " FROM host_identifiers"
@@ -50691,8 +50691,8 @@ init_os_host_iterator (iterator_t* iterator, resource_t os)
 {
   assert (os);
   init_iterator (iterator,
-                 "SELECT id, uuid, name, comment, iso_time (creation_time),"
-                 "       iso_time (modification_time), creation_time,"
+                 "SELECT id, uuid, name, comment, creation_time,"
+                 "       modification_time, creation_time,"
                  "       modification_time, owner, owner,"
                  "       (SELECT round (CAST (severity AS numeric), 1)"
                  "        FROM host_max_severities"
@@ -55046,8 +55046,8 @@ user_resources_in_use (user_t user,
    { "uuid", "uuid", KEYWORD_TYPE_STRING },                                  \
    { "name", "name", KEYWORD_TYPE_STRING },                                  \
    { "''", "comment", KEYWORD_TYPE_STRING },                                 \
-   { "iso_time (creation_time)", NULL, KEYWORD_TYPE_STRING },                \
-   { "iso_time (modification_time)", NULL, KEYWORD_TYPE_STRING },            \
+   { "creation_time", NULL, KEYWORD_TYPE_STRING },                           \
+   { "modification_time", NULL, KEYWORD_TYPE_STRING },                       \
    { "creation_time", "created", KEYWORD_TYPE_INTEGER },                     \
    { "modification_time", "modified", KEYWORD_TYPE_INTEGER },                \
    { "cast (null AS text)", "_owner", KEYWORD_TYPE_INTEGER },                \

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -248,9 +248,9 @@ typedef struct
  *
  * @param[in]  prefix  Column prefix.
  */
-#define GET_ITERATOR_COLUMNS_STRING                                \
-  "id, uuid, name, comment, iso_time (creation_time),"             \
-  " iso_time (modification_time), creation_time AS created,"       \
+#define GET_ITERATOR_COLUMNS_STRING                     \
+  "id, uuid, name, comment, creation_time,"             \
+  " modification_time, creation_time AS created,"       \
   " modification_time AS modified"
 
 /**
@@ -263,8 +263,8 @@ typedef struct
   { prefix "uuid", NULL, KEYWORD_TYPE_STRING },                             \
   { prefix "name", NULL, KEYWORD_TYPE_STRING },                             \
   { prefix "comment", NULL, KEYWORD_TYPE_STRING },                          \
-  { " iso_time (" prefix "creation_time)", NULL, KEYWORD_TYPE_STRING },     \
-  { " iso_time (" prefix "modification_time)", NULL, KEYWORD_TYPE_STRING }, \
+  { prefix "creation_time", NULL, KEYWORD_TYPE_INTEGER },                   \
+  { prefix "modification_time", NULL, KEYWORD_TYPE_INTEGER },               \
   { prefix "creation_time", "created", KEYWORD_TYPE_INTEGER },              \
   { prefix "modification_time", "modified", KEYWORD_TYPE_INTEGER }
 

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -2599,8 +2599,8 @@ report_format_trust (report_format_t report_format)
    { "uuid", NULL, KEYWORD_TYPE_STRING },                               \
    { "name", NULL, KEYWORD_TYPE_STRING },                               \
    { "''", NULL, KEYWORD_TYPE_STRING },                                 \
-   { "creation_time", NULL, KEYWORD_TYPE_STRING },                      \
-   { "modification_time", NULL, KEYWORD_TYPE_STRING },                  \
+   { "creation_time", NULL, KEYWORD_TYPE_INTEGER },                     \
+   { "modification_time", NULL, KEYWORD_TYPE_INTEGER },                 \
    { "creation_time", "created", KEYWORD_TYPE_INTEGER },                \
    { "modification_time", "modified", KEYWORD_TYPE_INTEGER },           \
    {                                                                    \
@@ -2630,8 +2630,8 @@ report_format_trust (report_format_t report_format)
    { "uuid", NULL, KEYWORD_TYPE_STRING },                               \
    { "name", NULL, KEYWORD_TYPE_STRING },                               \
    { "''", NULL, KEYWORD_TYPE_STRING },                                 \
-   { "creation_time", NULL, KEYWORD_TYPE_STRING },                      \
-   { "modification_time", NULL, KEYWORD_TYPE_STRING },                  \
+   { "creation_time", NULL, KEYWORD_TYPE_INTEGER },                     \
+   { "modification_time", NULL, KEYWORD_TYPE_INTEGER },                 \
    { "creation_time", "created", KEYWORD_TYPE_INTEGER },                \
    { "modification_time", "modified", KEYWORD_TYPE_INTEGER },           \
    {                                                                    \

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -2599,8 +2599,8 @@ report_format_trust (report_format_t report_format)
    { "uuid", NULL, KEYWORD_TYPE_STRING },                               \
    { "name", NULL, KEYWORD_TYPE_STRING },                               \
    { "''", NULL, KEYWORD_TYPE_STRING },                                 \
-   { "iso_time (creation_time)", NULL, KEYWORD_TYPE_STRING },           \
-   { "iso_time (modification_time)", NULL, KEYWORD_TYPE_STRING },       \
+   { "creation_time", NULL, KEYWORD_TYPE_STRING },                      \
+   { "modification_time", NULL, KEYWORD_TYPE_STRING },                  \
    { "creation_time", "created", KEYWORD_TYPE_INTEGER },                \
    { "modification_time", "modified", KEYWORD_TYPE_INTEGER },           \
    {                                                                    \
@@ -2630,8 +2630,8 @@ report_format_trust (report_format_t report_format)
    { "uuid", NULL, KEYWORD_TYPE_STRING },                               \
    { "name", NULL, KEYWORD_TYPE_STRING },                               \
    { "''", NULL, KEYWORD_TYPE_STRING },                                 \
-   { "iso_time (creation_time)", NULL, KEYWORD_TYPE_STRING },           \
-   { "iso_time (modification_time)", NULL, KEYWORD_TYPE_STRING },       \
+   { "creation_time", NULL, KEYWORD_TYPE_STRING },                      \
+   { "modification_time", NULL, KEYWORD_TYPE_STRING },                  \
    { "creation_time", "created", KEYWORD_TYPE_INTEGER },                \
    { "modification_time", "modified", KEYWORD_TYPE_INTEGER },           \
    {                                                                    \


### PR DESCRIPTION
## What

Move the ISO time calculations in the "GET" iterators from SQL to C.

## Why

Having the iterator do the time conversion is slower when there are many rows with a large offset, because Postgres still does the conversion for every row.

`time o m m '<get_info type="nvt" filter="sort-reverse=created rows=10 first=80000"/>' > /tmp/info`
patch 0.2, 0.2, 0.16
main  1.8, 2.2, 1.7

Leads to faster SecInfo pages when paging to the end, CPEs in particular.

## References

https://www.postgresql.org/docs/current/queries-limit.html 7.6 LIMIT and OFFSET:
`The rows skipped by an OFFSET clause still have to be computed inside the server; therefore a large OFFSET might be inefficient.`
