### PR TITLE
Install libcjson1 in container image

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -82,6 +82,7 @@ RUN apt-get update && \
     gpgsm \
     gnutls-bin \
     libbsd0 \
+    libcjson1 \
     libgpgme11 \
     libical3 \
     libpq5 \


### PR DESCRIPTION

## What

Install libcjson1 in container image

## Why

libcjson1 is now required as runtime dependency.


