### PR TITLE
Declare handle_get_credentials variables where they are used

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -12252,7 +12252,7 @@ handle_get_credentials (gmp_parser_t *gmp_parser, GError **error)
   SEND_GET_START("credential");
   while (1)
     {
-      const char *private_key, *public_key, *login, *type, *cert;
+      const char *login, *type, *cert;
       gchar *formats_xml;
 
       ret = get_next (&credentials, &get_credentials_data->get,
@@ -12266,8 +12266,6 @@ handle_get_credentials (gmp_parser_t *gmp_parser, GError **error)
         }
 
       SEND_GET_COMMON (credential, &get_credentials_data->get, &credentials);
-      private_key = credential_iterator_private_key (&credentials);
-      public_key = credential_iterator_public_key (&credentials);
       login = credential_iterator_login (&credentials);
       type = credential_iterator_type (&credentials);
       cert = credential_iterator_certificate (&credentials);
@@ -12346,6 +12344,10 @@ handle_get_credentials (gmp_parser_t *gmp_parser, GError **error)
 
           case CREDENTIAL_FORMAT_KEY:
             {
+              const char *public_key;
+
+              public_key = credential_iterator_public_key (&credentials);
+
               if (public_key && strcmp (public_key, ""))
                 {
                   SENDF_TO_CLIENT_OR_FAIL
@@ -12354,8 +12356,9 @@ handle_get_credentials (gmp_parser_t *gmp_parser, GError **error)
               else
                 {
                   char *pub;
-                  const char *pass;
+                  const char *pass, *private_key;
 
+                  private_key = credential_iterator_private_key (&credentials);
                   pass = credential_iterator_password (&credentials);
                   pub = gvm_ssh_public_from_private (private_key, pass);
                   SENDF_TO_CLIENT_OR_FAIL


### PR DESCRIPTION
## What

In `handle_get_credentials` move the declarations of variables `public_key` and `private_key` down to the blocks they are used in.

## Why

This reduces the scope of the variables, making the code easier to understand.

There is some performance gain to be made when getting the credentials, but the situation is complex. Hoping small changes like this will make the gains achievable in the future. 

## Test

To test `private_key`:
```
$ o m m "<create_credential><name>usk: username and ssh private key</name><type>usk</type><login>username</login><key><phrase></phrase><private>$(cat ~/tmp/key/ed25519)</private></key></create_credential>"
$ o m m '<get_credentials credential_id="7fc16405-c190-4a5a-999b-bd31a055933f" details="1" format="key"/>'
```

To test `public_key`:
```
$ o m m "<create_credential><name>gpg</name><type>pgp</type><login>username</login><key><phrase>test</phrase><public>$(cat ~/tmp/key/gpg.pub)</public></key></create_credential>"
$ o m m '<get_credentials credential_id="85fda2a1-ba94-4f64-b9d8-33935f469ab4" details="1" format="key"/>'
```

## References

greenbone/gvmd/pull/2122 explores the potential performance gains.

