### PR TITLE
Add: EPSS scores from referenced CVEs to VTs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 255)
+set (GVMD_DATABASE_VERSION 256)
 
 set (GVMD_SCAP_DATABASE_VERSION 21)
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -5085,6 +5085,8 @@ manage_sync (sigset_t *sigmask_current,
           wait_for_pid (scap_pid, "SCAP sync");
           wait_for_pid (cert_pid, "CERT sync");
 
+          update_scap_extra ();
+
           lockfile_unlock (&lockfile);
         }
     }
@@ -5975,6 +5977,54 @@ get_nvt_xml (iterator_t *nvts, int details, int pref_count,
 
           xml_string_append (buffer, "</preferences>");
           free (default_timeout);
+        }
+
+      if (nvt_iterator_epss_cve (nvts))
+        {
+          buffer_xml_append_printf 
+             (buffer,
+              "<epss>"
+              "<max_severity>"
+              "<score>%0.5f</score>"
+              "<percentile>%0.5f</percentile>"
+              "<cve id=\"%s\">",
+              nvt_iterator_epss_score (nvts),
+              nvt_iterator_epss_percentile (nvts),
+              nvt_iterator_epss_cve (nvts));
+
+          if (nvt_iterator_has_epss_severity (nvts))
+            {
+              buffer_xml_append_printf 
+                 (buffer,
+                  "<severity>%0.1f</severity>",
+                  nvt_iterator_epss_severity (nvts));
+            }
+
+          buffer_xml_append_printf
+             (buffer,
+              "</cve>"
+              "</max_severity>"
+              "<max_epss>"
+              "<score>%0.5f</score>"
+              "<percentile>%0.5f</percentile>"
+              "<cve id=\"%s\">",
+              nvt_iterator_max_epss_score (nvts),
+              nvt_iterator_max_epss_percentile (nvts),
+              nvt_iterator_max_epss_cve (nvts));
+
+          if (nvt_iterator_has_max_epss_severity (nvts))
+            {
+              buffer_xml_append_printf 
+                 (buffer,
+                  "<severity>%0.1f</severity>",
+                  nvt_iterator_max_epss_severity (nvts));
+            }
+
+          buffer_xml_append_printf
+             (buffer,
+              "</cve>"
+              "</max_epss>"
+              "</epss>");
         }
 
       xml_string_append (buffer, close_tag ? "</nvt>" : "");

--- a/src/manage.h
+++ b/src/manage.h
@@ -1982,6 +1982,36 @@ nvt_iterator_solution_type (iterator_t*);
 const char*
 nvt_iterator_solution_method (iterator_t*);
 
+double
+nvt_iterator_epss_score (iterator_t*);
+
+double
+nvt_iterator_epss_percentile (iterator_t*);
+
+const char*
+nvt_iterator_epss_cve (iterator_t*);
+
+double
+nvt_iterator_epss_severity (iterator_t*);
+
+gboolean
+nvt_iterator_has_epss_severity (iterator_t*);
+
+double
+nvt_iterator_max_epss_score (iterator_t*);
+
+double
+nvt_iterator_max_epss_percentile (iterator_t*);
+
+const char*
+nvt_iterator_max_epss_cve (iterator_t*);
+
+double
+nvt_iterator_max_epss_severity (iterator_t*);
+
+gboolean
+nvt_iterator_has_max_epss_severity (iterator_t*);
+
 char*
 nvt_default_timeout (const char *);
 

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -3176,6 +3176,46 @@ migrate_254_to_255 ()
   return 0;
 }
 
