### PR TITLE
Add: New compliance filter keywords for results

### DIFF
--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -291,7 +291,7 @@ typedef struct
 /**
  * @brief Delta results columns offset for result iterator.
  */
-#define RESULT_ITERATOR_DELTA_COLUMN_OFFSET GET_ITERATOR_COLUMN_COUNT + 37
+#define RESULT_ITERATOR_DELTA_COLUMN_OFFSET GET_ITERATOR_COLUMN_COUNT + 38
 
 
 /* Variables */

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -59,6 +59,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <pattern>text</pattern>
   </type>
   <type>
+    <name>compliance_levels</name>
+    <summary>A string selecting compliance levels that may include the characters y, n, i and u</summary>
+    <description>
+      The meanings of the letters for each level are: "y" for "yes" (compliant),
+      "n" for "no" (not compliant), "i" for "incomplete" and "u" for "undefined"
+      (without compliance information). 
+    </description>
+    <pattern>xsd:token { pattern = "y?n?i?u?" }</pattern>
+  </type>
+  <type>
     <name>ctime</name>
     <summary>A date and time, in the C `ctime' format</summary>
     <description>
@@ -15536,6 +15546,11 @@ END:VCALENDAR
             <summary>Whether to apply Overrides</summary>
           </option>
           <option>
+            <name>compliance_levels</name>
+            <type>compliance_levels</type>
+            <summary>Compliance levels to select</summary>
+          </option>
+          <option>
             <name>delta_states</name>
             <type>delta_states</type>
             <summary>States to select in a delta report</summary>
@@ -15604,6 +15619,18 @@ END:VCALENDAR
             <name>owner</name>
             <type>name</type>
             <summary>Name of the owner</summary>
+          </column>
+          <column>
+            <name>compliant</name>
+            <type>
+              <alts>
+                <alt>yes</alt>
+                <alt>no</alt>
+                <alt>incomplete</alt>
+                <alt>undefined</alt>
+              </alts>
+            </type>
+            <summary>Compliance status</summary>
           </column>
           <column>
             <name>host</name>
@@ -17058,6 +17085,11 @@ END:VCALENDAR
             <summary>Whether to apply Overrides</summary>
           </option>
           <option>
+            <name>compliance_levels</name>
+            <type>compliance_levels</type>
+            <summary>Compliance levels to select</summary>
+          </option>
+          <option>
             <name>levels</name>
             <type>levels</type>
             <summary>Severity levels to select</summary>
@@ -17121,6 +17153,18 @@ END:VCALENDAR
             <name>owner</name>
             <type>name</type>
             <summary>Name of the owner</summary>
+          </column>
+          <column>
+            <name>compliant</name>
+            <type>
+              <alts>
+                <alt>yes</alt>
+                <alt>no</alt>
+                <alt>incomplete</alt>
+                <alt>undefined</alt>
+              </alts>
+            </type>
+            <summary>Compliance status</summary>
           </column>
           <column>
             <name>host</name>


### PR DESCRIPTION
## What
The filters of the get_reports and get_results commands now support two new keywords for filtering results by their compliance status: The option "compliance_levels" that allows a selection applying to the whole filter similar to "levels" for severity and a "compliant" column that can be used with boolean operator keywords.

## Why

<!-- Describe why are these changes necessary? -->

## References
GEA-391
