### PR TITLE
Change: replace utf8_substring with g_utf8_substring

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -14085,10 +14085,22 @@ handle_get_overrides (gmp_parser_t *gmp_parser, GError **error)
 
       buffer = g_string_new ("");
 
-      // TODO: Do the iteration with get_next so it checks "first".
-      buffer_overrides_xml (buffer, &overrides,
-                            get_overrides_data->get.details,
-                            get_overrides_data->result, &count);
+      while (1)
+        {
+          ret = get_next (&overrides, &get_overrides_data->get, &first, &count,
+                          init_override_iterator_all);
+          if (ret == 1)
+            break;
+          if (ret == -1)
+            {
+              internal_error_send_to_client (error);
+              return;
+            }
+
+          buffer_override_xml (buffer, &overrides,
+                               get_overrides_data->get.details,
+                               get_overrides_data->result, &count);
+        }
 
       SEND_TO_CLIENT_OR_FAIL (buffer->str);
       g_string_free (buffer, TRUE);

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -13662,9 +13662,21 @@ handle_get_notes (gmp_parser_t *gmp_parser, GError **error)
 
       buffer = g_string_new ("");
 
-      // TODO: Do the iteration with get_next so it checks "first".
-      buffer_notes_xml (buffer, &notes, get_notes_data->get.details,
-                        get_notes_data->result, &count);
+      while (1)
+        {
+          ret = get_next (&notes, &get_notes_data->get, &first, &count,
+                          init_note_iterator_all);
+          if (ret == 1)
+            break;
+          if (ret == -1)
+            {
+              internal_error_send_to_client (error);
+              return;
+            }
+
+          buffer_note_xml (buffer, &notes, get_notes_data->get.details,
+                           get_notes_data->result, &count);
+        }
 
       SEND_TO_CLIENT_OR_FAIL (buffer->str);
       g_string_free (buffer, TRUE);

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -8064,33 +8064,6 @@ convert_to_newlines (const char *text)
 }
 
 /**
- * @brief Get substring of UTF8 string.
- *
- * @param[in]  str        String
- * @param[in]  start_pos  Start.
- * @param[in]  end_pos    End.
- *
- * @return Substring.
- */
-static gchar *
-utf8_substring (const gchar *str, glong start_pos, glong end_pos)
-{
-  gchar *start, *end, *out;
-
-  /* TODO This is a copy of g_utf8_substring from glib 2.38.2.  Once our glib
-   * minimum goes past 2.30 we can just use g_utf8_substring. */
-
-  start = g_utf8_offset_to_pointer (str, start_pos);
-  end = g_utf8_offset_to_pointer (start, end_pos - start_pos);
-
-  out = g_malloc (end - start + 1);
-  memcpy (out, start, end - start);
-  out[end - start] = 0;
-
-  return out;
-}
-
-/**
  * @brief Buffer XML for a single note.
  *
  * @param[in]  buffer                 Buffer into which to buffer note.
@@ -8169,7 +8142,7 @@ buffer_note_xml (GString *buffer, iterator_t *notes, int include_notes_details,
       const char *text;
 
       text = note_iterator_text (notes);
-      excerpt = utf8_substring (text, 0, setting_excerpt_size_int ());
+      excerpt = g_utf8_substring (text, 0, setting_excerpt_size_int ());
 
       /* This must match send_get_common. */
 
