### PR TITLE
Change: Allow any inheritor deleting user from CLI

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -53756,7 +53756,9 @@ delete_user (const char *user_id_arg, const char *name_arg, int ultimate,
       real_inheritor_id = user_uuid (inheritor);
 
       /* Only the current user, owned users or global users may inherit. */
-      if (strcmp (real_inheritor_id, current_credentials.uuid)
+      if (current_credentials.uuid
+          && strcmp (current_credentials.uuid, "")
+          && strcmp (real_inheritor_id, current_credentials.uuid)
           && sql_int ("SELECT NOT (" ACL_IS_GLOBAL () ")"
                       " FROM users WHERE id = %llu",
                       inheritor)


### PR DESCRIPTION
## What
When deleting users using the `--delete-user` option, do not apply any restrictions on which user can be selected as inheritor.

## Why
This gives users with command line access a way to circumvent the restrictions of the delete_user GMP command and addresses issues of the command line option being too restrictive to be useful.

## References
GEA-381
