### PR TITLE
Fix: The report now has the full size (no longer zero bytes).

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -8439,7 +8439,7 @@ buffer_overrides_xml (GString *buffer, iterator_t *overrides,
             "<in_use>0</in_use>"
             "<active>%i</active>"
             "<end_time>%s</end_time>"
-            "<text excerpt=\"%s\">%s</text>"
+            "<text excerpt=\"0\">%s</text>"
             "<hosts>%s</hosts>"
             "<port>%s</port>"
             "<threat>%s</threat>"
@@ -8458,7 +8458,6 @@ buffer_overrides_xml (GString *buffer, iterator_t *overrides,
             get_iterator_modification_time (overrides),
             override_iterator_active (overrides),
             end_time > 1 ? iso_time (&end_time) : "",
-            "0",
             override_iterator_text (overrides),
             override_iterator_hosts (overrides)
              ? override_iterator_hosts (overrides) : "",


### PR DESCRIPTION
## What
The Vulnerability Report PDF had in special cases only a length of zero bytes (it was empty) when sent by an alert. This is no longer the case.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This is a bug-fix.
<!-- Describe why are these changes necessary? -->

## References
<!-- Add identifier for issue tickets, links to other PRs, etc. -->
GEA-408
## Checklist
Tested manually on my development system
<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


