### PR TITLE
Change: include predefined in check for WRITABLE in GET_CONFIGS

### DIFF
--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -3316,12 +3316,12 @@ config_in_use (config_t config)
  *
  * @param[in]  config  Config.
  *
- * @return 1.
+ * @return 1 if writable, else 0.
  */
 int
 config_writable (config_t config)
 {
-  return 1;
+  return config_predefined (config) ? 0 : 1;
 }
 
 /**


### PR DESCRIPTION
## What

Check if the config is predefined in `config_writable`.

This means the `WRITABLE` flag in `GET_CONFIGS` changes from 1 to 0 for predefined configs.

## Why

`MODIFY_CONFIG` refuses to modify predefined configs.

## Reproduce

In GSA go to Menu > Configuration > Scan Configs.  The edit icon for config "Base" is greyed.  Before the PR the edit icon would be available but clicking `Save` in the edit dialog would always result in a `Permission denied` error.

GMP:

Before:
```xml
$ o m m '<get_configs config_id="d21f6c81-2b88-4ac1-b7b4-a2a9f2ad4663"/>'
<get_configs_response status="200" status_text="OK">
  <config id="d21f6c81-2b88-4ac1-b7b4-a2a9f2ad4663">
    <writable>1</writable>
```
After:
```xml
$ o m m '<get_configs config_id="d21f6c81-2b88-4ac1-b7b4-a2a9f2ad4663"/>'
<get_configs_response status="200" status_text="OK">
  <config id="d21f6c81-2b88-4ac1-b7b4-a2a9f2ad4663">
    <writable>0</writable>
```