### PR TITLE
Fix: Correct nvt column in OVERRIDE_ITERATOR_COLUMNS

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -39905,7 +39905,7 @@ modify_override (const gchar *override_id, const char *active, const char *nvt,
      " THEN overrides.nvt"                                                  \
      " ELSE (SELECT name FROM nvts WHERE oid = overrides.nvt)"              \
      " END)",                                                               \
-     "name",                                                                \
+     "nvt",                                                                 \
      KEYWORD_TYPE_STRING                                                    \
    },                                                                       \
    { "overrides.nvt", "nvt_id", KEYWORD_TYPE_STRING },                      \


### PR DESCRIPTION
## What

In OVERRIDE_ITERATOR_COLUMNS change the name of the NVT filter column from `name` to `nvt`.

## Why

The column corresponds to the filter keyword "nvt".  There is already a "name" column further up (column 3).

This solves an assertion failure, for example:
```
o m m '<get_overrides filter="nvt=Count.cgi"/>'
```
results in 
```
gvmd: /home/matt/fresh/main/gvmd/src/manage_sql.c:3491: filter_clause: Assertion `column' failed.
```
on gvmd stderr.

## References

I introduced this error in 2015 in ec97206a5a3aaf5404227f2db12c8f19e45e6f8c, see line [26947](https://github.com/greenbone/gvmd/commit/ec97206a5a3aaf5404227f2db12c8f19e45e6f8c#diff-f65adb0d64211e7dec5fb4e6239cb641f7a911699e04383761cd27cf8b8a9021L36947).
