### PR TITLE
Add: GMP doc: describe credential types

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -3990,6 +3990,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <ele>
       <name>type</name>
       <summary>The type of credential to create</summary>
+      <description>
+        <p>cc: Client certificate</p>
+        <p>pgp: PGP encryption key</p>
+        <p>pw: Password only</p>
+        <p>smime: S/MIME certificate</p>
+        <p>snmp: SNMP</p>
+        <p>up: User name + password</p>
+        <p>usk: User name + SSH key</p>
+      </description>
       <pattern>
         <alts>
           <alt>cc</alt>
@@ -10740,6 +10749,15 @@ END:VCALENDAR
         <ele>
           <name>type</name>
           <summary>The type of the credential</summary>
+          <description>
+            <p>cc: Client certificate</p>
+            <p>pgp: PGP encryption key</p>
+            <p>pw: Password only</p>
+            <p>smime: S/MIME certificate</p>
+            <p>snmp: SNMP</p>
+            <p>up: User name + password</p>
+            <p>usk: User name + SSH key</p>
+          </description>
           <pattern>
             <alts>
               <alt>cc</alt>


### PR DESCRIPTION
## What

In the GMP doc, describe what the credential type acronyms mean in `CREATE_CREDENTIAL` and `GET_CREDENTIALS`.

## Why

I struggle to remember what these mean, especially `usk`.

## Example

How it looks:

![shot](https://github.com/greenbone/gvmd/assets/32057441/48497a16-30ce-4c1c-bdca-e5287b73cdd3)
I'd like to move the descriptions up into the _One of_ section, but at least the words are there for now.

## References

Also listed in https://www.greenbone.net/wp-content/uploads/Filterkeywords_EN.pdf


