### PR TITLE
GMP doc: add missing GET_ALERTS elements

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -8519,6 +8519,7 @@ END:VCALENDAR
           <e>method</e>
           <e>filter</e>
           <o><e>tasks</e></o>
+          <e>active</e>
         </pattern>
         <ele>
           <name>owner</name>
@@ -8784,6 +8785,11 @@ END:VCALENDAR
               <pattern></pattern>
             </ele>
           </ele>
+        </ele>
+        <ele>
+          <name>active</name>
+          <summary>Whether the alert is active</summary>
+          <pattern><t>boolean</t></pattern>
         </ele>
       </ele>
       <ele>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -8679,7 +8679,7 @@ END:VCALENDAR
         </ele>
         <ele>
           <name>method</name>
-          <summary>The method by which he alert must occur</summary>
+          <summary>The method by which the alert must occur</summary>
           <pattern>
             text
             <any><e>data</e></any>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -523,6 +523,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <e>expiration_time</e>
       <e>issuer</e>
       <e>md5_fingerprint</e>
+      <o><e>sha256_fingerprint</e></o>
+      <o><e>subject</e></o>
+      <o><e>serial</e></o>
     </pattern>
     <ele>
       <name>time_status</name>
@@ -556,6 +559,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <ele>
       <name>md5_fingerprint</name>
       <summary>MD5 fingerprint of the certificate</summary>
+      <pattern>text</pattern>
+    </ele>
+    <ele>
+      <name>sha256_fingerprint</name>
+      <summary>SHA-256 fingerprint of the certificate</summary>
+      <pattern>text</pattern>
+    </ele>
+    <ele>
+      <name>subject</name>
+      <summary>Name of the certificate</summary>
+      <pattern>text</pattern>
+    </ele>
+    <ele>
+      <name>serial</name>
+      <summary>Serial number of certificate</summary>
       <pattern>text</pattern>
     </ele>
   </element>


### PR DESCRIPTION
## What

Add fields to element `CERTIFICATE` that are present in `GET_ALERTS/ALERT/METHOD/DATA/CERTIFICATE_INFO`.

Add `ACTIVE` to `ALERT` in the `GET_ALERTS` response.

## Why

Elements were missing.

## Verify

Create TippingPoint alert:
```xml
#!/bin/sh
CERT="`cat tmp/cert/MyCertificate.crt`"
time o m m "<create_alert><name>tp test tls7</name><active>1</active><condition>Severity at least<data>5.5<name>severity</name></data></condition><event>Task run status changed<data>Done<name>status</name></data></event><method>TippingPoint SMS<data>$CERT<name>tp_sms_tls_certificate</name></data><data>0cd54695-211f-4657-89a5-c74db477b9e7<name>tp_sms_credential</name></data><data>127.0.0.1<name>tp_sms_hostname</name></data><data>0<name>tp_sms_tls_workaround</name></data></method></create_alert>"
```
See fields:
```xml
$ o m m '<get_alerts alert_id="0937ad58-32c7-48b9-98f3-558a6827d0ec"/>'
<get_alerts_response status="200" status_text="OK">
  <alert id="0937ad58-32c7-48b9-98f3-558a6827d0ec">
    <method>
      TippingPoint SMS
      <data>
        <name>tp_sms_tls_certificate</name>
        <certificate_info>
          <activation_time>2024-07-06T20:08:43+02:00</activation_time>
          <expiration_time>2025-07-06T20:08:43+02:00</expiration_time>
          <md5_fingerprint>27:9d:9c:ba:32:f6:01:9d:25:34:76:c5:dc:9c:be:f1</md5_fingerprint>
          <sha256_fingerprint>3D6A887138236F62CD2EA3F6C85405B9A494A14777EAF58E2080D0D4F008BBC0</sha256_fingerprint>
          <subject>C=AU,ST=Some-State,O=Internet Widgits Pty Ltd</subject>
          <issuer>C=AU,ST=Some-State,O=Internet Widgits Pty Ltd</issuer>
          <serial>6018FFFFFFFA2744755606FFFFFFF5FFFFFF8AFFFFFFAAFFFFFFD20A20FFFFFF907A2E44FFFFFFAC1D</serial>
        </certificate_info>
    ...
    <active>1</active>
  </alert>
```
