### PR TITLE
Fix EPSS filtering in CVE aggregates

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -57795,6 +57795,8 @@ type_opts_table (const char *type, const char *filter)
 {
   if (type == NULL)
     return NULL;
+  if (strcasecmp (type, "CVE") == 0)
+    return g_strdup (" LEFT JOIN scap.epss_scores ON cve = cves.uuid");
   if (strcasecmp (type, "TASK") == 0)
     return task_iterator_opts_table (filter_term_apply_overrides (filter),
                                      filter_term_min_qod (filter), 0);


### PR DESCRIPTION
## What
The get_aggregates command can now handle the EPSS fields added to CVEs.

## Why
Filtering for CVEs by the new EPSS did not work.

## References
GEA-558