### PR TITLE
Fix: Prevent strcmp on NULL in CREATE_USER

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -54745,7 +54745,7 @@ modify_user (const gchar * user_id, gchar **name, const gchar *new_name,
   if (allowed_methods && (allowed_methods->len > 2))
     return -3;
 
-  if (allowed_methods && (allowed_methods->len <= 0))
+  if (allowed_methods && (allowed_methods->len <= 1))
     allowed_methods = NULL;
 
   if (allowed_methods

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -54745,12 +54745,11 @@ modify_user (const gchar * user_id, gchar **name, const gchar *new_name,
   if (allowed_methods && (allowed_methods->len > 2))
     return -3;
 
-  if (allowed_methods && (allowed_methods->len == 0))
+  if (allowed_methods && (allowed_methods->len <= 0))
     allowed_methods = NULL;
 
   if (allowed_methods
-      && ((g_ptr_array_index (allowed_methods, 0) == NULL)
-          || (strlen (g_ptr_array_index (allowed_methods, 0)) == 0)))
+      && (strlen (g_ptr_array_index (allowed_methods, 0)) == 0))
     allowed_methods = NULL;
 
   if (allowed_methods

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -53682,7 +53682,7 @@ create_user (const gchar * name, const gchar * password, const gchar *comment,
   if (allowed_methods && (allowed_methods->len > 2))
     return -3;
 
-  if (allowed_methods && (allowed_methods->len == 0))
+  if (allowed_methods && (allowed_methods->len <= 1))
     allowed_methods = NULL;
 
   if (allowed_methods


### PR DESCRIPTION
## What

In `create_user`, check if `allowed_methods` is an array before sending it to `strcmp`.

The `strcmp` is a little further down: `strcmp (g_ptr_array_index (allowed_methods, 0), "ldap_connect")`

Also simplify the existing check in `modify_user`.

## Why

This was causing a segfault when calling `CREATE_USER` with an empty `SOURCES`.

## Example

Before PR:
```
$ o m m '<create_user><name>test5</name><password>test</password><sources></sources></create_user>'
md   main:MESSAGE:2024-05-29 19h00.24 SAST:10124: BACKTRACE: gvmd: Serving client(create_user+0x1e3) [0x63b93866a102]
md manage:MESSAGE:2024-05-29 19h00.24 SAST:10124: Received Segmentation fault signal
```
After PR:
```
$ o m m '<create_user><name>test5</name><password>test</password><sources></sources></create_user>'
<create_user_response status="201" status_text="OK, resource created" id="6de6541f-2781-4699-9e79-b70e62a60a41" />
```


