### PR TITLE
GMP doc: add missing elements to OVERALL in GET_AGGREGATES

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -8107,6 +8107,7 @@ END:VCALENDAR
           <summary>Aggregate data for all resources of the selected type</summary>
           <pattern>
             <e>count</e>
+            <e>c_count</e>
             <e>min</e>
             <e>max</e>
             <e>mean</e>
@@ -8115,6 +8116,12 @@ END:VCALENDAR
           <ele>
             <name>count</name>
             <summary>Overall number of resources</summary>
+            <pattern><t>integer</t></pattern>
+          </ele>
+          <ele>
+            <name>c_count</name>
+            <summary>Cumulative number of resources</summary>
+            <description>For overall this is always the same as count.</description>
             <pattern><t>integer</t></pattern>
           </ele>
           <ele>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -8108,10 +8108,7 @@ END:VCALENDAR
           <pattern>
             <e>count</e>
             <e>c_count</e>
-            <e>min</e>
-            <e>max</e>
-            <e>mean</e>
-            <e>sum</e>
+            <any><e>stats</e></any>
           </pattern>
           <ele>
             <name>count</name>
@@ -8125,24 +8122,46 @@ END:VCALENDAR
             <pattern><t>integer</t></pattern>
           </ele>
           <ele>
-            <name>min</name>
-            <summary>Overall minimum value of the data column</summary>
-            <pattern><t>text</t></pattern>
-          </ele>
-          <ele>
-            <name>max</name>
-            <summary>Overall maximum value of the data column</summary>
-            <pattern><t>text</t></pattern>
-          </ele>
-          <ele>
-            <name>mean</name>
-            <summary>Overall arithmetic mean of the numeric values of the data</summary>
-            <pattern><t>text</t></pattern>
-          </ele>
-          <ele>
-            <name>sum</name>
-            <summary>Overall sum of the numeric values of the data column</summary>
-            <pattern><t>text</t></pattern>
+            <name>stats</name>
+            <summary>Statistics of a data column</summary>
+            <pattern>
+              <attrib>
+                <name>column</name>
+                <summary>Name of the column the stats apply to</summary>
+                <type>text</type>
+              </attrib>
+              <e>min</e>
+              <e>max</e>
+              <e>mean</e>
+              <e>sum</e>
+              <e>c_sum</e>
+            </pattern>
+            <ele>
+              <name>min</name>
+              <summary>Overall minimum value of the data column</summary>
+              <pattern><t>text</t></pattern>
+            </ele>
+            <ele>
+              <name>max</name>
+              <summary>Overall maximum value of the data column</summary>
+              <pattern><t>text</t></pattern>
+            </ele>
+            <ele>
+              <name>mean</name>
+              <summary>Overall arithmetic mean of the numeric values of the data</summary>
+              <pattern><t>text</t></pattern>
+            </ele>
+            <ele>
+              <name>sum</name>
+              <summary>Overall sum of the numeric values of the data column</summary>
+              <pattern><t>text</t></pattern>
+            </ele>
+            <ele>
+              <name>c_sum</name>
+              <summary>Cumulative sum of the numeric values of the data column</summary>
+              <description>For overall this is always the same as sum.</description>
+              <pattern><t>text</t></pattern>
+            </ele>
           </ele>
         </ele>
         <ele>


### PR DESCRIPTION
## What

In the GMP doc for the `GET_AGGREGATES` response, add `C_COUNT` and `STATS` to `AGGREGATE/OVERALL`.

## Why

Elements were missing.

## References

`C_COUNT` was added in f432c0bacc9e10dc48b589f17acd2d37b21cfed5.

`MIN`, `MAX`, etc were moved into `STATS` in 7ae7fdf42cd52153a3f5ba83adac4c9b96df6053.

In both instances, the elements were added to the `GROUP` case in OMP.xml.in, but left out of the `OVERALL` case.

## Example
``` xml
$ o m m '<get_aggregates type="cve" data_column="severity"/>'
<get_aggregates_response status_text="OK" status="200">
  <aggregate>
    ...
    <overall>
      <count>239404</count>
      <c_count>239404</c_count>
      <stats column="severity">
        <min>-99</min>
        <max>10</max>
        <mean>0.295498</mean>
        <sum>70641.8</sum>
        <c_sum>70641.8</c_sum>
      </stats>
    </overall>
```