### PR TITLE
Add: New config_id option for GMP get_reports

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -1634,12 +1634,14 @@ int
 report_progress (report_t);
 
 gchar *
-manage_report (report_t, report_t, const get_data_t *, report_format_t,
+manage_report (report_t, report_t, const get_data_t *,
+               report_format_t, report_config_t,
                int, int, gsize *, gchar **, gchar **, gchar **, gchar **,
                gchar **);
 
 int
-manage_send_report (report_t, report_t, report_format_t, const get_data_t *,
+manage_send_report (report_t, report_t, report_format_t, report_config_t,
+                    const get_data_t *,
                     int, int, int, int, int, int,
                     gboolean (*) (const char *,
                                   int (*) (const char*, void*),

--- a/src/manage_report_configs.h
+++ b/src/manage_report_configs.h
@@ -64,6 +64,9 @@ int
 delete_report_config (const char *, int);
 
 char *
+report_config_name (report_format_t);
+
+char *
 report_config_uuid (report_config_t);
 
 report_format_t

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -12254,6 +12254,8 @@ report_content_for_alert (alert_t alert, report_t report, task_t task,
 {
   int ret;
   report_format_t report_format;
+  gboolean report_format_is_fallback = FALSE;
+  report_config_t report_config;
   get_data_t *alert_filter_get;
   gchar *report_content;
   filter_t filter;
@@ -12362,6 +12364,8 @@ report_content_for_alert (alert_t alert, report_t report, task_t task,
           return -1;
         }
 
+      report_format_is_fallback = TRUE;
+
       if (find_report_format_with_permission
             (fallback_format_id,
              &report_format,
@@ -12380,12 +12384,26 @@ report_content_for_alert (alert_t alert, report_t report, task_t task,
         }
     }
 
+  // Get report config
+
+  if (report_format_is_fallback)
+    {
+      // Config would only be valid for the original report format
+      report_config = 0;
+    }
+  else
+    {
+      // TODO: Get report config from alert
+      report_config = 0;
+    }
+
   // Generate report content
 
   report_content = manage_report (report,
                                   get_delta_report (alert, task, report),
                                   alert_filter_get ? alert_filter_get : get,
                                   report_format,
+                                  report_config,
                                   notes_details,
                                   overrides_details,
                                   content_length,
@@ -12592,11 +12610,15 @@ escalate_to_vfire (alert_t alert, task_t task, report_t report, event_t event,
     {
       gchar *report_format_id;
       report_format_t report_format;
+      report_config_t report_config;
 
       report_format_id = g_strstrip (*point);
       find_report_format_with_permission (report_format_id,
                                           &report_format,
                                           "get_report_formats");
+
+      // TODO: Add option to set report configs
+      report_config = 0;
 
       if (report_format)
         {
@@ -12614,6 +12636,7 @@ escalate_to_vfire (alert_t alert, task_t task, report_t report, event_t event,
                                             ? alert_filter_get
                                             : get,
                                           report_format,
+                                          report_config,
                                           notes_details,
                                           overrides_details,
                                           &content_length,
@@ -30206,6 +30229,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
  * @param[in]  delta_report       Report to compare with.
  * @param[in]  get                GET data for report.
  * @param[in]  report_format      Report format.
+ * @param[in]  report_config      Report config.
  * @param[in]  notes_details      If notes, Whether to include details.
  * @param[in]  overrides_details  If overrides, Whether to include details.
  * @param[out] output_length      NULL or location for length of return.
@@ -30222,6 +30246,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
 gchar *
 manage_report (report_t report, report_t delta_report, const get_data_t *get,
                const report_format_t report_format,
+               const report_config_t report_config,
                int notes_details, int overrides_details,
                gsize *output_length, gchar **extension, gchar **content_type,
                gchar **filter_term_return, gchar **zone_return,
@@ -30274,14 +30299,14 @@ manage_report (report_t report, report_t delta_report, const get_data_t *get,
       /* Apply report format(s) */
       gchar* report_format_id = report_format_uuid (report_format);
 
-      output_file = apply_report_format (report_format_id,
+      output_file = apply_report_format (report_format_id, report_config,
                                          xml_start, xml_file, xml_dir,
                                          &used_rfps);
       g_free (report_format_id);
     }
   else
     {
-      print_report_xml_end(xml_start, xml_file, -1);
+      print_report_xml_end (xml_start, xml_file, -1, 0);
       output_file = g_strdup(xml_file);
     }
 
@@ -30374,6 +30399,7 @@ manage_report (report_t report, report_t delta_report, const get_data_t *get,
  * @param[in]  report             Report.
  * @param[in]  delta_report       Report to compare with.
  * @param[in]  report_format      Report format.
+ * @param[in]  report_config      Report config.
  * @param[in]  get                GET command data.
  * @param[in]  notes_details      If notes, Whether to include details.
  * @param[in]  overrides_details  If overrides, Whether to include details.
@@ -30395,7 +30421,9 @@ manage_report (report_t report, report_t delta_report, const get_data_t *get,
  */
 int
 manage_send_report (report_t report, report_t delta_report,
-                    report_format_t report_format, const get_data_t *get,
+                    report_format_t report_format,
+                    report_config_t report_config,
+                    const get_data_t *get,
                     int notes_details, int overrides_details, int result_tags,
                     int ignore_pagination, int lean, int base64,
                     gboolean (*send) (const char *,
@@ -30455,6 +30483,14 @@ manage_send_report (report_t report, report_t delta_report,
       && (report_format_trust (report_format) != TRUST_YES))
     return -1;
 
+  if (report_config
+      && report_config_report_format (report_config) != report_format)
+    {
+      g_warning ("%s: report config is not compatible with report_format",
+                 __func__);
+      return -1;
+    }
+
   if (mkdtemp (xml_dir) == NULL)
     {
       g_warning ("%s: mkdtemp failed", __func__);
@@ -30481,14 +30517,14 @@ manage_send_report (report_t report, report_t delta_report,
       /* Apply report format(s). */
       gchar* report_format_id = report_format_uuid (report_format);
 
-      output_file = apply_report_format (report_format_id,
+      output_file = apply_report_format (report_format_id, report_config,
                                          xml_start, xml_file, xml_dir,
                                          &used_rfps);
       g_free (report_format_id);
     }
   else
     {
-      print_report_xml_end(xml_start, xml_file, -1);
+      print_report_xml_end (xml_start, xml_file, -1, 0);
       output_file = g_strdup(xml_file);
     }
 

--- a/src/manage_sql_report_configs.c
+++ b/src/manage_sql_report_configs.c
@@ -1033,6 +1033,20 @@ report_config_param_iterator_using_default (iterator_t *iterator)
 /* Misc. functions */
 
 /**
+ * @brief Return the name of a config config.
+ *
+ * @param[in]  report_config  Report config.
+ *
+ * @return Newly allocated UUID.
+ */
+char *
+report_config_name (report_config_t report_config)
+{
+  return sql_string ("SELECT name FROM report_configs WHERE id = %llu;",
+                     report_config);
+}
+
+/**
  * @brief Return the UUID of a config config.
  *
  * @param[in]  report_config  Report config.

--- a/src/manage_sql_report_formats.h
+++ b/src/manage_sql_report_formats.h
@@ -49,7 +49,7 @@ int
 restore_report_format (const char *);
 
 gchar *
-apply_report_format (gchar *, gchar *, gchar *, gchar *,
+apply_report_format (gchar *, report_config_t, gchar *, gchar *, gchar *,
                      GList **);
 
 gboolean
@@ -89,6 +89,6 @@ int
 check_db_report_formats_trash ();
 
 int
-print_report_xml_end (gchar *, gchar *, report_format_t);
+print_report_xml_end (gchar *, gchar *, report_format_t, report_config_t);
 
 #endif /* not _GVMD_MANAGE_SQL_REPORT_FORMATS_H */

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -1806,6 +1806,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <attrib>
         <name>format_id</name>
         <type>uuid</type>
+        <summary>UUID of the report format used</summary>
+        <required>1</required>
+      </attrib>
+      <attrib>
+        <name>config_id</name>
+        <type>uuid</type>
+        <summary>UUID of the report config used</summary>
         <required>1</required>
       </attrib>
       <attrib>
@@ -1836,7 +1843,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <e>writable</e>
       <e>in_use</e>
       <e>task</e>
-      <e>report_format</e>
+      <o><e>report_format</e></o>
+      <o><e>report_config</e></o>
       <e>report</e>
     </pattern>
     <ele>
@@ -1912,6 +1920,23 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <ele>
         <name>name</name>
         <summary>The name of the report format</summary>
+        <pattern><t>name</t></pattern>
+      </ele>
+    </ele>
+    <ele>
+      <name>report_config</name>
+      <summary>The report config used</summary>
+      <pattern>
+        <attrib>
+          <name>id</name>
+          <type>uuid</type>
+          <required>1</required>
+        </attrib>
+        <e>name</e>
+      </pattern>
+      <ele>
+        <name>name</name>
+        <summary>The name of the report config</summary>
         <pattern><t>name</t></pattern>
       </ele>
     </ele>
@@ -17412,7 +17437,12 @@ END:VCALENDAR
       </attrib>
       <attrib>
         <name>format_id</name>
-        <summary>ID of required report format</summary>
+        <summary>ID of requested report format</summary>
+        <type>uuid</type>
+      </attrib>
+      <attrib>
+        <name>format_id</name>
+        <summary>ID of requested report config</summary>
         <type>uuid</type>
       </attrib>
       <attrib>


### PR DESCRIPTION
## What
It is now possible to specify a report config in the GMP command get_reports to override the default report format parameters with the ones from the config.

## Why
This is the first use case for the new report config type.

## References
GEA-473



