### PR TITLE
Change: GMP doc: start with Data Type Details RNC open

### DIFF
--- a/src/schema_formats/HTML/HTML.xsl
+++ b/src/schema_formats/HTML/HTML.xsl
@@ -342,7 +342,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       <xsl:apply-templates select="description"/>
 
-      <details>
+      <details open="">
         <xsl:call-template name="details-summary-4">
           <xsl:with-param name="text" select="concat($index, '.1 RNC')"/>
         </xsl:call-template>


### PR DESCRIPTION
## What

In the HTML GMP doc, start with all RNC subsections open in section 5 `Data Type Details`.

## Why

For section 5 it makes sense to show the RNC initially, because the RNC is the only description of what form the data type can take.

## References

Follow on to greenbone/gvmd/pull/2186, which closed all RNC in all sections.
