### PR TITLE
Doc: correct init_aggregate_iterator return

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -5266,7 +5266,7 @@ append_column (GArray *columns, const gchar *column_name,
  *                                resource.
  *
  * @return 0 success, 1 failed to find resource, 2 failed to find filter,
- *         3 invalid stat_column, 4 invalid group_column, 5 invalid type,
+ *         3 invalid data_column, 4 invalid group_column, 5 invalid type,
  *         6 trashcan not used by type, 7 invalid text column, 8 invalid
  *         subgroup_column, -1 error.
  */


### PR DESCRIPTION
## What

Very minor fix to reference in `@return` of init_aggregate_iterator.

## Why

Caught me out.

## References

`stat_column` was replaced by `data_column` in 7ae7fdf42cd52153a3f5ba83adac4c9b96df6053.

