### PR TITLE
Now the CPE dictionary is no longer continuously parsed again if the dictionary is corrupt.

### DIFF
--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -3095,13 +3095,15 @@ update_cert_timestamp ()
           g_free (timestamp);
           stamp = time(NULL);
         }
-
-      timestamp[8] = '\0';
-      g_debug ("%s: parsing: %s", __func__, timestamp);
-      stamp = parse_feed_timestamp (timestamp);
-      g_free (timestamp);
-      if (stamp == 0)
-        stamp = time(NULL);
+      else
+        {
+          timestamp[8] = '\0';
+          g_debug ("%s: parsing: %s", __func__, timestamp);
+          stamp = parse_feed_timestamp (timestamp);
+          g_free (timestamp);
+          if (stamp == 0)
+            stamp = time(NULL);
+        }
     }
 
   g_debug ("%s: setting last_update: %lld", __func__, (long long) stamp);
@@ -3364,13 +3366,15 @@ update_scap_timestamp ()
           g_free (timestamp);
           stamp = time(NULL);
         }
-
-      timestamp[8] = '\0';
-      g_debug ("%s: parsing: %s", __func__, timestamp);
-      stamp = parse_feed_timestamp (timestamp);
-      g_free (timestamp);
-      if (stamp == 0)
-        stamp = time(NULL);
+      else
+        {
+          timestamp[8] = '\0';
+          g_debug ("%s: parsing: %s", __func__, timestamp);
+          stamp = parse_feed_timestamp (timestamp);
+          g_free (timestamp);
+          if (stamp == 0)
+            stamp = time(NULL);
+        }
     }
 
   g_debug ("%s: setting last_update: %lld", __func__, (long long) stamp);


### PR DESCRIPTION

## What
Now the CPE dictionary is no longer continuously parsed again if the dictionary is corrupt.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This is a bug-fix
<!-- Describe why are these changes necessary? -->

## References
GEA-419
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist
