### PR TITLE
GMP doc: add missing SUBGROUP_COLUMN to GET_AGGREGATES response

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -7928,6 +7928,7 @@ END:VCALENDAR
           <e>data_type</e>
           <any><e>data_column</e></any>
           <o><e>group_column</e></o>
+          <o><e>subgroup_column</e></o>
           <any><e>text_column</e></any>
           <or>
             <any><e>group</e></any>
@@ -7949,6 +7950,11 @@ END:VCALENDAR
         <ele>
           <name>group_column</name>
           <summary>The column the data is grouped by</summary>
+          <pattern><t>text</t></pattern>
+        </ele>
+        <ele>
+          <name>subgroup_column</name>
+          <summary>The column to further group the resources by</summary>
           <pattern><t>text</t></pattern>
         </ele>
         <ele>


### PR DESCRIPTION
## What

Add `SUBGROUP_COLUMN` to the `GET_AGGREGATES` doc.

## Why

Element was missing.

## References

Looks like it was just missed in the original commit: 876b3e5eba1ab9d846115f73a7207fed43e7e6e0. See the patch to [src/schema_formats/XML/OMP.xml.in](https://github.com/greenbone/gvmd/commit/876b3e5eba1ab9d846115f73a7207fed43e7e6e0#diff-7a4ef738c338ef2fe68dea2ca4a8e3cde57f8f6d77f3fb3575c3c03bb0dd801b), the request attribute is added but the response element is missing.

## Quick test

```xml
$ o m m '<get_aggregates type="cve" group_column="severity" subgroup_column="created"/>'
<get_aggregates_response status_text="OK" status="200">
  <aggregate>
    <group_column>severity</group_column>
    <subgroup_column>created</subgroup_column>
```