### PR TITLE
Change: GMP doc: add active to CREATE_ALERT

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -3250,6 +3250,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <e>event</e>
       <e>method</e>
       <e>filter</e>
+      <o><e>active</e></o>
     </pattern>
     <ele>
       <name>name</name>
@@ -3352,6 +3353,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <type>uuid</type>
           <required>1</required>
         </attrib>
+      </pattern>
+    </ele>
+    <ele>
+      <name>active</name>
+      <summary>Whether the alert is active</summary>
+      <pattern>
+        <t>boolean</t>
       </pattern>
     </ele>
     <response>


### PR DESCRIPTION
## What

Add the element `ACTIVE` to the GMP `CREATE_ALERT` command in the GMP docs.

## Why

Useful to know all the options. With the PR the element is added:
```
7.2.1 Structure
    Command
        ...
        <active> ?   Whether the alert is active.
```

## References

The active attribute was added in 2017 in SVN r28255 (git 915fe95d6c5218cbe1b61d8986fda2f5b0a96721).
It is used by gsad for the create_alert cmd.
