### PR TITLE
CI: Don't trigger libthea on gvmd-build image changes anymore

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -60,10 +60,3 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      - name: Trigger libtheia container build
-        if: github.event_name != 'pull_request'
-        run: |
-          curl -X POST https://api.github.com/repos/greenbone/libtheia/actions/workflows/container.yml/dispatches \
-          -H "Accept: application/vnd.github.v3+json" \
-          -u greenbonebot:${{ secrets.GREENBONE_BOT_TOKEN }} \
-          -d '{"ref":"main"}'


### PR DESCRIPTION


## What

Don't trigger libthea on gvmd-build image changes anymore

## Why

Libthea project has been abandoned and will not get any further changes. Therefore there is no need to trigger any workflow of libthea.