@@ -8467,7 +8440,7 @@ buffer_override_xml (GString *buffer, iterator_t *overrides,
       const char *text;
 
       text = override_iterator_text (overrides);
-      excerpt = utf8_substring (text, 0, setting_excerpt_size_int ());
+      excerpt = g_utf8_substring (text, 0, setting_excerpt_size_int ());
 
       /* This must match send_get_common. */
 
@@ -18055,7 +18028,6 @@ handle_get_tasks (gmp_parser_t *gmp_parser, GError **error)
           g_free (task_schedule_xml);
 
           SENDF_TO_CLIENT_OR_FAIL ("</task>");
-
         }
       else
         {

--- a/src/gmp_get.c
+++ b/src/gmp_get.c
@@ -225,7 +225,7 @@ init_get (gchar *command, get_data_t * get, const gchar *setting_name,
  */
 int
 get_next (iterator_t *resources, get_data_t *get, int *first, int *count,
-          int (*init) (iterator_t*, const get_data_t *))
+          int (*init) (iterator_t*, get_data_t *))
 {
   if (next (resources) == FALSE)
    {

--- a/src/gmp_get.h
+++ b/src/gmp_get.h
@@ -57,7 +57,7 @@ init_get (gchar *, get_data_t *, const gchar *, int *);
 
 int
 get_next (iterator_t *, get_data_t *, int *, int *,
-          int (*) (iterator_t *, const get_data_t *));
+          int (*) (iterator_t *, get_data_t *));
 
 int
 send_get_start (const char *, int (*) (const char *, void *), void *);

--- a/src/manage.h
+++ b/src/manage.h
@@ -630,7 +630,7 @@ int
 alert_count (const get_data_t *);
 
 int
-init_alert_iterator (iterator_t*, const get_data_t*);
+init_alert_iterator (iterator_t*, get_data_t*);
 
 int
 alert_iterator_event (iterator_t*);
@@ -730,7 +730,7 @@ unsigned int
 task_count (const get_data_t *);
 
 int
-init_task_iterator (iterator_t*, const get_data_t *);
+init_task_iterator (iterator_t*, get_data_t *);
 
 task_status_t
 task_iterator_run_status (iterator_t*);
@@ -1746,7 +1746,7 @@ void
 init_target_iterator_one (iterator_t*, target_t);
 
 int
-init_target_iterator (iterator_t*, const get_data_t *);
+init_target_iterator (iterator_t*, get_data_t *);
 
 const char*
 target_iterator_hosts (iterator_t*);
@@ -2185,7 +2185,7 @@ void
 init_credential_iterator_one (iterator_t*, credential_t);
 
 int
-init_credential_iterator (iterator_t*, const get_data_t *);
+init_credential_iterator (iterator_t*, get_data_t *);
 
 const char*
 credential_iterator_login (iterator_t*);
@@ -2703,7 +2703,7 @@ char *
 openvas_default_scanner_host ();
 
 int
-init_scanner_iterator (iterator_t*, const get_data_t *);
+init_scanner_iterator (iterator_t*, get_data_t *);
 
 const char*
 scanner_iterator_host (iterator_t*);
@@ -2888,7 +2888,7 @@ int
 schedule_info (schedule_t, int, gchar **, gchar **);
 
 int
-init_schedule_iterator (iterator_t*, const get_data_t *);
+init_schedule_iterator (iterator_t*, get_data_t *);
 
 const char*
 schedule_iterator_timezone (iterator_t *);
@@ -2940,7 +2940,7 @@ set_schedule_timeout (int);
 /* Groups. */
 
 int
-init_group_iterator (iterator_t *, const get_data_t *);
+init_group_iterator (iterator_t *, get_data_t *);
 
 int
 copy_group (const char *, const char *, const char *, group_t *);
@@ -3007,7 +3007,7 @@ int
 permission_count (const get_data_t *);
 
 int
-init_permission_iterator (iterator_t*, const get_data_t *);
+init_permission_iterator (iterator_t*, get_data_t *);
 
 const char*
 permission_iterator_resource_type (iterator_t*);
@@ -3064,7 +3064,7 @@ int
 manage_get_roles (GSList *, const db_conn_info_t *, int);
 
 int
-init_role_iterator (iterator_t *, const get_data_t *);
+init_role_iterator (iterator_t *, get_data_t *);
 
 int
 copy_role (const char *, const char *, const char *, role_t *);
@@ -3221,7 +3221,7 @@ int
 filter_count (const get_data_t*);
 
 int
-init_filter_iterator (iterator_t*, const get_data_t*);
+init_filter_iterator (iterator_t*, get_data_t*);
 
 const char*
 filter_iterator_type (iterator_t*);
@@ -3519,7 +3519,7 @@ gchar *
 keyfile_to_auth_conf_settings_xml (const gchar *);
 
 int
-init_user_iterator (iterator_t*, const get_data_t*);
+init_user_iterator (iterator_t*, get_data_t*);
 
 const char*
 user_iterator_role (iterator_t*);
@@ -3665,7 +3665,7 @@ modify_tag (const char *, const char *, const char *, const char *,
             gchar **);
 
 int
-init_tag_iterator (iterator_t*, const get_data_t*);
+init_tag_iterator (iterator_t*, get_data_t*);
 
 int
 tag_count (const get_data_t *get);
@@ -3698,7 +3698,7 @@ int
 tag_resource_iterator_readable (iterator_t*);
 
 int
-init_tag_name_iterator (iterator_t*, const get_data_t*);
+init_tag_name_iterator (iterator_t*, get_data_t*);
 
 const char*
 tag_name_iterator_name (iterator_t*);

--- a/src/manage_configs.h
+++ b/src/manage_configs.h
@@ -69,7 +69,7 @@ void
 init_user_config_iterator (iterator_t*, config_t, int, int, const char*);
 
 int
-init_config_iterator (iterator_t*, const get_data_t*);
+init_config_iterator (iterator_t*, get_data_t*);
 
 const char*
 config_iterator_nvt_selector (iterator_t*);

--- a/src/manage_port_lists.h
+++ b/src/manage_port_lists.h
@@ -62,7 +62,7 @@ int
 port_list_count (const get_data_t *);
 
 int
-init_port_list_iterator (iterator_t *, const get_data_t *);
+init_port_list_iterator (iterator_t *, get_data_t *);
 
 int
 port_list_iterator_count_all (iterator_t *);

--- a/src/manage_report_configs.h
+++ b/src/manage_report_configs.h
@@ -89,7 +89,7 @@ report_config_count (const get_data_t *);
 
 
 int
-init_report_config_iterator (iterator_t*, const get_data_t *);
+init_report_config_iterator (iterator_t*, get_data_t *);
 
 const char*
 report_config_iterator_report_format_id (iterator_t *);

--- a/src/manage_report_formats.h
+++ b/src/manage_report_formats.h
@@ -111,7 +111,7 @@ int
 report_format_count (const get_data_t *);
 
 int
-init_report_format_iterator (iterator_t*, const get_data_t *);
+init_report_format_iterator (iterator_t*, get_data_t *);
 
 const char*
 report_format_iterator_extension (iterator_t *);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -8505,7 +8505,7 @@ trash_alert_writable (alert_t alert)
  *         -1 error.
  */
 int
-init_alert_iterator (iterator_t* iterator, const get_data_t *get)
+init_alert_iterator (iterator_t* iterator, get_data_t *get)
 {
   static const char *filter_columns[] = ALERT_ITERATOR_FILTER_COLUMNS;
   static column_t columns[] = ALERT_ITERATOR_COLUMNS;
@@ -15366,7 +15366,7 @@ init_user_task_iterator (iterator_t* iterator, int trash, int ignore_severity)
  *         -1 error.
  */
 int
-init_task_iterator (iterator_t* iterator, const get_data_t *get)
+init_task_iterator (iterator_t* iterator, get_data_t *get)
 {
   static const char *filter_columns[] = TASK_ITERATOR_FILTER_COLUMNS;
   static column_t columns[] = TASK_ITERATOR_COLUMNS;
@@ -34211,7 +34211,7 @@ init_target_iterator_one (iterator_t* iterator, target_t target)
  *         -1 error.
  */
 int
-init_target_iterator (iterator_t* iterator, const get_data_t *get)
+init_target_iterator (iterator_t* iterator, get_data_t *get)
 {
   static const char *filter_columns[] = TARGET_ITERATOR_FILTER_COLUMNS;
   static column_t columns[] = TARGET_ITERATOR_COLUMNS;
@@ -37556,7 +37556,7 @@ init_credential_iterator_one (iterator_t* iterator,
  *         filter (filt_id), -1 error.
  */
 int
-init_credential_iterator (iterator_t* iterator, const get_data_t *get)
+init_credential_iterator (iterator_t* iterator, get_data_t *get)
 {
   static const char *filter_columns[] = CREDENTIAL_ITERATOR_FILTER_COLUMNS;
   static column_t columns[] = CREDENTIAL_ITERATOR_COLUMNS;
@@ -41672,7 +41672,7 @@ delete_scanner (const char *scanner_id, int ultimate)
  * @return 0 success, 1 failed to find scanner, 2 failed to find filter, -1 error.
  */
 int
-init_scanner_iterator (iterator_t* iterator, const get_data_t *get)
+init_scanner_iterator (iterator_t* iterator, get_data_t *get)
 {
   static const char *filter_columns[] = SCANNER_ITERATOR_FILTER_COLUMNS;
   static column_t columns[] = SCANNER_ITERATOR_COLUMNS;
@@ -43154,7 +43154,7 @@ schedule_count (const get_data_t *get)
  *         filter (filt_id), -1 error.
  */
 int
-init_schedule_iterator (iterator_t* iterator, const get_data_t *get)
+init_schedule_iterator (iterator_t* iterator, get_data_t *get)
 {
   static const char *filter_columns[] = SCHEDULE_ITERATOR_FILTER_COLUMNS;
   static column_t columns[] = SCHEDULE_ITERATOR_COLUMNS;
@@ -44270,7 +44270,7 @@ group_count (const get_data_t *get)
  *         -1 error.
  */
 int
-init_group_iterator (iterator_t* iterator, const get_data_t *get)
+init_group_iterator (iterator_t* iterator, get_data_t *get)
 {
   static const char *filter_columns[] = GROUP_ITERATOR_FILTER_COLUMNS;
   static column_t columns[] = GROUP_ITERATOR_COLUMNS;
@@ -45518,7 +45518,7 @@ permission_count (const get_data_t *get)
  *         -1 error.
  */
 int
-init_permission_iterator (iterator_t* iterator, const get_data_t *get)
+init_permission_iterator (iterator_t* iterator, get_data_t *get)
 {
   static const char *filter_columns[] = PERMISSION_ITERATOR_FILTER_COLUMNS;
   static column_t columns[] = PERMISSION_ITERATOR_COLUMNS;
@@ -47138,7 +47138,7 @@ role_count (const get_data_t *get)
  *         -1 error.
  */
 int
-init_role_iterator (iterator_t* iterator, const get_data_t *get)
+init_role_iterator (iterator_t* iterator, get_data_t *get)
 {
   static const char *filter_columns[] = ROLE_ITERATOR_FILTER_COLUMNS;
   static column_t columns[] = ROLE_ITERATOR_COLUMNS;
@@ -47817,7 +47817,7 @@ filter_count (const get_data_t *get)
  *         -1 error.
  */
 int
-init_filter_iterator (iterator_t* iterator, const get_data_t *get)
+init_filter_iterator (iterator_t* iterator, get_data_t *get)
 {
   static const char *filter_columns[] = FILTER_ITERATOR_FILTER_COLUMNS;
   static column_t columns[] = FILTER_ITERATOR_COLUMNS;
@@ -55237,7 +55237,7 @@ user_count (const get_data_t *get)
  *         -1 error.
  */
 int
-init_user_iterator (iterator_t* iterator, const get_data_t *get)
+init_user_iterator (iterator_t* iterator, get_data_t *get)
 {
   static const char *filter_columns[] = USER_ITERATOR_FILTER_COLUMNS;
   static column_t columns[] = USER_ITERATOR_COLUMNS;
@@ -57144,7 +57144,7 @@ modify_tag (const char *tag_id, const char *name, const char *comment,
  *         -1 error.
  */
 int
-init_tag_iterator (iterator_t* iterator, const get_data_t *get)
+init_tag_iterator (iterator_t* iterator, get_data_t *get)
 {
   static const char *filter_columns[] = TAG_ITERATOR_FILTER_COLUMNS;
   static column_t columns[] = TAG_ITERATOR_COLUMNS;
@@ -57239,7 +57239,7 @@ tag_iterator_resources (iterator_t* iterator)
  * @return 0 success, -1 error.
  */
 int
-init_tag_name_iterator (iterator_t* iterator, const get_data_t *get)
+init_tag_name_iterator (iterator_t* iterator, get_data_t *get)
 {
   static const char *filter_columns[] = TAG_NAME_ITERATOR_FILTER_COLUMNS;
   static column_t columns[] = TAG_NAME_ITERATOR_COLUMNS;

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -3176,7 +3176,7 @@ init_user_config_iterator (iterator_t* iterator, config_t config, int trash,
  *         -1 error.
  */
 int
-init_config_iterator (iterator_t* iterator, const get_data_t *get)
+init_config_iterator (iterator_t* iterator, get_data_t *get)
 {
   int rc;
   static const char *filter_columns[] = CONFIG_ITERATOR_FILTER_COLUMNS;

--- a/src/manage_sql_port_lists.c
+++ b/src/manage_sql_port_lists.c
@@ -1967,7 +1967,7 @@ port_list_count (const get_data_t *get)
  *         -1 error.
  */
 int
-init_port_list_iterator (iterator_t* iterator, const get_data_t *get)
+init_port_list_iterator (iterator_t* iterator, get_data_t *get)
 {
   static const char *filter_columns[] = PORT_LIST_ITERATOR_FILTER_COLUMNS;
   static column_t columns[] = PORT_LIST_ITERATOR_COLUMNS;

--- a/src/manage_sql_report_configs.c
+++ b/src/manage_sql_report_configs.c
@@ -749,7 +749,7 @@ report_config_count (const get_data_t *get)
  *         -1 error.
  */
 int
-init_report_config_iterator (iterator_t* iterator, const get_data_t *get)
+init_report_config_iterator (iterator_t* iterator, get_data_t *get)
 {
   static const char *filter_columns[] = REPORT_CONFIG_ITERATOR_FILTER_COLUMNS;
   static column_t columns[] = REPORT_CONFIG_ITERATOR_COLUMNS;

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -2872,7 +2872,7 @@ report_format_count (const get_data_t *get)
  *         -1 error.
  */
 int
-init_report_format_iterator (iterator_t* iterator, const get_data_t *get)
+init_report_format_iterator (iterator_t* iterator, get_data_t *get)
 {
   static const char *filter_columns[] = REPORT_FORMAT_ITERATOR_FILTER_COLUMNS;
   static column_t columns[] = REPORT_FORMAT_ITERATOR_COLUMNS;

--- a/src/manage_sql_tickets.c
+++ b/src/manage_sql_tickets.c
@@ -277,7 +277,7 @@ ticket_count (const get_data_t *get)
  *         -1 error.
  */
 int
-init_ticket_iterator (iterator_t *iterator, const get_data_t *get)
+init_ticket_iterator (iterator_t *iterator, get_data_t *get)
 {
   static const char *filter_columns[] = TICKET_ITERATOR_FILTER_COLUMNS;
   static column_t columns[] = TICKET_ITERATOR_COLUMNS;

--- a/src/manage_sql_tls_certificates.c
+++ b/src/manage_sql_tls_certificates.c
@@ -298,7 +298,7 @@ tls_certificate_count (const get_data_t *get)
  *         2 failed to find filter, -1 error.
  */
 int
-init_tls_certificate_iterator (iterator_t *iterator, const get_data_t *get)
+init_tls_certificate_iterator (iterator_t *iterator, get_data_t *get)
 {
   static const char *filter_columns[] = TLS_CERTIFICATE_ITERATOR_FILTER_COLUMNS;
   static column_t columns[] = TLS_CERTIFICATE_ITERATOR_COLUMNS;

--- a/src/manage_tickets.h
+++ b/src/manage_tickets.h
@@ -26,7 +26,7 @@ int
 ticket_count (const get_data_t *);
 
 int
-init_ticket_iterator (iterator_t *, const get_data_t *);
+init_ticket_iterator (iterator_t *, get_data_t *);
 
 const char*
 ticket_iterator_user_id (iterator_t*);

--- a/src/manage_tls_certificates.h
+++ b/src/manage_tls_certificates.h
@@ -33,7 +33,7 @@ int
 tls_certificate_count (const get_data_t *);
 
 int
-init_tls_certificate_iterator (iterator_t *, const get_data_t *);
+init_tls_certificate_iterator (iterator_t *, get_data_t *);
 
 const char*
 tls_certificate_iterator_certificate (iterator_t*);


### PR DESCRIPTION
## What

Use the real `g_utf8_substring` from glib, instead of the copy `utf8_substring`.

## Why

`utf8_substring` was a workaround for older versions of glib. As the required version of glib is now `2.42` it is safe to use `g_utf8_substring`.

Simple test: create a note with utf8 text:
```
$ o m m '<create_note><text>012345678901234567890123456789012345678901234  49
012345678901234567890123456789012345678901234  99
012345678901234567890123456789012345678901234 149
012345678901234567890123456789012345678901234 199
012345678901234567890123456789012345678901234 249
 300th char is the 1EBF after the ti: Mình nói tiếng Việt
the excerpt should end there.</text><nvt oid="1.3.6.1.4.1.25623.1.0.80091"/></create_note>'
```
Then get the notes with excerpts on:
```
$ oraw m m '<get_notes details="0"/>'
<get_notes_response status="200" status_text="OK">...<text excerpt="1">012345678901234567890123456789012345678901234  49
012345678901234567890123456789012345678901234  99
012345678901234567890123456789012345678901234 149
012345678901234567890123456789012345678901234 199
012345678901234567890123456789012345678901234 249
 300th char is the 1EBF after the ti: Mình nói tiế</text>...
```

## References

Waits for greenbone/gvmd/pull/2203.
