### PR TITLE
GMP doc: HTML: small pad around whole doc

### DIFF
--- a/src/schema_formats/HTML/HTML.xsl
+++ b/src/schema_formats/HTML/HTML.xsl
@@ -898,7 +898,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </title>
       </head>
       <body style="background-color: #FFFFFF; margin: 0px; font: small Verdana, sans-serif; font-size: 12px; color: #1A1A1A;">
-        <div style="width: 98%; width:700px; align: center; margin-left: auto; margin-right: auto;">
+        <div style="width: 700px; align: center; margin-left: auto; margin-right: auto;">
           <table style="width: 100%;" cellpadding="3" cellspacing="0">
             <tr>
               <td valign="top">

--- a/src/schema_formats/HTML/HTML.xsl
+++ b/src/schema_formats/HTML/HTML.xsl
@@ -898,7 +898,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </title>
       </head>
       <body style="background-color: #FFFFFF; margin: 0px; font: small Verdana, sans-serif; font-size: 12px; color: #1A1A1A;">
-        <div style="width: 700px; align: center; margin-left: auto; margin-right: auto;">
+        <div style="width: 700px; padding-left: 4px; padding-right: 4px; align: center; margin-left: auto; margin-right: auto;">
           <table style="width: 100%;" cellpadding="3" cellspacing="0">
             <tr>
               <td valign="top">


### PR DESCRIPTION
## What

Add a small pad on the sides of the whole GMP HTML doc.

## Why

The doc text is too close to the side when the window is narrow, making it hard to read. 

#### Before:
![shot](https://github.com/greenbone/gvmd/assets/32057441/0060efd6-c415-4826-a90a-f80d46b4637d)

#### After:
![shot1](https://github.com/greenbone/gvmd/assets/32057441/244c680f-c16d-4df9-8190-65834a08fdaa)
