### PR TITLE
GMP doc: simplify summary of GET_CONFIGS/CONFIG/WRITABLE

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -10156,7 +10156,7 @@ END:VCALENDAR
         <ele>
           <name>writable</name>
           <summary>
-            Whether any tasks are using the config, including trashcan tasks
+            Whether the config may be modified
           </summary>
           <pattern><t>boolean</t></pattern>
         </ele>


### PR DESCRIPTION
## What

Be more general in the summary of `WRITABLE` in the GMP doc for `GET_CONFIGS`.

## Why

The previous summary was more specific but the details of when a config is writable are pretty complex (is it predefined? does the user have permissions?) so it's more accurate to just use a general summary here.

May seem minor but there are related errors in the `MODIFY_CONFIG` behaviour, so I want this summary to be correct.

## References

Related errors: greenbone/gvmd/pull/2243 exposed in GSA by greenbone/gvmd/pull/2244