### PR TITLE
Change: Wait for SecInfo sync before unlocking feed lock

### DIFF
--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1179,11 +1179,13 @@ update_nvt_cache_retry ()
 /**
  * @brief Update the NVT cache in a child process.
  *
+ * @param[out] child_pid_out  Optional output param for child PID.
+ *
  * @return 0 success, 1 update in progress, -1 error.  Always exits with
  *         EXIT_SUCCESS in child.
  */
 static int
-fork_update_nvt_cache ()
+fork_update_nvt_cache (pid_t *child_pid_out)
 {
   int pid;
   sigset_t sigmask_all, sigmask_current;
@@ -1210,6 +1212,8 @@ fork_update_nvt_cache ()
     }
 
   pid = fork_with_handlers ();
+  if (child_pid_out)
+    *child_pid_out = pid;
   switch (pid)
     {
       case 0:

--- a/src/manage.h
+++ b/src/manage.h
@@ -2853,7 +2853,7 @@ void
 set_scheduled_user_uuid (const gchar* uuid);
 
 void
-manage_sync (sigset_t *, int (*fork_update_nvt_cache) (), gboolean);
+manage_sync (sigset_t *, int (*fork_update_nvt_cache) (pid_t*), gboolean);
 
 int
 manage_rebuild_gvmd_data_from_feed (const char *,

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -2390,11 +2390,15 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
  * @brief Sync NVTs if newer NVTs are available.
  *
  * @param[in]  fork_update_nvt_cache  Function to do the update.
+ *
+ * @return PID of the forked process handling the VTs sync, -1 on error.
  */
-void
-manage_sync_nvts (int (*fork_update_nvt_cache) ())
+pid_t
+manage_sync_nvts (int (*fork_update_nvt_cache) (pid_t*))
 {
-  fork_update_nvt_cache ();
+  pid_t child_pid = -1;
+  fork_update_nvt_cache (&child_pid);
+  return child_pid;
 }
 
 /**

--- a/src/manage_sql_nvts.h
+++ b/src/manage_sql_nvts.h
@@ -130,8 +130,8 @@ check_db_nvts ();
 int
 check_config_families ();
 
-void
-manage_sync_nvts (int (*) ());
+pid_t
+manage_sync_nvts (int (*) (pid_t*));
 
 int
 update_or_rebuild_nvts (int);

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -2999,8 +2999,10 @@ manage_db_reinit (const gchar *name)
  * @param[in]  sigmask_current    Sigmask to restore in child.
  * @param[in]  update             Function to do the sync.
  * @param[in]  process_title      Process title.
+ *
+ * @return PID of the forked process handling the SecInfo sync, -1 on error.
  */
-static void
+static pid_t
 sync_secinfo (sigset_t *sigmask_current, int (*update) (void),
               const gchar *process_title)
 {
@@ -3038,11 +3040,11 @@ sync_secinfo (sigset_t *sigmask_current, int (*update) (void),
       case -1:
         /* Parent on error.  Reschedule and continue to next task. */
         g_warning ("%s: fork failed", __func__);
-        return;
+        return -1;
 
       default:
         /* Parent.  Continue to next task. */
-        return;
+        return pid;
 
     }
 
@@ -3439,13 +3441,15 @@ sync_cert ()
  * @brief Sync the CERT DB.
  *
  * @param[in]  sigmask_current  Sigmask to restore in child.
+ *
+ * @return PID of the forked process handling the CERT sync, -1 on error.
  */
-void
+pid_t
 manage_sync_cert (sigset_t *sigmask_current)
 {
-  sync_secinfo (sigmask_current,
-                sync_cert,
-                "Syncing CERT");
+  return sync_secinfo (sigmask_current,
+                       sync_cert,
+                       "Syncing CERT");
 }
 
 
@@ -3921,13 +3925,15 @@ sync_scap ()
  * @brief Sync the SCAP DB.
  *
  * @param[in]  sigmask_current  Sigmask to restore in child.
+ *
+ * @return PID of the forked process handling the SCAP sync, -1 on error.
  */
-void
+pid_t
 manage_sync_scap (sigset_t *sigmask_current)
 {
-  sync_secinfo (sigmask_current,
-                sync_scap,
-                "Syncing SCAP");
+  return sync_secinfo (sigmask_current,
+                       sync_scap,
+                       "Syncing SCAP");
 }
 
 /**

--- a/src/manage_sql_secinfo.h
+++ b/src/manage_sql_secinfo.h
@@ -174,13 +174,13 @@
 int
 secinfo_feed_version_status ();
 
-void
+pid_t
 manage_sync_scap (sigset_t *);
 
 int
 manage_rebuild_scap (GSList *, const db_conn_info_t *);
 
-void
+pid_t
 manage_sync_cert (sigset_t *);
 
 int

--- a/src/utils.h
+++ b/src/utils.h
@@ -100,4 +100,6 @@ setup_signal_handler_info (int, void (*) (int, siginfo_t *, void *), int);
 int
 fork_with_handlers ();
 
+void wait_for_pid (pid_t, const char*);
+
 #endif /* not _GVMD_UTILS_H */

--- a/src/utils.h
+++ b/src/utils.h
@@ -100,6 +100,7 @@ setup_signal_handler_info (int, void (*) (int, siginfo_t *, void *), int);
 int
 fork_with_handlers ();
 
-void wait_for_pid (pid_t, const char*);
+void
+wait_for_pid (pid_t, const char *);
 
 #endif /* not _GVMD_UTILS_H */


### PR DESCRIPTION
## What
The process starting the various feed sync processes with manage_sync will now wait for the VT, CERT and SCAP sync processes to finish before unlocking the feed lockfile.

## Why
This is preparation for assigning EPSS scores to VTs based on their CVE references, which requires both the VT and SCAP update to be finished.

## References
GEA-559
