### PR TITLE
Change: GMP doc: add summary to details for GET_NOTES and GET_OVERRIDES

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -13304,6 +13304,7 @@ END:VCALENDAR
       </attrib>
       <attrib>
         <name>details</name>
+        <summary>Whether to include full details</summary>
         <type>boolean</type>
       </attrib>
       <attrib>
@@ -14225,6 +14226,7 @@ END:VCALENDAR
       </attrib>
       <attrib>
         <name>details</name>
+        <summary>Whether to include full details</summary>
         <type>boolean</type>
       </attrib>
       <attrib>


### PR DESCRIPTION
## What

Add a summary to the `details` attribute in the GMP doc for `GET_NOTES` and `GET_OVERRIDES`.

## Why

This makes it clearer what the attribute does, and is consistent with the rest of the document.

The result is that the HTML output for GET_NOTES now includes this
```
7.59.1 Structure
    Command
        @details (boolean) Whether to include full details.
```
whereas before it was like this
```
7.59.1 Structure
    Command
        @details (boolean)
```
Same for overrides in 7.62.1.

