### PR TITLE
Remove stray ultimate arg from function delete_user

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -5103,7 +5103,6 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
           }
         else if (strcasecmp ("DELETE_USER", element_name) == 0)
           {
-            const gchar* attribute;
             append_attribute (attribute_names, attribute_values, "name",
                               &delete_user_data->name);
             append_attribute (attribute_names, attribute_values, "user_id",
@@ -5114,11 +5113,6 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
             append_attribute (attribute_names, attribute_values,
                               "inheritor_name",
                               &delete_user_data->inheritor_name);
-            if (find_attribute (attribute_names, attribute_values,
-                                "ultimate", &attribute))
-              delete_user_data->ultimate = strcmp (attribute, "0");
-            else
-              delete_user_data->ultimate = 0;
             set_client_state (CLIENT_DELETE_USER);
           }
         else if (strcasecmp ("DESCRIBE_AUTH", element_name) == 0)
@@ -19704,7 +19698,6 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
         if (delete_user_data->user_id || delete_user_data->name)
           switch (delete_user (delete_user_data->user_id,
                                delete_user_data->name,
-                               delete_user_data->ultimate,
                                1,
                                delete_user_data->inheritor_id,
                                delete_user_data->inheritor_name))

--- a/src/manage.h
+++ b/src/manage.h
@@ -3590,7 +3590,7 @@ create_user (const gchar *, const gchar *, const gchar *, const gchar *,
              array_t *, gchar **, gchar **, user_t *, int);
 
 int
-delete_user (const char *, const char *, int, int, const char*, const char*);
+delete_user (const char *, const char *, int, const char*, const char*);
 
 int
 modify_user (const gchar *, gchar **, const gchar *, const gchar *,

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -53374,7 +53374,7 @@ manage_delete_user (GSList *log_config, const db_conn_info_t *database,
   /* Setup a dummy user, so that delete_user will work. */
   current_credentials.uuid = "";
 
-  switch ((ret = delete_user (NULL, name, 1, 0, NULL, inheritor_name)))
+  switch ((ret = delete_user (NULL, name, 0, NULL, inheritor_name)))
     {
       case 0:
         printf ("User deleted.\n");
@@ -54009,7 +54009,6 @@ copy_user (const char* name, const char* comment, const char *user_id,
  *
  * @param[in]  user_id_arg  UUID of user.
  * @param[in]  name_arg     Name of user.  Overridden by user_id.
- * @param[in]  ultimate     Whether to remove entirely, or to trashcan.
  * @param[in]  forbid_super_admin  Whether to forbid removal of Super Admin.
  * @param[in]  inheritor_id   UUID of user who will inherit owned objects.
  * @param[in]  inheritor_name Name of user who will inherit owned objects.
@@ -54020,7 +54019,7 @@ copy_user (const char* name, const char* comment, const char *user_id,
  *         10 user is 'Feed Import Owner' 99 permission denied, -1 error.
  */
 int
-delete_user (const char *user_id_arg, const char *name_arg, int ultimate,
+delete_user (const char *user_id_arg, const char *name_arg,
              int forbid_super_admin,
              const char* inheritor_id, const char *inheritor_name)
 {


### PR DESCRIPTION
## What

Remove argument `ultimate` from function `delete_user`. This includes removing the redundant processing of attribute `ultimate` in GMP `DELETE_USER`. 

## Why

Cleaner.

I guess this arg was left there in case we wanted to add users to the trashcan.  It can be added back if this feature is ever needed.

## Quick check
```xml
$ o m m '<create_user><name>test8</name><password>test</password></create_user>'
<create_user_response status="201" status_text="OK, resource created" id="21852600-afaf-4053-aeb1-367cb2c3044a" />

$ time o m m '<delete_user user_id="21852600-afaf-4053-aeb1-367cb2c3044a"/>'
<delete_user_response status="200" status_text="OK" />

$ time o m m '<get_users user_id="21852600-afaf-4053-aeb1-367cb2c3044a"/>'
<get_users_response status="404" status_text="Failed to find user '21852600-afaf-4053-aeb1-367cb2c3044a'" />
```