### PR TITLE
Change: GMP doc: soften the RNC boxes

### DIFF
--- a/src/schema_formats/HTML/HTML.xsl
+++ b/src/schema_formats/HTML/HTML.xsl
@@ -294,7 +294,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:with-param name="id" select="'rnc_preamble'"/>
         <xsl:with-param name="text" select="'4 RNC Preamble'"/>
       </xsl:call-template>
-      <div style="border: 1px solid; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #d5d5d5;">
+      <div style="border: 1px solid #F5F5F5; border-radius: 4px; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #F5F5F5;">
         <pre>
           <xsl:call-template name="preamble"/>
         </pre>
@@ -347,7 +347,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <xsl:with-param name="text" select="concat($index, '.1 RNC')"/>
         </xsl:call-template>
 
-        <div style="border: 1px solid; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #d5d5d5;">
+        <div style="border: 1px solid #F5F5F5; border-radius: 4px; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #F5F5F5;">
           <pre>
             <xsl:value-of select="name"/>
             <xsl:text> = </xsl:text>
@@ -439,7 +439,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <xsl:with-param name="text" select="concat($index, '.2 RNC')"/>
         </xsl:call-template>
 
-        <div style="border: 1px solid; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #d5d5d5;">
+        <div style="border: 1px solid #F5F5F5; border-radius: 4px; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #F5F5F5;">
           <div style="margin-left: 5%">
             <xsl:call-template name="command-relax"/>
           </div>
@@ -710,7 +710,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <xsl:with-param name="text" select="concat($index, '.2 RNC')"/>
         </xsl:call-template>
 
-        <div style="border: 1px solid; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #d5d5d5;">
+        <div style="border: 1px solid #F5F5F5; border-radius: 4px; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #F5F5F5;">
           <i>Command</i>
           <div style="margin-left: 5%">
             <xsl:call-template name="command-relax"/>


### PR DESCRIPTION
## What

In the HTML GMP doc, soften the appearance of the boxes around the RNC sections:
 - lighten the background
 - round the border
 - use the background color for the border

The rounding (`4px`) and color (`--color-background-secondary`) are the same as used in the [Greenbone Community Documentation](https://greenbone.github.io/docs/latest/22.4/container/index.html) so this change should be good for the [Greenbone GMP page](https://docs.greenbone.net/API/GMP/gmp-22.5.html).

## Why

This makes the doc easier to read by reducing clutter and improving the contrast of the RNC text.

Here's what it looks like:
![shot](https://github.com/greenbone/gvmd/assets/32057441/7ab6ed95-07b6-479f-aa90-c529fa62fde2)

Versus what it looked like before:
![shot](https://github.com/greenbone/gvmd/assets/32057441/e8b18763-5323-46bf-863e-2c5e1852919d)


