### PR TITLE
Fix: Add DATA_TYPE back to GET_AGGREGATES/AGGREGATE

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -10141,6 +10141,10 @@ buffer_aggregate_wc_xml (GString *xml, iterator_t* aggregate,
   g_string_append_printf (xml, "<aggregate>");
 
   g_string_append_printf (xml,
+                          "<data_type>%s</data_type>",
+                          type);
+
+  g_string_append_printf (xml,
                           "<group_column>%s</group_column>",
                           group_column);
 
@@ -10295,6 +10299,10 @@ buffer_aggregate_xml (GString *xml, iterator_t* aggregate, const gchar* type,
   int has_groups = 0;
 
   g_string_append_printf (xml, "<aggregate>");
+
+  g_string_append_printf (xml,
+                          "<data_type>%s</data_type>",
+                          type);
 
   for (index = 0; index < data_columns->len ;index ++)
     {


### PR DESCRIPTION
## What

Add element `DATA_TYPE` back to element `AGGREGATE` in GMP `GET_AGGREGATES`.

## Why

Element was accidentally removed.

## References

This element was removed in d73fba850fbbb26927f6ab6070a01e2738dcbbd5 (SVN r23003) in 2015. In omp.c line [16809](https://github.com/greenbone/gvmd/commit/d73fba850fbbb26927f6ab6070a01e2738dcbbd5#diff-b3a341390113a1c8b6128823c6c1838afeedcaf2eb9b8c398f0ed2f9ed3aff1dL16809) was removed from `omp_xml_handle_end_element` but was missing from the addition `buffer_aggregate_xml` at line [11416]( https://github.com/greenbone/gvmd/commit/d73fba850fbbb26927f6ab6070a01e2738dcbbd5#diff-b3a341390113a1c8b6128823c6c1838afeedcaf2eb9b8c398f0ed2f9ed3aff1dR11416).

It looks like this was an accident because the element is still in the GMP doc, and the removal would likely have been mentioned in the commit log.  Let me know if this was intentional though, I'll adjust the doc instead.

## Quick test

Before PR:
```
$ o m m '<get_aggregates type="cve" group_column="severity"/>'
<get_aggregates_response status_text="OK" status="200">
  <aggregate>
    <group_column>severity</group_column>

$ o m m '<get_aggregates type="result" group_column="description" mode="word_counts" max_groups="10"/>'
<get_aggregates_response status_text="OK" status="200">
  <aggregate>
    <group_column>description</group_column>
```

After PR, element `data_type` is back:
```
$ o m m '<get_aggregates type="cve" group_column="severity"/>'
<get_aggregates_response status_text="OK" status="200">
  <aggregate>
    <data_type>cve</data_type>
    <group_column>severity</group_column>

$ o m m '<get_aggregates type="result" group_column="description" mode="word_counts" max_groups="10"/>'
<get_aggregates_response status_text="OK" status="200">
  <aggregate>
    <data_type>result</data_type>
    <group_column>description</group_column>
```