### PR TITLE
Fix: Speed up CVE affected products update

### DIFF
--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -2401,8 +2401,8 @@ insert_cve_products (element_t list, resource_t cve,
         }
       cleanup_iterator (&inserted_cpes);
       increment_transaction_size (transaction_size);
-      g_string_free (sql_cpes, TRUE);
     }
+    g_string_free (sql_cpes, TRUE);
 
   /**
    * Add the affected product references.


### PR DESCRIPTION
## What
When the affected products of CVEs are updated as part of the SCAP data update, all newly added placeholder CPEs are now added to the hashtable that is used to look up their row ids. This avoids having to look up CPE row ids via SQL when inserting entries into the affected_products table.
Also, to filter out duplicate product references, a hashmap is now used instead of iterating over all the product XML elements.

## Why
This speeds up the SCAP update when there are CVEs with many CPE references, especially if they do not appear in the CPE dictionary. The most noticeable case for this is the initial update or rebuild of the SCAP database.

## References
GEA-557

