### PR TITLE
Change: GMP doc: correct nvt and nvt_id in GET_OVERRIDES

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -14154,8 +14154,8 @@ END:VCALENDAR
           </column>
           <column>
             <name>nvt</name>
-            <type>oid</type>
-            <summary>OID of the NVT the Override applies to</summary>
+            <type>text</type>
+            <summary>Name of the NVT the Override applies to</summary>
           </column>
           <column>
             <name>text</name>
@@ -14165,7 +14165,7 @@ END:VCALENDAR
           <column>
             <name>nvt_id</name>
             <type>oid</type>
-            <summary>Alias of nvt</summary>
+            <summary>OID of the NVT the Override applies to</summary>
           </column>
           <column>
             <name>task_name</name>


### PR DESCRIPTION
## What

Correct the filter columns `nvt` and `nvt_id` for GET_OVERRIDES in the GMP doc. 

## Why

`nvt` is actually for an NVT name.

For example:
```
$ o m m '<get_overrides filter="nvt=1.3.6.1.4.1.25623.1.0.10049"/>'
<get_overrides_response status="200" status_text="OK">
  <filtered>0</filtered>
```
versus:
```
$ o m m '<get_overrides filter="nvt=Count.cgi"/>'
<get_overrides_response status="200" status_text="OK">
  <override id="1ecace58-88db-4c6c-82c2-81cd027ec7d2">...
  <filtered>1</filtered>
```

## References

Similar to greenbone/gvmd/pull/2171 for notes.

Examples above requires greenbone/gvmd/pull/2173 else they hit an assert fail.
