### PR TITLE
Fix: add missing returns in modify_config_run

### DIFF
--- a/src/gmp_configs.c
+++ b/src/gmp_configs.c
@@ -1026,12 +1026,18 @@ modify_config_run (gmp_parser_t *gmp_parser, GError **error)
   config_id = attr_or_null (entity, "config_id");
 
   if (config_id == NULL)
-    SEND_TO_CLIENT_OR_FAIL
-     (XML_ERROR_SYNTAX ("modify_config",
-                        "A config_id attribute is required"));
+    {
+      SEND_TO_CLIENT_OR_FAIL
+        (XML_ERROR_SYNTAX ("modify_config",
+                           "A config_id attribute is required"));
+      return;
+    }
   else if (config_predefined_uuid (config_id))
-    SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX ("modify_config",
-                                              "Permission denied"));
+    {
+      SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX ("modify_config",
+                                                "Permission denied"));
+      return;
+    }
 
   // Find the config
   switch (manage_modify_config_start (config_id, &config))
@@ -1053,6 +1059,7 @@ modify_config_run (gmp_parser_t *gmp_parser, GError **error)
         SEND_TO_CLIENT_OR_FAIL
           (XML_INTERNAL_ERROR ("modify_config"));
         log_event_fail ("config", "Scan Config", config_id, "modified");
+        return;
     }
 
   // Handle basic attributes and elements


### PR DESCRIPTION
## What

Add missing returns in the GMP `MODIFY_CONFIG` handler `modify_config_run`.

## Why

The handler must return in the exit cases, else it responds with the error and then tries to run the command anyway.

## Reproduce

### Missing config_id

Before, note three responses:
```xml
$ o m m '<modify_config/>'
<modify_config_response status="400" status_text="A config_id attribute is required" />
<modify_config_response status="500" status_text="Internal error" />
<modify_config_response status="200" status_text="OK" />
```
After:
```xml
$ o m m '<modify_config/>'
<modify_config_response status="400" status_text="A config_id attribute is required" />
```

### Trying to modify a predefined config

In GSA:
1. Menu > Configuration > Scan Configs
2. Click Edit icon of config `Base`
3. Change name to "BaseXXX"
4. Click `Save`.
5. Note `Permission denied` error
6. Click `Cancel`
7. Refresh page
8. Note that config is now called "BaseXXX".

Or in GMP:

Before, note two responses:
```xml
$ o m m '<modify_config config_id="d21f6c81-2b88-4ac1-b7b4-a2a9f2ad4663"><name>Base XXX</name></modify_config>'
<modify_config_response status="400" status_text="Permission denied" />
<modify_config_response status="200" status_text="OK" />
```

After:
```xml
$ o m m '<modify_config config_id="d21f6c81-2b88-4ac1-b7b4-a2a9f2ad4663"><name>Base XXX</name></modify_config>'
<modify_config_response status="400" status_text="Permission denied" />
```

