### PR TITLE
Fix: Use right type for serial buffer

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -526,7 +526,7 @@ get_certificate_info (const gchar* certificate, gssize certificate_len,
         {
           int i;
           size_t buffer_size = 0;
-          gchar* buffer;
+          unsigned char *buffer;
           GString *string;
 
           string = g_string_new ("");


### PR DESCRIPTION
## What

Use `unsigned char` for the buffer when printing the serial number in `get_certificate_info`.

## Why

With `char` the output text contained extra runs of `FF`.

Note that the fingerprint cases further up are doing similar printing and are already using `unsigned char`.

I think the extra `FF`s are because `char` ranges from `-127` to `-127`. So if the byte in the buffer is `250` that becomes `-6` instead of `250`, which `g_string_append_printf` prints as `FFFFFFFA` instead of `FA`.

## Verify
Before:
```xml
$ o m m '<get_alerts alert_id="0937ad58-32c7-48b9-98f3-558a6827d0ec"/>' | grep serial
      <serial>6018FFFFFFFA2744755606FFFFFFF5FFFFFF8AFFFFFFAAFFFFFFD20A20FFFFFF907A2E44FFFFFFAC1D</serial>
```
After:
```xml
$ o m m '<get_alerts alert_id="0937ad58-32c7-48b9-98f3-558a6827d0ec"/>' | grep serial
      <serial>6018FA2744755606F58AAAD20A20907A2E44AC1D</serial>
```
The same certificate using openssl:
```
$ cd ~/tmp/cert && openssl x509 -noout -serial -in MyCertificate.crt
serial=6018FA2744755606F58AAAD20A20907A2E44AC1D
```
## References

Serial was added in 408cbcf3fbc393747e8b2645a34503e5c1436409.

