### PR TITLE
GMP doc: add GROUPS to CREATE_USER

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -6226,6 +6226,7 @@ END:VCALENDAR
       <o><e>hosts</e></o>
       <o><e>password</e></o>
       <any><e>role</e></any>
+      <o><e>groups</e></o>
       <o><e>sources</e></o>
     </pattern>
     <ele>
@@ -6272,6 +6273,23 @@ END:VCALENDAR
           <required>1</required>
         </attrib>
       </pattern>
+    </ele>
+    <ele>
+      <name>groups</name>
+      <summary>Groups the user will be added to</summary>
+      <pattern>
+        <any><e>group</e></any>
+      </pattern>
+      <ele>
+        <name>group</name>
+        <pattern>
+          <attrib>
+            <name>id</name>
+            <type>uuid</type>
+            <required>1</required>
+          </attrib>
+        </pattern>
+      </ele>
     </ele>
     <ele>
       <name>sources</name>


### PR DESCRIPTION
## What

Add `GROUPS` to `CREATE_USER` in the GMP doc.

## Why

Element was missing.

## Example

Create user, adding to group:
``` xml
$ o m m '<create_user><name>test8</name><password>test</password><groups><group id="986c1365-0435-4cec-aaa0-ed0922aef8e0"/></groups></create_user>'
<create_user_response status="201" status_text="OK, resource created" id="c95ba093-ab3f-4d78-9533-546242c4b31e" />
```
Confirm in group:
``` xml
$ o m m '<get_users user_id="c95ba093-ab3f-4d78-9533-546242c4b31e"/>'
<get_users_response status="200" status_text="OK">
  <user id="c95ba093-ab3f-4d78-9533-546242c4b31e">
    <groups>
      <group id="986c1365-0435-4cec-aaa0-ed0922aef8e0">
        <name>test1</name>
      </group>
    </groups>
```