### PR TITLE
CI: Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # default reviewers
-*                 @greenbone/gvmd-maintainers @mattmundell
+*                 @greenbone/gvmd-maintainers
 
 # dev ops
-.github/          @greenbone/devops @greenbone/gvmd-maintainers @mattmundell
-.docker/          @greenbone/devops @greenbone/gvmd-maintainers @mattmundell
+.github/          @greenbone/devops @greenbone/gvmd-maintainers
+.docker/          @greenbone/devops @greenbone/gvmd-maintainers


### PR DESCRIPTION


## What
Update codeowners

## Why

Matt is a member of gvmd-maintainers now and therefore shouldn't be listed separately.


