### PR TITLE
GMP doc: add NAME to CREATE_REPORT_FORMAT

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -5050,13 +5050,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         The client uses the create_report_format command to create a new report
         format.
       </p>
+      <p>
+        Element "name" only applies when "copy" is given.
+      </p>
     </description>
     <pattern>
+      <o><e>name</e></o>
       <or>
         <e>copy</e>
         <r>get_report_formats</r>
       </or>
     </pattern>
+    <ele>
+      <name>name</name>
+      <summary>A name for the report format</summary>
+      <pattern><t>name</t></pattern>
+    </ele>
     <ele>
       <name>copy</name>
       <summary>The UUID of an existing report format</summary>


### PR DESCRIPTION
## What

Add element `NAME` to the GMP doc for `CREATE_REPORT_FORMAT`.

## Why

Element was missing.

## Example

Copy with `NAME`:
```
$ o m m '<create_report_format><name>Example</name><copy>5057e5cc-b825-11e4-9d0e-28d24461215b</copy></create_report_format>'
<create_report_format_response status="201" status_text="OK, resource created" id="d3dfac4c-378f-4e58-a781-1aa8f5d25066" />
```
See that name was used:
```
$ o m m '<get_report_formats report_format_id="d3dfac4c-378f-4e58-a781-1aa8f5d25066"/>'
<get_report_formats_response status="200" status_text="OK">
  <report_format id="d3dfac4c-378f-4e58-a781-1aa8f5d25066">
    <name>Example</name>
```