### PR TITLE
Fix: Fix SQL typo in delete_report_configs_user

### DIFF
--- a/src/manage_sql_report_configs.c
+++ b/src/manage_sql_report_configs.c
@@ -555,7 +555,7 @@ delete_report_configs_user (user_t user)
        " WHERE report_config IN"
        "   (SELECT id FROM report_configs_trash WHERE owner = %llu)",
        user);
-  sql ("DELETE report_configs_trash WHERE owner = %llu;", user);
+  sql ("DELETE FROM report_configs_trash WHERE owner = %llu;", user);
 }
 
 /**


### PR DESCRIPTION
## What
A missing "FROM" is added in the SQL run to delete all report configs of a given user.

## Why
This fixes deleting a user without an inheritor.

## References
GEA-542

