### PR TITLE
Change: GMP doc: start with section RNC Preamble closed

### DIFF
--- a/src/schema_formats/HTML/HTML.xsl
+++ b/src/schema_formats/HTML/HTML.xsl
@@ -272,7 +272,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   <!-- RNC preamble. -->
 
   <xsl:template name="rnc-preamble">
-    <details open="">
+    <details>
       <xsl:call-template name="details-summary">
         <xsl:with-param name="id" select="'rnc_preamble'"/>
         <xsl:with-param name="text" select="'4 RNC Preamble'"/>


### PR DESCRIPTION
## What

When the GMP HTML doc opens the `RNC Preamble` section is in the closed state.

## Why

This makes the doc a little easier to navigate, while keeping the preamble in the doc. Likely the RNC is of little value to most users of the doc, especially the preamble.

Here's how it looks on load:

![shot](https://github.com/greenbone/gvmd/assets/32057441/cf071d77-cdb7-4acd-9a06-936a1f03eb13)
