### PR TITLE
Update setup-mta.sh to include tls_certcheck

### DIFF
--- a/.docker/setup-mta.sh
+++ b/.docker/setup-mta.sh
@@ -8,6 +8,7 @@ if [ -n MTA_HOST ]; then
     [ -n MTA_PORT ] && echo "port $MTA_PORT" >> $CONFIG
     [ -n MTA_TLS ] && echo "tls $MTA_TLS" >> $CONFIG
     [ -n MTA_STARTTLS ] && echo "tls_starttls $MTA_STARTTLS" >> $CONFIG
+    [ -n MTA_TLS_CERTCHECK ] && echo "tls_certcheck $MTA_TLS_CERTCHECK" >> $CONFIG
     [ -n MTA_AUTH ] && echo "auth $MTA_AUTH" >> $CONFIG
     [ -n MTA_USER ] && echo "user $MTA_USER" >> $CONFIG
     [ -n MTA_FROM ] && echo "from $MTA_FROM" >> $CONFIG


### PR DESCRIPTION
## What

Added a simple option to ignore certificate errors.

## Why

could be if your running self-signed, or if the root certificate isn't accepted, maybe you just need a fast way to enable sending reports while waiting for your mail provider to update their expired certificate.
