### PR TITLE
Fix: Apply exclude_hosts of target in CVE scans

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -3243,9 +3243,19 @@ fork_cve_scan_handler (task_t task, target_t target)
   /* Add the results. */
 
   gvm_hosts = gvm_hosts_new (hosts);
-  gvm_hosts_exclude (gvm_hosts, exclude_hosts ?: "");
-
   free (hosts);
+  
+  if (gvm_hosts_exclude (gvm_hosts, exclude_hosts ?: "") < 0)
+    {
+      set_task_interrupted (task,
+                              "Failed to exclude hosts."
+                              "  Interrupting scan.");      
+      set_report_scan_run_status (global_current_report, TASK_STATUS_INTERRUPTED);
+      gvm_hosts_free (gvm_hosts);
+      free (exclude_hosts);
+      gvm_close_sentry ();
+      exit(1);
+    }
   free (exclude_hosts);
 
   while ((gvm_host = gvm_hosts_next (gvm_hosts)))

--- a/src/manage.c
+++ b/src/manage.c
@@ -3167,7 +3167,7 @@ static int
 fork_cve_scan_handler (task_t task, target_t target)
 {
   int pid;
-  char *report_id, *hosts;
+  char *report_id, *hosts, *exclude_hosts;
   gvm_hosts_t *gvm_hosts;
   gvm_host_t *gvm_host;
 
@@ -3234,6 +3234,8 @@ fork_cve_scan_handler (task_t task, target_t target)
       exit (1);
     }
 
+  exclude_hosts = target_exclude_hosts (target);
+
   reset_task (task);
   set_task_start_time_epoch (task, time (NULL));
   set_scan_start_time_epoch (global_current_report, time (NULL));
@@ -3241,7 +3243,11 @@ fork_cve_scan_handler (task_t task, target_t target)
   /* Add the results. */
 
   gvm_hosts = gvm_hosts_new (hosts);
+  gvm_hosts_exclude (gvm_hosts, exclude_hosts ?: "");
+
   free (hosts);
+  free (exclude_hosts);
+
   while ((gvm_host = gvm_hosts_next (gvm_hosts)))
     if (cve_scan_host (task, global_current_report, gvm_host))
       {


### PR DESCRIPTION
## What
CVE scans now exclude IP addresses specified in the exclude_hosts of the task target.

## Why
This makes the behavior consistent with normal OpenVAS scans.

## References
GEA-463