### PR TITLE
Remove old variable

### DIFF
--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -2351,7 +2351,6 @@ config_insert_preferences (config_t config,
         else if (preference->type)
           {
             gchar *quoted_type, *quoted_nvt_oid, *quoted_preference_name;
-            gchar *quoted_default;
             gchar *quoted_preference_id;
 
             /* Presume NVT or OSP preference. */
@@ -2375,9 +2374,6 @@ config_insert_preferences (config_t config,
                   : sql_quote (preference->type);
             quoted_value = sql_quote (value->str);
             g_string_free (value, TRUE);
-            quoted_default = preference->default_value
-                              ? sql_quote (preference->default_value)
-                              : NULL;
 
             /* NVT preference */
             /* OID:PrefID:PrefType:PrefName value */
@@ -2401,7 +2397,6 @@ config_insert_preferences (config_t config,
             g_free (quoted_preference_name);
             g_free (quoted_type);
             g_free (quoted_value);
-            g_free (quoted_default);
             g_free (quoted_preference_id);
           }
         else


### PR DESCRIPTION
## What

Remove variable `quoted_default` from `config_insert_preferences`.

## Why

Usage of this variable was removed in greenbone/gvmd/pull/1694, see line [2393](https://github.com/greenbone/gvmd/pull/1694/commits/52f3c3a19b72148507ea46b516d040f152ec61e1#diff-9dc7a5483fd5f094c2ff90dc52d9477a7085909134622c6a90f5ea306809e073L2393) in 52f3c3a19b72148507ea46b516d040f152ec61e1.

## Quick test

```
o m m '<create_config><copy>af240023-7111-40b5-9ed3-e8362a59238d</copy></create_config>'
o m m '<get_configs config_id="74a22450-45da-4639-9574-0e05792981a0" details="1"/>' > /tmp/cnew
o m m '<get_configs config_id="af240023-7111-40b5-9ed3-e8362a59238d" details="1"/>' > /tmp/cold
diff /tmp/cnew /tmp/cold # preferences should be the same
```