+/**
+ * @brief Migrate the database from version 255 to version 256.
+ *
+ * @return 0 success, -1 error.
+ */
+int
+migrate_255_to_256 ()
+{
+  sql_begin_immediate ();
+
+  /* Ensure that the database is currently version 255. */
+
+  if (manage_db_version () != 255)
+    {
+      sql_rollback ();
+      return -1;
+    }
+
+  /* Update the database. */
+
+  // Add new columns
+
+  sql ("ALTER TABLE nvts ADD COLUMN epss_cve TEXT;");
+  sql ("ALTER TABLE nvts ADD COLUMN epss_score DOUBLE PRECISION;");
+  sql ("ALTER TABLE nvts ADD COLUMN epss_percentile DOUBLE PRECISION;");
+  sql ("ALTER TABLE nvts ADD COLUMN epss_severity DOUBLE PRECISION;");
+  sql ("ALTER TABLE nvts ADD COLUMN max_epss_cve TEXT;");
+  sql ("ALTER TABLE nvts ADD COLUMN max_epss_score DOUBLE PRECISION;");
+  sql ("ALTER TABLE nvts ADD COLUMN max_epss_percentile DOUBLE PRECISION;");
+  sql ("ALTER TABLE nvts ADD COLUMN max_epss_severity DOUBLE PRECISION;");
+
+  /* Set the database version to 256. */
+
+  set_db_version (256);
+
+  sql_commit ();
+
+  return 0;
+}
+
 #undef UPDATE_DASHBOARD_SETTINGS
 
 /**
@@ -3237,6 +3277,7 @@ static migrator_t database_migrators[] = {
   {253, migrate_252_to_253},
   {254, migrate_253_to_254},
   {255, migrate_254_to_255},
+  {256, migrate_255_to_256},
   /* End marker. */
   {-1, NULL}};
 

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -1868,7 +1868,16 @@ create_tables_nvt (const gchar *suffix)
        "  solution_method text,"
        "  detection text,"
        "  qod integer,"
-       "  qod_type text);",
+       "  qod_type text,"
+       "  epss_cve TEXT,"
+       "  epss_score DOUBLE PRECISION,"
+       "  epss_percentile DOUBLE PRECISION,"
+       "  epss_severity DOUBLE PRECISION,"
+       "  max_epss_cve TEXT,"
+       "  max_epss_score DOUBLE PRECISION,"
+       "  max_epss_percentile DOUBLE PRECISION,"
+       "  max_epss_severity DOUBLE PRECISION"
+       ");",
        suffix);
 }
 

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -41,6 +41,7 @@
 #include "manage_preferences.h"
 #include "manage_sql.h"
 #include "manage_sql_configs.h"
+#include "manage_sql_secinfo.h"
 #include "sql.h"
 #include "utils.h"
 
@@ -1213,6 +1214,153 @@ DEF_ACCESS (nvt_iterator_detection, GET_ITERATOR_COLUMN_COUNT + 19);
  *         cleanup_iterator.
  */
 DEF_ACCESS (nvt_iterator_solution_method, GET_ITERATOR_COLUMN_COUNT + 20);
