### PR TITLE
Change: GMP doc: remove option timezone from GET_RESULTS

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -18088,11 +18088,6 @@ END:VCALENDAR
             <type>boolean</type>
             <summary>Whether to include Override descriptions in the report</summary>
           </option>
-          <option>
-            <name>timezone</name>
-            <type>text</type>
-            <summary>The timezone to use for the report</summary>
-          </option>
           <column>
             <name>tag</name>
             <type>text</type>


### PR DESCRIPTION
## What

Remove the `timezone` option from GET_RESULTS in the GMP doc.

## Why

There is no such option.  For example:
```
$ o m m '<get_results details="1" filter="rows=1 timezone=UTC"/>'
<get_results_response status="200" status_text="OK">
  <result id="3e3abe2e-1626-4b16-8812-d27ffd568e9f">
    <creation_time>2023-10-02T22:24:26+02:00</creation_time>
```
Note the **+02:00** on the time.  It is the same without the option:
```
$ o m m '<get_results filter="rows=1"/>'
<get_results_response status="200" status_text="OK">
  <result id="3e3abe2e-1626-4b16-8812-d27ffd568e9f">
    <creation_time>2023-10-02T22:24:26+02:00</creation_time>
```

## References

Looks like Timo accidentally added this in 587584bfdfeead487d39a050f118ac0936fb759c, probably because GET_RESULTS is very similar to GET_REPORTS.  However, GET_REPORTS is calling ```manage_report_filter_controls``` (in [print_report_xml_start](https://github.com/greenbone/gvmd/blob/v23.5.2/src/manage_sql.c#L29065)) with a return zone argument, whereas GET_RESULTS is calling ```manage_report_filter_controls``` (in [handle_get_results](https://github.com/greenbone/gvmd/blob/v23.5.2/src/gmp.c#L16082)) with a `NULL` zone argument.

So GET_REPORTS accepts the timezone option, for example:
```
o m m '<get_reports details="1" report_id="4b4bd3dc-cf4c-4c6d-8f5c-83384c95ed3f" filter="rows=1 timezone=UTC"/>'
<get_reports_response status="200" status_text="OK">
        <result id="3e3abe2e-1626-4b16-8812-d27ffd568e9f">
          <creation_time>2023-10-02T20:24:26Z</creation_time>
```
Note the **Z** in the time.

