### PR TITLE
Add libcjson-dev to build image

### DIFF
--- a/.docker/build.Dockerfile
+++ b/.docker/build.Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && \
     build-essential \
     cmake \
     gcc \
+    libcjson-dev \
     libglib2.0-dev \
     libgnutls28-dev \
     libpq-dev \


### PR DESCRIPTION
## What
Add libcjson-dev to build image.

## Why
This library will be used by upcoming features,

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->
