### PR TITLE
Docs: Remove trailing full stops from summaries

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -5141,7 +5141,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </ele>
     <ele>
       <name>ca_pub</name>
-      <summary>Certificate of CA to verify scanner certificate.</summary>
+      <summary>Certificate of CA to verify scanner certificate</summary>
       <pattern>text</pattern>
     </ele>
     <ele>
@@ -5230,7 +5230,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </ele>
     <ele>
       <name>icalendar</name>
-      <summary>iCalendar text containing the time data. Replaces first_time, duration and period.</summary>
+      <summary>iCalendar text containing the time data. Replaces first_time, duration and period</summary>
       <pattern>
         text
       </pattern>
@@ -7491,8 +7491,10 @@ END:VCALENDAR
       </attrib>
       <attrib>
         <name>sort_field</name>
-        <summary>The column to sort the aggregated rows by.
-        With a subgroup column, groups will be sorted by the group_column first.</summary>
+        <summary>The column to sort the aggregated rows by</summary>
+        <description>
+          With a subgroup column, groups will be sorted by the group_column first.
+        </description>
         <type>text</type>
       </attrib>
       <attrib>
@@ -7561,8 +7563,10 @@ END:VCALENDAR
       <pattern>
         <attrib>
           <name>field</name>
-          <summary>The column to sort the aggregated rows by.
-          With a subgroup column, groups will be sorted by the group_column first</summary>
+          <summary>The column to sort the aggregated rows by</summary>
+          <description>
+            With a subgroup column, groups will be sorted by the group_column first.
+          </description>
           <type>text</type>
         </attrib>
         <attrib>
@@ -7745,7 +7749,7 @@ END:VCALENDAR
           </ele>
           <ele>
             <name>text</name>
-            <summary>The value of a simple text column.</summary>
+            <summary>The value of a simple text column</summary>
             <pattern>
               <attrib>
                 <name>name</name>
@@ -17431,7 +17435,7 @@ END:VCALENDAR
         <name>details</name>
         <summary>
           Whether to get the details of the reports including the
-          results, hosts, ports etc.
+          results, hosts, ports etc
         </summary>
         <type>boolean</type>
       </attrib>
@@ -17485,7 +17489,7 @@ END:VCALENDAR
         <name>ignore_pagination</name>
         <summary>
           Whether to ignore info used to split the report into pages
-          like the filter terms "first" and "rows".
+          like the filter terms "first" and "rows"
         </summary>
         <type>boolean</type>
       </attrib>
@@ -17875,7 +17879,7 @@ END:VCALENDAR
       </attrib>
       <attrib>
         <name>resource_id</name>
-        <summary>ID of single resource to get.</summary>
+        <summary>ID of single resource to get</summary>
         <type>text</type>
       </attrib>
       <attrib>
@@ -19806,7 +19810,7 @@ END:VCALENDAR
         </ele>
         <ele>
           <name>icalendar</name>
-          <summary>iCalendar text containing the time data.</summary>
+          <summary>iCalendar text containing the time data</summary>
           <pattern>
             text
           </pattern>
@@ -21778,7 +21782,7 @@ END:VCALENDAR
         <name>ignore_pagination</name>
         <summary>
           Whether to ignore info used to split the report into pages
-          like the filter terms "first" and "rows".
+          like the filter terms "first" and "rows"
         </summary>
         <type>boolean</type>
       </attrib>
@@ -22196,12 +22200,12 @@ END:VCALENDAR
           </ele>
           <ele>
             <name>icalendar</name>
-            <summary>iCalendar text containing the time data.</summary>
+            <summary>iCalendar text containing the time data</summary>
             <pattern><t>iso_time</t></pattern>
           </ele>
           <ele>
             <name>timezone</name>
-            <summary>The timezone the schedule will follow.</summary>
+            <summary>The timezone the schedule will follow</summary>
             <pattern>text</pattern>
           </ele>
         </ele>
@@ -26969,7 +26973,7 @@ END:VCALENDAR
     </ele>
     <ele>
       <name>icalendar</name>
-      <summary>iCalendar text containing the time data. Replaces first_time, duration and period.</summary>
+      <summary>iCalendar text containing the time data. Replaces first_time, duration and period</summary>
       <pattern>
         text
       </pattern>


### PR DESCRIPTION
## What

Remove stray full stops from `SUMMARY` elements in the GMP docs.

## Why

The documentation generators expect the full stops to be missing, so this PR prevents double full stops.

For example, in the HTML this was happening in 7.17.1:

    <ca_pub> Certificate of CA to verify scanner certificate..



