### PR TITLE
CI: Push gvmd-build image to ghcr.io

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -2,7 +2,7 @@ ARG VERSION=edge
 ARG GVM_LIBS_VERSION=oldstable
 ARG DEBIAN_FRONTEND=noninteractive
 
-FROM greenbone/gvmd-build:${VERSION} as builder
+FROM ghcr.io/greenbone/gvmd-build:${VERSION} as builder
 
 COPY . /source
 WORKDIR /source

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -1,8 +1,9 @@
 ARG VERSION=edge
 ARG GVM_LIBS_VERSION=oldstable
 ARG DEBIAN_FRONTEND=noninteractive
+ARG IMAGE_REGISTRY=ghcr.io
 
-FROM ghcr.io/greenbone/gvmd-build:${VERSION} as builder
+FROM ${IMAGE_REGISTRY}/greenbone/gvmd-build:${VERSION} as builder
 
 COPY . /source
 WORKDIR /source

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
   scan-build:
     name: scan-build (clang static analyzer)
     runs-on: ubuntu-latest
-    container: greenbone/gvmd-build:stable
+    container: gchr.io/greenbone/gvmd-build:stable
     steps:
       - name: Check out gvmd
         uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
   test-units:
     name: Unit Tests
     runs-on: ubuntu-latest
-    container: greenbone/gvmd-build:stable
+    container: gchr.io/greenbone/gvmd-build:stable
     steps:
       - name: Check out gvmd
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
   scan-build:
     name: scan-build (clang static analyzer)
     runs-on: ubuntu-latest
-    container: gchr.io/greenbone/gvmd-build:stable
+    container: ${{ vars.IMAGE_REGISTRY }}/greenbone/gvmd-build:stable
     steps:
       - name: Check out gvmd
         uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
   test-units:
     name: Unit Tests
     runs-on: ubuntu-latest
-    container: gchr.io/greenbone/gvmd-build:stable
+    container: ${{ vars.IMAGE_REGISTRY }}/greenbone/gvmd-build:stable
     steps:
       - name: Check out gvmd
         uses: actions/checkout@v4

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -23,7 +23,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ github.repository }}-build
+          images: gchr.io/${{ github.repository }}-build
           labels: |
             org.opencontainers.image.vendor=Greenbone
             org.opencontainers.image.base.name=greenbone/gvm-libs
@@ -40,11 +40,12 @@ jobs:
           else
             echo "gvm-libs-version=oldstable-edge" >> $GITHUB_OUTPUT
           fi
-      - name: Login to DockerHub
+      - name: Login to GitHub Docker registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+            registry: ghcr.io
+            username: ${{ secrets.GREENBONE_BOT }}
+            password: ${{ secrets.GREENBONE_BOT_PACKAGES_WRITE_TOKEN }}
       - run: echo "Build and push ${{ steps.meta.outputs.tags }}"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -54,6 +54,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          push: true
           build-args: |
             GVM_LIBS_VERSION=${{ steps.container-opts.outputs.gvm-libs-version }}
           file: .docker/build.Dockerfile

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -23,7 +23,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: gchr.io/${{ github.repository }}-build
+          images: ${{ vars.IMAGE_REGISTRY }}/${{ github.repository }}-build
           labels: |
             org.opencontainers.image.vendor=Greenbone
             org.opencontainers.image.base.name=greenbone/gvm-libs

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -16,7 +16,7 @@ jobs:
   build-gmp-doc:
     name: Build GMP documentation
     runs-on: ubuntu-latest
-    container: greenbone/gvmd-build:stable
+    container: gchr.io/greenbone/gvmd-build:stable
     steps:
       - name: Check out gvmd
         uses: actions/checkout@v4

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -16,7 +16,7 @@ jobs:
   build-gmp-doc:
     name: Build GMP documentation
     runs-on: ubuntu-latest
-    container: gchr.io/greenbone/gvmd-build:stable
+    container: ${{ vars.IMAGE_REGISTRY }}/greenbone/gvmd-build:stable
     steps:
       - name: Check out gvmd
         uses: actions/checkout@v4

--- a/.github/workflows/codeql-analysis-c.yml
+++ b/.github/workflows/codeql-analysis-c.yml
@@ -19,7 +19,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    container: gchr.io/greenbone/gvmd-build:stable
+    container: ${{ vars.IMAGE_REGISTRY }}/greenbone/gvmd-build:stable
 
     strategy:
       fail-fast: false

--- a/.github/workflows/codeql-analysis-c.yml
+++ b/.github/workflows/codeql-analysis-c.yml
@@ -19,7 +19,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    container: greenbone/gvmd-build:stable
+    container: gchr.io/greenbone/gvmd-build:stable
 
     strategy:
       fail-fast: false

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -71,6 +71,7 @@ jobs:
           build-args: |
             VERSION=${{ steps.container-opts.outputs.version }}
             GVM_LIBS_VERSION=${{ steps.container-opts.outputs.gvm-libs-version }}
+            IMAGE_REGISTRY=${{ vars.IMAGE_REGISTRY }}
           file: .docker/prod.Dockerfile
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## What
The gvmd-build Docker image is now pushed to and pulled from ghcr.io.

## Why
This is done because the image is meant to be used only in the
gvmd building and testing workflows.

## References
GEA-441