+
+/**
+ * @brief Get the EPSS score selected by severity from an NVT iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The EPSS score.
+ */
+double
+nvt_iterator_epss_score (iterator_t* iterator)
+{
+  double ret;
+  if (iterator->done) return -1;
+  ret = iterator_double (iterator, GET_ITERATOR_COLUMN_COUNT + 21);
+  return ret;
+}
+
+/**
+ * @brief Get the EPSS percentile selected by severity from an NVT iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The EPSS percentile.
+ */
+double
+nvt_iterator_epss_percentile (iterator_t* iterator)
+{
+  double ret;
+  if (iterator->done) return -1;
+  ret = iterator_double (iterator, GET_ITERATOR_COLUMN_COUNT + 22);
+  return ret;
+}
+
+/**
+ * @brief Get the CVE of the EPSS score by severity from an NVT iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return CVE-ID of the EPSS score, or NULL if iteration is complete.
+ *         Freed by cleanup_iterator.
+ */
+DEF_ACCESS (nvt_iterator_epss_cve, GET_ITERATOR_COLUMN_COUNT + 23);
+
+/**
+ * @brief Get the maximum severity of CVEs with EPSS info from an NVT iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The severity score.
+ */
+double
+nvt_iterator_epss_severity (iterator_t* iterator)
+{
+  double ret;
+  if (iterator->done) return -1;
+  ret = iterator_double (iterator, GET_ITERATOR_COLUMN_COUNT + 24);
+  return ret;
+}
+
+/**
+ * @brief Get whether the NVT has a severity for the max severity EPSS score.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return Whether the severity exists.
+ */
+gboolean
+nvt_iterator_has_epss_severity (iterator_t* iterator)
+{
+  gboolean ret;
+  if (iterator->done) return -1;
+  ret = iterator_string (iterator, GET_ITERATOR_COLUMN_COUNT + 24) != NULL;
+  return ret;
+}
+
+/**
+ * @brief Get the maximum EPSS score from an NVT iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The maximum EPSS score.
+ */
+double
+nvt_iterator_max_epss_score (iterator_t* iterator)
+{
+  double ret;
+  if (iterator->done) return -1;
+  ret = iterator_double (iterator, GET_ITERATOR_COLUMN_COUNT + 25);
+  return ret;
+}
+
+/**
+ * @brief Get the maximum EPSS percentile from an NVT iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The maximum EPSS percentile.
+ */
+double
+nvt_iterator_max_epss_percentile (iterator_t* iterator)
+{
+  double ret;
+  if (iterator->done) return -1;
+  ret = iterator_double (iterator, GET_ITERATOR_COLUMN_COUNT + 26);
+  return ret;
+}
+
+/**
+ * @brief Get the CVE of the maximum EPSS score from an NVT iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return CVE-ID of the maximum EPSS score, or NULL if iteration is complete.
+ *         Freed by cleanup_iterator.
+ */
+DEF_ACCESS (nvt_iterator_max_epss_cve, GET_ITERATOR_COLUMN_COUNT + 27);
+
+/**
+ * @brief Get the severity of the maximum EPSS score from an NVT iterator.
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The severity score.
+ */
+double
+nvt_iterator_max_epss_severity (iterator_t* iterator)
+{
+  double ret;
+  if (iterator->done) return -1;
+  ret = iterator_double (iterator, GET_ITERATOR_COLUMN_COUNT + 28);
+  return ret;
+}
+
+/**
+ * @brief Get whether the NVT has a severity for the max EPSS score.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return Whether the severity exists.
+ */
+gboolean
+nvt_iterator_has_max_epss_severity (iterator_t* iterator)
+{
+  gboolean ret;
+  if (iterator->done) return -1;
+  ret = iterator_string (iterator, GET_ITERATOR_COLUMN_COUNT + 28) != NULL;
+  return ret;
+}
 
 /**
  * @brief Get the default timeout of an NVT.
@@ -2531,6 +2679,9 @@ manage_rebuild (GSList *log_config, const db_conn_info_t *database)
         sql_rollback ();
         break;
     }
+
+  if (ret == 0)
+    ret = update_scap_extra ();
 
   feed_lockfile_unlock (&lockfile);
   manage_option_cleanup ();

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -2681,7 +2681,7 @@ manage_rebuild (GSList *log_config, const db_conn_info_t *database)
     }
 
   if (ret == 0)
-    ret = update_scap_extra ();
+    update_scap_extra ();
 
   feed_lockfile_unlock (&lockfile);
   manage_option_cleanup ();

--- a/src/manage_sql_nvts.h
+++ b/src/manage_sql_nvts.h
@@ -31,7 +31,9 @@
  { GET_ITERATOR_FILTER_COLUMNS, "version", "cve",                           \
    "family", "cvss_base", "severity", "cvss", "script_tags", "qod",         \
    "qod_type", "solution_type", "solution", "summary", "insight",           \
-   "affected", "impact", "detection", "solution_method", NULL }
+   "affected", "impact", "detection", "solution_method", "epss_score",      \
+   "epss_percentile", "max_epss_score", "max_epss_percentile",              \
+   NULL }
 
 /**
  * @brief NVT iterator columns.
@@ -62,6 +64,18 @@
    { "impact", NULL, KEYWORD_TYPE_STRING },                                 \
    { "detection", NULL, KEYWORD_TYPE_STRING },                              \
    { "solution_method", NULL, KEYWORD_TYPE_STRING },                        \
+   { "coalesce (epss_score, 0.0)", "epss_score",                            \
+     KEYWORD_TYPE_DOUBLE },                                                 \
+   { "coalesce (epss_percentile, 0.0)", "epss_percentile",                  \
+     KEYWORD_TYPE_DOUBLE },                                                 \
+   { "epss_cve", NULL, KEYWORD_TYPE_STRING },                               \
+   { "epss_severity", NULL, KEYWORD_TYPE_DOUBLE },                          \
+   { "coalesce (max_epss_score, 0.0)", "max_epss_score",                    \
+     KEYWORD_TYPE_DOUBLE },                                                 \
+   { "coalesce (max_epss_percentile, 0.0)", "max_epss_percentile",          \
+     KEYWORD_TYPE_DOUBLE },                                                 \
+   { "max_epss_cve", NULL, KEYWORD_TYPE_STRING },                           \
+   { "max_epss_severity", NULL, KEYWORD_TYPE_DOUBLE },                      \
    { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                                     \
  }
 
@@ -94,6 +108,18 @@
    { "impact", NULL, KEYWORD_TYPE_STRING },                                 \
    { "detection", NULL, KEYWORD_TYPE_STRING },                              \
    { "solution_method", NULL, KEYWORD_TYPE_STRING },                        \
+   { "coalesce (epss_score, 0.0)", "epss_score",                            \
+     KEYWORD_TYPE_DOUBLE },                                                 \
+   { "coalesce (epss_percentile, 0.0)", "epss_percentile",                  \
+     KEYWORD_TYPE_DOUBLE },                                                 \
+   { "epss_cve", NULL, KEYWORD_TYPE_STRING },                               \
+   { "epss_severity", NULL, KEYWORD_TYPE_DOUBLE },                          \
+   { "coalesce (max_epss_score, 0.0)", "max_epss_score",                    \
+     KEYWORD_TYPE_DOUBLE },                                                 \
+   { "coalesce (max_epss_percentile, 0.0)", "max_epss_percentile",          \
+     KEYWORD_TYPE_DOUBLE },                                                 \
+   { "max_epss_cve", NULL, KEYWORD_TYPE_STRING },                           \
+   { "max_epss_severity", NULL, KEYWORD_TYPE_DOUBLE },                      \
    { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                                     \
  }
 

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -4041,8 +4041,6 @@ rebuild_scap ()
     return -1;
 
   ret = update_scap (TRUE);
-  if (ret == 1)
-    ret = 2;
 
   if (ret == 0)
     update_scap_extra ();

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -3980,25 +3980,21 @@ update_scap (gboolean reset_scap_db)
 
 /**
  * @brief Update extra data in the SCAP DB that depends on other feeds.
- *
- * @return 0 success, -1 error.
  */
