### PR TITLE
Fix: Fix the fallback filter for alerts with no compose filter

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -12155,7 +12155,7 @@ generate_alert_filter_get (alert_t alert, const get_data_t *base_get_data,
   else
     {
       (*alert_filter_get)->filt_id = NULL;
-      (*alert_filter_get)->filter = g_strdup("");
+      (*alert_filter_get)->filter = base_get_data->filter;
     }
 
   /* Adjust filter for report composer.


### PR DESCRIPTION
## What
Fix the the fallback filter for alerts with no compose filter.

## Why
An empty filter was used when the alert had no filter causing an incomplete report when the alert was triggered manually.

## References
GEA-504


