### PR TITLE
Change: GMP doc: add boxes around example XML

### DIFF
--- a/src/schema_formats/HTML/HTML.xsl
+++ b/src/schema_formats/HTML/HTML.xsl
@@ -733,17 +733,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <xsl:apply-templates select="description"/>
               <div style="margin-left: 5%; margin-right: 5%;">
                 <i>Client</i>
-                <div style="margin-left: 2%; margin-right: 2%;">
+                <div style="margin-left: 2%; margin-right: 2%; display: flex; align-items: start;">
                   <xsl:for-each select="request/*">
-                    <pre>
+                    <pre style="border: 1px solid #F5F5F5; border-radius: 4px; padding: 10px 10px 10px 5px; background: #F5F5F5;">
                       <xsl:call-template name="pretty"/>
                     </pre>
                   </xsl:for-each>
                 </div>
                 <i>Manager</i>
-                <div style="margin-left: 2%; margin-right: 2%;">
+                <div style="margin-left: 2%; margin-right: 2%; display: flex; align-items: start;">
                   <xsl:for-each select="response/*">
-                    <pre>
+                    <pre style="border: 1px solid #F5F5F5; border-radius: 4px; padding: 10px 10px 10px 5px; background: #F5F5F5;">
                       <xsl:call-template name="pretty"/>
                     </pre>
                   </xsl:for-each>


### PR DESCRIPTION
## What

Add background boxes to the examples in the HTML GMP doc.

This only affects section 7 (`Command Details`).

The color is chosen to match the [Greenbone Community Documentation](https://greenbone.github.io/docs/latest/22.4/container/index.html) because the HTML will end up as the [Greenbone GMP page](https://docs.greenbone.net/API/GMP/gmp-22.5.html).

## Why

The GMP doc is very long. Adding these boxes makes it easier to read by showing which parts of the doc are code.

Here's how it looks:
![shot](https://github.com/greenbone/gvmd/assets/32057441/8e2706c4-fb2c-4f62-a032-adee3926daac)

Versus how it looked before:
![shot-pre](https://github.com/greenbone/gvmd/assets/32057441/d90ecda4-4e60-449f-af07-b8c697dc7225)


## References

Similar to greenbone/gvmd/pull/2189 for the RNC boxes.

