### PR TITLE
GMP doc: add HR_NAME and adjust DEFAULT in GET_CONFIGS

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -10307,6 +10307,7 @@ END:VCALENDAR
             <pattern>
               <e>nvt</e>
               <e>name</e>
+              <o><e>hr_name</e></o>
               <e>id</e>
               <e>type</e>
               <e>value</e>
@@ -10333,6 +10334,11 @@ END:VCALENDAR
             <ele>
               <name>name</name>
               <summary>The compact name of the preference as used by the scanner</summary>
+              <pattern><t>name</t></pattern>
+            </ele>
+            <ele>
+              <name>hr_name</name>
+              <summary>The human readable name of the preference</summary>
               <pattern><t>name</t></pattern>
             </ele>
             <ele>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -10310,7 +10310,7 @@ END:VCALENDAR
               <e>id</e>
               <e>type</e>
               <e>value</e>
-              <e>default</e>
+              <o><e>default</e></o>
               <any><e>alt</e></any>
             </pattern>
             <ele>


### PR DESCRIPTION
## What

In the GMP doc for the `GET_CONFIGS` response make `PREFERENCE/DEFAULT` optional and add `PREFERENCE/HR_NAME`.

## Why

`DEFAULT` is omitted for timeout preferences.

`HR_NAME` was missing.

## References

`HR_NAME` was added in 52f3c3a19b72148507ea46b516d040f152ec61e1 in 2021.

## Example

Note that `DEFAULT` is missing from the first `PREFERENCE` and `HR_NAME` is present in the second.

``` xml
$ o m m '<get_configs config_id="55385e2f-cd85-4a4a-954a-c89495aca669" details="1"/>'
<get_configs_response status="200" status_text="OK">
  <config id="55385e2f-cd85-4a4a-954a-c89495aca669">
    <preferences>
      <preference>
        <nvt oid="1.3.6.1.4.1.25623.1.0.103128">
          <name>7T Interactive Graphical SCADA System Multiple
          Security Vulnerabilities</name>
        </nvt>
        <id>0</id>
        <name>Timeout</name>
        <type>entry</type>
        <value>22</value>
      </preference>
      <preference>
        <nvt oid="1.3.6.1.4.1.25623.1.0.100151">
          <name>PostgreSQL Detection (TCP)</name>
        </nvt>
        <id>2</id>
        <hr_name>Postgres Password:</hr_name>
        <name>Postgres Password:</name>
        <type>password</type>
        <value></value>
        <default></default>
      </preference>
```

