### PR TITLE
Change: GMP doc: Flesh out result in GET_NOTES and GET_OVERRIDES

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -13318,6 +13318,8 @@ END:VCALENDAR
       <attrib>
         <name>result</name>
         <type>boolean</type>
+        <summary>Whether to include the associated result</summary>
+        <description>Requires "details" to be true.</description>
       </attrib>
     </pattern>
     <response>
@@ -14240,6 +14242,8 @@ END:VCALENDAR
       <attrib>
         <name>result</name>
         <type>boolean</type>
+        <summary>Whether to include the associated result</summary>
+        <description>Requires "details" to be true.</description>
       </attrib>
     </pattern>
     <response>


### PR DESCRIPTION
## What

Add summary and details to the `result` attribute in the GMP docs for GET_NOTES and GET_OVERRIDES.

## Why

Clarity.

Before PR:
```
7.59.1 Structure
    @result (boolean)
```
after PR:
```
7.59.1 Structure
  Command
    @result (boolean) Whether to include the associated result.
      More Details
        Requires "details" to be true.
```

Here's the associated GMP:
```
$ o m m '<get_notes filter="rows=1"/>'
<get_notes_response status="200" status_text="OK">
  <note id="4ca00487-2c6a-4eeb-a645-dbebb6aa956a">
```

```
$ o m m '<get_notes details="1" filter="rows=1"/>'
<get_notes_response status="200" status_text="OK">
  <note id="4ca00487-2c6a-4eeb-a645-dbebb6aa956a">
    <result id="e7ef79c7-6252-4787-9a1f-64e672620ce7" />
```

