### PR TITLE
Change: GMP doc: correct nvt and nvt_id in GET_NOTES

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -13252,8 +13252,8 @@ END:VCALENDAR
           </column>
           <column>
             <name>nvt</name>
-            <type>oid</type>
-            <summary>OID of the NVT the Note applies to</summary>
+            <type>text</type>
+            <summary>Name of the NVT the Note applies to</summary>
           </column>
           <column>
             <name>text</name>
@@ -13263,7 +13263,7 @@ END:VCALENDAR
           <column>
             <name>nvt_id</name>
             <type>oid</type>
-            <summary>Alias of nvt</summary>
+            <summary>OID of the NVT the Note applies to</summary>
           </column>
           <column>
             <name>task_name</name>


### PR DESCRIPTION
## What

Correct the filter columns `nvt` and `nvt_id` for GET_NOTES in the GMP doc. 

## Why

`nvt` is actually for an NVT name.

For example:
```
o m m '<get_notes filter="nvt=1.3.6.1.4.1.25623.1.0.10049"/>'
<get_notes_response status="200" status_text="OK">
  <filtered>0</filtered>
```
versus:
```
time o m m '<get_notes filter="nvt=Count.cgi"/>'
<get_notes_response status="200" status_text="OK">
  <note id="d0be5b1b-90d0-4dc7-9aa0-a9b80ed7f136">
    <nvt oid="1.3.6.1.4.1.25623.1.0.10049">
    ...
  <filtered>1</filtered>
```



