### PR TITLE
Add: hiding of sections in HTML GMP doc

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -13514,7 +13514,6 @@ handle_get_notes (gmp_parser_t *gmp_parser, GError **error)
     }
   get_notes_data_reset (get_notes_data);
   set_client_state (CLIENT_AUTHENTIC);
-
 }
 
 /**

--- a/src/schema_formats/HTML/HTML.xsl
+++ b/src/schema_formats/HTML/HTML.xsl
@@ -260,15 +260,29 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
   </xsl:template>
 
+  <xsl:template name="details-summary">
+    <xsl:param name="id"/>
+    <xsl:param name="text"/>
+    <summary id="{$id}"
+             style="margin-block-start: .83em; margin-block-end: .83em; cursor: pointer;">
+      <h2 style="display: inline;"><xsl:value-of select="$text"/></h2>
+    </summary>
+  </xsl:template>
+
   <!-- RNC preamble. -->
 
   <xsl:template name="rnc-preamble">
-    <h2 id="rnc_preamble">4 RNC Preamble</h2>
-    <div style="border: 1px solid; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #d5d5d5;">
-      <pre>
-        <xsl:call-template name="preamble"/>
-      </pre>
-    </div>
+    <details open="">
+      <xsl:call-template name="details-summary">
+        <xsl:with-param name="id" select="'rnc_preamble'"/>
+        <xsl:with-param name="text" select="'4 RNC Preamble'"/>
+      </xsl:call-template>
+      <div style="border: 1px solid; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #d5d5d5;">
+        <pre>
+          <xsl:call-template name="preamble"/>
+        </pre>
+      </div>
+    </details>
   </xsl:template>
 
   <!-- Types. -->
@@ -285,10 +299,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   </xsl:template>
 
   <xsl:template name="type-summary">
-    <h2 id="type_summary">1 Summary of Data Types</h2>
-    <table id="index">
-    <xsl:apply-templates select="type" mode="index"/>
-    </table>
+    <details open="">
+      <xsl:call-template name="details-summary">
+        <xsl:with-param name="id" select="'type_summary'"/>
+        <xsl:with-param name="text" select="'1 Summary of Data Types'"/>
+      </xsl:call-template>
+      <table id="index">
+        <xsl:apply-templates select="type" mode="index"/>
+      </table>
+    </details>
   </xsl:template>
 
   <xsl:template match="type" mode="details">
@@ -325,8 +344,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   </xsl:template>
 
   <xsl:template name="type-details">
-    <h2 id="type_details">5 Data Type Details</h2>
-    <xsl:apply-templates select="type" mode="details"/>
+    <details open="">
+      <xsl:call-template name="details-summary">
+        <xsl:with-param name="id" select="'type_details'"/>
+        <xsl:with-param name="text" select="'5 Data Type Details'"/>
+      </xsl:call-template>
+      <xsl:apply-templates select="type" mode="details"/>
+    </details>
   </xsl:template>
 
   <!-- Elements. -->
@@ -343,15 +367,25 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   </xsl:template>
 
   <xsl:template name="element-summary">
-    <h2 id="element_summary">2 Summary of Elements</h2>
-    <table id="index">
-    <xsl:apply-templates select="element" mode="index"/>
-    </table>
+    <details open="">
+      <xsl:call-template name="details-summary">
+        <xsl:with-param name="id" select="'element_summary'"/>
+        <xsl:with-param name="text" select="'2 Summary of Elements'"/>
+      </xsl:call-template>
+      <table id="index">
+        <xsl:apply-templates select="element" mode="index"/>
+      </table>
+    </details>
   </xsl:template>
 
   <xsl:template name="element-details">
-    <h2 id="element_details">6 Element Details</h2>
-    <xsl:apply-templates select="element"/>
+    <details open="">
+      <xsl:call-template name="details-summary">
+        <xsl:with-param name="id" select="'element_details'"/>
+        <xsl:with-param name="text" select="'6 Element Details'"/>
+      </xsl:call-template>
+      <xsl:apply-templates select="element"/>
+    </details>
   </xsl:template>
 
   <xsl:template match="element">
@@ -691,15 +725,25 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   </xsl:template>
 
   <xsl:template name="command-summary">
-    <h2 id="command_summary">3 Summary of Commands</h2>
-    <table id="index">
-    <xsl:apply-templates select="command" mode="index"/>
-    </table>
+    <details open="">
+      <xsl:call-template name="details-summary">
+        <xsl:with-param name="id" select="'command_summary'"/>
+        <xsl:with-param name="text" select="'3 Summary of Commands'"/>
+      </xsl:call-template>
+      <table id="index">
+        <xsl:apply-templates select="command" mode="index"/>
+      </table>
+    </details>
   </xsl:template>
 
   <xsl:template name="command-details">
-    <h2 id="command_details">7 Command Details</h2>
-    <xsl:apply-templates select="command"/>
+    <details open="">
+      <xsl:call-template name="details-summary">
+        <xsl:with-param name="id" select="'command_details'"/>
+        <xsl:with-param name="text" select="'7 Command Details'"/>
+      </xsl:call-template>
+      <xsl:apply-templates select="command"/>
+    </details>
   </xsl:template>
 
   <!-- Filter keywords -->
@@ -749,11 +793,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   </xsl:template>
 
   <xsl:template name="changes">
-    <h2 id="changes">
-      8 Compatibility Changes in Version
-      <xsl:value-of select="/protocol/version"/>
-    </h2>
-    <xsl:apply-templates select="change[version=/protocol/version]"/>
+    <details open="">
+      <xsl:call-template name="details-summary">
+        <xsl:with-param name="id" select="'changes'"/>
+        <xsl:with-param name="text">
+          <xsl:value-of select="'8 Compatibility Changes in Version '"/>
+          <xsl:value-of select="/protocol/version"/>
+        </xsl:with-param>
+      </xsl:call-template>
+      <xsl:apply-templates select="change[version=/protocol/version]"/>
+    </details>
   </xsl:template>
 
   <!-- Deprecation Warnings. -->

--- a/src/schema_formats/HTML/HTML.xsl
+++ b/src/schema_formats/HTML/HTML.xsl
@@ -733,17 +733,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <xsl:apply-templates select="description"/>
               <div style="margin-left: 5%; margin-right: 5%;">
                 <i>Client</i>
-                <div style="margin-left: 2%; margin-right: 2%;">
+                <div style="margin-left: 2%; margin-right: 2%; display: flex; align-items: start;">
                   <xsl:for-each select="request/*">
-                    <pre>
+                    <pre style="border: 1px solid #7F7F7F; border-radius: 4px; padding: 10px 10px 10px 5px; background: #F3F3F3;">
                       <xsl:call-template name="pretty"/>
                     </pre>
                   </xsl:for-each>
                 </div>
                 <i>Manager</i>
-                <div style="margin-left: 2%; margin-right: 2%;">
+                <div style="margin-left: 2%; margin-right: 2%; display: flex; align-items: start;">
                   <xsl:for-each select="response/*">
-                    <pre>
+                    <pre style="border: 1px solid #7F7F7F; border-radius: 4px; padding: 10px 10px 10px 5px; background: #F3F3F3;">
                       <xsl:call-template name="pretty"/>
                     </pre>
                   </xsl:for-each>

--- a/src/schema_formats/HTML/HTML.xsl
+++ b/src/schema_formats/HTML/HTML.xsl
@@ -269,6 +269,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </summary>
   </xsl:template>
 
+  <xsl:template name="details-summary-3">
+    <xsl:param name="id"/>
+    <xsl:param name="name"/>
+    <xsl:param name="text"/>
+    <summary id="{$id}"
+             style="margin-block-start: .83em; margin-block-end: .83em; cursor: pointer;">
+      <h3 style="display: inline;"><xsl:value-of select="$text"/> <tt><xsl:value-of select="$name"/></tt></h3>
+    </summary>
+  </xsl:template>
+
   <!-- RNC preamble. -->
 
   <xsl:template name="rnc-preamble">
@@ -312,12 +322,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   <xsl:template match="type" mode="details">
     <xsl:param name="index">5.<xsl:value-of select="position()"/></xsl:param>
-    <div>
-      <div>
-        <h3 id="type_{name}">
-        <xsl:value-of select="$index"/>
-        Data Type <tt><xsl:value-of select="name"/></tt></h3>
-      </div>
+    <details open="">
+      <xsl:call-template name="details-summary-3">
+        <xsl:with-param name="id" select="concat('type_', name)"/>
+        <xsl:with-param name="text" select="concat($index, ' Data Type ')"/>
+        <xsl:with-param name="name" select="name"/>
+      </xsl:call-template>
 
       <xsl:if test="summary">
         <p>In short: <xsl:value-of select="normalize-space(summary)"/>.</p>
@@ -340,7 +350,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </pre>
       </div>
 
-    </div>
+    </details>
   </xsl:template>
 
   <xsl:template name="type-details">
@@ -390,12 +400,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   <xsl:template match="element">
     <xsl:param name="index">6.<xsl:value-of select="position()"/></xsl:param>
-    <div>
-      <div>
-        <h3 id="element_{name}">
-        <xsl:value-of select="$index"/>
-        Element <tt><xsl:value-of select="name"/></tt></h3>
-      </div>
+    <details open="">
+      <xsl:call-template name="details-summary-3">
+        <xsl:with-param name="id" select="concat('element_', name)"/>
+        <xsl:with-param name="text" select="concat($index, ' Element ')"/>
+        <xsl:with-param name="name" select="name"/>
+      </xsl:call-template>
 
       <p>In short: <xsl:value-of select="normalize-space(summary)"/>.</p>
 
@@ -417,7 +427,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </div>
       </div>
 
-    </div>
+    </details>
   </xsl:template>
 
   <!-- Commands. -->
@@ -646,12 +656,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   <xsl:template match="command">
     <xsl:param name="index">7.<xsl:value-of select="position()"/></xsl:param>
-    <div>
-      <div>
-        <h3 id="command_{name}">
-        <xsl:value-of select="$index"/>
-        Command <tt><xsl:value-of select="name"/></tt></h3>
-      </div>
+    <details open="">
+      <xsl:call-template name="details-summary-3">
+        <xsl:with-param name="id" select="concat('command_', name)"/>
+        <xsl:with-param name="text" select="concat($index, ' Command ')"/>
+        <xsl:with-param name="name" select="name"/>
+      </xsl:call-template>
 
       <p>In short: <xsl:value-of select="normalize-space(summary)"/>.</p>
 
@@ -714,7 +724,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:otherwise>
       </xsl:choose>
 
-    </div>
+    </details>
   </xsl:template>
 
   <xsl:template match="command" mode="index">

--- a/src/schema_formats/HTML/HTML.xsl
+++ b/src/schema_formats/HTML/HTML.xsl
@@ -342,7 +342,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       <xsl:apply-templates select="description"/>
 
-      <details open="">
+      <details>
         <xsl:call-template name="details-summary-4">
           <xsl:with-param name="text" select="concat($index, '.1 RNC')"/>
         </xsl:call-template>
@@ -434,7 +434,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </ul>
       </details>
 
-      <details open="">
+      <details>
         <xsl:call-template name="details-summary-4">
           <xsl:with-param name="text" select="concat($index, '.2 RNC')"/>
         </xsl:call-template>
@@ -705,7 +705,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </ul>
       </details>
 
-      <details open="">
+      <details>
         <xsl:call-template name="details-summary-4">
           <xsl:with-param name="text" select="concat($index, '.2 RNC')"/>
         </xsl:call-template>

--- a/src/schema_formats/HTML/HTML.xsl
+++ b/src/schema_formats/HTML/HTML.xsl
@@ -260,7 +260,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
   </xsl:template>
 
-  <xsl:template name="details-summary">
+  <xsl:template name="details-summary-2">
     <xsl:param name="id"/>
     <xsl:param name="text"/>
     <summary id="{$id}"
@@ -290,7 +290,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   <xsl:template name="rnc-preamble">
     <details>
-      <xsl:call-template name="details-summary">
+      <xsl:call-template name="details-summary-2">
         <xsl:with-param name="id" select="'rnc_preamble'"/>
         <xsl:with-param name="text" select="'4 RNC Preamble'"/>
       </xsl:call-template>
@@ -317,7 +317,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   <xsl:template name="type-summary">
     <details open="">
-      <xsl:call-template name="details-summary">
+      <xsl:call-template name="details-summary-2">
         <xsl:with-param name="id" select="'type_summary'"/>
         <xsl:with-param name="text" select="'1 Summary of Data Types'"/>
       </xsl:call-template>
@@ -366,7 +366,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   <xsl:template name="type-details">
     <details open="">
-      <xsl:call-template name="details-summary">
+      <xsl:call-template name="details-summary-2">
         <xsl:with-param name="id" select="'type_details'"/>
         <xsl:with-param name="text" select="'5 Data Type Details'"/>
       </xsl:call-template>
@@ -389,7 +389,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   <xsl:template name="element-summary">
     <details open="">
-      <xsl:call-template name="details-summary">
+      <xsl:call-template name="details-summary-2">
         <xsl:with-param name="id" select="'element_summary'"/>
         <xsl:with-param name="text" select="'2 Summary of Elements'"/>
       </xsl:call-template>
@@ -401,7 +401,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   <xsl:template name="element-details">
     <details open="">
-      <xsl:call-template name="details-summary">
+      <xsl:call-template name="details-summary-2">
         <xsl:with-param name="id" select="'element_details'"/>
         <xsl:with-param name="text" select="'6 Element Details'"/>
       </xsl:call-template>
@@ -768,7 +768,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   <xsl:template name="command-summary">
     <details open="">
-      <xsl:call-template name="details-summary">
+      <xsl:call-template name="details-summary-2">
         <xsl:with-param name="id" select="'command_summary'"/>
         <xsl:with-param name="text" select="'3 Summary of Commands'"/>
       </xsl:call-template>
@@ -780,7 +780,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   <xsl:template name="command-details">
     <details open="">
-      <xsl:call-template name="details-summary">
+      <xsl:call-template name="details-summary-2">
         <xsl:with-param name="id" select="'command_details'"/>
         <xsl:with-param name="text" select="'7 Command Details'"/>
       </xsl:call-template>
@@ -836,7 +836,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   <xsl:template name="changes">
     <details open="">
-      <xsl:call-template name="details-summary">
+      <xsl:call-template name="details-summary-2">
         <xsl:with-param name="id" select="'changes'"/>
         <xsl:with-param name="text">
           <xsl:value-of select="'8 Compatibility Changes in Version '"/>

--- a/src/schema_formats/HTML/HTML.xsl
+++ b/src/schema_formats/HTML/HTML.xsl
@@ -272,7 +272,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   <!-- RNC preamble. -->
 
   <xsl:template name="rnc-preamble">
-    <details open="">
+    <details>
       <xsl:call-template name="details-summary">
         <xsl:with-param name="id" select="'rnc_preamble'"/>
         <xsl:with-param name="text" select="'4 RNC Preamble'"/>

--- a/src/schema_formats/HTML/HTML.xsl
+++ b/src/schema_formats/HTML/HTML.xsl
@@ -294,7 +294,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:with-param name="id" select="'rnc_preamble'"/>
         <xsl:with-param name="text" select="'4 RNC Preamble'"/>
       </xsl:call-template>
-      <div style="border: 1px solid; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #d5d5d5;">
+      <div style="border: 1px solid #7F7F7F; border-radius: 4px; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #F3F3F3;">
         <pre>
           <xsl:call-template name="preamble"/>
         </pre>
@@ -347,7 +347,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <xsl:with-param name="text" select="concat($index, '.1 RNC')"/>
         </xsl:call-template>
 
-        <div style="border: 1px solid; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #d5d5d5;">
+        <div style="border: 1px solid #7F7F7F; border-radius: 4px; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #F3F3F3;">
           <pre>
             <xsl:value-of select="name"/>
             <xsl:text> = </xsl:text>
@@ -439,7 +439,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <xsl:with-param name="text" select="concat($index, '.2 RNC')"/>
         </xsl:call-template>
 
-        <div style="border: 1px solid; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #d5d5d5;">
+        <div style="border: 1px solid #7F7F7F; border-radius: 4px; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #F3F3F3;">
           <div style="margin-left: 5%">
             <xsl:call-template name="command-relax"/>
           </div>
@@ -710,7 +710,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <xsl:with-param name="text" select="concat($index, '.2 RNC')"/>
         </xsl:call-template>
 
-        <div style="border: 1px solid; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #d5d5d5;">
+        <div style="border: 1px solid #7F7F7F; border-radius: 4px; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #F3F3F3;">
           <i>Command</i>
           <div style="margin-left: 5%">
             <xsl:call-template name="command-relax"/>

--- a/src/schema_formats/HTML/HTML.xsl
+++ b/src/schema_formats/HTML/HTML.xsl
@@ -279,6 +279,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </summary>
   </xsl:template>
 
+  <xsl:template name="details-summary-4">
+    <xsl:param name="text"/>
+    <summary style="margin-block-start: .83em; margin-block-end: .83em; cursor: pointer;">
+      <h4 style="display: inline;"><xsl:value-of select="$text"/></h4>
+    </summary>
+  </xsl:template>
+
   <!-- RNC preamble. -->
 
   <xsl:template name="rnc-preamble">
@@ -335,20 +342,24 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       <xsl:apply-templates select="description"/>
 
-      <h4><xsl:value-of select="$index"/>.1 RNC</h4>
+      <details open="">
+        <xsl:call-template name="details-summary-4">
+          <xsl:with-param name="text" select="concat($index, '.1 RNC')"/>
+        </xsl:call-template>
 
-      <div style="border: 1px solid; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #d5d5d5;">
-        <pre>
-          <xsl:value-of select="name"/>
-          <xsl:text> = </xsl:text>
-          <xsl:call-template name="wrap">
-            <xsl:with-param name="string">
-              <xsl:value-of select="normalize-space (pattern)"/>
-            </xsl:with-param>
-          </xsl:call-template>
-          <xsl:call-template name="newline"/>
-        </pre>
-      </div>
+        <div style="border: 1px solid; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #d5d5d5;">
+          <pre>
+            <xsl:value-of select="name"/>
+            <xsl:text> = </xsl:text>
+            <xsl:call-template name="wrap">
+              <xsl:with-param name="string">
+                <xsl:value-of select="normalize-space (pattern)"/>
+              </xsl:with-param>
+            </xsl:call-template>
+            <xsl:call-template name="newline"/>
+          </pre>
+        </div>
+      </details>
 
     </details>
   </xsl:template>
@@ -411,21 +422,29 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       <xsl:apply-templates select="description"/>
 
-      <h4><xsl:value-of select="$index"/>.1 Structure</h4>
+      <details open="">
+        <xsl:call-template name="details-summary-4">
+          <xsl:with-param name="text" select="concat($index, '.1 Structure')"/>
+        </xsl:call-template>
 
-      <ul style="list-style: none">
-        <li>
-          <xsl:call-template name="command-structure"/>
-        </li>
-      </ul>
+        <ul style="list-style: none">
+          <li>
+            <xsl:call-template name="command-structure"/>
+          </li>
+        </ul>
+      </details>
 
-      <h4><xsl:value-of select="$index"/>.2 RNC</h4>
+      <details open="">
+        <xsl:call-template name="details-summary-4">
+          <xsl:with-param name="text" select="concat($index, '.2 RNC')"/>
+        </xsl:call-template>
 
-      <div style="border: 1px solid; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #d5d5d5;">
-        <div style="margin-left: 5%">
-          <xsl:call-template name="command-relax"/>
+        <div style="border: 1px solid; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #d5d5d5;">
+          <div style="margin-left: 5%">
+            <xsl:call-template name="command-relax"/>
+          </div>
         </div>
-      </div>
+      </details>
 
     </details>
   </xsl:template>
@@ -667,57 +686,70 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       <xsl:apply-templates select="description"/>
 
-      <h4><xsl:value-of select="$index"/>.1 Structure</h4>
+      <details open="">
+        <xsl:call-template name="details-summary-4">
+          <xsl:with-param name="text" select="concat($index, '.1 Structure')"/>
+        </xsl:call-template>
 
-      <ul style="list-style: none">
-        <li>
-          <i>Command</i>
-          <xsl:call-template name="command-structure"/>
-        </li>
-        <li style="margin-top: 15px;">
-          <i>Response</i>
-          <xsl:for-each select="response">
+        <ul style="list-style: none">
+          <li>
+            <i>Command</i>
             <xsl:call-template name="command-structure"/>
-          </xsl:for-each>
-        </li>
-      </ul>
+          </li>
+          <li style="margin-top: 15px;">
+            <i>Response</i>
+            <xsl:for-each select="response">
+              <xsl:call-template name="command-structure"/>
+            </xsl:for-each>
+          </li>
+        </ul>
+      </details>
 
-      <h4><xsl:value-of select="$index"/>.2 RNC</h4>
+      <details open="">
+        <xsl:call-template name="details-summary-4">
+          <xsl:with-param name="text" select="concat($index, '.2 RNC')"/>
+        </xsl:call-template>
 
-      <div style="border: 1px solid; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #d5d5d5;">
-        <i>Command</i>
-        <div style="margin-left: 5%">
-          <xsl:call-template name="command-relax"/>
+        <div style="border: 1px solid; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #d5d5d5;">
+          <i>Command</i>
+          <div style="margin-left: 5%">
+            <xsl:call-template name="command-relax"/>
+          </div>
+          <i>Response</i>
+          <div style="margin-left: 5%">
+            <xsl:call-template name="response-relax"/>
+          </div>
         </div>
-        <i>Response</i>
-        <div style="margin-left: 5%">
-          <xsl:call-template name="response-relax"/>
-        </div>
-      </div>
+      </details>
 
       <xsl:choose>
         <xsl:when test="count(example) &gt; 0">
           <xsl:for-each select="example">
-            <h4><xsl:value-of select="$index"/>.3 Example: <xsl:value-of select="summary"/></h4>
-            <xsl:apply-templates select="description"/>
-            <div style="margin-left: 5%; margin-right: 5%;">
-              <i>Client</i>
-              <div style="margin-left: 2%; margin-right: 2%;">
-                <xsl:for-each select="request/*">
-                  <pre>
-                    <xsl:call-template name="pretty"/>
-                  </pre>
-                </xsl:for-each>
+            <details open="">
+              <xsl:call-template name="details-summary-4">
+                <xsl:with-param name="text" select="concat($index, '.3 Example: ', summary)"/>
+              </xsl:call-template>
+
+              <xsl:apply-templates select="description"/>
+              <div style="margin-left: 5%; margin-right: 5%;">
+                <i>Client</i>
+                <div style="margin-left: 2%; margin-right: 2%;">
+                  <xsl:for-each select="request/*">
+                    <pre>
+                      <xsl:call-template name="pretty"/>
+                    </pre>
+                  </xsl:for-each>
+                </div>
+                <i>Manager</i>
+                <div style="margin-left: 2%; margin-right: 2%;">
+                  <xsl:for-each select="response/*">
+                    <pre>
+                      <xsl:call-template name="pretty"/>
+                    </pre>
+                  </xsl:for-each>
+                </div>
               </div>
-              <i>Manager</i>
-              <div style="margin-left: 2%; margin-right: 2%;">
-                <xsl:for-each select="response/*">
-                  <pre>
-                    <xsl:call-template name="pretty"/>
-                  </pre>
-                </xsl:for-each>
-              </div>
-            </div>
+            </details>
           </xsl:for-each>
         </xsl:when>
         <xsl:otherwise>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -13120,6 +13120,7 @@ END:VCALENDAR
       </attrib>
       <attrib>
         <name>details</name>
+        <summary>Whether to include full details</summary>
         <type>boolean</type>
       </attrib>
       <attrib>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -20058,6 +20058,11 @@ END:VCALENDAR
         <summary>Whether to include list of tasks that use the target</summary>
         <type>boolean</type>
       </attrib>
+      <attrib>
+        <name>details</name>
+        <summary>Whether to include port range and tag info</summary>
+        <type>boolean</type>
+      </attrib>
     </pattern>
     <response>
       <pattern>
@@ -20103,7 +20108,7 @@ END:VCALENDAR
           <e>snmp_credential</e>
           <e>ssh_elevate_credential</e>
           <e>permissions</e>
-          <e>port_range</e>
+          <o><e>port_range</e></o>
           <e>port_list</e>
           <e>alive_tests</e>
           <e>reverse_lookup_only</e>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -13126,6 +13126,8 @@ END:VCALENDAR
       <attrib>
         <name>result</name>
         <type>boolean</type>
+        <summary>Whether to include the associated result</summary>
+        <description>Requires "details" to be true.</description>
       </attrib>
     </pattern>
     <response>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -17203,29 +17203,6 @@ END:VCALENDAR
         <type>text</type>
         <filter_keywords>
           <option>
-            <name>first</name>
-            <type>integer</type>
-            <summary>
-              Index of the first item returned, starting at 1 (e.g. first=5
-              starts at the 5th item)
-            </summary>
-          </option>
-          <option>
-            <name>rows</name>
-            <type>integer</type>
-            <summary>Number of items to return</summary>
-          </option>
-          <option>
-            <name>sort</name>
-            <type>text</type>
-            <summary>Column to sort by in ascending order</summary>
-          </option>
-          <option>
-            <name>sort-reverse</name>
-            <type>text</type>
-            <summary>Column to sort by in descending order</summary>
-          </option>
-          <option>
             <name>apply_overrides</name>
             <type>boolean</type>
             <summary>Whether to apply Overrides</summary>
@@ -17234,6 +17211,14 @@ END:VCALENDAR
             <name>compliance_levels</name>
             <type>compliance_levels</type>
             <summary>Compliance levels to select</summary>
+          </option>
+          <option>
+            <name>first</name>
+            <type>integer</type>
+            <summary>
+              Index of the first item returned, starting at 1 (e.g. first=5
+              starts at the 5th item)
+            </summary>
           </option>
           <option>
             <name>levels</name>
@@ -17256,50 +17241,25 @@ END:VCALENDAR
             <summary>Whether to include Override descriptions in the report</summary>
           </option>
           <option>
+            <name>rows</name>
+            <type>integer</type>
+            <summary>Number of items to return</summary>
+          </option>
+          <option>
+            <name>sort</name>
+            <type>text</type>
+            <summary>Column to sort by in ascending order</summary>
+          </option>
+          <option>
+            <name>sort-reverse</name>
+            <type>text</type>
+            <summary>Column to sort by in descending order</summary>
+          </option>
+          <option>
             <name>timezone</name>
             <type>text</type>
             <summary>The timezone to use for the report</summary>
           </option>
-          <column>
-            <name>tag</name>
-            <type>text</type>
-            <summary>
-              Name and optional "=" separted value of an attached tag
-              (e.g. "mytag" or "mytag=myvalue")
-            </summary>
-          </column>
-          <column>
-            <name>tag_id</name>
-            <type>UUID</type>
-            <summary>
-              UUID of an attached tag
-            </summary>
-          </column>
-          <column>
-            <name>uuid</name>
-            <type>uuid</type>
-            <summary>Unique ID</summary>
-          </column>
-          <column>
-            <name>name</name>
-            <type>name</type>
-            <summary>Name of the NVT</summary>
-          </column>
-          <column>
-            <name>created</name>
-            <type>iso_time</type>
-            <summary>Creation time</summary>
-          </column>
-          <column>
-            <name>modified</name>
-            <type>iso_time</type>
-            <summary>Modification time</summary>
-          </column>
-          <column>
-            <name>owner</name>
-            <type>name</type>
-            <summary>Name of the owner</summary>
-          </column>
           <column>
             <name>compliant</name>
             <type>
@@ -17311,6 +17271,31 @@ END:VCALENDAR
               </alts>
             </type>
             <summary>Compliance status</summary>
+          </column>
+          <column>
+            <name>created</name>
+            <type>iso_time</type>
+            <summary>Creation time</summary>
+          </column>
+          <column>
+            <name>cve</name>
+            <type>text</type>
+            <summary>List of CVEs of the result</summary>
+          </column>
+          <column>
+            <name>cvss_base</name>
+            <type>severity</type>
+            <summary>CVSS base score of the NVT that generated the result</summary>
+          </column>
+          <column>
+            <name>date</name>
+            <type>iso_time</type>
+            <summary>Time the result was generated</summary>
+          </column>
+          <column>
+            <name>description</name>
+            <type>text</type>
+            <summary>Description of the result</summary>
           </column>
           <column>
             <name>host</name>
@@ -17328,9 +17313,14 @@ END:VCALENDAR
             <summary>Port and protocol of the result</summary>
           </column>
           <column>
-            <name>path</name>
-            <type>text</type>
-            <summary>The local path on the host, e.g. a file location</summary>
+            <name>modified</name>
+            <type>iso_time</type>
+            <summary>Modification time</summary>
+          </column>
+          <column>
+            <name>name</name>
+            <type>name</type>
+            <summary>Name of the NVT</summary>
           </column>
           <column>
             <name>nvt</name>
@@ -17338,44 +17328,9 @@ END:VCALENDAR
             <summary>Unique ID of the test that produced the result</summary>
           </column>
           <column>
-            <name>type</name>
-            <type>threat</type>
-            <summary>Severity type of the result with overrides</summary>
-          </column>
-          <column>
-            <name>original_type</name>
-            <type>threat</type>
-            <summary>Original severity type of the result</summary>
-          </column>
-          <column>
-            <name>description</name>
-            <type>text</type>
-            <summary>Description of the result</summary>
-          </column>
-          <column>
-            <name>task</name>
-            <type>text</type>
-            <summary>Name of the task</summary>
-          </column>
-          <column>
-            <name>report</name>
-            <type>number</type>
-            <summary>Internal ID of the report</summary>
-          </column>
-          <column>
-            <name>cvss_base</name>
-            <type>severity</type>
-            <summary>CVSS base score of the NVT that generated the result</summary>
-          </column>
-          <column>
             <name>nvt_version</name>
             <type>text</type>
             <summary>Version of the NVT that generated the result</summary>
-          </column>
-          <column>
-            <name>severity</name>
-            <type>severity</type>
-            <summary>Severity of the result with overrides</summary>
           </column>
           <column>
             <name>original_severity</name>
@@ -17383,24 +17338,19 @@ END:VCALENDAR
             <summary>Original severity of the result</summary>
           </column>
           <column>
-            <name>vulnerability</name>
+            <name>original_type</name>
+            <type>threat</type>
+            <summary>Original severity type of the result</summary>
+          </column>
+          <column>
+            <name>owner</name>
+            <type>name</type>
+            <summary>Name of the owner</summary>
+          </column>
+          <column>
+            <name>path</name>
             <type>text</type>
-            <summary>Name of the NVT that generated result</summary>
-          </column>
-          <column>
-            <name>date</name>
-            <type>iso_time</type>
-            <summary>Time the result was generated</summary>
-          </column>
-          <column>
-            <name>report_id</name>
-            <type>uuid</type>
-            <summary>UUID of the report</summary>
-          </column>
-          <column>
-            <name>solution_type</name>
-            <type>text</type>
-            <summary>Solution type of the result</summary>
+            <summary>The local path on the host, e.g. a file location</summary>
           </column>
           <column>
             <name>qod</name>
@@ -17413,14 +17363,64 @@ END:VCALENDAR
             <summary>QoD type of the result</summary>
           </column>
           <column>
+            <name>report</name>
+            <type>number</type>
+            <summary>Internal ID of the report</summary>
+          </column>
+          <column>
+            <name>report_id</name>
+            <type>uuid</type>
+            <summary>UUID of the report</summary>
+          </column>
+          <column>
+            <name>severity</name>
+            <type>severity</type>
+            <summary>Severity of the result with overrides</summary>
+          </column>
+          <column>
+            <name>solution_type</name>
+            <type>text</type>
+            <summary>Solution type of the result</summary>
+          </column>
+          <column>
+            <name>tag</name>
+            <type>text</type>
+            <summary>
+              Name and optional "=" separted value of an attached tag
+              (e.g. "mytag" or "mytag=myvalue")
+            </summary>
+          </column>
+          <column>
+            <name>tag_id</name>
+            <type>UUID</type>
+            <summary>
+              UUID of an attached tag
+            </summary>
+          </column>
+          <column>
+            <name>task</name>
+            <type>text</type>
+            <summary>Name of the task</summary>
+          </column>
+          <column>
             <name>task_id</name>
             <type>uuid</type>
             <summary>UUID of the task</summary>
           </column>
           <column>
-            <name>cve</name>
+            <name>type</name>
+            <type>threat</type>
+            <summary>Severity type of the result with overrides</summary>
+          </column>
+          <column>
+            <name>uuid</name>
+            <type>uuid</type>
+            <summary>Unique ID</summary>
+          </column>
+          <column>
+            <name>vulnerability</name>
             <type>text</type>
-            <summary>List of CVEs of the result</summary>
+            <summary>Name of the NVT that generated result</summary>
           </column>
         </filter_keywords>
       </attrib>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -5001,7 +5001,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </ele>
     <ele>
       <name>ca_pub</name>
-      <summary>Certificate of CA to verify scanner certificate.</summary>
+      <summary>Certificate of CA to verify scanner certificate</summary>
       <pattern>text</pattern>
     </ele>
     <ele>
@@ -5090,7 +5090,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </ele>
     <ele>
       <name>icalendar</name>
-      <summary>iCalendar text containing the time data. Replaces first_time, duration and period.</summary>
+      <summary>iCalendar text containing the time data. Replaces first_time, duration and period</summary>
       <pattern>
         text
       </pattern>
@@ -7299,8 +7299,10 @@ END:VCALENDAR
       </attrib>
       <attrib>
         <name>sort_field</name>
-        <summary>The column to sort the aggregated rows by.
-        With a subgroup column, groups will be sorted by the group_column first.</summary>
+        <summary>The column to sort the aggregated rows by</summary>
+        <description>
+          With a subgroup column, groups will be sorted by the group_column first.
+        </description>
         <type>text</type>
       </attrib>
       <attrib>
@@ -7369,8 +7371,10 @@ END:VCALENDAR
       <pattern>
         <attrib>
           <name>field</name>
-          <summary>The column to sort the aggregated rows by.
-          With a subgroup column, groups will be sorted by the group_column first</summary>
+          <summary>The column to sort the aggregated rows by</summary>
+          <description>
+            With a subgroup column, groups will be sorted by the group_column first.
+          </description>
           <type>text</type>
         </attrib>
         <attrib>
@@ -7553,7 +7557,7 @@ END:VCALENDAR
           </ele>
           <ele>
             <name>text</name>
-            <summary>The value of a simple text column.</summary>
+            <summary>The value of a simple text column</summary>
             <pattern>
               <attrib>
                 <name>name</name>
@@ -16613,7 +16617,7 @@ END:VCALENDAR
         <name>details</name>
         <summary>
           Whether to get the details of the reports including the
-          results, hosts, ports etc.
+          results, hosts, ports etc
         </summary>
         <type>boolean</type>
       </attrib>
@@ -16662,7 +16666,7 @@ END:VCALENDAR
         <name>ignore_pagination</name>
         <summary>
           Whether to ignore info used to split the report into pages
-          like the filter terms "first" and "rows".
+          like the filter terms "first" and "rows"
         </summary>
         <type>boolean</type>
       </attrib>
@@ -17052,7 +17056,7 @@ END:VCALENDAR
       </attrib>
       <attrib>
         <name>resource_id</name>
-        <summary>ID of single resource to get.</summary>
+        <summary>ID of single resource to get</summary>
         <type>text</type>
       </attrib>
       <attrib>
@@ -18983,7 +18987,7 @@ END:VCALENDAR
         </ele>
         <ele>
           <name>icalendar</name>
-          <summary>iCalendar text containing the time data.</summary>
+          <summary>iCalendar text containing the time data</summary>
           <pattern>
             text
           </pattern>
@@ -20955,7 +20959,7 @@ END:VCALENDAR
         <name>ignore_pagination</name>
         <summary>
           Whether to ignore info used to split the report into pages
-          like the filter terms "first" and "rows".
+          like the filter terms "first" and "rows"
         </summary>
         <type>boolean</type>
       </attrib>
@@ -21373,12 +21377,12 @@ END:VCALENDAR
           </ele>
           <ele>
             <name>icalendar</name>
-            <summary>iCalendar text containing the time data.</summary>
+            <summary>iCalendar text containing the time data</summary>
             <pattern><t>iso_time</t></pattern>
           </ele>
           <ele>
             <name>timezone</name>
-            <summary>The timezone the schedule will follow.</summary>
+            <summary>The timezone the schedule will follow</summary>
             <pattern>text</pattern>
           </ele>
         </ele>
@@ -26054,7 +26058,7 @@ END:VCALENDAR
     </ele>
     <ele>
       <name>icalendar</name>
-      <summary>iCalendar text containing the time data. Replaces first_time, duration and period.</summary>
+      <summary>iCalendar text containing the time data. Replaces first_time, duration and period</summary>
       <pattern>
         text
       </pattern>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -13957,7 +13957,7 @@ END:VCALENDAR
           <column>
             <name>nvt</name>
             <type>oid</type>
-            <summary>OID of the NVT the Override applies to</summary>
+            <summary>Name of the NVT the Override applies to</summary>
           </column>
           <column>
             <name>text</name>
@@ -13967,7 +13967,7 @@ END:VCALENDAR
           <column>
             <name>nvt_id</name>
             <type>oid</type>
-            <summary>Alias of nvt</summary>
+            <summary>OID of the NVT the Override applies to</summary>
           </column>
           <column>
             <name>task_name</name>
@@ -14027,20 +14027,15 @@ END:VCALENDAR
         <type>uuid</type>
       </attrib>
       <attrib>
-        <name>nvt_oid</name>
-        <type>oid</type>
-      </attrib>
-      <attrib>
-        <name>task_id</name>
-        <type>uuid</type>
-      </attrib>
-      <attrib>
         <name>details</name>
+        <summary>Whether to include full details</summary>
         <type>boolean</type>
       </attrib>
       <attrib>
         <name>result</name>
         <type>boolean</type>
+        <summary>Whether to include the associated result</summary>
+        <description>Requires "details" to be true.</description>
       </attrib>
     </pattern>
     <response>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -13111,14 +13111,6 @@ END:VCALENDAR
         <type>uuid</type>
       </attrib>
       <attrib>
-        <name>nvt_oid</name>
-        <type>oid</type>
-      </attrib>
-      <attrib>
-        <name>task_id</name>
-        <type>uuid</type>
-      </attrib>
-      <attrib>
         <name>details</name>
         <summary>Whether to include full details</summary>
         <type>boolean</type>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -13061,7 +13061,7 @@ END:VCALENDAR
           <column>
             <name>nvt</name>
             <type>oid</type>
-            <summary>OID of the NVT the Note applies to</summary>
+            <summary>Name of the NVT the Note applies to</summary>
           </column>
           <column>
             <name>text</name>
@@ -13071,7 +13071,7 @@ END:VCALENDAR
           <column>
             <name>nvt_id</name>
             <type>oid</type>
-            <summary>Alias of nvt</summary>
+            <summary>OID of the NVT the Note applies to</summary>
           </column>
           <column>
             <name>task_name</name>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -17255,11 +17255,6 @@ END:VCALENDAR
             <type>text</type>
             <summary>Column to sort by in descending order</summary>
           </option>
-          <option>
-            <name>timezone</name>
-            <type>text</type>
-            <summary>The timezone to use for the report</summary>
-          </option>
           <column>
             <name>compliant</name>
             <type>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -3225,6 +3225,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <e>event</e>
       <e>method</e>
       <e>filter</e>
+      <o><e>active</e></o>
     </pattern>
     <ele>
       <name>name</name>
@@ -3327,6 +3328,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <type>uuid</type>
           <required>1</required>
         </attrib>
+      </pattern>
+    </ele>
+    <ele>
+      <name>active</name>
+      <summary>Whether to alert will be active</summary>
+      <pattern>
+        <t>boolean</t>
       </pattern>
     </ele>
     <response>


### PR DESCRIPTION
## What

In the HTML GMP doc, use HTML's `DETAILS` to allow the reader to open and close sections. Start with all the RNC sections closed.

Also improve the RNC boxes, and add boxes around the XML code in the examples.

## Why

The doc is very long which makes it hard to navigate. The RNC is likely used less often.

## References

Waits for greenbone/gvmd/pull/2124.

