### PR TITLE
Docs: Use a simpler structure for the HTML GMP doc

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -13514,7 +13514,6 @@ handle_get_notes (gmp_parser_t *gmp_parser, GError **error)
     }
   get_notes_data_reset (get_notes_data);
   set_client_state (CLIENT_AUTHENTIC);
-
 }
 
 /**

--- a/src/schema_formats/HTML/HTML.xsl
+++ b/src/schema_formats/HTML/HTML.xsl
@@ -260,11 +260,33 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
   </xsl:template>
 
+  <xsl:template name="details-summary-2">
+    <xsl:param name="id"/>
+    <xsl:param name="text"/>
+    <summary id="{$id}"
+             style="cursor: pointer; margin-top: 1.66em;">
+      <h2 style="display: inline;"><xsl:value-of select="$text"/></h2>
+    </summary>
+  </xsl:template>
+
+  <xsl:template name="details-summary-3">
+    <xsl:param name="id"/>
+    <xsl:param name="text"/>
+    <xsl:param name="name"/>
+    <summary id="{$id}"
+             style="cursor: pointer; margin-top: .83em;">
+      <h3 style="display: inline;">
+        <xsl:value-of select="$text"/>
+        <tt style="font-weight: normal;"><xsl:value-of select="$name"/></tt>
+      </h3>
+    </summary>
+  </xsl:template>
+
   <!-- RNC preamble. -->
 
   <xsl:template name="rnc-preamble">
     <details>
-      <xsl:call-template name="details-summary">
+      <xsl:call-template name="details-summary-2">
         <xsl:with-param name="id" select="'rnc_preamble'"/>
         <xsl:with-param name="text" select="'4 RNC Preamble'"/>
       </xsl:call-template>
@@ -289,18 +311,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </tr>
   </xsl:template>
 
-  <xsl:template name="details-summary">
-    <xsl:param name="id"/>
-    <xsl:param name="text"/>
-    <summary id="$id"
-             style="margin-block-start: .83em; margin-block-end: .83em;">
-      <h2 style="display: inline; cursor: pointer;"><xsl:value-of select="$text"/></h2>
-    </summary>
-  </xsl:template>
-
   <xsl:template name="type-summary">
     <details>
-      <xsl:call-template name="details-summary">
+      <xsl:call-template name="details-summary-2">
         <xsl:with-param name="id" select="'type_summary'"/>
         <xsl:with-param name="text" select="'1 Summary of Data Types'"/>
       </xsl:call-template>
@@ -311,13 +324,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   </xsl:template>
 
   <xsl:template match="type" mode="details">
-    <xsl:param name="index">5.<xsl:value-of select="position()"/></xsl:param>
-    <div>
-      <div>
-        <h3 id="type_{name}">
-        <xsl:value-of select="$index"/>
-        Data Type <tt><xsl:value-of select="name"/></tt></h3>
-      </div>
+    <xsl:param name="index">1.<xsl:value-of select="position()"/></xsl:param>
+    <details>
+      <xsl:call-template name="details-summary-3">
+        <xsl:with-param name="id" select="concat('type_', name)"/>
+        <xsl:with-param name="text" select="concat($index, ' Data Type ')"/>
+        <xsl:with-param name="name" select="name"/>
+      </xsl:call-template>
 
       <xsl:if test="summary">
         <p>In short: <xsl:value-of select="normalize-space(summary)"/>.</p>
@@ -340,14 +353,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </pre>
       </div>
 
-    </div>
+    </details>
   </xsl:template>
 
   <xsl:template name="type-details">
-    <details>
-      <xsl:call-template name="details-summary">
+    <details open="1">
+      <xsl:call-template name="details-summary-2">
         <xsl:with-param name="id" select="'type_details'"/>
-        <xsl:with-param name="text" select="'5 Data Type Details'"/>
+        <xsl:with-param name="text" select="'1 Data Types'"/>
       </xsl:call-template>
       <xsl:apply-templates select="type" mode="details"/>
     </details>
@@ -368,7 +381,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   <xsl:template name="element-summary">
     <details>
-      <xsl:call-template name="details-summary">
+      <xsl:call-template name="details-summary-2">
         <xsl:with-param name="id" select="'element_summary'"/>
         <xsl:with-param name="text" select="'2 Summary of Elements'"/>
       </xsl:call-template>
@@ -379,23 +392,23 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   </xsl:template>
 
   <xsl:template name="element-details">
-    <details>
-      <xsl:call-template name="details-summary">
+    <details open="1">
+      <xsl:call-template name="details-summary-2">
         <xsl:with-param name="id" select="'element_details'"/>
-        <xsl:with-param name="text" select="'6 Element Details'"/>
+        <xsl:with-param name="text" select="'2 Elements'"/>
       </xsl:call-template>
       <xsl:apply-templates select="element"/>
     </details>
   </xsl:template>
 
   <xsl:template match="element">
-    <xsl:param name="index">6.<xsl:value-of select="position()"/></xsl:param>
-    <div>
-      <div>
-        <h3 id="element_{name}">
-        <xsl:value-of select="$index"/>
-        Element <tt><xsl:value-of select="name"/></tt></h3>
-      </div>
+    <xsl:param name="index">2.<xsl:value-of select="position()"/></xsl:param>
+    <details>
+      <xsl:call-template name="details-summary-3">
+        <xsl:with-param name="id" select="concat('element_', name)"/>
+        <xsl:with-param name="text" select="concat($index, ' Element ')"/>
+        <xsl:with-param name="name" select="name"/>
+      </xsl:call-template>
 
       <p>In short: <xsl:value-of select="normalize-space(summary)"/>.</p>
 
@@ -417,7 +430,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </div>
       </div>
 
-    </div>
+    </details>
   </xsl:template>
 
   <!-- Commands. -->
@@ -645,13 +658,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   </xsl:template>
 
   <xsl:template match="command">
-    <xsl:param name="index">7.<xsl:value-of select="position()"/></xsl:param>
-    <div>
-      <div>
-        <h3 id="command_{name}">
-        <xsl:value-of select="$index"/>
-        Command <tt><xsl:value-of select="name"/></tt></h3>
-      </div>
+    <xsl:param name="index">3.<xsl:value-of select="position()"/></xsl:param>
+    <details>
+      <xsl:call-template name="details-summary-3">
+        <xsl:with-param name="id" select="concat('command_', name)"/>
+        <xsl:with-param name="text" select="concat($index, ' Command ')"/>
+        <xsl:with-param name="name" select="name"/>
+      </xsl:call-template>
 
       <p>In short: <xsl:value-of select="normalize-space(summary)"/>.</p>
 
@@ -714,7 +727,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:otherwise>
       </xsl:choose>
 
-    </div>
+    </details>
   </xsl:template>
 
   <xsl:template match="command" mode="index">
@@ -726,7 +739,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   <xsl:template name="command-summary">
     <details>
-      <xsl:call-template name="details-summary">
+      <xsl:call-template name="details-summary-2">
         <xsl:with-param name="id" select="'command_summary'"/>
         <xsl:with-param name="text" select="'3 Summary of Commands'"/>
       </xsl:call-template>
@@ -737,10 +750,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   </xsl:template>
 
   <xsl:template name="command-details">
-    <details>
-      <xsl:call-template name="details-summary">
+    <details open="1">
+      <xsl:call-template name="details-summary-2">
         <xsl:with-param name="id" select="'command_details'"/>
-        <xsl:with-param name="text" select="'7 Command Details'"/>
+        <xsl:with-param name="text" select="'3 Commands'"/>
       </xsl:call-template>
       <xsl:apply-templates select="command"/>
     </details>
@@ -794,10 +807,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   <xsl:template name="changes">
     <details>
-      <xsl:call-template name="details-summary">
+      <xsl:call-template name="details-summary-2">
         <xsl:with-param name="id" select="'changes'"/>
         <xsl:with-param name="text">
-          <xsl:value-of select="'8 Compatibility Changes in Version '"/>
+          <xsl:value-of select="'5 Compatibility Changes in Version '"/>
           <xsl:value-of select="/protocol/version"/>
         </xsl:with-param>
       </xsl:call-template>
@@ -872,13 +885,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                   <p><xsl:value-of select="normalize-space(summary)"/>.</p>
                 </xsl:if>
 
-                <xsl:call-template name="type-summary"/>
-                <xsl:call-template name="element-summary"/>
-                <xsl:call-template name="command-summary"/>
-                <xsl:call-template name="rnc-preamble"/>
                 <xsl:call-template name="type-details"/>
                 <xsl:call-template name="element-details"/>
                 <xsl:call-template name="command-details"/>
+                <xsl:call-template name="rnc-preamble"/>
                 <xsl:call-template name="changes"/>
                 <xsl:call-template name="deprecations"/>
 

--- a/src/schema_formats/HTML/HTML.xsl
+++ b/src/schema_formats/HTML/HTML.xsl
@@ -263,12 +263,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   <!-- RNC preamble. -->
 
   <xsl:template name="rnc-preamble">
-    <h2 id="rnc_preamble">4 RNC Preamble</h2>
-    <div style="border: 1px solid; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #d5d5d5;">
-      <pre>
-        <xsl:call-template name="preamble"/>
-      </pre>
-    </div>
+    <details>
+      <xsl:call-template name="details-summary">
+        <xsl:with-param name="id" select="'rnc_preamble'"/>
+        <xsl:with-param name="text" select="'4 RNC Preamble'"/>
+      </xsl:call-template>
+      <div style="border: 1px solid; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #d5d5d5;">
+        <pre>
+          <xsl:call-template name="preamble"/>
+        </pre>
+      </div>
+    </details>
   </xsl:template>
 
   <!-- Types. -->
@@ -284,11 +289,25 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </tr>
   </xsl:template>
 
+  <xsl:template name="details-summary">
+    <xsl:param name="id"/>
+    <xsl:param name="text"/>
+    <summary id="$id"
+             style="margin-block-start: .83em; margin-block-end: .83em;">
+      <h2 style="display: inline; cursor: pointer;"><xsl:value-of select="$text"/></h2>
+    </summary>
+  </xsl:template>
+
   <xsl:template name="type-summary">
-    <h2 id="type_summary">1 Summary of Data Types</h2>
-    <table id="index">
-    <xsl:apply-templates select="type" mode="index"/>
-    </table>
+    <details>
+      <xsl:call-template name="details-summary">
+        <xsl:with-param name="id" select="'type_summary'"/>
+        <xsl:with-param name="text" select="'1 Summary of Data Types'"/>
+      </xsl:call-template>
+      <table id="index">
+        <xsl:apply-templates select="type" mode="index"/>
+      </table>
+    </details>
   </xsl:template>
 
   <xsl:template match="type" mode="details">
@@ -325,8 +344,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   </xsl:template>
 
   <xsl:template name="type-details">
-    <h2 id="type_details">5 Data Type Details</h2>
-    <xsl:apply-templates select="type" mode="details"/>
+    <details>
+      <xsl:call-template name="details-summary">
+        <xsl:with-param name="id" select="'type_details'"/>
+        <xsl:with-param name="text" select="'5 Data Type Details'"/>
+      </xsl:call-template>
+      <xsl:apply-templates select="type" mode="details"/>
+    </details>
   </xsl:template>
 
   <!-- Elements. -->
@@ -343,15 +367,25 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   </xsl:template>
 
   <xsl:template name="element-summary">
-    <h2 id="element_summary">2 Summary of Elements</h2>
-    <table id="index">
-    <xsl:apply-templates select="element" mode="index"/>
-    </table>
+    <details>
+      <xsl:call-template name="details-summary">
+        <xsl:with-param name="id" select="'element_summary'"/>
+        <xsl:with-param name="text" select="'2 Summary of Elements'"/>
+      </xsl:call-template>
+      <table id="index">
+        <xsl:apply-templates select="element" mode="index"/>
+      </table>
+    </details>
   </xsl:template>
 
   <xsl:template name="element-details">
-    <h2 id="element_details">6 Element Details</h2>
-    <xsl:apply-templates select="element"/>
+    <details>
+      <xsl:call-template name="details-summary">
+        <xsl:with-param name="id" select="'element_details'"/>
+        <xsl:with-param name="text" select="'6 Element Details'"/>
+      </xsl:call-template>
+      <xsl:apply-templates select="element"/>
+    </details>
   </xsl:template>
 
   <xsl:template match="element">
@@ -691,15 +725,25 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   </xsl:template>
 
   <xsl:template name="command-summary">
-    <h2 id="command_summary">3 Summary of Commands</h2>
-    <table id="index">
-    <xsl:apply-templates select="command" mode="index"/>
-    </table>
+    <details>
+      <xsl:call-template name="details-summary">
+        <xsl:with-param name="id" select="'command_summary'"/>
+        <xsl:with-param name="text" select="'3 Summary of Commands'"/>
+      </xsl:call-template>
+      <table id="index">
+        <xsl:apply-templates select="command" mode="index"/>
+      </table>
+    </details>
   </xsl:template>
 
   <xsl:template name="command-details">
-    <h2 id="command_details">7 Command Details</h2>
-    <xsl:apply-templates select="command"/>
+    <details>
+      <xsl:call-template name="details-summary">
+        <xsl:with-param name="id" select="'command_details'"/>
+        <xsl:with-param name="text" select="'7 Command Details'"/>
+      </xsl:call-template>
+      <xsl:apply-templates select="command"/>
+    </details>
   </xsl:template>
 
   <!-- Filter keywords -->
@@ -749,11 +793,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   </xsl:template>
 
   <xsl:template name="changes">
-    <h2 id="changes">
-      8 Compatibility Changes in Version
-      <xsl:value-of select="/protocol/version"/>
-    </h2>
-    <xsl:apply-templates select="change[version=/protocol/version]"/>
+    <details>
+      <xsl:call-template name="details-summary">
+        <xsl:with-param name="id" select="'changes'"/>
+        <xsl:with-param name="text">
+          <xsl:value-of select="'8 Compatibility Changes in Version '"/>
+          <xsl:value-of select="/protocol/version"/>
+        </xsl:with-param>
+      </xsl:call-template>
+      <xsl:apply-templates select="change[version=/protocol/version]"/>
+    </details>
   </xsl:template>
 
   <!-- Deprecation Warnings. -->
@@ -822,31 +871,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:if test="summary">
                   <p><xsl:value-of select="normalize-space(summary)"/>.</p>
                 </xsl:if>
-
-                <h2 id="contents">Contents</h2>
-                <ol>
-                  <li><a href="#type_summary">Summary of Data Types</a></li>
-                  <li><a href="#element_summary">Summary of Elements</a></li>
-                  <li><a href="#command_summary">Summary of Commands</a></li>
-                  <li><a href="#rnc_preamble">RNC Preamble</a></li>
-                  <li><a href="#type_details">Data Type Details</a></li>
-                  <li><a href="#element_details">Element Details</a></li>
-                  <li><a href="#command_details">Command Details</a></li>
-                  <li>
-                    <a href="#changes">
-                      Compatibility Changes in Version
-                      <xsl:value-of select="/protocol/version"/>
-                    </a>
-                  </li>
-                  <xsl:if test="deprecation[version=/protocol/version]">
-                    <li>
-                      <a href="#deprecations">
-                        Deprecation Warnings for Version
-                        <xsl:value-of select="/protocol/version"/>
-                      </a>
-                    </li>
-                  </xsl:if>
-                </ol>
 
                 <xsl:call-template name="type-summary"/>
                 <xsl:call-template name="element-summary"/>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -13120,6 +13120,7 @@ END:VCALENDAR
       </attrib>
       <attrib>
         <name>details</name>
+        <summary>Whether to include full details</summary>
         <type>boolean</type>
       </attrib>
       <attrib>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -20058,6 +20058,11 @@ END:VCALENDAR
         <summary>Whether to include list of tasks that use the target</summary>
         <type>boolean</type>
       </attrib>
+      <attrib>
+        <name>details</name>
+        <summary>Whether to include port range and tag info</summary>
+        <type>boolean</type>
+      </attrib>
     </pattern>
     <response>
       <pattern>
@@ -20103,7 +20108,7 @@ END:VCALENDAR
           <e>snmp_credential</e>
           <e>ssh_elevate_credential</e>
           <e>permissions</e>
-          <e>port_range</e>
+          <o><e>port_range</e></o>
           <e>port_list</e>
           <e>alive_tests</e>
           <e>reverse_lookup_only</e>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -13126,6 +13126,8 @@ END:VCALENDAR
       <attrib>
         <name>result</name>
         <type>boolean</type>
+        <summary>Whether to include the associated result</summary>
+        <description>Requires "details" to be true.</description>
       </attrib>
     </pattern>
     <response>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -17203,29 +17203,6 @@ END:VCALENDAR
         <type>text</type>
         <filter_keywords>
           <option>
-            <name>first</name>
-            <type>integer</type>
-            <summary>
-              Index of the first item returned, starting at 1 (e.g. first=5
-              starts at the 5th item)
-            </summary>
-          </option>
-          <option>
-            <name>rows</name>
-            <type>integer</type>
-            <summary>Number of items to return</summary>
-          </option>
-          <option>
-            <name>sort</name>
-            <type>text</type>
-            <summary>Column to sort by in ascending order</summary>
-          </option>
-          <option>
-            <name>sort-reverse</name>
-            <type>text</type>
-            <summary>Column to sort by in descending order</summary>
-          </option>
-          <option>
             <name>apply_overrides</name>
             <type>boolean</type>
             <summary>Whether to apply Overrides</summary>
@@ -17234,6 +17211,14 @@ END:VCALENDAR
             <name>compliance_levels</name>
             <type>compliance_levels</type>
             <summary>Compliance levels to select</summary>
+          </option>
+          <option>
+            <name>first</name>
+            <type>integer</type>
+            <summary>
+              Index of the first item returned, starting at 1 (e.g. first=5
+              starts at the 5th item)
+            </summary>
           </option>
           <option>
             <name>levels</name>
@@ -17256,50 +17241,25 @@ END:VCALENDAR
             <summary>Whether to include Override descriptions in the report</summary>
           </option>
           <option>
+            <name>rows</name>
+            <type>integer</type>
+            <summary>Number of items to return</summary>
+          </option>
+          <option>
+            <name>sort</name>
+            <type>text</type>
+            <summary>Column to sort by in ascending order</summary>
+          </option>
+          <option>
+            <name>sort-reverse</name>
+            <type>text</type>
+            <summary>Column to sort by in descending order</summary>
+          </option>
+          <option>
             <name>timezone</name>
             <type>text</type>
             <summary>The timezone to use for the report</summary>
           </option>
-          <column>
-            <name>tag</name>
-            <type>text</type>
-            <summary>
-              Name and optional "=" separted value of an attached tag
-              (e.g. "mytag" or "mytag=myvalue")
-            </summary>
-          </column>
-          <column>
-            <name>tag_id</name>
-            <type>UUID</type>
-            <summary>
-              UUID of an attached tag
-            </summary>
-          </column>
-          <column>
-            <name>uuid</name>
-            <type>uuid</type>
-            <summary>Unique ID</summary>
-          </column>
-          <column>
-            <name>name</name>
-            <type>name</type>
-            <summary>Name of the NVT</summary>
-          </column>
-          <column>
-            <name>created</name>
-            <type>iso_time</type>
-            <summary>Creation time</summary>
-          </column>
-          <column>
-            <name>modified</name>
-            <type>iso_time</type>
-            <summary>Modification time</summary>
-          </column>
-          <column>
-            <name>owner</name>
-            <type>name</type>
-            <summary>Name of the owner</summary>
-          </column>
           <column>
             <name>compliant</name>
             <type>
@@ -17311,6 +17271,31 @@ END:VCALENDAR
               </alts>
             </type>
             <summary>Compliance status</summary>
+          </column>
+          <column>
+            <name>created</name>
+            <type>iso_time</type>
+            <summary>Creation time</summary>
+          </column>
+          <column>
+            <name>cve</name>
+            <type>text</type>
+            <summary>List of CVEs of the result</summary>
+          </column>
+          <column>
+            <name>cvss_base</name>
+            <type>severity</type>
+            <summary>CVSS base score of the NVT that generated the result</summary>
+          </column>
+          <column>
+            <name>date</name>
+            <type>iso_time</type>
+            <summary>Time the result was generated</summary>
+          </column>
+          <column>
+            <name>description</name>
+            <type>text</type>
+            <summary>Description of the result</summary>
           </column>
           <column>
             <name>host</name>
@@ -17328,9 +17313,14 @@ END:VCALENDAR
             <summary>Port and protocol of the result</summary>
           </column>
           <column>
-            <name>path</name>
-            <type>text</type>
-            <summary>The local path on the host, e.g. a file location</summary>
+            <name>modified</name>
+            <type>iso_time</type>
+            <summary>Modification time</summary>
+          </column>
+          <column>
+            <name>name</name>
+            <type>name</type>
+            <summary>Name of the NVT</summary>
           </column>
           <column>
             <name>nvt</name>
@@ -17338,44 +17328,9 @@ END:VCALENDAR
             <summary>Unique ID of the test that produced the result</summary>
           </column>
           <column>
-            <name>type</name>
-            <type>threat</type>
-            <summary>Severity type of the result with overrides</summary>
-          </column>
-          <column>
-            <name>original_type</name>
-            <type>threat</type>
-            <summary>Original severity type of the result</summary>
-          </column>
-          <column>
-            <name>description</name>
-            <type>text</type>
-            <summary>Description of the result</summary>
-          </column>
-          <column>
-            <name>task</name>
-            <type>text</type>
-            <summary>Name of the task</summary>
-          </column>
-          <column>
-            <name>report</name>
-            <type>number</type>
-            <summary>Internal ID of the report</summary>
-          </column>
-          <column>
-            <name>cvss_base</name>
-            <type>severity</type>
-            <summary>CVSS base score of the NVT that generated the result</summary>
-          </column>
-          <column>
             <name>nvt_version</name>
             <type>text</type>
             <summary>Version of the NVT that generated the result</summary>
-          </column>
-          <column>
-            <name>severity</name>
-            <type>severity</type>
-            <summary>Severity of the result with overrides</summary>
           </column>
           <column>
             <name>original_severity</name>
@@ -17383,24 +17338,19 @@ END:VCALENDAR
             <summary>Original severity of the result</summary>
           </column>
           <column>
-            <name>vulnerability</name>
+            <name>original_type</name>
+            <type>threat</type>
+            <summary>Original severity type of the result</summary>
+          </column>
+          <column>
+            <name>owner</name>
+            <type>name</type>
+            <summary>Name of the owner</summary>
+          </column>
+          <column>
+            <name>path</name>
             <type>text</type>
-            <summary>Name of the NVT that generated result</summary>
-          </column>
-          <column>
-            <name>date</name>
-            <type>iso_time</type>
-            <summary>Time the result was generated</summary>
-          </column>
-          <column>
-            <name>report_id</name>
-            <type>uuid</type>
-            <summary>UUID of the report</summary>
-          </column>
-          <column>
-            <name>solution_type</name>
-            <type>text</type>
-            <summary>Solution type of the result</summary>
+            <summary>The local path on the host, e.g. a file location</summary>
           </column>
           <column>
             <name>qod</name>
@@ -17413,14 +17363,64 @@ END:VCALENDAR
             <summary>QoD type of the result</summary>
           </column>
           <column>
+            <name>report</name>
+            <type>number</type>
+            <summary>Internal ID of the report</summary>
+          </column>
+          <column>
+            <name>report_id</name>
+            <type>uuid</type>
+            <summary>UUID of the report</summary>
+          </column>
+          <column>
+            <name>severity</name>
+            <type>severity</type>
+            <summary>Severity of the result with overrides</summary>
+          </column>
+          <column>
+            <name>solution_type</name>
+            <type>text</type>
+            <summary>Solution type of the result</summary>
+          </column>
+          <column>
+            <name>tag</name>
+            <type>text</type>
+            <summary>
+              Name and optional "=" separted value of an attached tag
+              (e.g. "mytag" or "mytag=myvalue")
+            </summary>
+          </column>
+          <column>
+            <name>tag_id</name>
+            <type>UUID</type>
+            <summary>
+              UUID of an attached tag
+            </summary>
+          </column>
+          <column>
+            <name>task</name>
+            <type>text</type>
+            <summary>Name of the task</summary>
+          </column>
+          <column>
             <name>task_id</name>
             <type>uuid</type>
             <summary>UUID of the task</summary>
           </column>
           <column>
-            <name>cve</name>
+            <name>type</name>
+            <type>threat</type>
+            <summary>Severity type of the result with overrides</summary>
+          </column>
+          <column>
+            <name>uuid</name>
+            <type>uuid</type>
+            <summary>Unique ID</summary>
+          </column>
+          <column>
+            <name>vulnerability</name>
             <type>text</type>
-            <summary>List of CVEs of the result</summary>
+            <summary>Name of the NVT that generated result</summary>
           </column>
         </filter_keywords>
       </attrib>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -5001,7 +5001,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </ele>
     <ele>
       <name>ca_pub</name>
-      <summary>Certificate of CA to verify scanner certificate.</summary>
+      <summary>Certificate of CA to verify scanner certificate</summary>
       <pattern>text</pattern>
     </ele>
     <ele>
@@ -5090,7 +5090,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </ele>
     <ele>
       <name>icalendar</name>
-      <summary>iCalendar text containing the time data. Replaces first_time, duration and period.</summary>
+      <summary>iCalendar text containing the time data. Replaces first_time, duration and period</summary>
       <pattern>
         text
       </pattern>
@@ -7299,8 +7299,10 @@ END:VCALENDAR
       </attrib>
       <attrib>
         <name>sort_field</name>
-        <summary>The column to sort the aggregated rows by.
-        With a subgroup column, groups will be sorted by the group_column first.</summary>
+        <summary>The column to sort the aggregated rows by</summary>
+        <description>
+          With a subgroup column, groups will be sorted by the group_column first.
+        </description>
         <type>text</type>
       </attrib>
       <attrib>
@@ -7369,8 +7371,10 @@ END:VCALENDAR
       <pattern>
         <attrib>
           <name>field</name>
-          <summary>The column to sort the aggregated rows by.
-          With a subgroup column, groups will be sorted by the group_column first</summary>
+          <summary>The column to sort the aggregated rows by</summary>
+          <description>
+            With a subgroup column, groups will be sorted by the group_column first.
+          </description>
           <type>text</type>
         </attrib>
         <attrib>
@@ -7553,7 +7557,7 @@ END:VCALENDAR
           </ele>
           <ele>
             <name>text</name>
-            <summary>The value of a simple text column.</summary>
+            <summary>The value of a simple text column</summary>
             <pattern>
               <attrib>
                 <name>name</name>
@@ -16613,7 +16617,7 @@ END:VCALENDAR
         <name>details</name>
         <summary>
           Whether to get the details of the reports including the
-          results, hosts, ports etc.
+          results, hosts, ports etc
         </summary>
         <type>boolean</type>
       </attrib>
@@ -16662,7 +16666,7 @@ END:VCALENDAR
         <name>ignore_pagination</name>
         <summary>
           Whether to ignore info used to split the report into pages
-          like the filter terms "first" and "rows".
+          like the filter terms "first" and "rows"
         </summary>
         <type>boolean</type>
       </attrib>
@@ -17052,7 +17056,7 @@ END:VCALENDAR
       </attrib>
       <attrib>
         <name>resource_id</name>
-        <summary>ID of single resource to get.</summary>
+        <summary>ID of single resource to get</summary>
         <type>text</type>
       </attrib>
       <attrib>
@@ -18983,7 +18987,7 @@ END:VCALENDAR
         </ele>
         <ele>
           <name>icalendar</name>
-          <summary>iCalendar text containing the time data.</summary>
+          <summary>iCalendar text containing the time data</summary>
           <pattern>
             text
           </pattern>
@@ -20955,7 +20959,7 @@ END:VCALENDAR
         <name>ignore_pagination</name>
         <summary>
           Whether to ignore info used to split the report into pages
-          like the filter terms "first" and "rows".
+          like the filter terms "first" and "rows"
         </summary>
         <type>boolean</type>
       </attrib>
@@ -21373,12 +21377,12 @@ END:VCALENDAR
           </ele>
           <ele>
             <name>icalendar</name>
-            <summary>iCalendar text containing the time data.</summary>
+            <summary>iCalendar text containing the time data</summary>
             <pattern><t>iso_time</t></pattern>
           </ele>
           <ele>
             <name>timezone</name>
-            <summary>The timezone the schedule will follow.</summary>
+            <summary>The timezone the schedule will follow</summary>
             <pattern>text</pattern>
           </ele>
         </ele>
@@ -26054,7 +26058,7 @@ END:VCALENDAR
     </ele>
     <ele>
       <name>icalendar</name>
-      <summary>iCalendar text containing the time data. Replaces first_time, duration and period.</summary>
+      <summary>iCalendar text containing the time data. Replaces first_time, duration and period</summary>
       <pattern>
         text
       </pattern>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -13957,7 +13957,7 @@ END:VCALENDAR
           <column>
             <name>nvt</name>
             <type>oid</type>
-            <summary>OID of the NVT the Override applies to</summary>
+            <summary>Name of the NVT the Override applies to</summary>
           </column>
           <column>
             <name>text</name>
@@ -13967,7 +13967,7 @@ END:VCALENDAR
           <column>
             <name>nvt_id</name>
             <type>oid</type>
-            <summary>Alias of nvt</summary>
+            <summary>OID of the NVT the Override applies to</summary>
           </column>
           <column>
             <name>task_name</name>
@@ -14027,20 +14027,15 @@ END:VCALENDAR
         <type>uuid</type>
       </attrib>
       <attrib>
-        <name>nvt_oid</name>
-        <type>oid</type>
-      </attrib>
-      <attrib>
-        <name>task_id</name>
-        <type>uuid</type>
-      </attrib>
-      <attrib>
         <name>details</name>
+        <summary>Whether to include full details</summary>
         <type>boolean</type>
       </attrib>
       <attrib>
         <name>result</name>
         <type>boolean</type>
+        <summary>Whether to include the associated result</summary>
+        <description>Requires "details" to be true.</description>
       </attrib>
     </pattern>
     <response>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -13111,14 +13111,6 @@ END:VCALENDAR
         <type>uuid</type>
       </attrib>
       <attrib>
-        <name>nvt_oid</name>
-        <type>oid</type>
-      </attrib>
-      <attrib>
-        <name>task_id</name>
-        <type>uuid</type>
-      </attrib>
-      <attrib>
         <name>details</name>
         <summary>Whether to include full details</summary>
         <type>boolean</type>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -13061,7 +13061,7 @@ END:VCALENDAR
           <column>
             <name>nvt</name>
             <type>oid</type>
-            <summary>OID of the NVT the Note applies to</summary>
+            <summary>Name of the NVT the Note applies to</summary>
           </column>
           <column>
             <name>text</name>
@@ -13071,7 +13071,7 @@ END:VCALENDAR
           <column>
             <name>nvt_id</name>
             <type>oid</type>
-            <summary>Alias of nvt</summary>
+            <summary>OID of the NVT the Note applies to</summary>
           </column>
           <column>
             <name>task_name</name>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -17255,11 +17255,6 @@ END:VCALENDAR
             <type>text</type>
             <summary>Column to sort by in descending order</summary>
           </option>
-          <option>
-            <name>timezone</name>
-            <type>text</type>
-            <summary>The timezone to use for the report</summary>
-          </option>
           <column>
             <name>compliant</name>
             <type>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -3225,6 +3225,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <e>event</e>
       <e>method</e>
       <e>filter</e>
+      <o><e>active</e></o>
     </pattern>
     <ele>
       <name>name</name>
@@ -3327,6 +3328,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <type>uuid</type>
           <required>1</required>
         </attrib>
+      </pattern>
+    </ele>
+    <ele>
+      <name>active</name>
+      <summary>Whether to alert will be active</summary>
+      <pattern>
+        <t>boolean</t>
       </pattern>
     </ele>
     <response>


### PR DESCRIPTION
## What

In the GMP HTML doc, use an HTML `<details>` for every item. As a result remove the contents and the summary sections.

Initially most of the top level items (eg "1 Data Types") are open.  The second level items are all closed (eg "1.1 Data Type alive_test").  This makes the initial view concise while still supporting links that jump to the second level items.

## Why

The doc is big and hard to take in. The idea is to collapse everything so it's easier to see and navigate.

One downside is that when an item is closed it is excluded from text search.

## References

Waits for greenbone/gvmd/pull/2124.
