### PR TITLE
Remove old definition

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -1171,8 +1171,6 @@ result_detection_reference (result_t, report_t, const char *, const char *,
 
 /* Reports. */
 
-#define OVAS_MANAGE_REPORT_ID_LENGTH UUID_LEN_STR
-
 /**
  * @brief Default apply_overrides setting
  */

--- a/src/manage.h
+++ b/src/manage.h
@@ -1171,7 +1171,6 @@ result_detection_reference (result_t, report_t, const char *, const char *,
 
 /* Reports. */
 
-/** @todo How is this documented? */
 #define OVAS_MANAGE_REPORT_ID_LENGTH UUID_LEN_STR
 
 /**


### PR DESCRIPTION
## What

Remove the stray definition `OVAS_MANAGE_REPORT_ID_LENGTH`.

## References

Usage was removed in 209b2fc83340c06cd81eff43622d4fdba9d15794 in 2009.

