### PR TITLE
GMP doc: improve DESCRIBE_AUTH

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -6451,7 +6451,7 @@ END:VCALENDAR
       </pattern>
     </response>
     <example>
-      <summary>Delete a asset</summary>
+      <summary>Delete an asset</summary>
       <request>
         <delete_asset asset_id="267a3405-e84a-47da-97b2-5fa0d2e8995e">
         </delete_asset>
@@ -7535,7 +7535,7 @@ END:VCALENDAR
             <type>text</type>
             <required>1</required>
           </attrib>
-          <e>auth_conf_setting</e>
+          <any><e>auth_conf_setting</e></any>
         </pattern>
         <ele>
           <name>auth_conf_setting</name>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -7570,10 +7570,14 @@ END:VCALENDAR
       </request>
       <response>
         <describe_auth_response status="200" status_text="OK">
-          <group name="Foo">
+          <group name="method:file">
             <auth_conf_setting>
-              <key>Bar</key>
-              <value>Baz</value>
+              <key>enable</key>
+              <value>true</value>
+            </auth_conf_setting>
+            <auth_conf_setting>
+              <key>order</key>
+              <value>1</value>
             </auth_conf_setting>
           </group>
         </describe_auth_response>


### PR DESCRIPTION
## What

In the GMP doc for `DESCRIBE_AUTH` add `any` to `AUTH_CONF_SETTING`. Also improve the example.

## Why

There can be any number of settings in a group.

## Example
```xml
$ o m m '<describe_auth/>'
<describe_auth_response status="200" status_text="OK">
  <group name="method:file">
    <auth_conf_setting>
      <key>enable</key>
      <value>true</value>
    </auth_conf_setting>
    <auth_conf_setting>
      <key>order</key>
      <value>1</value>
    </auth_conf_setting>
  </group>
</describe_auth_response>
```