### PR TITLE
Clear out Doxygen warnings

### DIFF
--- a/src/gmp_get.h
+++ b/src/gmp_get.h
@@ -66,7 +66,6 @@ send_get_start (const char *, int (*) (const char *, void *), void *);
  * @brief Send start of GET response to client, returning on fail.
  *
  * @param[in]  type  Type of resource.
- * @param[in]  get   GET data.
  */
 #define SEND_GET_START(type)                               \
   do                                                       \

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -262,10 +262,10 @@ static gchar*
 vulns_extra_where (int);
 
 static gchar*
-vuln_iterator_opts_from_filter (const char*);
+vuln_iterator_opts_from_filter (const gchar *);
 
 static gchar*
-vuln_iterator_extra_with_from_filter ();
+vuln_iterator_extra_with_from_filter (const gchar *);
 
 static int
 task_last_report_any_status (task_t, report_t *);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -22340,6 +22340,9 @@ where_qod (int min_qod)
     { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                                      \
   }
 
+/**
+ * @brief SQL for result iterator column.
+ */
 #define RESULT_HOSTNAME_SQL(hostname_col, host_col, report_col)               \
       "(CASE WHEN (" hostname_col " IS NULL) "                                \
       "           OR (" hostname_col " = '')"                                 \
@@ -55551,7 +55554,6 @@ user_resources_in_use (user_t user,
  * @param[in]  task_id    UUID of the task to limit vulns to.
  * @param[in]  report_id  UUID of the report to limit vulns to.
  * @param[in]  host       IP address of the task to limit vulns to.
- * @param[in]  min_qod    Minimum QoD.
  *
  * @return Newly allocated string with the extra_with clause.
  */
@@ -55947,6 +55949,8 @@ vuln_count (const get_data_t *get)
 
 /**
  * @brief Extra WHERE clause for vulns.
+ *
+ * @param[in]  min_qod  Min QOD.
  *
  * @return WHERE clause.
  */
@@ -57956,7 +57960,8 @@ type_extra_where (const char *type, int trash, const char *filter,
 /**
  * @brief Get the extra WITH clauses for a resource type.
  *
- * @param[in]  type  The resource type.
+ * @param[in]  type    The resource type.
+ * @param[in]  filter  Filter term.
  *
  * @return The extra WITH clauses.
  */
@@ -57965,7 +57970,7 @@ type_extra_with (const char *type, const char *filter)
 {
   if (strcasecmp (type, "VULN") == 0)
     {
-      return vuln_iterator_extra_with_from_filter(filter);
+      return vuln_iterator_extra_with_from_filter (filter);
     }
   return NULL;
 }

--- a/src/manage_sql_report_configs.h
+++ b/src/manage_sql_report_configs.h
@@ -44,9 +44,4 @@ restore_report_config (const char *);
 void
 delete_report_configs_user (user_t);
 
-gboolean
-inherit_report_configs (user_t, user_t);
-
-
-
 #endif /* not _GVMD_MANAGE_SQL_REPORT_CONFIGS_H */

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -3087,7 +3087,7 @@ report_format_alert_iterator_readable (iterator_t* iterator)
  * Iterates over all report configs that use the Report Format.
  *
  * @param[in]  iterator          Iterator.
- * @param[in]  report_format     Report Format.
+ * @param[in]  report_format_id  Report Format.
  */
 void
 init_report_format_report_config_iterator (iterator_t* iterator,

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -196,6 +196,8 @@ increment_transaction_size (int* current_size)
 
 /**
  * @brief Get the SQL buffer size threshold converted from MiB to bytes.
+ *
+ * @return Number of bytes.
  */
 int
 setting_secinfo_sql_buffer_threshold_bytes ()
@@ -471,7 +473,6 @@ init_cpe_info_iterator (iterator_t* iterator, get_data_t *get, const char *name)
  *
  * @param[in]  iterator        Iterator.
  * @param[in]  get             GET data.
- * @param[in]  name            Name of the info
  *
  * @return 0 success, 1 failed to find target, 2 failed to find filter,
  *         -1 error.
@@ -716,7 +717,6 @@ init_cve_info_iterator (iterator_t* iterator, get_data_t *get, const char *name)
  *
  * @param[in]  iterator        Iterator.
  * @param[in]  get             GET data.
- * @param[in]  name            Name of the info
  *
  * @return 0 success, 1 failed to find target, 2 failed to find filter,
  *         -1 error.
@@ -3209,8 +3209,6 @@ check_cert_db_version ()
 
 /**
  * @brief Update timestamp in CERT db from feed timestamp.
- *
- * @return 0 success, -1 error.
  */
 static void
 update_cert_timestamp ()
@@ -3482,8 +3480,6 @@ check_scap_db_version ()
 
 /**
  * @brief Update timestamp in SCAP db from feed timestamp.
- *
- * @return 0 success, -1 error.
  */
 static void
 update_scap_timestamp ()


### PR DESCRIPTION
## What

Clear out warnings produced by `make doc` and `make doc-full`.

## Why

Cleaner.


