### PR TITLE
Fix: GMP doc: remove SCANNER from config commands

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -25930,7 +25930,6 @@ END:VCALENDAR
       </attrib>
       <o>><e>name</e></o>
       <o><e>comment</e></o>
-      <o><e>scanner</e></o>
       <any><e>preference</e></any>
       <o><e>family_selection</e></o>
       <any><e>nvt_selection</e></any>
@@ -25943,11 +25942,6 @@ END:VCALENDAR
     <ele>
       <name>comment</name>
       <summary>New comment for the config</summary>
-      <pattern>text</pattern>
-    </ele>
-    <ele>
-      <name>scanner</name>
-      <summary>New scanner's UUID for the config</summary>
       <pattern>text</pattern>
     </ele>
     <ele>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -3731,7 +3731,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <or>
         <e>copy</e>
         <r>get_configs</r>
-        <e>scanner</e>
       </or>
       <e>name</e>
       <o><e>usage_type</e></o>
@@ -3746,13 +3745,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <ele>
       <name>copy</name>
       <summary>The UUID of an existing config</summary>
-      <pattern>
-        <t>uuid</t>
-      </pattern>
-    </ele>
-    <ele>
-      <name>scanner</name>
-      <summary>The UUID of an OSP scanner to get config data from</summary>
       <pattern>
         <t>uuid</t>
       </pattern>
@@ -3815,20 +3807,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               <truncated>...</truncated>
             </config>
           </get_configs_response>
-        </create_config>
-      </request>
-      <response>
-        <create_config_response status="201" status_text="OK, resource created"
-                                id="254cd3ef-bbe1-4d58-859d-21b8d0c046c6">
-        </create_config_response>
-      </response>
-    </example>
-    <example>
-      <summary>Create an OSP config from a scanner</summary>
-      <request>
-        <create_config>
-          <name>Full</name>
-          <scanner>daba56c8-73ec-11df-a475-002264764cea</scanner>
         </create_config>
       </request>
       <response>


### PR DESCRIPTION
## What

Remove `SCANNER` elements from the GMP docs for `CREATE_CONFIG` and `MODIFY_CONFIG`.

## Why

These elements were removed with OSP scanners in greenbone/gvmd/pull/1689.

## References

See  [44c83fec74](https://github.com/greenbone/gvmd/commit/44c83fec74e94652c6c10bd4768e73e78005d39a#diff-12a7f01f67c7f0133ce4d569b208dfbf6481ba5f89ab063462b3215d7d789670L532) for the `CREATE_CONFIG` case (line 532 of gmp_configs.c).

See [9d95703aa5](https://github.com/greenbone/gvmd/commit/9d95703aa510ebc74cf19df635bd231ccedd8f1f#diff-12a7f01f67c7f0133ce4d569b208dfbf6481ba5f89ab063462b3215d7d789670L1075)  for the `MODIFY_CONFIG` case (line 1075 of gmp_config.c).
