### PR TITLE
Fix: add missing trash suffix when getting by id 

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -5039,7 +5039,7 @@ init_get_iterator2_with (iterator_t* iterator, const char *type,
     init_iterator (iterator,
                    "%sSELECT %s"
                    " FROM %ss%s %s"
-                   " WHERE %ss.id = %llu"
+                   " WHERE %ss%s.id = %llu"
                    " AND %s%s"
                    "%s%s;",
                    with_clause ? with_clause : "",
@@ -5048,6 +5048,7 @@ init_get_iterator2_with (iterator_t* iterator, const char *type,
                    type_trash_in_table (type) ? "" : "_trash",
                    extra_tables ? extra_tables : "",
                    type,
+                   type_trash_in_table (type) ? "" : "_trash",
                    resource,
                    owned_clause,
                    extra_where_single ? extra_where_single : "",


### PR DESCRIPTION
## What

In `init_get_iterator2_with` be sure to add the "_trash" suffix on the table name when getting a single resource.

## Why

Otherwise there's an SQL error, for example:

```
o m m '<get_scanners trash="1" scanner_id="6521a066-26cd-4019-af73-8f822ee6f833"/>'
```

fails, with
```
ERROR:  missing FROM-clause entry for table "scanners"
LINE 1: ...ST ('secret' AS TEXT)) FROM scanners_trash  WHERE scanners.i...
                                                             ^
 (7)
```
in the log.

## References

Introduced in 2020 in c9dc67a01ed0f9b381172634d4514ccd2bd83ef2 in greenbone/gvmd/pull/1076.
