### PR TITLE
Handle alert_filter_get with and without a filter selected.

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -12139,25 +12139,21 @@ generate_alert_filter_get (alert_t alert, const get_data_t *base_get_data,
   if (filter_return)
     *filter_return = filter;
 
+  (*alert_filter_get) = g_malloc0 (sizeof (get_data_t));
+  (*alert_filter_get)->details = base_get_data->details;
+  (*alert_filter_get)->ignore_pagination = base_get_data->ignore_pagination;
+  (*alert_filter_get)->ignore_max_rows_per_page
+    = base_get_data->ignore_max_rows_per_page;
+
   if (filter)
     {
-      (*alert_filter_get) = g_malloc0 (sizeof (get_data_t));
-      (*alert_filter_get)->details = base_get_data->details;
-      (*alert_filter_get)->ignore_pagination = base_get_data->ignore_pagination;
-      (*alert_filter_get)->ignore_max_rows_per_page
-        = base_get_data->ignore_max_rows_per_page;
       (*alert_filter_get)->filt_id = g_strdup (filt_id);
       (*alert_filter_get)->filter = filter_term (filt_id);
     }
   else
-    (*alert_filter_get) = NULL;
-
-  ignore_pagination = alert_data (alert, "method",
-                                  "composer_ignore_pagination");
-  if (ignore_pagination)
     {
-      (*alert_filter_get)->ignore_pagination = atoi (ignore_pagination);
-      g_free (ignore_pagination);
+      (*alert_filter_get)->filt_id = NULL;
+      (*alert_filter_get)->filter = g_strdup("");
     }
 
   /* Adjust filter for report composer.
@@ -12168,39 +12164,44 @@ generate_alert_filter_get (alert_t alert, const get_data_t *base_get_data,
    * We simply use these fields to adjust the filter.  In the future we'll
    * remove the filter terms and extend the way we get the report. */
 
-  if (filter)
+  gchar *include_notes, *include_overrides;
+
+  ignore_pagination = alert_data (alert, "method",
+                                  "composer_ignore_pagination");
+  if (ignore_pagination)
     {
-      gchar *include_notes, *include_overrides;
+      (*alert_filter_get)->ignore_pagination = atoi (ignore_pagination);
+      g_free (ignore_pagination);
+    }
 
-      include_notes = alert_data (alert, "method",
-                                  "composer_include_notes");
-      if (include_notes)
-        {
-          gchar *new_filter;
+  include_notes = alert_data (alert, "method",
+                              "composer_include_notes");
+  if (include_notes)
+    {
+      gchar *new_filter;
 
-          new_filter = g_strdup_printf ("notes=%i %s",
-                                        atoi (include_notes),
-                                        (*alert_filter_get)->filter);
-          g_free ((*alert_filter_get)->filter);
-          (*alert_filter_get)->filter = new_filter;
-          (*alert_filter_get)->filt_id = NULL;
-          g_free (include_notes);
-        }
+      new_filter = g_strdup_printf ("notes=%i %s",
+                                    atoi (include_notes),
+                                    (*alert_filter_get)->filter);
+      g_free ((*alert_filter_get)->filter);
+      (*alert_filter_get)->filter = new_filter;
+      (*alert_filter_get)->filt_id = NULL;
+      g_free (include_notes);
+    }
 
-      include_overrides = alert_data (alert, "method",
-                                      "composer_include_overrides");
-      if (include_overrides)
-        {
-          gchar *new_filter;
+  include_overrides = alert_data (alert, "method",
+                                  "composer_include_overrides");
+  if (include_overrides)
+    {
+      gchar *new_filter;
 
-          new_filter = g_strdup_printf ("overrides=%i %s",
-                                        atoi (include_overrides),
-                                        (*alert_filter_get)->filter);
-          g_free ((*alert_filter_get)->filter);
-          (*alert_filter_get)->filter = new_filter;
-          (*alert_filter_get)->filt_id = NULL;
-          g_free (include_overrides);
-        }
+      new_filter = g_strdup_printf ("overrides=%i %s",
+                                    atoi (include_overrides),
+                                    (*alert_filter_get)->filter);
+      g_free ((*alert_filter_get)->filter);
+      (*alert_filter_get)->filter = new_filter;
+      (*alert_filter_get)->filt_id = NULL;
+      g_free (include_overrides);
     }
 
   return 0;


### PR DESCRIPTION
## What
When an alert with compose data but with no filter selected was added to a task, the task was set to interrupted after it reached a progress of 100 % due to a not allocated alert_filter_get struct. This bug is fixed now.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This is a bug-fix.
<!-- Describe why are these changes necessary? -->

## References
GEA-469
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist
Tested manually on my local development system.
<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


