### PR TITLE
GMP doc: add OBSERVERS/GROUP to CREATE_TASK

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -23137,8 +23137,8 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
               gchar *fail_group_id;
 
               switch (set_task_groups (create_task_data->task,
-                                               create_task_data->groups,
-                                               &fail_group_id))
+                                       create_task_data->groups,
+                                       &fail_group_id))
                 {
                   case 0:
                     break;

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -5921,8 +5921,24 @@ END:VCALENDAR
     </ele>
     <ele>
       <name>observers</name>
-      <summary>Users allowed to observe this task</summary>
-      <pattern><t>user_list</t></pattern>
+      <summary>Users and/or groups allowed to observe this task</summary>
+      <description>
+        The optional text of element observers is a space separated list of users.
+      </description>
+      <pattern>
+        <t>user_list</t>
+        <any><e>group</e></any>
+      </pattern>
+      <ele>
+        <name>group</name>
+        <pattern>
+          <attrib>
+            <name>id</name>
+            <type>uuid</type>
+            <required>1</required>
+          </attrib>
+        </pattern>
+      </ele>
     </ele>
     <ele>
       <name>preferences</name>


### PR DESCRIPTION
## What

Add `GROUP` to `CREATE_TASK/OBSERVERS` in the GMP doc.

## Why

Element was missing.

## Example

Create task with two GROUP observers.
```
$ o m m '<create_task> <name>group obs test 2</name> <target id="0de4c2b4-987d-4a3b-9eba-fe92b3eaa8b2"/> <config id="d21f6c81-2b88-4ac1-b7b4-a2a9f2ad4663"/> <observers><group id="986c1365-0435-4cec-aaa0-ed0922aef8e0"/><group id="50e15244-0f7c-4d0d-8a2e-266fa043110c"/></observers> </create_task>'
<create_task_response status="201" status_text="OK, resource created" id="8f068524-687d-4886-a64f-a78dfa8a5526" />
```
See that permission was created for groups.
```
o m m '<get_permissions filter="subject_type=group"/>'
<get_permissions_response status="200" status_text="OK">
  <permission id="c1217fe1-f355-424b-acf9-ede5c1e2b89b">
    <name>get_tasks</name>
    <resource id="8f068524-687d-4886-a64f-a78dfa8a5526">
    <subject id="986c1365-0435-4cec-aaa0-ed0922aef8e0">
      <name>test1</name>
      <type>group</type>
```