### PR TITLE
Change: GMP doc: add boxes around command structures

### DIFF
--- a/src/schema_formats/HTML/HTML.xsl
+++ b/src/schema_formats/HTML/HTML.xsl
@@ -661,6 +661,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:when test="(count(pattern/*) = 0) and (string-length(normalize-space(pattern)) = 0)">
           <i>Empty single element.</i>
         </xsl:when>
+        <xsl:when test="(count(pattern/*) = 0)">
+          <xsl:value-of select="pattern"/>
+        </xsl:when>
         <xsl:otherwise>
           <xsl:variable name="command" select="."/>
           <xsl:for-each select="pattern/*">

--- a/src/schema_formats/HTML/HTML.xsl
+++ b/src/schema_formats/HTML/HTML.xsl
@@ -427,7 +427,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <xsl:with-param name="text" select="concat($index, '.1 Structure')"/>
         </xsl:call-template>
 
-        <ul style="list-style: none">
+        <ul style="list-style: none; padding-left: 10px;">
           <li>
             <xsl:call-template name="command-structure"/>
           </li>
@@ -656,7 +656,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   </xsl:template>
 
   <xsl:template name="command-structure">
-    <ul style="list-style: none">
+    <ul style="list-style: none; border: 1px solid #F5F5F5; border-radius: 4px; margin-left: 2%; padding: 10px; background: #F5F5F5;">
       <xsl:choose>
         <xsl:when test="(count(pattern/*) = 0) and (string-length(normalize-space(pattern)) = 0)">
           <i>Empty single element.</i>
@@ -693,11 +693,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
         <ul style="list-style: none">
           <li>
-            <i>Command</i>
+            <div style="padding-bottom: 5px;"><i>Command</i></div>
             <xsl:call-template name="command-structure"/>
           </li>
           <li style="margin-top: 15px;">
-            <i>Response</i>
+            <div style="padding-bottom: 5px;"><i>Response</i></div>
             <xsl:for-each select="response">
               <xsl:call-template name="command-structure"/>
             </xsl:for-each>


### PR DESCRIPTION
## What

Add background boxes to the command structures in the HTML GMP doc.

This affects the Commands and Responses in section 7 (`Command Details`) and the Structures in section 6 (`Element Details`).

The color is chosen to match the [Greenbone Community Documentation](https://greenbone.github.io/docs/latest/22.4/container/index.html) because the HTML will end up as the [Greenbone GMP page](https://docs.greenbone.net/API/GMP/gmp-22.5.html).

## Why

The GMP doc is long and hard to read. The boxes make it easier to see where the XML is broken down.

## Example: Element Details

Before
![shot-6-before](https://github.com/greenbone/gvmd/assets/32057441/ba15207b-c1a2-435f-b34b-9c78649c0137)

After
![shot-6-after](https://github.com/greenbone/gvmd/assets/32057441/8d04157a-d277-4fb1-a8e3-2a7e4f8db70d)

## Example: Command Details

Before
![shot-7-before](https://github.com/greenbone/gvmd/assets/32057441/e55302a7-d6b1-4eaf-9a96-32f47f2495a2)

After
![shot-7-after](https://github.com/greenbone/gvmd/assets/32057441/450fcc2c-43fd-4150-b4f9-bbe60eff63a1)

## References

Similar to XML boxes in greenbone/gvmd/pull/2192
