### PR TITLE
Fix: Also create NVT indexes after rebuild

### DIFF
--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -1882,6 +1882,33 @@ create_tables_nvt (const gchar *suffix)
 }
 
 /**
+ * @brief Create NVT related indexes.
+ *
+ * @param[in]  suffix  String to append to table names.
+ */
+void
+create_indexes_nvt ()
+{
+  sql ("SELECT create_index ('nvts_by_creation_time',"
+       "                     'nvts',"
+       "                     'creation_time');");
+  sql ("SELECT create_index ('nvts_by_family', 'nvts', 'family');");
+  sql ("SELECT create_index ('nvts_by_name', 'nvts', 'name');");
+  sql ("SELECT create_index ('nvts_by_modification_time',"
+       "                     'nvts', 'modification_time');");
+  sql ("SELECT create_index ('nvts_by_cvss_base',"
+       "                     'nvts', 'cvss_base');");
+  sql ("SELECT create_index ('nvts_by_solution_type',"
+       "                     'nvts', 'solution_type');");
+  
+  sql ("SELECT create_index ('vt_refs_by_vt_oid',"
+       "                     'vt_refs', 'vt_oid');");
+
+  sql ("SELECT create_index ('vt_severities_by_vt_oid',"
+       "                     'vt_severities', 'vt_oid');");
+}
+
+/**
  * @brief Create all tables.
  */
 void
@@ -3021,17 +3048,8 @@ create_tables ()
   sql ("SELECT create_index ('nvt_selectors_by_name',"
        "                     'nvt_selectors',"
        "                     'name');");
-  sql ("SELECT create_index ('nvts_by_creation_time',"
-       "                     'nvts',"
-       "                     'creation_time');");
-  sql ("SELECT create_index ('nvts_by_family', 'nvts', 'family');");
-  sql ("SELECT create_index ('nvts_by_name', 'nvts', 'name');");
-  sql ("SELECT create_index ('nvts_by_modification_time',"
-       "                     'nvts', 'modification_time');");
-  sql ("SELECT create_index ('nvts_by_cvss_base',"
-       "                     'nvts', 'cvss_base');");
-  sql ("SELECT create_index ('nvts_by_solution_type',"
-       "                     'nvts', 'solution_type');");
+
+  create_indexes_nvt ();
 
   sql ("SELECT create_index ('permissions_by_name',"
        "                     'permissions', 'name');");
@@ -3062,12 +3080,6 @@ create_tables ()
   sql ("SELECT create_index ('tls_certificate_origins_by_origin_id_and_type',"
        "                     'tls_certificate_origins',"
        "                     'origin_id, origin_type')");
-
-  sql ("SELECT create_index ('vt_refs_by_vt_oid',"
-       "                     'vt_refs', 'vt_oid');");
-
-  sql ("SELECT create_index ('vt_severities_by_vt_oid',"
-       "                     'vt_severities', 'vt_oid');");
 
   /* Previously this included the value column but that can be bigger than 8191,
    * the maximum size that Postgres can handle.  For example, this can happen

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -505,6 +505,9 @@ add_role_permission_resource (const gchar *, const gchar *, const gchar *,
 void
 create_view_vulns ();
 
+void
+create_indexes_nvt ();
+
 int
 config_family_entire_and_growing (config_t, const char*);
 

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1987,6 +1987,7 @@ update_nvts_from_vts (element_t *get_vts_response,
     sql ("ALTER TABLE nvts_rebuild RENAME TO nvts;");
 
     create_view_vulns ();
+    create_indexes_nvt ();
   }
 
   set_nvts_check_time (count_new_vts, count_modified_vts);


### PR DESCRIPTION
## What
If the nvts, vt_refs and vt_severities tables have been replaced in a VTs rebuild, indexes are now created for the new tables.

## Why
This addresses the the indexes not existing after a rebuild and the subsequent performance issues.

## References
GEA-579
https://forum.greenbone.net/t/issue-with-result-report-fetch-times-from-gvm/18161
