### PR TITLE
Add: GMP doc: hiding of main sections

### DIFF
--- a/src/schema_formats/HTML/HTML.xsl
+++ b/src/schema_formats/HTML/HTML.xsl
@@ -260,15 +260,29 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </xsl:choose>
   </xsl:template>
 
+  <xsl:template name="details-summary">
+    <xsl:param name="id"/>
+    <xsl:param name="text"/>
+    <summary id="{$id}"
+             style="margin-block-start: .83em; margin-block-end: .83em; cursor: pointer;">
+      <h2 style="display: inline;"><xsl:value-of select="$text"/></h2>
+    </summary>
+  </xsl:template>
+
   <!-- RNC preamble. -->
 
   <xsl:template name="rnc-preamble">
-    <h2 id="rnc_preamble">4 RNC Preamble</h2>
-    <div style="border: 1px solid; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #d5d5d5;">
-      <pre>
-        <xsl:call-template name="preamble"/>
-      </pre>
-    </div>
+    <details open="">
+      <xsl:call-template name="details-summary">
+        <xsl:with-param name="id" select="'rnc_preamble'"/>
+        <xsl:with-param name="text" select="'4 RNC Preamble'"/>
+      </xsl:call-template>
+      <div style="border: 1px solid; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #d5d5d5;">
+        <pre>
+          <xsl:call-template name="preamble"/>
+        </pre>
+      </div>
+    </details>
   </xsl:template>
 
   <!-- Types. -->
@@ -285,10 +299,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   </xsl:template>
 
   <xsl:template name="type-summary">
-    <h2 id="type_summary">1 Summary of Data Types</h2>
-    <table id="index">
-    <xsl:apply-templates select="type" mode="index"/>
-    </table>
+    <details open="">
+      <xsl:call-template name="details-summary">
+        <xsl:with-param name="id" select="'type_summary'"/>
+        <xsl:with-param name="text" select="'1 Summary of Data Types'"/>
+      </xsl:call-template>
+      <table id="index">
+        <xsl:apply-templates select="type" mode="index"/>
+      </table>
+    </details>
   </xsl:template>
 
   <xsl:template match="type" mode="details">
@@ -325,8 +344,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   </xsl:template>
 
   <xsl:template name="type-details">
-    <h2 id="type_details">5 Data Type Details</h2>
-    <xsl:apply-templates select="type" mode="details"/>
+    <details open="">
+      <xsl:call-template name="details-summary">
+        <xsl:with-param name="id" select="'type_details'"/>
+        <xsl:with-param name="text" select="'5 Data Type Details'"/>
+      </xsl:call-template>
+      <xsl:apply-templates select="type" mode="details"/>
+    </details>
   </xsl:template>
 
   <!-- Elements. -->
@@ -343,15 +367,25 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   </xsl:template>
 
   <xsl:template name="element-summary">
-    <h2 id="element_summary">2 Summary of Elements</h2>
-    <table id="index">
-    <xsl:apply-templates select="element" mode="index"/>
-    </table>
+    <details open="">
+      <xsl:call-template name="details-summary">
+        <xsl:with-param name="id" select="'element_summary'"/>
+        <xsl:with-param name="text" select="'2 Summary of Elements'"/>
+      </xsl:call-template>
+      <table id="index">
+        <xsl:apply-templates select="element" mode="index"/>
+      </table>
+    </details>
   </xsl:template>
 
   <xsl:template name="element-details">
-    <h2 id="element_details">6 Element Details</h2>
-    <xsl:apply-templates select="element"/>
+    <details open="">
+      <xsl:call-template name="details-summary">
+        <xsl:with-param name="id" select="'element_details'"/>
+        <xsl:with-param name="text" select="'6 Element Details'"/>
+      </xsl:call-template>
+      <xsl:apply-templates select="element"/>
+    </details>
   </xsl:template>
 
   <xsl:template match="element">
@@ -691,15 +725,25 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   </xsl:template>
 
   <xsl:template name="command-summary">
-    <h2 id="command_summary">3 Summary of Commands</h2>
-    <table id="index">
-    <xsl:apply-templates select="command" mode="index"/>
-    </table>
+    <details open="">
+      <xsl:call-template name="details-summary">
+        <xsl:with-param name="id" select="'command_summary'"/>
+        <xsl:with-param name="text" select="'3 Summary of Commands'"/>
+      </xsl:call-template>
+      <table id="index">
+        <xsl:apply-templates select="command" mode="index"/>
+      </table>
+    </details>
   </xsl:template>
 
   <xsl:template name="command-details">
-    <h2 id="command_details">7 Command Details</h2>
-    <xsl:apply-templates select="command"/>
+    <details open="">
+      <xsl:call-template name="details-summary">
+        <xsl:with-param name="id" select="'command_details'"/>
+        <xsl:with-param name="text" select="'7 Command Details'"/>
+      </xsl:call-template>
+      <xsl:apply-templates select="command"/>
+    </details>
   </xsl:template>
 
   <!-- Filter keywords -->
@@ -749,11 +793,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   </xsl:template>
 
   <xsl:template name="changes">
-    <h2 id="changes">
-      8 Compatibility Changes in Version
-      <xsl:value-of select="/protocol/version"/>
-    </h2>
-    <xsl:apply-templates select="change[version=/protocol/version]"/>
+    <details open="">
+      <xsl:call-template name="details-summary">
+        <xsl:with-param name="id" select="'changes'"/>
+        <xsl:with-param name="text">
+          <xsl:value-of select="'8 Compatibility Changes in Version '"/>
+          <xsl:value-of select="/protocol/version"/>
+        </xsl:with-param>
+      </xsl:call-template>
+      <xsl:apply-templates select="change[version=/protocol/version]"/>
+    </details>
   </xsl:template>
 
   <!-- Deprecation Warnings. -->


### PR DESCRIPTION
## What

Allow opening and closing of the main sections in the HTML GMP doc.

The main sections are `1 Summary of Data Types`, `2 Summary of Elements`, etc.

This wraps each of the main sections in an HTML `DETAILS` element.  The new template `details-summary` is used to add an HTML `SUMMARY` as the header inside each section. The ids and texts of the headers are kept the same. So is the section contents.

## Why

This doc is very long with lots of details, making it hard to navigate. With foldable sections at least some things can be hidden to make navigation easier.

Here's how it looks with the first section folded:

![shot](https://github.com/greenbone/gvmd/assets/32057441/a00e9f62-1dfc-4308-9409-6f7e8a56c9fc)

## References

MDN [\<details\> reference](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details)