-int
+void
 update_scap_extra ()
 {
   if (manage_scap_loaded () == 0)
     {
       g_info ("%s: SCAP database missing, skipping extra data update",
               __func__);
-      return 0;
+      return;
     }
 
   g_debug ("%s: update SCAP extra data of VTs", __func__);
   setproctitle ("Syncing SCAP: Updating VT extra data");
 
   update_vt_scap_extra_data ();
-
-  return 0;
 }
 
 /**
@@ -4049,7 +4045,7 @@ rebuild_scap ()
     ret = 2;
 
   if (ret == 0)
-    ret = update_scap_extra ();
+    update_scap_extra ();
 
   if (feed_lockfile_unlock (&lockfile))
     {

--- a/src/manage_sql_secinfo.h
+++ b/src/manage_sql_secinfo.h
@@ -195,4 +195,7 @@ get_secinfo_commit_size ();
 void
 set_secinfo_commit_size (int);
 
+int
+update_scap_extra ();
+
 #endif /* not _GVMD_MANAGE_SQL_SECINFO_H */

--- a/src/manage_sql_secinfo.h
+++ b/src/manage_sql_secinfo.h
@@ -195,7 +195,7 @@ get_secinfo_commit_size ();
 void
 set_secinfo_commit_size (int);
 
-int
+void
 update_scap_extra ();
 
 #endif /* not _GVMD_MANAGE_SQL_SECINFO_H */

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -582,6 +582,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <e>timeout</e>
       <e>default_timeout</e>
       <e>solution</e>
+      <o><e>epss</e></o>
       <e>preferences</e>
     </pattern>
     <ele>
@@ -679,6 +680,112 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <required>0</required>
         </attrib>
       </pattern>
