### PR TITLE
Change: Raise required gvm-libs version to 22.8

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,10 +26,10 @@ find_package (Threads)
 ## list and throw an error, otherwise long install-cmake-install-cmake cycles
 ## might occur.
 
-pkg_check_modules (LIBGVM_BASE REQUIRED libgvm_base>=22.7)
-pkg_check_modules (LIBGVM_UTIL REQUIRED libgvm_util>=22.6)
-pkg_check_modules (LIBGVM_OSP REQUIRED libgvm_osp>=22.6)
-pkg_check_modules (LIBGVM_GMP REQUIRED libgvm_gmp>=22.6)
+pkg_check_modules (LIBGVM_BASE REQUIRED libgvm_base>=22.8)
+pkg_check_modules (LIBGVM_UTIL REQUIRED libgvm_util>=22.8)
+pkg_check_modules (LIBGVM_OSP REQUIRED libgvm_osp>=22.8)
+pkg_check_modules (LIBGVM_GMP REQUIRED libgvm_gmp>=22.8)
 pkg_check_modules (GNUTLS REQUIRED gnutls>=3.2.15)
 pkg_check_modules (GLIB REQUIRED glib-2.0>=2.42)
 pkg_check_modules (LIBBSD REQUIRED libbsd)


### PR DESCRIPTION
## What
Raise required gvm-libs version to 22.8

## Why
Preparation for next release

## References
GEA-436
