### PR TITLE
Change: Raised log level for output of backtrace for signal handler.

### DIFF
--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -999,7 +999,7 @@ handle_sigabrt (int given_signal)
       frame_count = 0;
     }
   for (index = 0; index < frame_count; index++)
-    g_debug ("BACKTRACE: %s", frames_text[index]);
+    g_message ("BACKTRACE: %s", frames_text[index]);
   free (frames_text);
 
   manage_cleanup_process_error (given_signal);
@@ -1043,7 +1043,7 @@ handle_sigsegv (/* unused */ int given_signal)
       frame_count = 0;
     }
   for (index = 0; index < frame_count; index++)
-    g_debug ("BACKTRACE: %s", frames_text[index]);
+    g_message ("BACKTRACE: %s", frames_text[index]);
   free (frames_text);
 
   manage_cleanup_process_error (given_signal);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -17133,12 +17133,12 @@ cleanup_manage_process (gboolean cleanup)
 void
 manage_cleanup_process_error (int signal)
 {
-  g_debug ("Received %s signal", strsignal (signal));
+  g_message ("Received %s signal", strsignal (signal));
   if (sql_is_open ())
     {
       if (current_scanner_task)
         {
-          g_warning ("%s: Error exit, setting running task to Interrupted",
+          g_message ("%s: Error exit, setting running task to Interrupted",
                      __func__);
           set_task_interrupted (current_scanner_task,
                                 "Error exit, setting running task to"

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -17138,7 +17138,7 @@ manage_cleanup_process_error (int signal)
     {
       if (current_scanner_task)
         {
-          g_message ("%s: Error exit, setting running task to Interrupted",
+          g_warning ("%s: Error exit, setting running task to Interrupted",
                      __func__);
           set_task_interrupted (current_scanner_task,
                                 "Error exit, setting running task to"


### PR DESCRIPTION
## What
We raised the log level for the output of the back trace in the signal handler so that
the back trace is always printed, when a signal occurs.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
When a signal occurs the back trace is sometimes not printed. We assume that the
log level is not evaluated correctly in that case. We now set the log level of the back trace
messages fixed to the maximum, so that the back trace is hopefully always printed.
<!-- Describe why are these changes necessary? -->

## References
GEA-526
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


