### PR TITLE
Change: GMP doc: add details attribute to GET_TARGETS

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -20891,6 +20891,11 @@ END:VCALENDAR
         <summary>Whether to include list of tasks that use the target</summary>
         <type>boolean</type>
       </attrib>
+      <attrib>
+        <name>details</name>
+        <summary>Whether to include port range and tag info</summary>
+        <type>boolean</type>
+      </attrib>
     </pattern>
     <response>
       <pattern>


### PR DESCRIPTION
## What

Add attribute `details` to GET_TARGETS in the GMP doc.

## Why

Attribute was missing.

## References

This attribute controls the presence of `port_range` (see [handle_get_targets](https://github.com/greenbone/gvmd/blob/v23.5.2/src/gmp.c#L17610)) and `user_tags/tag` (see [send_get_common](https://github.com/greenbone/gvmd/blob/v23.5.2/src/gmp_get.c#L429)).

For example:
```
$ o m m '<get_targets filter="rows=10"/>'
<get_targets_response status="200" status_text="OK">
  <target id="0de4c2b4-987d-4a3b-9eba-fe92b3eaa8b2">
```
versus
```
$ o m m '<get_targets details="1" filter="rows=10"/>'
<get_targets_response status="200" status_text="OK">
  <target id="0de4c2b4-987d-4a3b-9eba-fe92b3eaa8b2">
    <port_range>T:1-3,5,7,...,49150</port_range>
```