### PR TITLE
Change: GMP doc: Start with all RNC sections closed

### DIFF
--- a/src/schema_formats/HTML/HTML.xsl
+++ b/src/schema_formats/HTML/HTML.xsl
@@ -342,7 +342,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       <xsl:apply-templates select="description"/>
 
-      <details open="">
+      <details>
         <xsl:call-template name="details-summary-4">
           <xsl:with-param name="text" select="concat($index, '.1 RNC')"/>
         </xsl:call-template>
@@ -434,7 +434,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </ul>
       </details>
 
-      <details open="">
+      <details>
         <xsl:call-template name="details-summary-4">
           <xsl:with-param name="text" select="concat($index, '.2 RNC')"/>
         </xsl:call-template>
@@ -705,7 +705,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </ul>
       </details>
 
-      <details open="">
+      <details>
         <xsl:call-template name="details-summary-4">
           <xsl:with-param name="text" select="concat($index, '.2 RNC')"/>
         </xsl:call-template>


### PR DESCRIPTION
## What

For the HTML GMP doc, all RNC sections are initially closed.

## Why

The doc is large and hard to navigate. Hiding the RNC reduces the clutter, especially showing the command examples directly below their structure.

## References

See the image in greenbone/gvmd/pull/2183 for an example.



