### PR TITLE
Fix: added PostgreSQL 16 to the list of known versions in FindPostgre…

### DIFF
--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -87,7 +87,7 @@ set(PostgreSQL_ROOT_DIR_MESSAGE "Set the PostgreSQL_ROOT system variable to wher
 
 
 set(PostgreSQL_KNOWN_VERSIONS ${PostgreSQL_ADDITIONAL_VERSIONS}
-    "15" "14" "13" "12" "11" "10" "9.6" "9.5" "9.4" "9.3" "9.2" "9.1" "9.0" "8.4" "8.3" "8.2" "8.1" "8.0")
+   "16" "15" "14" "13" "12" "11" "10" "9.6" "9.5" "9.4" "9.3" "9.2" "9.1" "9.0" "8.4" "8.3" "8.2" "8.1" "8.0")
 
 # Define additional search paths for root directories.
 set( PostgreSQL_ROOT_DIRECTORIES

--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -87,7 +87,7 @@ set(PostgreSQL_ROOT_DIR_MESSAGE "Set the PostgreSQL_ROOT system variable to wher
 
 
 set(PostgreSQL_KNOWN_VERSIONS ${PostgreSQL_ADDITIONAL_VERSIONS}
-   "16" "15" "14" "13" "12" "11" "10" "9.6" "9.5" "9.4" "9.3" "9.2" "9.1" "9.0" "8.4" "8.3" "8.2" "8.1" "8.0")
+    "16" "15" "14" "13" "12" "11" "10" "9.6" "9.5" "9.4" "9.3" "9.2" "9.1" "9.0" "8.4" "8.3" "8.2" "8.1" "8.0")
 
 # Define additional search paths for root directories.
 set( PostgreSQL_ROOT_DIRECTORIES


### PR DESCRIPTION
…SQL.cmake

The gvm compiles only when used with PostgreSQL (Debian 16.2-1). The older version of PSQL (PSQL 15) isn't in Kali's rolling repo anymore.

## What

This fixes cmake when compiling from source on Kali 2024.1, as the older version of PSQL no longer present in the APT's repository. Without it, cmake isn't able to find the PSQL-16. After the change was made, I was able to compile gvmd.

## Why

PSQL-16 was released at 2023-09-14, and its only a matter of time untill it will become default version on LTS builds also. 
You also can't use the apt-package version of the greenborne on kali, as it's broken, so compiling seems to be the only way.
The fix doesn't seem to break the build process*, so I'd say suggest bumping the version.

## Tests
The only thing to consider, is that I was following the [guide](https://greenbone.github.io/docs/latest/22.4/source-build/index.html), that seems to download source of an older version - 23.2.0
