### PR TITLE
Change: Differentiate between audit and scan reports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,12 +247,24 @@ if (NOT CVSS3_RATINGS)
 endif (NOT CVSS3_RATINGS)
 add_definitions (-DCVSS3_RATINGS=${CVSS3_RATINGS})
 
+if (NOT COMPLIANCE_REPORTS)
+  set (COMPLIANCE_REPORTS 0)
+endif (NOT COMPLIANCE_REPORTS)
+add_definitions (-DCOMPLIANCE_REPORTS=${COMPLIANCE_REPORTS})
 
 message ("-- Install prefix: ${CMAKE_INSTALL_PREFIX}")
 
 ## Version
 
 set (GVMD_VERSION "${PROJECT_VERSION_STRING}")
+
+if (COMPLIANCE_REPORTS EQUAL 1)
+  set(IF_COMPLIANCE_REPORTS "")
+  set(ENDIF_COMPLIANCE_REPORTS "")
+elseif (COMPLIANCE_REPORTS EQUAL 0)
+  set(IF_COMPLIANCE_REPORTS "<!--")
+  set(ENDIF_COMPLIANCE_REPORTS "-->")
+endif()
 
 # Configure Doxyfile with version number
 configure_file (doc/Doxyfile.in doc/Doxyfile)

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -15940,7 +15940,17 @@ select_resource_iterator (get_resource_names_data_t *resource_names_data,
   else if (g_strcmp0 ("config", resource_names_data->type) == 0)
     {
       *iterator = (int (*) (iterator_t*, get_data_t *))init_config_iterator;
-    }                
+      get_data_set_extra (&resource_names_data->get,
+                          "usage_type",
+                          g_strdup ("scan"));
+    }
+  else if (g_strcmp0 ("policy", resource_names_data->type) == 0)
+    {
+      *iterator = (int (*) (iterator_t*, get_data_t *))init_config_iterator;
+      get_data_set_extra (&resource_names_data->get,
+                          "usage_type",
+                          g_strdup ("policy"));
+    }
   else if (g_strcmp0 ("scanner", resource_names_data->type) == 0)
     {
       *iterator = (int (*) (iterator_t*, get_data_t *))init_scanner_iterator;
@@ -15956,7 +15966,17 @@ select_resource_iterator (get_resource_names_data_t *resource_names_data,
   else if (g_strcmp0 ("task", resource_names_data->type) == 0)
     {
       *iterator = (int (*) (iterator_t*, get_data_t *))init_task_iterator;
-    } 
+      get_data_set_extra (&resource_names_data->get,
+                    "usage_type",
+                    g_strdup ("scan"));
+    }
+  else if (g_strcmp0 ("audit", resource_names_data->type) == 0)
+    {
+      *iterator = (int (*) (iterator_t*, get_data_t *))init_task_iterator;
+      get_data_set_extra (&resource_names_data->get,
+                    "usage_type",
+                    g_strdup ("audit"));
+    }
   else if (g_strcmp0 ("tls_certificate", resource_names_data->type) == 0)
     {
       *iterator = (int (*) (iterator_t*, get_data_t *))init_tls_certificate_iterator;
@@ -16008,7 +16028,13 @@ handle_get_resource_names (gmp_parser_t *gmp_parser, GError **error)
            || (g_strcmp0 ("nvt", get_resource_names_data->type) == 0)
            || (g_strcmp0 ("cert_bund_adv", get_resource_names_data->type) == 0)
            || (g_strcmp0 ("dfn_cert_adv", get_resource_names_data->type) == 0))
-          && (acl_user_may ("get_info") == 0)))
+          && (acl_user_may ("get_info") == 0))
+      || (((g_strcmp0 ("config", get_resource_names_data->type) == 0)
+          ||(g_strcmp0 ("policy", get_resource_names_data->type) == 0))
+       && (acl_user_may ("get_configs") == 0))
+      || (((g_strcmp0 ("task", get_resource_names_data->type) == 0)
+          ||(g_strcmp0 ("audit", get_resource_names_data->type) == 0))
+       && (acl_user_may ("get_tasks") == 0)))
       {
         SEND_TO_CLIENT_OR_FAIL
           (XML_ERROR_SYNTAX ("get_resource_names",
@@ -16092,14 +16118,6 @@ handle_get_resource_names (gmp_parser_t *gmp_parser, GError **error)
 
   while (next (&resource))
     {
-      if ((g_strcmp0 ("task", get_resource_names_data->type) == 0 
-           && g_strcmp0 ("audit", task_iterator_usage_type(&resource)) == 0)
-          || (g_strcmp0 ("config", get_resource_names_data->type) == 0 
-           && g_strcmp0 ("policy", config_iterator_usage_type(&resource)) == 0))
-      {
-        continue;
-      }
-
       GString *result;
       result = g_string_new ("");
       

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -9429,6 +9429,7 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
   const char *severity, *original_severity, *original_level;
   const char *host, *hostname, *result_id, *port, *path, *asset_id, *qod, *qod_type;
   char *detect_oid, *detect_ref, *detect_cpe, *detect_loc, *detect_name;
+  const char *compliance;
   double severity_double;
   gchar *nl_descr, *nl_descr_escaped;
   result_t result;
@@ -9459,6 +9460,7 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
       hostname = result_iterator_delta_hostname (results);
       if (host)
         asset_id = result_iterator_delta_host_asset_id (results);
+      compliance = result_iterator_delta_compliance (results);
     }
   else
     {
@@ -9477,6 +9479,7 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
       hostname = result_iterator_hostname (results);
       if (host)
         asset_id = result_iterator_asset_host_id (results);
+      compliance = result_iterator_compliance (results);
     }
 
 
@@ -9730,6 +9733,8 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
                               "<original_severity>%s</original_severity>",
                               original_level,
                               original_severity);
+
+  buffer_xml_append_printf (buffer, "<compliance>%s</compliance>", compliance);
 
   if (include_notes
       && use_delta_fields 

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -12956,6 +12956,11 @@ handle_get_features (gmp_parser_t *gmp_parser, GError **error)
                           " status_text=\"" STATUS_OK_TEXT "\">");
 
   SENDF_TO_CLIENT_OR_FAIL ("<feature enabled=\"%d\">"
+                           "<name>COMPLIANCE_REPORTS</name>"
+                           "</feature>",
+                           COMPLIANCE_REPORTS ? 1 : 0);
+
+  SENDF_TO_CLIENT_OR_FAIL ("<feature enabled=\"%d\">"
                            "<name>CVSS3_RATINGS</name>"
                            "</feature>",
                            CVSS3_RATINGS ? 1 : 0);
@@ -14831,7 +14836,7 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
       || (strlen (get_reports_data->report_get.id) == 0))
     {
       int overrides, min_qod;
-      gchar *filter, *levels, *compliance_levels;
+      gchar *filter, *levels;
       get_data_t * get;
 
       /* For simplicity, use a fixed result filter when filtering
@@ -14853,22 +14858,33 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
       overrides = filter_term_apply_overrides (filter ? filter : get->filter);
       min_qod = filter_term_min_qod (filter ? filter : get->filter);
       levels = filter_term_value (filter ? filter : get->filter, "levels");
-      compliance_levels = filter_term_value (filter 
-                                                ? filter 
-                                                : get->filter,
-                                             "compliance_levels");
-      g_free (filter);
+      #if COMPLIANCE_REPORTS == 1
+        gchar *compliance_levels;
+        compliance_levels = filter_term_value (filter
+                                                  ? filter
+                                                  : get->filter,
+                                              "compliance_levels");
 
-      /* Setup result filter from overrides. */
-      get_reports_data->get.filter
-        = g_strdup_printf 
-            ("apply_overrides=%i min_qod=%i levels=%s compliance_levels=%s",
-             overrides, 
-             min_qod, 
-             levels ? levels : "hmlgdf", 
-             compliance_levels ? compliance_levels : "yniu");
+        /* Setup result filter from overrides. */
+        get_reports_data->get.filter
+          = g_strdup_printf
+              ("apply_overrides=%i min_qod=%i levels=%s compliance_levels=%s",
+              overrides,
+              min_qod,
+              levels ? levels : "hmlgdf",
+              compliance_levels ? compliance_levels : "yniu");
+        g_free (compliance_levels);
+      #else
+        /* Setup result filter from overrides. */
+        get_reports_data->get.filter
+          = g_strdup_printf
+              ("apply_overrides=%i min_qod=%i levels=%s",
+              overrides,
+              min_qod,
+              levels ? levels : "hmlgdf");
+      #endif
+      g_free (filter);
       g_free (levels);
-      g_free (compliance_levels);
     }
 
   ret = init_report_iterator (&reports, &get_reports_data->report_get);
@@ -15914,6 +15930,7 @@ select_resource_iterator (get_resource_names_data_t *resource_names_data,
   else if (g_strcmp0 ("report", resource_names_data->type) == 0)
     {
       *iterator = (int (*) (iterator_t*, get_data_t *))init_report_iterator;
+#if COMPLIANCE_REPORTS == 1
       get_data_set_extra (&resource_names_data->get, 
                           "usage_type",
                           g_strdup ("scan"));
@@ -15924,6 +15941,7 @@ select_resource_iterator (get_resource_names_data_t *resource_names_data,
       get_data_set_extra (&resource_names_data->get, 
                           "usage_type",
                           g_strdup ("audit"));
+#endif
     }
   else if (g_strcmp0 ("report_config", resource_names_data->type) == 0)
     {

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -15914,7 +15914,17 @@ select_resource_iterator (get_resource_names_data_t *resource_names_data,
   else if (g_strcmp0 ("report", resource_names_data->type) == 0)
     {
       *iterator = (int (*) (iterator_t*, get_data_t *))init_report_iterator;
+      get_data_set_extra (&resource_names_data->get, 
+                          "usage_type",
+                          g_strdup ("scan"));
     }                
+  else if (g_strcmp0 ("audit_report", resource_names_data->type) == 0)
+    {
+      *iterator = (int (*) (iterator_t*, get_data_t *))init_report_iterator;
+      get_data_set_extra (&resource_names_data->get, 
+                          "usage_type",
+                          g_strdup ("audit"));
+    }
   else if (g_strcmp0 ("report_config", resource_names_data->type) == 0)
     {
       *iterator = (int (*) (iterator_t*, get_data_t *))init_report_config_iterator;
@@ -15990,7 +16000,8 @@ handle_get_resource_names (gmp_parser_t *gmp_parser, GError **error)
        && (acl_user_may ("get_assets") == 0))
       || ((g_strcmp0 ("result", get_resource_names_data->type) == 0) 
           && (acl_user_may ("get_results") == 0))
-      || ((g_strcmp0 ("report", get_resource_names_data->type) == 0)
+      || (((g_strcmp0 ("report", get_resource_names_data->type) == 0)
+           || (g_strcmp0 ("audit_report", get_resource_names_data->type) == 0))
           && (acl_user_may ("get_reports") == 0))
       || (((g_strcmp0 ("cpe", get_resource_names_data->type) == 0)
            || (g_strcmp0 ("cve", get_resource_names_data->type) == 0)
@@ -22510,8 +22521,8 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
              (XML_ERROR_SYNTAX ("create_tag",
                                 "RESOURCES requires"
                                 " a TYPE element"));
-          else if (valid_db_resource_type (create_tag_data->resource_type)
-                     == 0)
+          else if (valid_db_resource_type (create_tag_data->resource_type) == 0
+                    && valid_subtype (create_tag_data->resource_type) == 0)
             SEND_TO_CLIENT_OR_FAIL
              (XML_ERROR_SYNTAX ("create_tag",
                                 "TYPE in RESOURCES must be"
@@ -25263,7 +25274,8 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                                 "name must be at least one"
                                 " character long or omitted completely"));
           else if (modify_tag_data->resource_type &&
-                   valid_db_resource_type (modify_tag_data->resource_type) == 0)
+                   valid_db_resource_type (modify_tag_data->resource_type) == 0
+                   && valid_subtype (modify_tag_data->resource_type) == 0)
             SEND_TO_CLIENT_OR_FAIL
              (XML_ERROR_SYNTAX ("modify_tag",
                                 "TYPE in RESOURCES must be"

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -2318,6 +2318,9 @@ gvmd (int argc, char** argv, char *env[])
 #if CVSS3_RATINGS == 1
       printf ("CVSS3 severity ratings enabled\n");
 #endif
+#if COMPLIANCE_REPORTS == 1
+      printf ("Compliance reports enabled\n");
+#endif
       printf ("Copyright (C) 2009-2021 Greenbone AG\n");
       printf ("License: AGPL-3.0-or-later\n");
       printf

--- a/src/manage.h
+++ b/src/manage.h
@@ -1557,6 +1557,9 @@ gchar **
 result_iterator_dfn_certs (iterator_t*);
 
 const char *
+result_iterator_compliance (iterator_t*);
+
+const char *
 result_iterator_delta_state (iterator_t*);
 
 const char *
@@ -1567,6 +1570,9 @@ result_iterator_delta_severity (iterator_t*);
 
 double
 result_iterator_delta_severity_double (iterator_t*);
+
+const char *
+result_iterator_delta_compliance (iterator_t*);
 
 const char*
 result_iterator_delta_level (iterator_t*);

--- a/src/manage.h
+++ b/src/manage.h
@@ -838,6 +838,9 @@ set_task_hosts_ordering (task_t, const char *);
 void
 set_task_scanner (task_t, scanner_t);
 
+int
+task_usage_type (task_t, char**);
+
 void
 set_task_usage_type (task_t, const char *);
 
@@ -1328,7 +1331,7 @@ gboolean
 report_task (report_t, task_t*);
 
 void
-report_compliance_by_uuid (const char *, int *, int *, int *);
+report_compliance_by_uuid (const char *, int *, int *, int *, int *);
 
 int
 report_scan_result_count (report_t, const char*, const char*, int, const char*,
@@ -1724,8 +1727,8 @@ manage_filter_controls (const gchar *, int *, int *, gchar **, int *);
 
 void
 manage_report_filter_controls (const gchar *, int *, int *, gchar **, int *,
-                               int *, gchar **, gchar **, gchar **, gchar **,
-                               int *, int *, int *, int *, gchar **);
+                               int *, gchar **, gchar **, gchar **, gchar **, 
+                               gchar **, int *, int *, int *, int *, gchar **);
 
 gchar *
 manage_clean_filter (const gchar *);

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -895,7 +895,44 @@ manage_create_sql_functions ()
        "$$ LANGUAGE plpgsql"
        " IMMUTABLE;");
 
-  /* Functions in SQL. */
+  sql ("CREATE OR REPLACE FUNCTION compliance_status ("
+       "  report_id integer)"
+       "RETURNS text AS $$ "
+       "BEGIN"
+       "  CASE"
+       "  WHEN (SELECT count(*) FROM results"
+       "        WHERE report = report_id"
+       "        AND description LIKE 'Compliant:%%NO%%') > 0"
+       "  THEN RETURN 'no';"
+       "  WHEN (SELECT count(*) FROM results"
+       "        WHERE report = report_id"
+       "        AND description LIKE 'Compliant:%%INCOMPLETE%%') > 0"
+       "  THEN RETURN 'incomplete';"
+       "  WHEN (SELECT count(*) FROM results"
+       "        WHERE report = report_id"
+       "        AND description LIKE 'Compliant:%%YES%%') > 0"
+       "  THEN RETURN 'yes';"
+       "  ELSE RETURN 'undefined';"
+       "  END CASE;" 
+       "END;"
+       "$$ LANGUAGE plpgsql"
+       " IMMUTABLE;");
+
+  sql ("CREATE OR REPLACE FUNCTION compliance_count (report_id integer, compliance text)"
+       " RETURNS integer AS $$"
+       " DECLARE count integer := 0;"
+       " BEGIN"
+       "   WITH compliance_count AS"
+       "   (SELECT count(*) AS total FROM results WHERE report = report_id"                        
+       "        AND description LIKE 'Compliant:%%' || compliance || '%%')"
+       "   SELECT total FROM compliance_count"
+       "   INTO count;"
+       "   RETURN count;"
+       " END;"
+       " $$ LANGUAGE plpgsql"
+       " IMMUTABLE;");
+
+ /* Functions in SQL. */       
 
   if (sql_int ("SELECT (EXISTS (SELECT * FROM information_schema.tables"
                "                WHERE table_catalog = '%s'"

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -895,7 +895,7 @@ manage_create_sql_functions ()
        "$$ LANGUAGE plpgsql"
        " IMMUTABLE;");
 
-  sql ("CREATE OR REPLACE FUNCTION compliance_status ("
+  sql ("CREATE OR REPLACE FUNCTION report_compliance_status ("
        "  report_id integer)"
        "RETURNS text AS $$ "
        "BEGIN"
@@ -918,7 +918,9 @@ manage_create_sql_functions ()
        "$$ LANGUAGE plpgsql"
        " IMMUTABLE;");
 
-  sql ("CREATE OR REPLACE FUNCTION compliance_count (report_id integer, compliance text)"
+  sql ("CREATE OR REPLACE FUNCTION report_compliance_count ("
+       "  report_id integer,"
+       "  compliance text)"
        " RETURNS integer AS $$"
        " DECLARE count integer := 0;"
        " BEGIN"

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -57545,6 +57545,10 @@ tag_remove_resources_filter (tag_t tag, const char *type, const char *filter)
                               "usage_type",
                               g_strdup ("audit"));
         }
+      else if (strcasecmp (type, "report") == 0)
+        {
+          get_data_set_extra (&resources_get, "usage_type", g_strdup ("scan"));
+        }
 
       gchar *columns;
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -22164,11 +22164,14 @@ init_report_iterator (iterator_t* iterator, const get_data_t *get)
   overrides = filter_term_apply_overrides (filter ? filter : get->filter);
   min_qod = filter_term_min_qod (filter ? filter : get->filter);
 
-  free (filter);
-
   extra_tables = report_iterator_opts_table (overrides, min_qod);
   usage_type = get_data_get_extra (get, "usage_type");
-  extra_where = reports_extra_where (get->trash, get->filter, usage_type);
+
+  extra_where = reports_extra_where (get->trash, 
+                                     filter ? filter : get->filter,
+                                     usage_type);
+
+  free (filter);
 
   ret = init_get_iterator2 (iterator,
                             "report",

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -57382,6 +57382,10 @@ tag_add_resources_filter (tag_t tag, const char *type, const char *filter)
           resources_get.type = g_strdup (type);
           get_data_set_extra (&resources_get, "usage_type", g_strdup ("audit"));
         }
+      else if (strcasecmp (type, "report") == 0)
+        {
+          get_data_set_extra (&resources_get, "usage_type", g_strdup ("scan"));
+        }
 
       gchar *columns;
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -2037,7 +2037,7 @@ filter_control_str (keyword_t **point, const char *column, gchar **string)
  * @param[out]  levels         String describing threat levels (message types)
  *                             to include in count (for example, "hmlg" for
  *                             High, Medium, Low and loG). All levels if NULL.
- * @param[out]  comliance_levels   String describing compliance levels
+ * @param[out]  compliance_levels   String describing compliance levels
  *                             to include in count (for example, "yniu" for
  *                             "yes" (compliant), "n" for "no" (not compliant),
  *                             "i" for "incomplete" and "u" for "undefined" 
@@ -21992,22 +21992,22 @@ report_add_results_array (report_t report, GArray *results)
      KEYWORD_TYPE_INTEGER                                                    \
    },                                                                        \
    {                                                                         \
-     "compliance_count (id, 'YES')",                                         \
+     "report_compliance_count (id, 'YES')",                                  \
      "compliance_yes",                                                       \
      KEYWORD_TYPE_INTEGER                                                    \
    },                                                                        \
    {                                                                         \
-     "compliance_count (id, 'NO')",                                          \
+     "report_compliance_count (id, 'NO')",                                   \
      "compliance_no",                                                        \
      KEYWORD_TYPE_INTEGER                                                    \
    },                                                                        \
    {                                                                         \
-     "compliance_count (id, 'INCOMPLETE')",                                  \
+     "report_compliance_count (id, 'INCOMPLETE')",                           \
      "compliance_incomplete",                                                \
      KEYWORD_TYPE_INTEGER                                                    \
    },                                                                        \
    {                                                                         \
-     "compliance_status (id)",                                               \
+     "report_compliance_status (id)",                                        \
      "compliant",                                                            \
      KEYWORD_TYPE_STRING                                                     \
    },                                                                        \
@@ -22055,7 +22055,8 @@ where_compliance_status (const char *compliance)
   compliance_sql = g_string_new ("");
   count = 0;
 
-  g_string_append_printf (compliance_sql, " AND compliance_status(reports.id) IN (");
+  g_string_append_printf (compliance_sql,
+    " AND report_compliance_status(reports.id) IN (");
 
   if (strchr (compliance, 'y'))
     {
@@ -22080,9 +22081,9 @@ where_compliance_status (const char *compliance)
 
   g_string_append (compliance_sql, ")");
 
-  if (count == 4)
+  if ((count == 4) || (count == 0))
     {
-      /* All compliance levels selected. */
+      /* All compliance levels or no valid ones selected. */
       g_string_free (compliance_sql, TRUE);
       return NULL;
     }
@@ -22422,9 +22423,9 @@ where_compliance_levels (const char *levels)
     }
   g_string_append (levels_sql, ")");
 
-  if (count == 4)
+  if ((count == 4) || (count == 0))
     {
-      /* All compliance levels selected, so no restriction is necessary. */
+      /* All compliance levels or none selected, so no restriction is necessary. */
       g_string_free (levels_sql, TRUE);
       return NULL;
     }

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -3980,7 +3980,9 @@ valid_type (const char* type)
 int
 valid_subtype (const char* type)
 {
-  return (strcasecmp (type, "audit_report") == 0);
+  return (strcasecmp (type, "audit_report") == 0)
+         || (strcasecmp (type, "audit") == 0)
+         || (strcasecmp (type, "policy") == 0);
 }
 
 /**
@@ -4090,6 +4092,32 @@ static int
 type_is_report_subtype (const char *type)
 {
   return (strcasecmp (type, "audit_report") == 0);
+}
+
+/**
+ * @brief Check whether a resource type is a task subtype.
+ *
+ * @param[in]  type  Type of resource.
+ *
+ * @return 1 yes, 0 no.
+ */
+static int
+type_is_task_subtype (const char *type)
+{
+  return (strcasecmp (type, "audit") == 0);
+}
+
+/**
+ * @brief Check whether a resource type is a config subtype.
+ *
+ * @param[in]  type  Type of resource.
+ *
+ * @return 1 yes, 0 no.
+ */
+static int
+type_is_config_subtype (const char *type)
+{
+  return (strcasecmp (type, "policy") == 0);
 }
 
 /**
@@ -57309,10 +57337,20 @@ tag_add_resources_list (tag_t tag, const char *type, array_t *uuids,
   else if (type_is_asset_subtype (type))
     resource_permission = g_strdup ("get_assets");
   else if (type_is_report_subtype (type)) 
-  {
-    resource_permission = g_strdup ("get_reports");
-    type = g_strdup("report");
-  }
+    {
+      resource_permission = g_strdup ("get_reports");
+      type = g_strdup("report");
+    }
+  else if (type_is_task_subtype (type))
+    {
+      resource_permission = g_strdup ("get_tasks");
+      type = g_strdup("task");
+    }
+  else if (type_is_config_subtype (type))
+    {
+      resource_permission = g_strdup ("get_configs");
+      type = g_strdup("config");
+    }
   else
     resource_permission = g_strdup_printf ("get_%ss", type);
 
@@ -57383,6 +57421,26 @@ tag_add_resources_filter (tag_t tag, const char *type, const char *filter)
           get_data_set_extra (&resources_get, "usage_type", g_strdup ("audit"));
         }
       else if (strcasecmp (type, "report") == 0)
+        {
+          get_data_set_extra (&resources_get, "usage_type", g_strdup ("scan"));
+        }
+      else if (strcasecmp (type, "task") == 0)
+        {
+          get_data_set_extra (&resources_get, "usage_type", g_strdup ("scan"));
+        }
+      else if (strcasecmp (type, "audit") == 0)
+        {
+          type = g_strdup ("task");
+          resources_get.type = g_strdup (type);
+          get_data_set_extra (&resources_get, "usage_type", g_strdup ("audit"));
+        }
+      else if (strcasecmp (type, "policy") == 0)
+        {
+          type = g_strdup ("config");
+          resources_get.type = g_strdup (type);
+          get_data_set_extra (&resources_get, "usage_type", g_strdup ("policy"));
+        }
+      else if (strcasecmp (type, "config") == 0)
         {
           get_data_set_extra (&resources_get, "usage_type", g_strdup ("scan"));
         }
@@ -57546,6 +57604,26 @@ tag_remove_resources_filter (tag_t tag, const char *type, const char *filter)
                               g_strdup ("audit"));
         }
       else if (strcasecmp (type, "report") == 0)
+        {
+          get_data_set_extra (&resources_get, "usage_type", g_strdup ("scan"));
+        }
+      else if (strcasecmp (type, "task") == 0)
+        {
+          get_data_set_extra (&resources_get, "usage_type", g_strdup ("scan"));
+        }
+      else if (strcasecmp (type, "audit") == 0)
+        {
+          type = g_strdup ("task");
+          resources_get.type = g_strdup (type);
+          get_data_set_extra (&resources_get, "usage_type", g_strdup ("audit"));
+        }
+      else if (strcasecmp (type, "policy") == 0)
+        {
+          type = g_strdup ("config");
+          resources_get.type = g_strdup (type);
+          get_data_set_extra (&resources_get, "usage_type", g_strdup ("policy"));
+        }
+      else if (strcasecmp (type, "config") == 0)
         {
           get_data_set_extra (&resources_get, "usage_type", g_strdup ("scan"));
         }

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -58823,7 +58823,7 @@ type_extra_where (const char *type, int trash, const char *filter,
       else
         usage_type = NULL;
       
-      extra_where = reports_extra_where (trash, NULL, usage_type);
+      extra_where = reports_extra_where (trash, filter, usage_type);
     }
   else if (strcasecmp (type, "RESULT") == 0)
     {

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -3980,9 +3980,14 @@ valid_type (const char* type)
 int
 valid_subtype (const char* type)
 {
-  return (strcasecmp (type, "audit_report") == 0)
-         || (strcasecmp (type, "audit") == 0)
-         || (strcasecmp (type, "policy") == 0);
+  #if COMPLIANCE_REPORTS == 1
+    return (strcasecmp (type, "audit_report") == 0)
+          || (strcasecmp (type, "audit") == 0)
+          || (strcasecmp (type, "policy") == 0);
+  #else
+    return (strcasecmp (type, "audit") == 0)
+          || (strcasecmp (type, "policy") == 0);
+  #endif
 }
 
 /**
@@ -22033,6 +22038,7 @@ report_iterator_opts_table (int override, int min_qod)
                           min_qod);
 }
 
+#if COMPLIANCE_REPORTS == 1
 /**
  * @brief Return SQL WHERE for restricting a SELECT to compliance statuses.
  *
@@ -22090,7 +22096,7 @@ where_compliance_status (const char *compliance)
 
    return g_string_free (compliance_sql, FALSE);;
 }
-
+#endif
 
 /**
  * @brief  Generate an extra WHERE clause for selecting reports
@@ -22104,9 +22110,9 @@ where_compliance_status (const char *compliance)
 static gchar *
 reports_extra_where (int trash, const gchar *filter, const char *usage_type)
 {
-  gchar *extra_where = NULL;
-  gchar *usage_type_clause, *trash_clause, *compliance_clause = NULL;
-  gchar *compliance_filter = NULL;
+
+  GString *extra_where = g_string_new ("");
+  gchar *trash_clause;
 
   if (trash)
     {
@@ -22122,36 +22128,37 @@ reports_extra_where (int trash, const gchar *filter, const char *usage_type)
     }
 
 
-  if (usage_type && strcmp (usage_type, ""))
-    {
-      gchar *quoted_usage_type;
-      quoted_usage_type = sql_quote (usage_type);
-      usage_type_clause = g_strdup_printf (" AND task in (SELECT id from tasks"
-                                           "              WHERE usage_type='%s')",
-                                           quoted_usage_type);
-      
-      g_free (quoted_usage_type);
-    }
-  else
-    usage_type_clause = NULL;
-
-  if (filter)
-    compliance_filter = filter_term_value(filter, "report_compliance_levels");
-
-  compliance_clause = where_compliance_status (compliance_filter ?: "yniu");
-  
-
-  extra_where = g_strdup_printf("%s%s%s",
-                                trash_clause,
-                                usage_type_clause ?: "",
-                                compliance_clause ?: "");
-
-  g_free (compliance_filter);
+  g_string_append_printf(extra_where, "%s", trash_clause);
   g_free (trash_clause);
-  g_free (compliance_clause);
-  g_free (usage_type_clause);
 
-  return extra_where;
+  #if COMPLIANCE_REPORTS == 1
+    gchar *usage_type_clause, *compliance_clause = NULL;
+    gchar *compliance_filter = NULL;
+    if (usage_type && strcmp (usage_type, ""))
+      {
+        gchar *quoted_usage_type;
+        quoted_usage_type = sql_quote (usage_type);
+        usage_type_clause = g_strdup_printf (" AND task in (SELECT id from tasks"
+                                            "              WHERE usage_type='%s')",
+                                            quoted_usage_type);
+
+        g_free (quoted_usage_type);
+      }
+    else
+      usage_type_clause = NULL;
+
+    if (filter)
+      compliance_filter = filter_term_value(filter, "report_compliance_levels");
+
+    compliance_clause = where_compliance_status (compliance_filter ?: "yniu");
+
+    g_string_append_printf (extra_where, "%s%s", usage_type_clause ?: "", compliance_clause ?: "");
+    g_free (compliance_filter);
+    g_free (compliance_clause);
+    g_free (usage_type_clause);
+  #endif
+
+  return g_string_free (extra_where, FALSE);
 }
 
 /**
@@ -25967,6 +25974,7 @@ report_counts_id_full (report_t report, int* holes, int* infos,
   return 0;
 }
 
+#if COMPLIANCE_REPORTS == 1
 /**
  * @brief Get the compliance state from compliance counts.
  *
@@ -26111,7 +26119,7 @@ report_compliance_counts (report_t report,
 
   return 0;
 }
-
+#endif
 
 
 /**
@@ -28437,7 +28445,52 @@ print_report_host_xml (FILE *stream,
     PRINT (stream,
             "<asset asset_id=\"\"/>");
 
-  if (strcmp (usage_type, "audit"))
+  #if COMPLIANCE_REPORTS == 1
+    if (strcmp (usage_type, "audit") == 0)
+      {
+        int yes_count, no_count, incomplete_count, undefined_count;
+
+        yes_count
+          = GPOINTER_TO_INT
+              (g_hash_table_lookup (f_host_compliant, current_host));
+        no_count
+          = GPOINTER_TO_INT
+              (g_hash_table_lookup (f_host_notcompliant, current_host));
+        incomplete_count
+          = GPOINTER_TO_INT
+              (g_hash_table_lookup (f_host_incomplete, current_host));
+        undefined_count
+          = GPOINTER_TO_INT
+              (g_hash_table_lookup (f_host_undefined, current_host));
+
+        PRINT (stream,
+              "<start>%s</start>"
+              "<end>%s</end>"
+              "<port_count><page>%d</page></port_count>"
+              "<compliance_count>"
+              "<page>%d</page>"
+              "<yes><page>%d</page></yes>"
+              "<no><page>%d</page></no>"
+              "<incomplete><page>%d</page></incomplete>"
+              "<undefined><page>%d</page></undefined>"
+              "</compliance_count>"
+              "<host_compliance>%s</host_compliance>",
+              host_iterator_start_time (hosts),
+              host_iterator_end_time (hosts)
+                ? host_iterator_end_time (hosts)
+                : "",
+              ports_count,
+              (yes_count + no_count + incomplete_count + undefined_count),
+              yes_count,
+              no_count,
+              incomplete_count,
+              undefined_count,
+              report_compliance_from_counts (&yes_count,
+                                              &no_count,
+                                              &incomplete_count,
+                                              &undefined_count));
+      } else
+  #endif
     {
       int holes_count, warnings_count, infos_count;
       int logs_count, false_positives_count;
@@ -28483,50 +28536,6 @@ print_report_host_xml (FILE *stream,
             infos_count,
             logs_count,
             false_positives_count);
-    }
-  else
-    {
-      int yes_count, no_count, incomplete_count, undefined_count;
-
-      yes_count
-        = GPOINTER_TO_INT
-            (g_hash_table_lookup (f_host_compliant, current_host));
-      no_count
-        = GPOINTER_TO_INT
-            (g_hash_table_lookup (f_host_notcompliant, current_host));
-      incomplete_count
-        = GPOINTER_TO_INT
-            (g_hash_table_lookup (f_host_incomplete, current_host));
-      undefined_count
-        = GPOINTER_TO_INT
-            (g_hash_table_lookup (f_host_undefined, current_host));
-
-      PRINT (stream,
-            "<start>%s</start>"
-            "<end>%s</end>"
-            "<port_count><page>%d</page></port_count>"
-            "<compliance_count>"
-            "<page>%d</page>"
-            "<yes><page>%d</page></yes>"
-            "<no><page>%d</page></no>"
-            "<incomplete><page>%d</page></incomplete>"
-            "<undefined><page>%d</page></undefined>"
-            "</compliance_count>"
-            "<host_compliance>%s</host_compliance>",
-            host_iterator_start_time (hosts),
-            host_iterator_end_time (hosts)
-              ? host_iterator_end_time (hosts)
-              : "",
-            ports_count,
-            (yes_count + no_count + incomplete_count + undefined_count),
-            yes_count,
-            no_count,
-            incomplete_count,
-            undefined_count,
-            report_compliance_from_counts (&yes_count,
-                                           &no_count,
-                                           &incomplete_count,
-                                           &undefined_count));
     }
 
   if (print_report_host_details_xml
@@ -29641,7 +29650,8 @@ print_v2_report_delta_xml (FILE *out, iterator_t *results,
   *orig_filtered_result_count = *filtered_result_count;
   gchar *usage_type = NULL;
 
-  if (task && task_usage_type(task, &usage_type)) return -1;
+  if (task && task_usage_type(task, &usage_type))
+    return -1;
 
   ports = g_tree_new_full ((GCompareDataFunc) strcmp, NULL, g_free,
                            (GDestroyNotify) free_host_ports);
@@ -29652,7 +29662,30 @@ print_v2_report_delta_xml (FILE *out, iterator_t *results,
 
     if (strchr (delta_states, state[0]) == NULL) continue;
 
-    if (strcmp (usage_type, "audit")) 
+    #if COMPLIANCE_REPORTS == 1
+      if (strcmp (usage_type, "audit") == 0)
+        {
+            const char* compliance;
+            compliance = result_iterator_compliance (results);
+            (*f_compliance_count)++;
+            if (strcasecmp (compliance, "yes") == 0)
+              {
+                  (*f_compliance_yes)++;
+              }
+            else if (strcasecmp (compliance, "no") == 0)
+              {
+                  (*f_compliance_no)++;
+              }
+            else if (strcasecmp (compliance, "incomplete") == 0)
+              {
+                  (*f_compliance_incomplete)++;
+              }
+            else if (strcasecmp (compliance, "undefined") == 0)
+              {
+                  (*f_compliance_undefined)++;
+              }
+        } else
+    #endif
       {
         const char *level;
         /* Increase the result count. */
@@ -29684,28 +29717,6 @@ print_v2_report_delta_xml (FILE *out, iterator_t *results,
             (*orig_f_false_positives)++;
             (*f_false_positives)++;
           }
-      }
-    else
-      {
-          const char* compliance;
-          compliance = result_iterator_compliance (results);
-          (*f_compliance_count)++;
-          if (strcasecmp (compliance, "yes") == 0)
-            {              
-                (*f_compliance_yes)++;
-            }
-          else if (strcasecmp (compliance, "no") == 0)
-            {
-                (*f_compliance_no)++;
-            }      
-          else if (strcasecmp (compliance, "incomplete") == 0)
-            {
-                (*f_compliance_incomplete)++;
-            }
-          else if (strcasecmp (compliance, "undefined") == 0)
-            {
-                (*f_compliance_undefined)++;
-            }            
       }
 
     buffer_results_xml (buffer,
@@ -29839,11 +29850,9 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
   GHashTable  *f_host_incomplete, *f_host_undefined;
   task_status_t run_status;
   gchar *tsk_usage_type = NULL;
-  int compliance_yes, compliance_no;
-  int compliance_incomplete, compliance_undefined;
   int f_compliance_yes, f_compliance_no;
   int f_compliance_incomplete, f_compliance_undefined;
-  int total_compliance_count, f_compliance_count;
+  int f_compliance_count;
 
   int delta_reports_version = 0;
 
@@ -29856,7 +29865,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
   min_qod = NULL;
   search_phrase = NULL;
   total_result_count = filtered_result_count = 0;
-  total_compliance_count = f_compliance_count = 0;
+  f_compliance_count = 0;
   orig_filtered_result_count = 0;
   orig_f_false_positives = orig_f_warnings = orig_f_logs = orig_f_infos = 0;
   orig_f_holes = 0;
@@ -29947,14 +29956,11 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
 
   levels = levels ? levels : g_strdup ("hmlgdf");
 
-  compliance_levels = compliance_levels ? compliance_levels : g_strdup ("yniu");
-
   if (task && (task_uuid (task, &tsk_uuid) || task_usage_type(task, &tsk_usage_type)))
     {
       fclose (out);
       g_free (term);
       g_free (levels);
-      g_free (compliance_levels);
       g_free (search_phrase);
       g_free (min_qod);
       g_free (delta_states);
@@ -30027,7 +30033,6 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
         {
           free (uuid);
           g_free (levels);
-          g_free (compliance_levels);
           g_free (search_phrase);
           g_free (min_qod);
           g_free (delta_states);
@@ -30062,7 +30067,9 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
   if (report)
     {
       /* Get total counts of full results. */
-      if (strcmp (tsk_usage_type, "audit"))
+      #if COMPLIANCE_REPORTS == 1
+        if (strcmp (tsk_usage_type, "audit"))
+      #endif
         {
           if (delta == 0)
             {         
@@ -30200,7 +30207,22 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
 
   filters_extra_buffer = g_string_new ("");
 
-  if (strcmp (tsk_usage_type, "audit"))
+  #if COMPLIANCE_REPORTS == 1
+    if (strcmp (tsk_usage_type, "audit") == 0)
+      {
+        compliance_levels = compliance_levels ? compliance_levels : g_strdup ("yniu");
+
+        if (strchr (compliance_levels, 'y'))
+          g_string_append (filters_extra_buffer, "<filter>Yes</filter>");
+        if (strchr (compliance_levels, 'n'))
+          g_string_append (filters_extra_buffer, "<filter>No</filter>");
+        if (strchr (compliance_levels, 'i'))
+          g_string_append (filters_extra_buffer, "<filter>Incomplete</filter>");
+        if (strchr (compliance_levels, 'u'))
+          g_string_append (filters_extra_buffer, "<filter>Undefined</filter>");
+      }
+    else
+  #endif
     {
       if (strchr (levels, 'h'))
         g_string_append (filters_extra_buffer, "<filter>High</filter>");
@@ -30212,17 +30234,6 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
         g_string_append (filters_extra_buffer, "<filter>Log</filter>");
       if (strchr (levels, 'f'))
         g_string_append (filters_extra_buffer, "<filter>False Positive</filter>");
-    }
-  else
-    {
-      if (strchr (compliance_levels, 'y'))
-        g_string_append (filters_extra_buffer, "<filter>Yes</filter>");
-      if (strchr (compliance_levels, 'n'))
-        g_string_append (filters_extra_buffer, "<filter>No</filter>");
-      if (strchr (compliance_levels, 'i'))
-        g_string_append (filters_extra_buffer, "<filter>Incomplete</filter>");
-      if (strchr (compliance_levels, 'u'))
-        g_string_append (filters_extra_buffer, "<filter>Undefined</filter>");
     }
 
   if (delta)
@@ -30488,56 +30499,60 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
     }
 
   /* Prepare result counts. */
+  #if COMPLIANCE_REPORTS == 1
+    int compliance_yes, compliance_no;
+    int compliance_incomplete, compliance_undefined;
+    int total_compliance_count = 0;
 
-  if (strcmp (tsk_usage_type, "audit") == 0)
-    {
-      report_compliance_counts (report, get, &compliance_yes, &compliance_no,
-                                &compliance_incomplete, &compliance_undefined);
+    if (strcmp (tsk_usage_type, "audit") == 0)
+      {
+        report_compliance_counts (report, get, &compliance_yes, &compliance_no,
+                                  &compliance_incomplete, &compliance_undefined);
 
-      total_compliance_count = compliance_yes 
-                               + compliance_no 
-                               + compliance_incomplete
-                               + compliance_undefined;
+        total_compliance_count = compliance_yes
+                                + compliance_no
+                                + compliance_incomplete
+                                + compliance_undefined;
 
-      f_compliance_yes = f_compliance_no = 0;
-      f_compliance_incomplete = f_compliance_undefined = 0;
+        f_compliance_yes = f_compliance_no = 0;
+        f_compliance_incomplete = f_compliance_undefined = 0;
 
-      if (count_filtered == 0)
-        {
-          report_compliance_f_counts (report, 
-                                      get, 
-                                      &f_compliance_yes,
-                                      &f_compliance_no, 
-                                      &f_compliance_incomplete,
-                                      &f_compliance_undefined);
-          
-          f_compliance_count = f_compliance_yes 
-                               + f_compliance_no
-                               + f_compliance_incomplete
-                               + f_compliance_undefined;
-        }
-    }
-  else
-    {
-      if (count_filtered)
-        {
-          /* We're getting all the filtered results, so we can count them as we
-          * print them, to save time. */
+        if (count_filtered == 0)
+          {
+            report_compliance_f_counts (report,
+                                        get,
+                                        &f_compliance_yes,
+                                        &f_compliance_no,
+                                        &f_compliance_incomplete,
+                                        &f_compliance_undefined);
 
-          report_counts_id_full (report, &holes, &infos, &logs,
-                                &warnings, &false_positives, &severity,
-                                get, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+            f_compliance_count = f_compliance_yes
+                                + f_compliance_no
+                                + f_compliance_incomplete
+                                + f_compliance_undefined;
+          }
+      } else
+  #endif
+  {
+    if (count_filtered)
+      {
+        /* We're getting all the filtered results, so we can count them as we
+        * print them, to save time. */
 
-          f_holes = f_infos = f_logs = f_warnings = 0;
-          f_false_positives = f_severity = 0;
-        }
-      else
-          report_counts_id_full (report, &holes, &infos, &logs,
-                                &warnings, &false_positives, &severity,
-                                get, NULL,
-                                &f_holes, &f_infos, &f_logs, &f_warnings,
-                                &f_false_positives, &f_severity);   
-    }
+        report_counts_id_full (report, &holes, &infos, &logs,
+                              &warnings, &false_positives, &severity,
+                              get, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+        f_holes = f_infos = f_logs = f_warnings = 0;
+        f_false_positives = f_severity = 0;
+      }
+    else
+        report_counts_id_full (report, &holes, &infos, &logs,
+                              &warnings, &false_positives, &severity,
+                              get, NULL,
+                              &f_holes, &f_infos, &f_logs, &f_warnings,
+                              &f_false_positives, &f_severity);
+  }
 
   /* Results. */
 
@@ -30602,31 +30617,31 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
     /* Quiet erroneous compiler warning. */
     result_hosts = NULL;
 
-  if (strcmp (tsk_usage_type, "audit"))
-    {
-      f_host_holes = g_hash_table_new_full (g_str_hash, g_str_equal,
+  #if COMPLIANCE_REPORTS == 1
+    if (strcmp (tsk_usage_type, "audit") == 0)
+      {
+        f_host_compliant = g_hash_table_new_full (g_str_hash, g_str_equal,
+                                                  g_free, NULL);
+        f_host_notcompliant = g_hash_table_new_full (g_str_hash, g_str_equal,
+                                                     g_free, NULL);
+        f_host_incomplete = g_hash_table_new_full (g_str_hash, g_str_equal,
+                                                   g_free, NULL);
+        f_host_undefined = g_hash_table_new_full (g_str_hash, g_str_equal,
+                                                  g_free, NULL);
+      } else
+  #endif
+  {
+    f_host_holes = g_hash_table_new_full (g_str_hash, g_str_equal,
+                                          g_free, NULL);
+    f_host_warnings = g_hash_table_new_full (g_str_hash, g_str_equal,
                                             g_free, NULL);
-      f_host_warnings = g_hash_table_new_full (g_str_hash, g_str_equal,
-                                              g_free, NULL);
-      f_host_infos = g_hash_table_new_full (g_str_hash, g_str_equal,
-                                          g_free, NULL);
-      f_host_logs = g_hash_table_new_full (g_str_hash, g_str_equal,
-                                          g_free, NULL);
-      f_host_false_positives = g_hash_table_new_full (g_str_hash, g_str_equal,
-                                                      g_free, NULL);
-    }
-  else
-    {
-      f_host_compliant = g_hash_table_new_full (g_str_hash, g_str_equal,
-                                                      g_free, NULL);
-      f_host_notcompliant = g_hash_table_new_full (g_str_hash, g_str_equal,
-                                                      g_free, NULL);
-      f_host_incomplete = g_hash_table_new_full (g_str_hash, g_str_equal,
-                                                      g_free, NULL);
-      f_host_undefined = g_hash_table_new_full (g_str_hash, g_str_equal,
-                                                      g_free, NULL);                                                      
-    }
-
+    f_host_infos = g_hash_table_new_full (g_str_hash, g_str_equal,
+                                        g_free, NULL);
+    f_host_logs = g_hash_table_new_full (g_str_hash, g_str_equal,
+                                        g_free, NULL);
+    f_host_false_positives = g_hash_table_new_full (g_str_hash, g_str_equal,
+                                                    g_free, NULL);
+  }
 
   if (delta && get->details)
     {
@@ -30649,36 +30664,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
                                       &orig_f_false_positives, 
                                       &f_false_positives,
                                       result_hosts))
-            {
-              fclose (out);
-              g_free (sort_field);
-              g_free (levels);
-              g_free (compliance_levels);
-              g_free (search_phrase);
-              g_free (min_qod);
-              g_free (delta_states);
-              cleanup_iterator (&results);
-              cleanup_iterator (&delta_results);
-              tz_revert (zone, tz, old_tz_override);
-              g_hash_table_destroy (f_host_ports);
-              if (strcmp (tsk_usage_type, "audit"))
-                {
-                  g_hash_table_destroy (f_host_holes);
-                  g_hash_table_destroy (f_host_warnings);
-                  g_hash_table_destroy (f_host_infos);
-                  g_hash_table_destroy (f_host_logs);
-                  g_hash_table_destroy (f_host_false_positives);
-
-                }
-              else
-                {
-                  g_hash_table_destroy (f_host_compliant);
-                  g_hash_table_destroy (f_host_notcompliant);
-                  g_hash_table_destroy (f_host_incomplete);
-                  g_hash_table_destroy (f_host_undefined);
-                }
-              return -1;
-            }
+          goto failed_delta_report;
         } 
       else 
         {
@@ -30703,35 +30689,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
                                         &f_compliance_undefined,
                                         &f_compliance_count,
                                         result_hosts))
-            {
-              fclose (out);
-              g_free (sort_field);
-              g_free (levels);
-              g_free (compliance_levels);
-              g_free (search_phrase);
-              g_free (min_qod);
-              g_free (delta_states);
-              cleanup_iterator (&results);
-              cleanup_iterator (&delta_results);
-              tz_revert (zone, tz, old_tz_override);
-              g_hash_table_destroy (f_host_ports);
-              if (strcmp (tsk_usage_type, "audit"))
-                {
-                    g_hash_table_destroy (f_host_holes);
-                    g_hash_table_destroy (f_host_warnings);
-                    g_hash_table_destroy (f_host_infos);
-                    g_hash_table_destroy (f_host_logs);
-                    g_hash_table_destroy (f_host_false_positives);
-                }
-              else
-                {
-                    g_hash_table_destroy (f_host_compliant);
-                    g_hash_table_destroy (f_host_notcompliant);
-                    g_hash_table_destroy (f_host_incomplete);
-                    g_hash_table_destroy (f_host_undefined);                
-                }
-              return -1;
-            }
+            goto failed_delta_report;
         }
     }
   else if (get->details)
@@ -30767,107 +30725,108 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
             array_add_new_string (result_hosts,
                                   result_iterator_host (&results));
 
-          if (strcmp (tsk_usage_type, "audit"))
-            {
-              double result_severity;
-              result_severity = result_iterator_severity_double (&results);
-              if (result_severity > f_severity)
-                f_severity = result_severity;
+          #if COMPLIANCE_REPORTS == 1
+            if (strcmp (tsk_usage_type, "audit") == 0)
+              {
+                const char* compliance;
+                compliance = result_iterator_compliance (&results);
 
-              level = result_iterator_level (&results);
+                if (strcasecmp (compliance, "yes") == 0)
+                  {
+                    f_host_result_counts = f_host_compliant;
+                    if (count_filtered)
+                      f_compliance_yes++;
+                  }
+                else if (strcasecmp (compliance, "no") == 0)
+                  {
+                    f_host_result_counts = f_host_notcompliant;
+                    if (count_filtered)
+                      f_compliance_no++;
+                  }
+                else if (strcasecmp (compliance, "incomplete") == 0)
+                  {
+                    f_host_result_counts = f_host_incomplete;
+                    if (count_filtered)
+                      f_compliance_incomplete++;
+                  }
+                else if (strcasecmp (compliance, "undefined") == 0)
+                  {
+                    f_host_result_counts = f_host_undefined;
+                    if (count_filtered)
+                      f_compliance_undefined++;
+                  }
+                else
+                  {
+                    f_host_result_counts = NULL;
+                  }
 
-              if (strcasecmp (level, "log") == 0)
-                {
-                  f_host_result_counts = f_host_logs;
-                  if (count_filtered)
-                    f_logs++;
-                }
-              else if (strcasecmp (level, "high") == 0)
-                {
-                  f_host_result_counts = f_host_holes;
-                  if (count_filtered)
-                    f_holes++;
-                }
-              else if (strcasecmp (level, "medium") == 0)
-                {
-                  f_host_result_counts = f_host_warnings;
-                  if (count_filtered)
-                    f_warnings++;
-                }
-              else if (strcasecmp (level, "low") == 0)
-                {
-                  f_host_result_counts = f_host_infos;
-                  if (count_filtered)
-                    f_infos++;
-                }
-              else if (strcasecmp (level, "false positive") == 0)
-                {
-                  f_host_result_counts = f_host_false_positives;
-                  if (count_filtered)
-                    f_false_positives++;
-                }
-              else
-                f_host_result_counts = NULL;
+                if (f_host_result_counts)
+                  {
+                    const char *result_host = result_iterator_host (&results);
+                    int result_count
+                          = GPOINTER_TO_INT
+                              (g_hash_table_lookup (f_host_result_counts,
+                                                    result_host));
 
-              if (f_host_result_counts)
-                {
-                  const char *result_host = result_iterator_host (&results);
-                  int result_count
-                        = GPOINTER_TO_INT
-                            (g_hash_table_lookup (f_host_result_counts, result_host));
+                    g_hash_table_replace (f_host_result_counts,
+                                          g_strdup (result_host),
+                                          GINT_TO_POINTER (result_count + 1));
+                }
+              } else
+          #endif
+          {
+            double result_severity;
+            result_severity = result_iterator_severity_double (&results);
+            if (result_severity > f_severity)
+              f_severity = result_severity;
 
-                  g_hash_table_replace (f_host_result_counts,
-                                        g_strdup (result_host),
-                                        GINT_TO_POINTER (result_count + 1));
-                }
-            }
-          else
-            {
-              const char* compliance;
-              compliance = result_iterator_compliance (&results);
+            level = result_iterator_level (&results);
 
-              if (strcasecmp (compliance, "yes") == 0)
-                {
-                  f_host_result_counts = f_host_compliant;
-                  if (count_filtered)                  
-                    f_compliance_yes++;
-                }
-              else if (strcasecmp (compliance, "no") == 0)
-                {
-                  f_host_result_counts = f_host_notcompliant;
-                  if (count_filtered)                  
-                    f_compliance_no++;
-                }      
-              else if (strcasecmp (compliance, "incomplete") == 0)
-                {
-                  f_host_result_counts = f_host_incomplete;
-                  if (count_filtered)                  
-                    f_compliance_incomplete++;
-                }
-              else if (strcasecmp (compliance, "undefined") == 0)
-                {
-                  f_host_result_counts = f_host_undefined;
-                  if (count_filtered)                  
-                    f_compliance_undefined++;
-                }                
-              else
-                {
-                  f_host_result_counts = NULL;
-                }
+            if (strcasecmp (level, "log") == 0)
+              {
+                f_host_result_counts = f_host_logs;
+                if (count_filtered)
+                  f_logs++;
+              }
+            else if (strcasecmp (level, "high") == 0)
+              {
+                f_host_result_counts = f_host_holes;
+                if (count_filtered)
+                  f_holes++;
+              }
+            else if (strcasecmp (level, "medium") == 0)
+              {
+                f_host_result_counts = f_host_warnings;
+                if (count_filtered)
+                  f_warnings++;
+              }
+            else if (strcasecmp (level, "low") == 0)
+              {
+                f_host_result_counts = f_host_infos;
+                if (count_filtered)
+                  f_infos++;
+              }
+            else if (strcasecmp (level, "false positive") == 0)
+              {
+                f_host_result_counts = f_host_false_positives;
+                if (count_filtered)
+                  f_false_positives++;
+              }
+            else
+              f_host_result_counts = NULL;
 
-              if (f_host_result_counts)
-                {
-                  const char *result_host = result_iterator_host (&results);
-                  int result_count
-                        = GPOINTER_TO_INT
-                            (g_hash_table_lookup (f_host_result_counts, 
-                                                  result_host));
+            if (f_host_result_counts)
+              {
+                const char *result_host = result_iterator_host (&results);
+                int result_count
+                      = GPOINTER_TO_INT
+                          (g_hash_table_lookup (f_host_result_counts, result_host));
 
-                  g_hash_table_replace (f_host_result_counts,
-                                        g_strdup (result_host),
-                                        GINT_TO_POINTER (result_count + 1));
-                }
-            }
+                g_hash_table_replace (f_host_result_counts,
+                                      g_strdup (result_host),
+                                      GINT_TO_POINTER (result_count + 1));
+              }
+          }
 
         }
       PRINT (out, "</results>");
@@ -30879,131 +30838,131 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
 
   /* Print result counts and severity. */
 
-  if (strcmp (tsk_usage_type, "audit"))
-    {
-      if (delta)
-        /** @todo The f_holes, etc. vars are setup to give the page count. */
-        PRINT (out,
-              "<result_count>"
-              "<filtered>%i</filtered>"
-              "<hole><filtered>%i</filtered></hole>"
-              "<info><filtered>%i</filtered></info>"
-              "<log><filtered>%i</filtered></log>"
-              "<warning><filtered>%i</filtered></warning>"
-              "<false_positive>"
-              "<filtered>%i</filtered>"
-              "</false_positive>"
-              "</result_count>",
-              orig_filtered_result_count,
-              (strchr (levels, 'h') ? orig_f_holes : 0),
-              (strchr (levels, 'l') ? orig_f_infos : 0),
-              (strchr (levels, 'g') ? orig_f_logs : 0),
-              (strchr (levels, 'm') ? orig_f_warnings : 0),
-              (strchr (levels, 'f') ? orig_f_false_positives : 0));
-      else
-        {
-          if (count_filtered)
-            filtered_result_count = f_holes + f_infos + f_logs
-                                    + f_warnings + false_positives;
-
+  #if COMPLIANCE_REPORTS == 1
+    if (strcmp (tsk_usage_type, "audit") == 0)
+      {
+        if (delta)
           PRINT (out,
-                "<result_count>"
+                "<compliance_count>"
+                "<filtered>%i</filtered>"
+                "<yes><filtered>%i</filtered></yes>"
+                "<no><filtered>%i</filtered></no>"
+                "<incomplete><filtered>%i</filtered></incomplete>"
+                "<undefined><filtered>%i</filtered></undefined>"
+                "</compliance_count>",
+                f_compliance_count,
+                (strchr (compliance_levels, 'y') ? f_compliance_yes : 0),
+                (strchr (compliance_levels, 'n') ? f_compliance_no : 0),
+                (strchr (compliance_levels, 'i') ? f_compliance_incomplete : 0),
+                (strchr (compliance_levels, 'u') ? f_compliance_undefined : 0));
+        else
+          {
+            if (count_filtered)
+              f_compliance_count = f_compliance_yes
+                                    + f_compliance_no
+                                    + f_compliance_incomplete
+                                    + f_compliance_undefined;
+            PRINT (out,
+                "<compliance_count>"
                 "%i"
                 "<full>%i</full>"
                 "<filtered>%i</filtered>"
-                "<hole><full>%i</full><filtered>%i</filtered></hole>"
-                "<info><full>%i</full><filtered>%i</filtered></info>"
-                "<log><full>%i</full><filtered>%i</filtered></log>"
-                "<warning><full>%i</full><filtered>%i</filtered></warning>"
-                "<false_positive>"
-                "<full>%i</full>"
-                "<filtered>%i</filtered>"
-                "</false_positive>"
-                "</result_count>",
-                total_result_count,
-                total_result_count,
-                filtered_result_count,
-                holes,
-                (strchr (levels, 'h') ? f_holes : 0),
-                infos,
-                (strchr (levels, 'l') ? f_infos : 0),
-                logs,
-                (strchr (levels, 'g') ? f_logs : 0),
-                warnings,
-                (strchr (levels, 'm') ? f_warnings : 0),
-                false_positives,
-                (strchr (levels, 'f') ? f_false_positives : 0));
+                "<yes><full>%i</full><filtered>%i</filtered></yes>"
+                "<no><full>%i</full><filtered>%i</filtered></no>"
+                "<incomplete><full>%i</full><filtered>%i</filtered></incomplete>"
+                "<undefined><full>%i</full><filtered>%i</filtered></undefined>"
+                "</compliance_count>",
+                total_compliance_count,
+                total_compliance_count,
+                f_compliance_count,
+                compliance_yes,
+                (strchr (compliance_levels, 'y') ? f_compliance_yes : 0),
+                compliance_no,
+                (strchr (compliance_levels, 'n') ? f_compliance_no : 0),
+                compliance_incomplete,
+                (strchr (compliance_levels, 'i') ? f_compliance_incomplete : 0),
+                compliance_undefined,
+                (strchr (compliance_levels, 'i') ? f_compliance_undefined : 0));
 
-          PRINT (out,
-                "<severity>"
-                "<full>%1.1f</full>"
-                "<filtered>%1.1f</filtered>"
-                "</severity>",
-                severity,
-                f_severity);
-        }
-    }
-  else
-    {
-      if (delta)
+            PRINT (out,
+                  "<compliance>"
+                  "<full>%s</full>"
+                  "<filtered>%s</filtered>"
+                  "</compliance>",
+                  report_compliance_from_counts (&compliance_yes,
+                                                  &compliance_no,
+                                                  &compliance_incomplete,
+                                                  &compliance_undefined),
+                  report_compliance_from_counts (&f_compliance_yes,
+                                                  &f_compliance_no,
+                                                  &f_compliance_incomplete,
+                                                  &f_compliance_undefined));
+          }
+    } else
+  #endif
+  {
+    if (delta)
+      /** @todo The f_holes, etc. vars are setup to give the page count. */
+      PRINT (out,
+            "<result_count>"
+            "<filtered>%i</filtered>"
+            "<hole><filtered>%i</filtered></hole>"
+            "<info><filtered>%i</filtered></info>"
+            "<log><filtered>%i</filtered></log>"
+            "<warning><filtered>%i</filtered></warning>"
+            "<false_positive>"
+            "<filtered>%i</filtered>"
+            "</false_positive>"
+            "</result_count>",
+            orig_filtered_result_count,
+            (strchr (levels, 'h') ? orig_f_holes : 0),
+            (strchr (levels, 'l') ? orig_f_infos : 0),
+            (strchr (levels, 'g') ? orig_f_logs : 0),
+            (strchr (levels, 'm') ? orig_f_warnings : 0),
+            (strchr (levels, 'f') ? orig_f_false_positives : 0));
+    else
+      {
+        if (count_filtered)
+          filtered_result_count = f_holes + f_infos + f_logs
+                                  + f_warnings + false_positives;
+
         PRINT (out,
-              "<compliance_count>"
-              "<filtered>%i</filtered>"
-              "<yes><filtered>%i</filtered></yes>"
-              "<no><filtered>%i</filtered></no>"
-              "<incomplete><filtered>%i</filtered></incomplete>"
-              "<undefined><filtered>%i</filtered></undefined>"
-              "</compliance_count>",
-              f_compliance_count,
-              (strchr (compliance_levels, 'y') ? f_compliance_yes : 0),
-              (strchr (compliance_levels, 'n') ? f_compliance_no : 0),
-              (strchr (compliance_levels, 'i') ? f_compliance_incomplete : 0),
-              (strchr (compliance_levels, 'u') ? f_compliance_undefined : 0));
-      else
-        {
-          if (count_filtered)
-            f_compliance_count = f_compliance_yes
-                                 + f_compliance_no
-                                 + f_compliance_incomplete
-                                 + f_compliance_undefined;
-          PRINT (out,
-              "<compliance_count>"
+              "<result_count>"
               "%i"
               "<full>%i</full>"
               "<filtered>%i</filtered>"
-              "<yes><full>%i</full><filtered>%i</filtered></yes>"
-              "<no><full>%i</full><filtered>%i</filtered></no>"
-              "<incomplete><full>%i</full><filtered>%i</filtered></incomplete>"
-              "<undefined><full>%i</full><filtered>%i</filtered></undefined>"
-              "</compliance_count>",
-              total_compliance_count,
-              total_compliance_count,
-              f_compliance_count,
-              compliance_yes,
-              (strchr (compliance_levels, 'y') ? f_compliance_yes : 0),
-              compliance_no,
-              (strchr (compliance_levels, 'n') ? f_compliance_no : 0),
-              compliance_incomplete,
-              (strchr (compliance_levels, 'i') ? f_compliance_incomplete : 0),
-              compliance_undefined,
-              (strchr (compliance_levels, 'i') ? f_compliance_undefined : 0));
+              "<hole><full>%i</full><filtered>%i</filtered></hole>"
+              "<info><full>%i</full><filtered>%i</filtered></info>"
+              "<log><full>%i</full><filtered>%i</filtered></log>"
+              "<warning><full>%i</full><filtered>%i</filtered></warning>"
+              "<false_positive>"
+              "<full>%i</full>"
+              "<filtered>%i</filtered>"
+              "</false_positive>"
+              "</result_count>",
+              total_result_count,
+              total_result_count,
+              filtered_result_count,
+              holes,
+              (strchr (levels, 'h') ? f_holes : 0),
+              infos,
+              (strchr (levels, 'l') ? f_infos : 0),
+              logs,
+              (strchr (levels, 'g') ? f_logs : 0),
+              warnings,
+              (strchr (levels, 'm') ? f_warnings : 0),
+              false_positives,
+              (strchr (levels, 'f') ? f_false_positives : 0));
 
-          PRINT (out,
-                "<compliance>"
-                "<full>%s</full>"
-                "<filtered>%s</filtered>"
-                "</compliance>",
-                report_compliance_from_counts (&compliance_yes,
-                                               &compliance_no,
-                                               &compliance_incomplete,
-                                               &compliance_undefined),
-                report_compliance_from_counts (&f_compliance_yes,
-                                               &f_compliance_no,
-                                               &f_compliance_incomplete,
-                                               &f_compliance_undefined));
-        }
-    }
-
+        PRINT (out,
+              "<severity>"
+              "<full>%1.1f</full>"
+              "<filtered>%1.1f</filtered>"
+              "</severity>",
+              severity,
+              f_severity);
+      }
+  }
 
   if (host_summary)
     {
@@ -31034,45 +30993,25 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
             }
           if (present)
             {
-              
-              if (print_report_host_xml (out,
-                                         &hosts,
-                                         result_host,
-                                         tsk_usage_type,
-                                         lean,
-                                         host_summary_buffer,
-                                         f_host_ports,
-                                         f_host_holes,
-                                         f_host_warnings,
-                                         f_host_infos,
-                                         f_host_logs,
-                                         f_host_false_positives,
-                                         f_host_compliant,
-                                         f_host_notcompliant,
-                                         f_host_incomplete,
-                                         f_host_undefined))
-                {
-                  tz_revert (zone, tz, old_tz_override);
-                  if (host_summary_buffer)
-                    g_string_free (host_summary_buffer, TRUE);
-                  g_hash_table_destroy (f_host_ports);
-                  if (strcmp (tsk_usage_type, "audit"))
-                    {
-                      g_hash_table_destroy (f_host_holes);
-                      g_hash_table_destroy (f_host_warnings);
-                      g_hash_table_destroy (f_host_infos);
-                      g_hash_table_destroy (f_host_logs);
-                      g_hash_table_destroy (f_host_false_positives);
+                if (print_report_host_xml (out,
+                                          &hosts,
+                                          result_host,
+                                          tsk_usage_type,
+                                          lean,
+                                          host_summary_buffer,
+                                          f_host_ports,
+                                          f_host_holes,
+                                          f_host_warnings,
+                                          f_host_infos,
+                                          f_host_logs,
+                                          f_host_false_positives,
+                                          f_host_compliant,
+                                          f_host_notcompliant,
+                                          f_host_incomplete,
+                                          f_host_undefined))
 
-                    }
-                  else
-                    {
-                      g_hash_table_destroy (f_host_compliant);
-                      g_hash_table_destroy (f_host_notcompliant);
-                      g_hash_table_destroy (f_host_incomplete);
-                      g_hash_table_destroy (f_host_undefined);
-                    }                  
-                  return -1;
+                {
+                    goto failed_print_report_host;
                 }
             }
           cleanup_iterator (&hosts);
@@ -31084,67 +31023,43 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
       init_report_host_iterator (&hosts, report, NULL, 0);
       while (next (&hosts))
         {
-
           if (print_report_host_xml (out,
-                                     &hosts,
-                                     NULL,
-                                     tsk_usage_type,
-                                     lean,
-                                     host_summary_buffer,
-                                     f_host_ports,
-                                     f_host_holes,
-                                     f_host_warnings,
-                                     f_host_infos,
-                                     f_host_logs,
-                                     f_host_false_positives,
-                                     f_host_compliant,
-                                     f_host_notcompliant,
-                                     f_host_incomplete,
-                                     f_host_undefined))
-            {
-              tz_revert (zone, tz, old_tz_override);
-              if (host_summary_buffer)
-                g_string_free (host_summary_buffer, TRUE);
-              g_hash_table_destroy (f_host_ports);
-              if (strcmp (tsk_usage_type, "audit"))
-                {
-                  g_hash_table_destroy (f_host_holes);
-                  g_hash_table_destroy (f_host_warnings);
-                  g_hash_table_destroy (f_host_infos);
-                  g_hash_table_destroy (f_host_logs);
-                  g_hash_table_destroy (f_host_false_positives);
-
-                }
-              else
-                {
-                  g_hash_table_destroy (f_host_compliant);
-                  g_hash_table_destroy (f_host_notcompliant);
-                  g_hash_table_destroy (f_host_incomplete);
-                  g_hash_table_destroy (f_host_undefined);
-                }
-              return -1;
-            }
+                                    &hosts,
+                                    NULL,
+                                    tsk_usage_type,
+                                    lean,
+                                    host_summary_buffer,
+                                    f_host_ports,
+                                    f_host_holes,
+                                    f_host_warnings,
+                                    f_host_infos,
+                                    f_host_logs,
+                                    f_host_false_positives,
+                                    f_host_compliant,
+                                    f_host_notcompliant,
+                                    f_host_incomplete,
+                                    f_host_undefined))
+            goto failed_print_report_host;
         }
       cleanup_iterator (&hosts);
     }
-
-  if (strcmp (tsk_usage_type, "audit"))
-    {
-      g_hash_table_destroy (f_host_holes);
-      g_hash_table_destroy (f_host_warnings);
-      g_hash_table_destroy (f_host_infos);
-      g_hash_table_destroy (f_host_logs);
-      g_hash_table_destroy (f_host_false_positives);
-
-    }
-  else
-    {
-      g_hash_table_destroy (f_host_compliant);
-      g_hash_table_destroy (f_host_notcompliant);
-      g_hash_table_destroy (f_host_incomplete);
-      g_hash_table_destroy (f_host_undefined);  
-    }
-    g_hash_table_destroy (f_host_ports);
+  #if COMPLIANCE_REPORTS == 1
+    if (strcmp (tsk_usage_type, "audit") == 0)
+      {
+        g_hash_table_destroy (f_host_compliant);
+        g_hash_table_destroy (f_host_notcompliant);
+        g_hash_table_destroy (f_host_incomplete);
+        g_hash_table_destroy (f_host_undefined);
+      } else
+  #endif
+  {
+    g_hash_table_destroy (f_host_holes);
+    g_hash_table_destroy (f_host_warnings);
+    g_hash_table_destroy (f_host_infos);
+    g_hash_table_destroy (f_host_logs);
+    g_hash_table_destroy (f_host_false_positives);
+  }
+  g_hash_table_destroy (f_host_ports);
 
   /* Print TLS certificates */
 
@@ -31239,6 +31154,39 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
     }
 
   return 0;
+
+  failed_delta_report:
+     fclose (out);
+     g_free (sort_field);
+     g_free (levels);
+     g_free (search_phrase);
+     g_free (min_qod);
+     g_free (delta_states);
+     cleanup_iterator (&results);
+     cleanup_iterator (&delta_results);
+  failed_print_report_host:
+    if (host_summary_buffer)
+        g_string_free (host_summary_buffer, TRUE);
+    tz_revert (zone, tz, old_tz_override);
+    g_hash_table_destroy (f_host_ports);
+    #if COMPLIANCE_REPORTS == 1
+      g_free (compliance_levels);
+      if (strcmp (tsk_usage_type, "audit") == 0)
+      {
+        g_hash_table_destroy (f_host_compliant);
+        g_hash_table_destroy (f_host_notcompliant);
+        g_hash_table_destroy (f_host_incomplete);
+        g_hash_table_destroy (f_host_undefined);
+      } else
+    #endif
+    {
+      g_hash_table_destroy (f_host_holes);
+      g_hash_table_destroy (f_host_warnings);
+      g_hash_table_destroy (f_host_infos);
+      g_hash_table_destroy (f_host_logs);
+      g_hash_table_destroy (f_host_false_positives);
+    }
+    return -1;
 }
 
 /**
@@ -53545,8 +53493,10 @@ modify_setting (const gchar *uuid, const gchar *name,
         setting_name = g_strdup ("Alerts Filter");
       else if (strcmp (uuid, "0f040d06-abf9-43a2-8f94-9de178b0e978") == 0)
         setting_name = g_strdup ("Assets Filter");
-      else if (strcmp (uuid, "45414da7-55f0-44c1-abbb-6b7d1126fbdf") == 0)
-        setting_name = g_strdup ("Audit Reports Filter");
+      #if COMPLIANCE_REPORTS == 1
+        else if (strcmp (uuid, "45414da7-55f0-44c1-abbb-6b7d1126fbdf") == 0)
+          setting_name = g_strdup ("Audit Reports Filter");
+      #endif
       else if (strcmp (uuid, "1a9fbd91-0182-44cd-bc88-a13a9b3b1bef") == 0)
         setting_name = g_strdup ("Configs Filter");
       else if (strcmp (uuid, "186a5ac8-fe5a-4fb1-aa22-44031fb339f3") == 0)
@@ -53670,9 +53620,10 @@ modify_setting (const gchar *uuid, const gchar *name,
         setting_name = g_strdup ("Reports Top Dashboard Configuration");
 
       /* Audit Reports dashboard settings */
-      else if (strcmp (uuid, "8083d77b-05bb-4b17-ab39-c81175cb512c") == 0)
-        setting_name = g_strdup ("Audit Reports Top Dashboard Configuration");      
-
+      #if COMPLIANCE_REPORTS == 1
+        else if (strcmp (uuid, "8083d77b-05bb-4b17-ab39-c81175cb512c") == 0)
+          setting_name = g_strdup ("Audit Reports Top Dashboard Configuration");
+      #endif
       /* Results dashboard settings */
       else if (strcmp (uuid, "0b8ae70d-d8fc-4418-8a72-e65ac8d2828e") == 0)
         setting_name = g_strdup ("Results Top Dashboard Configuration");

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -57366,17 +57366,7 @@ tag_add_resources_filter (tag_t tag, const char *type, const char *filter)
     }
   else
     {
-      if (strcasecmp (type, "audit_report") == 0)
-        {
-          type = g_strdup ("report");
-          resources_get.type = g_strdup (type);
-          get_data_set_extra (&resources_get, "usage_type", g_strdup ("audit"));
-        }
-      else if (strcasecmp (type, "report") == 0)
-        {
-          get_data_set_extra (&resources_get, "usage_type", g_strdup ("scan"));
-        }
-      else if (strcasecmp (type, "task") == 0)
+      if (strcasecmp (type, "task") == 0)
         {
           get_data_set_extra (&resources_get, "usage_type", g_strdup ("scan"));
         }
@@ -57396,6 +57386,18 @@ tag_add_resources_filter (tag_t tag, const char *type, const char *filter)
         {
           get_data_set_extra (&resources_get, "usage_type", g_strdup ("scan"));
         }
+      #if COMPLIANCE_REPORTS == 1
+        else if (strcasecmp (type, "audit_report") == 0)
+          {
+            type = g_strdup ("report");
+            resources_get.type = g_strdup (type);
+            get_data_set_extra (&resources_get, "usage_type", g_strdup ("audit"));
+          }
+        else if (strcasecmp (type, "report") == 0)
+          {
+            get_data_set_extra (&resources_get, "usage_type", g_strdup ("scan"));
+          }
+      #endif
 
       gchar *columns;
 
@@ -57547,19 +57549,7 @@ tag_remove_resources_filter (tag_t tag, const char *type, const char *filter)
     }
   else
     {
-      if (strcasecmp (type, "audit_report") == 0)
-        {
-          type = g_strdup ("report");
-          resources_get.type = g_strdup (type);
-          get_data_set_extra (&resources_get,
-                              "usage_type",
-                              g_strdup ("audit"));
-        }
-      else if (strcasecmp (type, "report") == 0)
-        {
-          get_data_set_extra (&resources_get, "usage_type", g_strdup ("scan"));
-        }
-      else if (strcasecmp (type, "task") == 0)
+      if (strcasecmp (type, "task") == 0)
         {
           get_data_set_extra (&resources_get, "usage_type", g_strdup ("scan"));
         }
@@ -57579,6 +57569,20 @@ tag_remove_resources_filter (tag_t tag, const char *type, const char *filter)
         {
           get_data_set_extra (&resources_get, "usage_type", g_strdup ("scan"));
         }
+      #if COMPLIANCE_REPORTS == 1
+        else if (strcasecmp (type, "audit_report") == 0)
+          {
+            type = g_strdup ("report");
+            resources_get.type = g_strdup (type);
+            get_data_set_extra (&resources_get,
+                                "usage_type",
+                                g_strdup ("audit"));
+          }
+        else if (strcasecmp (type, "report") == 0)
+          {
+            get_data_set_extra (&resources_get, "usage_type", g_strdup ("scan"));
+          }
+      #endif
 
       gchar *columns;
 

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -508,6 +508,9 @@ setting_value (const char *, char **);
 int
 valid_type (const char *);
 
+int
+valid_subtype (const char *);
+
 void
 add_role_permission_resource (const gchar *, const gchar *, const gchar *,
                               const gchar *);

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -69,6 +69,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <pattern>xsd:token { pattern = "y?n?i?u?" }</pattern>
   </type>
   <type>
+    <name>compliance_status</name>
+    <summary>A compliance status</summary>
+    <pattern>
+      xsd:token { pattern = "yes|no|incomplete|undefined" }
+    </pattern>
+  </type>  
+  <type>
     <name>ctime</name>
     <summary>A date and time, in the C `ctime' format</summary>
     <description>
@@ -1512,6 +1519,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <e>qod</e>
       <o><e>original_threat</e></o>
       <o><e>original_severity</e></o>
+      <e>compliance</e>
       <e>description</e>
       <o><e>delta</e></o>
       <o><e>detection</e></o>
@@ -1896,6 +1904,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <pattern><t>severity</t></pattern>
     </ele>
     <ele>
+      <name>compliance</name>
+      <summary>Result compliance ("yes", "no", "incomplete" or "undefined")</summary>
+      <pattern><t>compliance_status</t></pattern>
+    </ele>    
+    <ele>
       <name>description</name>
       <summary>Description of the result</summary>
       <pattern>text</pattern>
@@ -2201,8 +2214,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <e>permissions</e>
             <o><e>user_tags</e></o>
             <e>scan_run_status</e>
-            <e>result_count</e>
-            <e>severity</e>
+            <o><e>result_count</e></o>
+            <o><e>compliance_count</e></o>
+            <o><e>severity</e></o>
+            <o><e>compliance</e></o>
             <e>task</e>
             <e>ports</e>
             <e>results</e>
@@ -2529,7 +2544,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </ele>
       <ele>
         <name>result_count</name>
-        <summary>Counts of results produced by scan</summary>
+        <summary>Counts of results produced by scan. Only for reports of a scan task</summary>
         <description>
           <p>
             The text contains the full count -- the total number of results
@@ -2637,6 +2652,114 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </ele>
       </ele>
       <ele>
+        <name>compliance_count</name>
+        <summary>Counts of compliance results. Only for reports of an audit task.</summary>
+        <description>
+          <p>
+            The text contains the full count -- the total number of compliance results.
+          </p>
+        </description>
+        <pattern>
+          text
+          <e>full</e>
+          <e>filtered</e>
+          <e>yes</e>
+          <e>no</e>
+          <e>incomplete</e>
+          <e>undefined</e>
+        </pattern>
+        <ele>
+          <name>full</name>
+          <summary>Total number of compliance results</summary>
+          <pattern><t>integer</t></pattern>
+        </ele>
+        <ele>
+          <name>filtered</name>
+          <summary>Number of compliance results after filtering</summary>
+          <pattern><t>integer</t></pattern>
+        </ele>
+        <ele>
+          <name>yes</name>
+          <summary>
+            Number of "yes" results (compliant)
+          </summary>
+          <pattern>
+            <e>full</e>
+            <e>filtered</e>
+          </pattern>
+          <ele>
+            <name>full</name>
+            <summary>Total number of results</summary>
+            <pattern><t>integer</t></pattern>
+          </ele>
+          <ele>
+            <name>filtered</name>
+            <summary>Number of results after filtering</summary>
+            <pattern><t>integer</t></pattern>
+          </ele>
+        </ele>
+        <ele>
+          <name>no</name>
+          <summary>
+            Number of "no" results (not compliant)
+          </summary>
+          <pattern>
+            <e>full</e>
+            <e>filtered</e>
+          </pattern>
+          <ele>
+            <name>full</name>
+            <summary>Total number of results</summary>
+            <pattern><t>integer</t></pattern>
+          </ele>
+          <ele>
+            <name>filtered</name>
+            <summary>Number of results after filtering</summary>
+            <pattern><t>integer</t></pattern>
+          </ele>
+        </ele>
+        <ele>
+          <name>incomplete</name>
+          <summary>
+            Number of "incomplete" results (incomplete compliance)
+          </summary>
+          <pattern>
+            <e>full</e>
+            <e>filtered</e>
+          </pattern>
+          <ele>
+            <name>full</name>
+            <summary>Total number of results</summary>
+            <pattern><t>integer</t></pattern>
+          </ele>
+          <ele>
+            <name>filtered</name>
+            <summary>Number of results after filtering</summary>
+            <pattern><t>integer</t></pattern>
+          </ele>
+        </ele>
+        <ele>
+          <name>undefined</name>
+          <summary>
+            Number of "undefined" results (undefined compliance)
+          </summary>
+          <pattern>
+            <e>full</e>
+            <e>filtered</e>
+          </pattern>
+          <ele>
+            <name>full</name>
+            <summary>Total number of results</summary>
+            <pattern><t>integer</t></pattern>
+          </ele>
+          <ele>
+            <name>filtered</name>
+            <summary>Number of results after filtering</summary>
+            <pattern><t>integer</t></pattern>
+          </ele>
+        </ele>
+      </ele>      
+      <ele>
         <name>severity</name>
         <pattern>
           <e>full</e>
@@ -2653,6 +2776,23 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <summary>Maximum severity of the report after filtering</summary>
         </ele>
       </ele>
+      <ele>
+        <name>compliance</name>
+        <pattern>
+          <e>full</e>
+          <e>filtered</e>
+        </pattern>
+        <ele>
+          <name>full</name>
+          <pattern><t>compliance_status</t></pattern>
+          <summary>Compliance of the full report ("yes", "no", "incomplete" or "undefined")</summary>
+        </ele>
+        <ele>
+          <name>filtered</name>
+          <pattern><t>compliance_status</t></pattern>
+          <summary>Compliance of the report after filtering ("yes", "no", "incomplete" or "undefined")</summary>
+        </ele>
+      </ele>      
       <ele>
         <name>task</name>
         <pattern>
@@ -2914,7 +3054,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <e>start</e>
           <e>end</e>
           <e>port_count</e>
-          <e>result_count</e>
+          <o><e>result_count</e></o>
+          <o><e>compliance_count</e></o>
+          <o><e>host_compliance</e></o>
           <any><e>detail</e></any>
         </pattern>
         <ele>
@@ -2957,7 +3099,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </ele>
         <ele>
           <name>result_count</name>
-          <summary></summary>
+          <summary>Only for scan reports</summary>
           <pattern>
             <e>page</e>
             <e>hole</e>
@@ -3032,6 +3174,75 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </ele>
           </ele>
         </ele>
+        <ele>
+          <name>compliance_count</name>
+          <summary>Only for audit reports</summary>
+          <pattern>
+            <e>page</e>
+            <e>yes</e>
+            <e>no</e>
+            <e>incomplete</e>
+            <e>undefined</e>
+          </pattern>
+          <ele>
+            <name>page</name>
+            <summary>Total number of results for current host on current page</summary>
+            <pattern><t>integer</t></pattern>
+          </ele>
+          <ele>
+            <name>yes</name>
+            <summary>Number of "yes" results (compliant)</summary>
+            <pattern>
+              <e>page</e>
+            </pattern>
+            <ele>
+              <name>page</name>
+              <summary>Number of results on current page</summary>
+              <pattern><t>integer</t></pattern>
+            </ele>
+          </ele>
+          <ele>
+            <name>no</name>
+            <summary>Number of "no" results (not compliant)</summary>
+            <pattern>
+              <e>page</e>
+            </pattern>
+            <ele>
+              <name>page</name>
+              <summary>Number of results on current page</summary>
+              <pattern><t>integer</t></pattern>
+            </ele>
+          </ele>
+          <ele>
+            <name>incomplete</name>
+            <summary>Number of "incomplete" results (incomplete compliance)</summary>
+            <pattern>
+              <e>page</e>
+            </pattern>
+            <ele>
+              <name>page</name>
+              <summary>Number of results on current page</summary>
+              <pattern><t>integer</t></pattern>
+            </ele>
+          </ele>
+          <ele>
+            <name>undefined</name>
+            <summary>Number of "undefined" results (undefined compliance)</summary>
+            <pattern>
+              <e>page</e>
+            </pattern>
+            <ele>
+              <name>page</name>
+              <summary>Number of results on current page</summary>
+              <pattern><t>integer</t></pattern>
+            </ele>
+          </ele>          
+        </ele>
+        <ele>
+          <name>host_compliance</name>
+          <summary>Only for audit reports. Host compliance</summary>
+          <pattern><t>compliance_status</t></pattern>
+        </ele>               
         <ele>
           <name>detail</name>
           <summary>A detail associated with the host</summary>
@@ -17914,6 +18125,11 @@ END:VCALENDAR
             <type>integer</type>
             <summary>Minimum QoD of the results</summary>
           </option>
+          <option>
+            <name>report_compliance_levels</name>
+            <type>compliance_levels</type>
+            <summary>report compliance level to select</summary>
+          </option>          
           <column>
             <name>tag</name>
             <type>text</type>
@@ -18059,6 +18275,26 @@ END:VCALENDAR
             <type>iso_time</type>
             <summary>Scan end time</summary>
           </column>
+          <column>
+            <name>compliance_yes</name>
+            <type>integer</type>
+            <summary>Number of compliance yes results</summary>
+          </column>
+          <column>
+            <name>compliance_no</name>
+            <type>integer</type>
+            <summary>Number of compliance no results</summary>
+          </column>
+          <column>
+            <name>compliance_incomplete</name>
+            <type>integer</type>
+            <summary>Number of compliance incomplete results</summary>
+          </column>
+          <column>
+            <name>compliant</name>
+            <type>compliance_status</type>
+            <summary>Compliance state of the report. Can be yes, no, incomplete or undefined</summary>
+          </column>                      
         </filter_keywords>
       </attrib>
       <attrib>
@@ -18128,6 +18364,17 @@ END:VCALENDAR
         </summary>
         <type>boolean</type>
       </attrib>
+      <attrib>
+          <name>usage_type</name>
+          <summary>Optional usage type to limit the reports to. Affects total count unlike filter</summary>
+          <type>
+            <alts>
+              <alt>scan</alt>
+              <alt>audit</alt>
+              <alt></alt>
+            </alts>
+          </type>
+        </attrib>    
     </pattern>
     <response>
       <pattern>
@@ -22906,8 +23153,9 @@ END:VCALENDAR
               </attrib>
               <e>timestamp</e>
               <e>scan_end</e>
-              <e>result_count</e>
-              <e>severity</e>
+              <o><e>result_count</e></o>
+              <o><e>severity</e></o>
+              <o><e>compliance_count</e></o>
             </pattern>
             <ele>
               <name>timestamp</name>
@@ -22919,7 +23167,7 @@ END:VCALENDAR
             </ele>
             <ele>
               <name>result_count</name>
-              <summary>Result counts for this report</summary>
+              <summary>Result counts for this report. Only for scan tasks</summary>
               <pattern>
                 <e>false_positive</e>
                 <e>log</e>
@@ -22951,8 +23199,34 @@ END:VCALENDAR
             <ele>
               <name>severity</name>
               <pattern><t>severity</t></pattern>
-              <summary>Maximum severity of the report</summary>
+              <summary>Maximum severity of the report. Only for scan tasks</summary>
             </ele>
+            <ele>
+              <name>compliance_count</name>
+              <summary>Complaince counts. Only for audit tasks</summary>
+              <pattern>
+                <e>yes</e>
+                <e>no</e>
+                <e>incomplete</e>
+                <e>undefined</e>
+              </pattern>
+              <ele>
+                <name>yes</name>
+                <pattern><t>integer</t></pattern>
+              </ele>
+              <ele>
+                <name>no</name>
+                <pattern><t>integer</t></pattern>
+              </ele>
+              <ele>
+                <name>incomplete</name>
+                <pattern><t>integer</t></pattern>
+              </ele>
+              <ele>
+                <name>undefined</name>
+                <pattern><t>integer</t></pattern>
+              </ele>
+            </ele>            
           </ele>
         </ele>
         <ele>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -68,13 +68,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </description>
     <pattern>xsd:token { pattern = "y?n?i?u?" }</pattern>
   </type>
+  @IF_COMPLIANCE_REPORTS@
   <type>
     <name>compliance_status</name>
     <summary>A compliance status</summary>
     <pattern>
       xsd:token { pattern = "yes|no|incomplete|undefined" }
     </pattern>
-  </type>  
+  </type>
+  @ENDIF_COMPLIANCE_REPORTS@
   <type>
     <name>ctime</name>
     <summary>A date and time, in the C `ctime' format</summary>
@@ -2214,10 +2216,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <e>permissions</e>
             <o><e>user_tags</e></o>
             <e>scan_run_status</e>
-            <o><e>result_count</e></o>
+            @IF_COMPLIANCE_REPORTS@
+            <o>
+            @ENDIF_COMPLIANCE_REPORTS@
+            <e>result_count</e>
+            <e>severity</e>
+            @IF_COMPLIANCE_REPORTS@
+            </o>
             <o><e>compliance_count</e></o>
-            <o><e>severity</e></o>
             <o><e>compliance</e></o>
+            @ENDIF_COMPLIANCE_REPORTS@
             <e>task</e>
             <e>ports</e>
             <e>results</e>
@@ -2544,7 +2552,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </ele>
       <ele>
         <name>result_count</name>
-        <summary>Counts of results produced by scan. Only for reports of a scan task</summary>
+        <summary>Counts of results produced by scan</summary>
         <description>
           <p>
             The text contains the full count -- the total number of results
@@ -2651,12 +2659,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </ele>
         </ele>
       </ele>
+      @IF_COMPLIANCE_REPORTS@
       <ele>
         <name>compliance_count</name>
         <summary>Counts of compliance results. Only for reports of an audit task.</summary>
         <description>
           <p>
-            The text contains the full count -- the total number of compliance results.
+            The text contains the full count. The total number of compliance results.
           </p>
         </description>
         <pattern>
@@ -2758,7 +2767,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <pattern><t>integer</t></pattern>
           </ele>
         </ele>
-      </ele>      
+      </ele>
+      @ENDIF_COMPLIANCE_REPORTS@
       <ele>
         <name>severity</name>
         <pattern>
@@ -2776,6 +2786,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <summary>Maximum severity of the report after filtering</summary>
         </ele>
       </ele>
+      @IF_COMPLIANCE_REPORTS@
       <ele>
         <name>compliance</name>
         <pattern>
@@ -2792,7 +2803,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <pattern><t>compliance_status</t></pattern>
           <summary>Compliance of the report after filtering ("yes", "no", "incomplete" or "undefined")</summary>
         </ele>
-      </ele>      
+      </ele>
+      @ENDIF_COMPLIANCE_REPORTS@
       <ele>
         <name>task</name>
         <pattern>
@@ -3054,9 +3066,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <e>start</e>
           <e>end</e>
           <e>port_count</e>
-          <o><e>result_count</e></o>
+          @IF_COMPLIANCE_REPORTS@
+          <o>
+          @ENDIF_COMPLIANCE_REPORTS@
+          <e>result_count</e>
+          @IF_COMPLIANCE_REPORTS@
+          </o>
           <o><e>compliance_count</e></o>
           <o><e>host_compliance</e></o>
+          @ENDIF_COMPLIANCE_REPORTS@
           <any><e>detail</e></any>
         </pattern>
         <ele>
@@ -3099,7 +3117,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </ele>
         <ele>
           <name>result_count</name>
-          <summary>Only for scan reports</summary>
+          <summary></summary>
           <pattern>
             <e>page</e>
             <e>hole</e>
@@ -3174,6 +3192,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </ele>
           </ele>
         </ele>
+        @IF_COMPLIANCE_REPORTS@
         <ele>
           <name>compliance_count</name>
           <summary>Only for audit reports</summary>
@@ -3242,7 +3261,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <name>host_compliance</name>
           <summary>Only for audit reports. Host compliance</summary>
           <pattern><t>compliance_status</t></pattern>
-        </ele>               
+        </ele>
+        @ENDIF_COMPLIANCE_REPORTS@
         <ele>
           <name>detail</name>
           <summary>A detail associated with the host</summary>
@@ -18125,11 +18145,13 @@ END:VCALENDAR
             <type>integer</type>
             <summary>Minimum QoD of the results</summary>
           </option>
+          @IF_COMPLIANCE_REPORTS@
           <option>
             <name>report_compliance_levels</name>
             <type>compliance_levels</type>
             <summary>report compliance level to select</summary>
-          </option>          
+          </option>
+          @ENDIF_COMPLIANCE_REPORTS@   
           <column>
             <name>tag</name>
             <type>text</type>
@@ -18275,6 +18297,7 @@ END:VCALENDAR
             <type>iso_time</type>
             <summary>Scan end time</summary>
           </column>
+          @IF_COMPLIANCE_REPORTS@
           <column>
             <name>compliance_yes</name>
             <type>integer</type>
@@ -18294,7 +18317,8 @@ END:VCALENDAR
             <name>compliant</name>
             <type>compliance_status</type>
             <summary>Compliance state of the report. Can be yes, no, incomplete or undefined</summary>
-          </column>                      
+          </column>
+          @ENDIF_COMPLIANCE_REPORTS@      
         </filter_keywords>
       </attrib>
       <attrib>
@@ -18364,6 +18388,7 @@ END:VCALENDAR
         </summary>
         <type>boolean</type>
       </attrib>
+      @IF_COMPLIANCE_REPORTS@
       <attrib>
           <name>usage_type</name>
           <summary>Optional usage type to limit the reports to. Affects total count unlike filter</summary>
@@ -18374,7 +18399,8 @@ END:VCALENDAR
               <alt></alt>
             </alts>
           </type>
-        </attrib>    
+      </attrib>
+      @ENDIF_COMPLIANCE_REPORTS@
     </pattern>
     <response>
       <pattern>
@@ -23153,9 +23179,15 @@ END:VCALENDAR
               </attrib>
               <e>timestamp</e>
               <e>scan_end</e>
-              <o><e>result_count</e></o>
-              <o><e>severity</e></o>
+              @IF_COMPLIANCE_REPORTS@
+              <o>
+              @ENDIF_COMPLIANCE_REPORTS@
+              <e>result_count</e>
+              <e>severity</e>
+              @IF_COMPLIANCE_REPORTS@
+              </o>
               <o><e>compliance_count</e></o>
+              @ENDIF_COMPLIANCE_REPORTS@
             </pattern>
             <ele>
               <name>timestamp</name>
@@ -23167,7 +23199,7 @@ END:VCALENDAR
             </ele>
             <ele>
               <name>result_count</name>
-              <summary>Result counts for this report. Only for scan tasks</summary>
+              <summary>Result counts for this report</summary>
               <pattern>
                 <e>false_positive</e>
                 <e>log</e>
@@ -23199,8 +23231,9 @@ END:VCALENDAR
             <ele>
               <name>severity</name>
               <pattern><t>severity</t></pattern>
-              <summary>Maximum severity of the report. Only for scan tasks</summary>
+              <summary>Maximum severity of the report</summary>
             </ele>
+            @IF_COMPLIANCE_REPORTS@
             <ele>
               <name>compliance_count</name>
               <summary>Complaince counts. Only for audit tasks</summary>
@@ -23226,7 +23259,8 @@ END:VCALENDAR
                 <name>undefined</name>
                 <pattern><t>integer</t></pattern>
               </ele>
-            </ele>            
+            </ele>
+            @ENDIF_COMPLIANCE_REPORTS@
           </ele>
         </ele>
         <ele>


### PR DESCRIPTION
## What

- Add usage_type to GMP command get_reports command to differentiate between audit and scan reports. In the response, compliance / compliance count is now used for audit reports instead of severity / result count.
- GMP command get_results now includes compliance state for the results.
- Sub-types (audit, audit_report and policy) are allowed for tags.
- Filters are allowed for audit_report.
- The feature can be enabled by toggling COMPLIANCE_REPORTS. It is disabled by default.

## Why
To be used in a dedicated view for compliance audit reports in GSA.

## References
GEA-397, GEA-613


