### PR TITLE
GMP doc: add TEXT to AGGREGATE/OVERALL in GET_AGGREGATES

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -7982,6 +7982,7 @@ END:VCALENDAR
           <summary>Aggregate data for all resources of the selected type</summary>
           <pattern>
             <e>count</e>
+            <e>c_count</e>
             <e>min</e>
             <e>max</e>
             <e>mean</e>
@@ -7990,6 +7991,12 @@ END:VCALENDAR
           <ele>
             <name>count</name>
             <summary>Overall number of resources</summary>
+            <pattern><t>integer</t></pattern>
+          </ele>
+          <ele>
+            <name>c_count</name>
+            <summary>Cumulative number of resources</summary>
+            <description>For overall this is always the same as count.</description>
             <pattern><t>integer</t></pattern>
           </ele>
           <ele>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -7983,10 +7983,7 @@ END:VCALENDAR
           <pattern>
             <e>count</e>
             <e>c_count</e>
-            <e>min</e>
-            <e>max</e>
-            <e>mean</e>
-            <e>sum</e>
+            <any><e>stats</e></any>
           </pattern>
           <ele>
             <name>count</name>
@@ -8000,24 +7997,46 @@ END:VCALENDAR
             <pattern><t>integer</t></pattern>
           </ele>
           <ele>
-            <name>min</name>
-            <summary>Overall minimum value of the data column</summary>
-            <pattern><t>text</t></pattern>
-          </ele>
-          <ele>
-            <name>max</name>
-            <summary>Overall maximum value of the data column</summary>
-            <pattern><t>text</t></pattern>
-          </ele>
-          <ele>
-            <name>mean</name>
-            <summary>Overall arithmetic mean of the numeric values of the data</summary>
-            <pattern><t>text</t></pattern>
-          </ele>
-          <ele>
-            <name>sum</name>
-            <summary>Overall sum of the numeric values of the data column</summary>
-            <pattern><t>text</t></pattern>
+            <name>stats</name>
+            <summary>Statistics of a data column</summary>
+            <pattern>
+              <attrib>
+                <name>column</name>
+                <summary>Name of the column the stats apply to</summary>
+                <type>text</type>
+              </attrib>
+              <e>min</e>
+              <e>max</e>
+              <e>mean</e>
+              <e>sum</e>
+              <e>c_sum</e>
+            </pattern>
+            <ele>
+              <name>min</name>
+              <summary>Overall minimum value of the data column</summary>
+              <pattern><t>text</t></pattern>
+            </ele>
+            <ele>
+              <name>max</name>
+              <summary>Overall maximum value of the data column</summary>
+              <pattern><t>text</t></pattern>
+            </ele>
+            <ele>
+              <name>mean</name>
+              <summary>Overall arithmetic mean of the numeric values of the data</summary>
+              <pattern><t>text</t></pattern>
+            </ele>
+            <ele>
+              <name>sum</name>
+              <summary>Overall sum of the numeric values of the data column</summary>
+              <pattern><t>text</t></pattern>
+            </ele>
+            <ele>
+              <name>c_sum</name>
+              <summary>Cumulative sum of the numeric values of the data column</summary>
+              <description>For overall this is always the same as sum.</description>
+              <pattern><t>text</t></pattern>
+            </ele>
           </ele>
         </ele>
         <ele>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -7984,6 +7984,7 @@ END:VCALENDAR
             <e>count</e>
             <e>c_count</e>
             <any><e>stats</e></any>
+            <any><e>text</e></any>
           </pattern>
           <ele>
             <name>count</name>
@@ -8037,6 +8038,18 @@ END:VCALENDAR
               <description>For overall this is always the same as sum.</description>
               <pattern><t>text</t></pattern>
             </ele>
+          </ele>
+          <ele>
+            <name>text</name>
+            <summary>The value of a simple text column</summary>
+            <pattern>
+              <attrib>
+                <name>name</name>
+                <summary>Name of the text column</summary>
+                <type>text</type>
+              </attrib>
+              text
+            </pattern>
           </ele>
         </ele>
         <ele>


### PR DESCRIPTION
## What

Add `TEXT` to `AGGREGATES/OVERALL` in the GMP doc for the response to `GET_AGGREGATES`.

## Why

The element was missing.

## References

`TEXT` was added to `GET_AGGREGATES` in be36b94840f1380cb6691e11a4ed21a70392bee4 in 2015. The element was added to the `GROUP` case in OMP.xml.in, but missed from the `OVERALL` case.

Waits for greenbone/gvmd/pull/2238, which is a similar patch for `C_COUNT` and `STATS`.

## Example
```xml
$ o m m '<get_aggregates type="os" data_column="average_severity"><data_column>average_severity_score</data_column><text_column>name</text_column><text_column>hosts</text_column></get_aggregates>'
<get_aggregates_response status_text="OK" status="200">
  <aggregate>
    <overall>
      ...
      <text column="name">cpe:/o:debian:debian_linux:12</text>
      <text column="hosts">2</text>
    </overall>
```