### PR TITLE
Fix: Allow results port to take value package for notes and overrides

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -32674,6 +32674,9 @@ validate_results_port (const char *port)
   if (!port)
     return 1;
 
+  if (strcmp (port, "package") == 0)
+    return 0;
+
   /* "cpe:abc", "general/tcp", "20/udp"
    *
    * We keep the "general/tcp" case pretty open because it is not clearly

--- a/src/manage_sql_tests.c
+++ b/src/manage_sql_tests.c
@@ -42,6 +42,7 @@ Ensure (manage_sql, validate_results_port_validates)
   PASS ("1/tcp");
   PASS ("8080/tcp");
   PASS ("65535/tcp");
+  PASS ("package");
 
   FAIL (NULL);
   FAIL ("cpe:/a:.joomclan:com_joomclip cpe:two");


### PR DESCRIPTION
## What
Allow package as a valid value for a result port in notes and overrides.

## Why
Results can have the location "package" instead of a port number. When this is entered as a note object specification, it's not accepted.

## References
GEA-534

