### PR TITLE
Add: GET_FEATURES command and CVSS3_RATINGS toggle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,9 +236,17 @@ if (NOT GVM_DEFAULT_DROP_USER)
 endif (NOT GVM_DEFAULT_DROP_USER)
 
 
+# Feature toggles
 if (NOT OPENVASD)
   set (OPENVASD 0)
 endif (NOT OPENVASD)
+add_definitions (-DOPENVASD=${OPENVASD})
+
+if (NOT CVSS3_RATINGS)
+  set (CVSS3_RATINGS 0)
+endif (NOT CVSS3_RATINGS)
+add_definitions (-DCVSS3_RATINGS=${CVSS3_RATINGS})
+
 
 message ("-- Install prefix: ${CMAKE_INSTALL_PREFIX}")
 
@@ -286,7 +294,7 @@ set (HARDENING_FLAGS            "-Wformat -Wformat-security -D_FORTIFY_SOURCE=2 
 set (LINKER_HARDENING_FLAGS     "-Wl,-z,relro -Wl,-z,now")
 
 # To find unused functions, add: -flto -fwhole-program -ffunction-sections -Wl,--gc-sections -Wl,--print-gc-sections
-set (CMAKE_C_FLAGS              "${CMAKE_C_FLAGS} -Wall -D_BSD_SOURCE -D_ISOC99_SOURCE -D_SVID_SOURCE -D_DEFAULT_SOURCE -D_FILE_OFFSET_BITS=64 -DOPENVASD=${OPENVASD} ${COVERAGE_FLAGS}")
+set (CMAKE_C_FLAGS              "${CMAKE_C_FLAGS} -Wall -D_BSD_SOURCE -D_ISOC99_SOURCE -D_SVID_SOURCE -D_DEFAULT_SOURCE -D_FILE_OFFSET_BITS=64 ${COVERAGE_FLAGS}")
 
 set (CMAKE_C_FLAGS_DEBUG        "${CMAKE_C_FLAGS_DEBUG} -Werror -Wshadow ${COVERAGE_FLAGS} ${DEBUG_FUNCTION_NAMES_FLAGS}")
 set (CMAKE_C_FLAGS_RELEASE      "${CMAKE_C_FLAGS_RELEASE} ${HARDENING_FLAGS} ${COVERAGE_FLAGS}")

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -4360,6 +4360,7 @@ typedef enum
   CLIENT_GET_ASSETS,
   CLIENT_GET_CONFIGS,
   CLIENT_GET_CREDENTIALS,
+  CLIENT_GET_FEATURES,
   CLIENT_GET_FEEDS,
   CLIENT_GET_FILTERS,
   CLIENT_GET_GROUPS,
@@ -5294,6 +5295,10 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
             append_attribute (attribute_names, attribute_values, "format",
                               &get_credentials_data->format);
             set_client_state (CLIENT_GET_CREDENTIALS);
+          }
+        else if (strcasecmp ("GET_FEATURES", element_name) == 0)
+          {
+            set_client_state (CLIENT_GET_FEATURES);
           }
         else if (strcasecmp ("GET_FEEDS", element_name) == 0)
           {
@@ -12880,6 +12885,32 @@ get_feed (gmp_parser_t *gmp_parser, GError **error, int feed_type)
 }
 
 /**
+ * @brief Handle end of GET_FEATURES element.
+ *
+ * @param[in]  gmp_parser   GMP parser.
+ * @param[in]  error        Error parameter.
+ */
+static void
+handle_get_features (gmp_parser_t *gmp_parser, GError **error)
+{
+  SEND_TO_CLIENT_OR_FAIL ("<get_features_response"
+                          " status=\"" STATUS_OK "\""
+                          " status_text=\"" STATUS_OK_TEXT "\">");
+
+  SENDF_TO_CLIENT_OR_FAIL ("<feature enabled=\"%d\">"
+                           "<name>CVSS3_RATINGS</name>"
+                           "</feature>",
+                           CVSS3_RATINGS ? 1 : 0);
+
+  SENDF_TO_CLIENT_OR_FAIL ("<feature enabled=\"%d\">"
+                           "<name>OPENVASD</name>"
+                           "</feature>",
+                           OPENVASD ? 1 : 0);
+
+  SEND_TO_CLIENT_OR_FAIL ("</get_features_response>");
+}
+
+/**
  * @brief Handle end of GET_FEEDS element.
  *
  * @param[in]  gmp_parser   GMP parser.
@@ -19958,6 +19989,10 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
 
       case CLIENT_GET_CREDENTIALS:
         handle_get_credentials (gmp_parser, error);
+        break;
+
+      case CLIENT_GET_FEATURES:
+        handle_get_features (gmp_parser, error);
         break;
 
       case CLIENT_GET_FEEDS:

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -2303,6 +2303,9 @@ gvmd (int argc, char** argv, char *env[])
 #if OPENVASD == 1
       printf ("OpenVASD is enabled\n");
 #endif
+#if CVSS3_RATINGS == 1
+      printf ("CVSS3 severity ratings enabled\n");
+#endif
       printf ("Copyright (C) 2009-2021 Greenbone AG\n");
       printf ("License: AGPL-3.0-or-later\n");
       printf

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -11164,6 +11164,64 @@ END:VCALENDAR
     </example>
   </command>
   <command>
+    <name>get_features</name>
+    <summary>Get a list of optional features</summary>
+    <description>
+      <p>
+        The client uses the get_feeds command to get a list of optional
+        features.
+        If the command sent by the client was valid, the manager will
+        reply with a list of feeds to the client.
+      </p>
+    </description>
+    <response>
+      <pattern>
+        <attrib>
+          <name>status</name>
+          <type>status</type>
+          <required>1</required>
+        </attrib>
+        <attrib>
+          <name>status_text</name>
+          <type>text</type>
+          <required>1</required>
+        </attrib>
+        <any><e>feature</e></any>
+      </pattern>
+      <ele>
+        <name>feature</name>
+        <pattern>
+          <attrib>
+            <name>enabled</name>
+            <type>boolean</type>
+            <summary>Whether the feature is enabled</summary>
+            <required>1</required>
+          </attrib>
+          <e>name</e>
+        </pattern>
+        <ele>
+          <name>name</name>
+          <summary>The name of the feature</summary>
+          <pattern>text</pattern>
+        </ele>
+      </ele>
+    </response>
+    <example>
+      <summary>Get the optional features</summary>
+      <request>
+        <get_feeds>
+        </get_feeds>
+      </request>
+      <response>
+        <get_features_response status_text="OK" status="200">
+          <feature enabled="0">
+            <name>OPENVASD</name>
+          </feature>
+        </get_features_response>
+      </response>
+    </example>
+  </command>
+  <command>
     <name>get_feeds</name>
     <summary>Get one or many feeds</summary>
     <description>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -11168,12 +11168,13 @@ END:VCALENDAR
     <summary>Get a list of optional features</summary>
     <description>
       <p>
-        The client uses the get_feeds command to get a list of optional
+        The client uses the get_features command to get a list of optional
         features.
         If the command sent by the client was valid, the manager will
-        reply with a list of feeds to the client.
+        reply with a list of features to the client.
       </p>
     </description>
+    <pattern></pattern>
     <response>
       <pattern>
         <attrib>


### PR DESCRIPTION
## What
The GMP command GET_FEATURES has been added to get the status of optional features that can be enabled or disabled at build time.

This includes the OPENVASD toggle as well as a new one (CVSS3_RATINGS) that will later be used to toggle CVSS3 / CVSS4 severity ratings.

## Why
The new command will allow GSA to get the current state of these feature toggles

## References
GEA-612



