### PR TITLE
Change: GMP doc: be more accurate about user SOURCES

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -6272,14 +6272,17 @@ END:VCALENDAR
     </ele>
     <ele>
       <name>sources</name>
-      <summary>List of authentication sources for this user (if omitted then 'file')</summary>
+      <summary>Authentication source for this user (if omitted then 'file')</summary>
       <description>
         <p>
           'file' means to store the user in the database.
         </p>
+        <p>
+          The element is called SOURCES for historic reasons. Only one SOURCE is allowed.
+        </p>
       </description>
       <pattern>
-        <any><e>source</e></any>
+        <o><e>source</e></o>
       </pattern>
       <ele>
         <name>source</name>
@@ -28163,14 +28166,17 @@ END:VCALENDAR
     </ele>
     <ele>
       <name>sources</name>
-      <summary>List of authentication sources for this user (if omitted, no changes)</summary>
+      <summary>Authentication source for this user (if omitted, no changes)</summary>
       <description>
         <p>
           'file' means to store the user in the database.
         </p>
+        <p>
+          The element is called SOURCES for historic reasons. Only one SOURCE is allowed.
+        </p>
       </description>
       <pattern>
-        <any><e>source</e></any>
+        <o><e>source</e></o>
       </pattern>
       <ele>
         <name>source</name>


### PR DESCRIPTION
## What

In GMP `CREATE_USER` and `MODIFY_USER`, clarify that `SOURCES` may contain at most one `SOURCE`.

## Why

Clearer.

## References

`SOURCES` were restricted to a single `SOURCE` when user management was moved into the db in aacc589a6ff060b410e9aa952df3b98a3d78af75.

## Example

Single source is OK:
```
$ o m m '<modify_user><name>test7</name><password>test</password><sources><source>file</source></sources></modify_user>'
<modify_user_response status="200" status_text="OK" />
```
Multiple sources is an error:
```
$ o m m '<modify_user><name>test7</name><password>test</password><sources><source>file</source><source>ldap_connect</source></sources></modify_user>'
<modify_user_response status="400" status_text="Error in SOURCES" />
```
