### PR TITLE
Fix start gvmd script

### DIFF
--- a/.docker/start-gvmd.sh
+++ b/.docker/start-gvmd.sh
@@ -20,7 +20,7 @@
 [ -z "$PASSWORD" ] && PASSWORD="admin"
 [ -z "$GVMD_ARGS" ] && GVMD_ARGS="--listen-mode=666"
 [ -z "$GVMD_USER" ] && GVMD_USER="gvmd"
-[ -z "$PGRES_DATA"] && PGRES_DATA="/var/lib/postgresql"
+[ -z "$PGRES_DATA" ] && PGRES_DATA="/var/lib/postgresql"
 
 if [ -n "$GVM_CERTS" ] && [ "$GVM_CERTS" = true ]; then
     echo "Generating certs"

--- a/.docker/start-gvmd.sh
+++ b/.docker/start-gvmd.sh
@@ -44,7 +44,7 @@ gvmd --migrate || true
 gvmd --create-user=$USER --password=$PASSWORD || true
 
 # set the feed import owner
-uid=$(gvmd --get-users --verbose | grep $USER | awk '{print $2}')
+uid=$(gvmd --get-users --verbose | grep "^$USER " | awk '{print $2}')
 gvmd --modify-setting 78eceaec-3385-11ea-b237-28d24461215b --value "$uid"
 
 echo "starting gvmd"

--- a/.docker/start-gvmd.sh
+++ b/.docker/start-gvmd.sh
@@ -23,19 +23,19 @@
 [ -z "$PGRES_DATA"] && PGRES_DATA="/var/lib/postgresql"
 
 if [ -n "$GVM_CERTS" ] && [ "$GVM_CERTS" = true ]; then
-	echo "Generating certs"
-	gvm-manage-certs -a
+    echo "Generating certs"
+    gvm-manage-certs -a
 fi
 
 # check for psql connection
 FILE=$PGRES_DATA/started
 until test -f "$FILE"; do
-	echo "waiting 1 second for ready postgres container"
+    echo "waiting 1 second for ready postgres container"
     sleep 1
 done
 until psql -U "$GVMD_USER" -d gvmd -c "SELECT 'connected' as connection"; do
-	echo "waiting 1 second to retry psql connection"
-	sleep 1
+    echo "waiting 1 second to retry psql connection"
+    sleep 1
 done
 
 # migrate db if necessary
@@ -49,6 +49,6 @@ gvmd --modify-setting 78eceaec-3385-11ea-b237-28d24461215b --value "$uid"
 
 echo "starting gvmd"
 gvmd $GVMD_ARGS ||
-	(cat /var/log/gvm/gvmd.log && exit 1)
+    (cat /var/log/gvm/gvmd.log && exit 1)
 
 tail -f /var/log/gvm/gvmd.log

--- a/.docker/start-gvmd.sh
+++ b/.docker/start-gvmd.sh
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#!/bin/sh
-
 [ -z "$USER" ] && USER="admin"
 [ -z "$PASSWORD" ] && PASSWORD="admin"
 [ -z "$GVMD_ARGS" ] && GVMD_ARGS="--listen-mode=666"


### PR DESCRIPTION
## What

Update and fix the container startup script

## Why

It wasn't possible to override the postgres data dir and contained an issue when users similar to the initial user exist (like if the user is `admin` and the users `foo_admin` and `admin_bar` exist).