+    </ele>
+    <ele>
+      <name>epss</name>
+      <summary>Exploit Prediction Scoring System (EPSS) info if available</summary>
+      <pattern>
+        <e>max_severity</e>
+        <e>max_epss</e>
+      </pattern>
+      <ele>
+        <name>max_severity</name>
+        <summary>
+          EPSS info of the referenced CVE with the highest severity
+        </summary>
+        <description>
+          In case there are multiple CVEs referenced by the NVT tied for the
+          highest severity, they are also sorted by EPSS score and modification
+          time and the first one is chosen.
+        </description>
+        <pattern>
+          <e>score</e>
+          <e>percentile</e>
+          <e>cve</e>
+        </pattern>
+        <ele>
+          <name>score</name>
+          <summary>EPSS score of the CVE</summary>
+          <pattern>
+            <t>decimal</t>
+          </pattern>
+        </ele>
+        <ele>
+          <name>percentile</name>
+          <summary>EPSS percentile of the CVE</summary>
+          <pattern>
+            <t>decimal</t>
+          </pattern>
+        </ele>
+        <ele>
+          <name>cve</name>
+          <summary>The representative CVE chosen</summary>
+          <pattern>
+            <attrib>
+              <name>id</name>
+              <summary>CVE-ID of the CVE</summary>
+              <type>text</type>
+            </attrib>
+            <o><e>severity</e></o>
+          </pattern>
+          <ele>
+            <name>severity</name>
+            <summary>Severity (CVSS) score of the CVE if available</summary>
+            <pattern>
+              <t>severity</t>
+            </pattern>
+          </ele>
+        </ele>
+      </ele>
+      <ele>
+        <name>max_epss</name>
+        <summary>
+          EPSS info of the referenced CVE with the highest EPSS score
+        </summary>
+        <description>
+          In case there are multiple CVEs referenced by the NVT tied for the
+          highest EPSS score, they are also sorted by severity and modification
+          time and the first one is chosen.
+        </description>
+        <pattern>
+          <e>score</e>
+          <e>percentile</e>
+          <e>cve</e>
+        </pattern>
+        <ele>
+          <name>score</name>
+          <summary>EPSS score of the CVE</summary>
+          <pattern>
+            <t>decimal</t>
+          </pattern>
+        </ele>
+        <ele>
+          <name>percentile</name>
+          <summary>EPSS percentile of the CVE</summary>
+          <pattern>
+            <t>decimal</t>
+          </pattern>
+        </ele>
+        <ele>
+          <name>cve</name>
+          <summary>The representative CVE chosen</summary>
+          <pattern>
+            <attrib>
+              <name>id</name>
+              <summary>CVE-ID of the CVE</summary>
+              <type>text</type>
+            </attrib>
+            <o><e>severity</e></o>
+          </pattern>
+          <ele>
+            <name>severity</name>
+            <summary>Severity (CVSS) score of the CVE if available</summary>
+            <pattern>
+              <t>severity</t>
+            </pattern>
+          </ele>
+        </ele>
+      </ele>
     </ele>
     <ele>
       <name>preferences</name>
@@ -12199,6 +12306,34 @@ END:VCALENDAR
             <type>integer</type>
             <summary>Version of the NVT (deprected)</summary>
           </column>
+          <column>
+            <name>epss_score</name>
+            <type>decimal</type>
+            <summary>
+              EPSS score of highest severity CVE (see epss/max_severity)
+            </summary>
+          </column>
+          <column>
+            <name>epss_percentile</name>
+            <type>decimal</type>
+            <summary>
+              EPSS percentile of highest severity CVE (see epss/max_severity)
+            </summary>
+          </column>
+          <column>
+            <name>max_epss_score</name>
+            <type>decimal</type>
+            <summary>
+              Highest EPSS score of referenced CVEs (see epss/max_epss)
+            </summary>
+          </column>
+          <column>
+            <name>max_epss_percentile</name>
+            <type>decimal</type>
+            <summary>
+              Highest EPSS percentile of referenced CVEs (see epss/max_epss)
+            </summary>
+          </column>
         </filter_keywords>
         <filter_keywords>
           <condition>type is "cve"</condition>
@@ -12221,6 +12356,16 @@ END:VCALENDAR
             <name>published</name>
             <type><t>iso_time</t></type>
             <summary>Time the CVE was published, alias for created</summary>
