### PR TITLE
error

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -12200,11 +12200,15 @@ handle_get_credentials (gmp_parser_t *gmp_parser, GError **error)
   else
     format = CREDENTIAL_FORMAT_NONE;
 
-  if (format == CREDENTIAL_FORMAT_ERROR)
+  if (format == CREDENTIAL_FORMAT_ERROR) {
     SEND_TO_CLIENT_OR_FAIL
       (XML_ERROR_SYNTAX ("get_credentials",
                          "Format attribute should"
                          " be 'key', 'rpm', 'deb', 'exe' or 'pem'"));
+    get_credentials_data_reset (get_credentials_data);
+    set_client_state (CLIENT_AUTHENTIC);
+    return;
+  }
 
   INIT_GET (credential, Credential);
 


### PR DESCRIPTION
## What

In the GET_CREDENTIALS handler, add a `return` after the credential format error.

## Why

The `return` is required else gvmd also sends the credentials after the error response.

This format error can be invoked by calling GET_CREDENTIALS with an erroneous `format` attribute, for example:
```
$ o m m '<get_credentials format="err" filter="rows=1 sort=name"/>'
```
Here's the response before the PR (note the extra `get_credentials_response` element):
```
<get_credentials_response status="400" status_text="Format attribute should be 'key', 'rpm', 'deb', 'exe' or 'pem'" />
<get_credentials_response status="200" status_text="OK">
  <credential id="c1e69303-bd6b-4c02-860b-8c41f34064f4">
  ...
```
Here's the response after the PR, with the single correct element:
```
<get_credentials_response status="400"
status_text="Format attribute should be 'key', 'rpm', 'deb', 'exe' or 'pem'" />```
```