+          </column>
+          <column>
+            <name>epss_score</name>
+            <type>decimal</type>
+            <summary>EPSS score the CVE</summary>
+          </column>
+          <column>
+            <name>epss_percentile</name>
+            <type>decimal</type>
+            <summary>EPSS percentile of the CVE</summary>
           </column>
         </filter_keywords>
         <filter_keywords>
@@ -13793,6 +13938,7 @@ END:VCALENDAR
               <o><e>timeout</e></o>
               <o><e>default_timeout</e></o>
               <e>solution</e>
+              <o><e>epss</e></o>
               <o><e>preferences</e></o>
             </g>
           </o>
@@ -13968,6 +14114,112 @@ END:VCALENDAR
             </attrib>
             text
           </pattern>
+        </ele>
+        <ele>
+          <name>epss</name>
+          <summary>Exploit Prediction Scoring System (EPSS) info if available</summary>
+          <pattern>
+            <e>max_severity</e>
+            <e>max_epss</e>
+          </pattern>
+          <ele>
+            <name>max_severity</name>
+            <summary>
+              EPSS info of the referenced CVE with the highest severity
+            </summary>
+            <description>
+              In case there are multiple CVEs referenced by the NVT tied for the
+              highest severity, they are also sorted by EPSS score and modification
+              time and the first one is chosen.
+            </description>
+            <pattern>
+              <e>score</e>
+              <e>percentile</e>
+              <e>cve</e>
+            </pattern>
+            <ele>
+              <name>score</name>
+              <summary>EPSS score of the CVE</summary>
+              <pattern>
+                <t>decimal</t>
+              </pattern>
+            </ele>
+            <ele>
+              <name>percentile</name>
+              <summary>EPSS percentile of the CVE</summary>
+              <pattern>
+                <t>decimal</t>
+              </pattern>
+            </ele>
+            <ele>
+              <name>cve</name>
+              <summary>The representative CVE chosen</summary>
+              <pattern>
+                <attrib>
+                  <name>id</name>
+                  <summary>CVE-ID of the CVE</summary>
+                  <type>text</type>
+                </attrib>
+                <o><e>severity</e></o>
+              </pattern>
+              <ele>
+                <name>severity</name>
+                <summary>Severity (CVSS) score of the CVE if available</summary>
+                <pattern>
+                  <t>severity</t>
+                </pattern>
+              </ele>
+            </ele>
+          </ele>
+          <ele>
+            <name>max_epss</name>
+            <summary>
+              EPSS info of the referenced CVE with the highest EPSS score
+            </summary>
+            <description>
+              In case there are multiple CVEs referenced by the NVT tied for the
+              highest EPSS score, they are also sorted by severity and modification
+              time and the first one is chosen.
+            </description>
+            <pattern>
+              <e>score</e>
+              <e>percentile</e>
+              <e>cve</e>
+            </pattern>
+            <ele>
+              <name>score</name>
+              <summary>EPSS score of the CVE</summary>
+              <pattern>
+                <t>decimal</t>
+              </pattern>
+            </ele>
+            <ele>
+              <name>percentile</name>
+              <summary>EPSS percentile of the CVE</summary>
+              <pattern>
+                <t>decimal</t>
+              </pattern>
+            </ele>
+            <ele>
+              <name>cve</name>
+              <summary>The representative CVE chosen</summary>
+              <pattern>
+                <attrib>
+                  <name>id</name>
+                  <summary>CVE-ID of the CVE</summary>
+                  <type>text</type>
+                </attrib>
+                <o><e>severity</e></o>
+              </pattern>
+              <ele>
+                <name>severity</name>
+                <summary>Severity (CVSS) score of the CVE if available</summary>
+                <pattern>
+                  <t>severity</t>
+                </pattern>
+              </ele>
+            </ele>
+          </ele>
         </ele>
         <ele>
           <name>preferences</name>


### PR DESCRIPTION
## What
The VTs can now contain the maximum EPSS scores of the referenced CVE(s) with the highest severity and of any referenced EPSS score.


## Why
This will provide an estimation of how likely a vulnerability detected by a VT is to be exploited.

## References
GEA-559
