### PR TITLE
GMP doc: add missing elements to GET_ASSETS

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -11719,7 +11719,6 @@ handle_get_assets (gmp_parser_t *gmp_parser, GError **error)
       gchar *routes_xml;
 
       asset = get_iterator_resource (&assets);
-      /* Assets are currently always writable. */
       if (send_get_common ("asset", &get_assets_data->get, &assets,
                            gmp_parser->client_writer,
                            gmp_parser->client_writer_data,

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -9190,6 +9190,7 @@ END:VCALENDAR
           <e>permissions</e>
           <o><e>user_tags</e></o>
           <o><e>identifiers</e></o>
+          <e>type</e>
           <or>
             <e>host</e>
             <e>os</e>
@@ -9316,6 +9317,13 @@ END:VCALENDAR
               </ele>
             </ele>
           </ele>
+        </ele>
+        <ele>
+          <name>type</name>
+          <summary>Either "host" or "os"</summary>
+          <pattern>
+            xsd:token { pattern = "host|os" }
+          </pattern>
         </ele>
         <ele>
           <name>host</name>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -9331,7 +9331,7 @@ END:VCALENDAR
           <pattern>
             <e>severity</e>
             <any><e>detail</e></any>
-            <e>routes</e>
+            <o><e>routes</e></o>
           </pattern>
           <ele>
             <name>severity</name>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -9494,7 +9494,7 @@ END:VCALENDAR
               Hosts on which this OS has been detected as the best match
             </summary>
             <pattern>
-              <e>asset</e>
+              <any><e>asset</e></any>
             </pattern>
             <ele>
               <name>asset</name>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -9276,6 +9276,7 @@ END:VCALENDAR
                 <e>type</e>
                 <e>data</e>
                 <e>deleted</e>
+                <e>name</e>
               </pattern>
               <ele>
                 <name>type</name>
@@ -9290,6 +9291,11 @@ END:VCALENDAR
               <ele>
                 <name>deleted</name>
                 <summary>Whether the source has been deleted</summary>
+                <pattern>boolean</pattern>
+              </ele>
+              <ele>
+                <name>name</name>
+                <summary>User name when source type is User, else empty</summary>
                 <pattern>boolean</pattern>
               </ele>
             </ele>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -9150,7 +9150,7 @@ END:VCALENDAR
       </attrib>
       <attrib>
         <name>details</name>
-        <summary>Whether to include additional information (e.g., tags)</summary>
+        <summary>Whether to include additional information (e.g. tags)</summary>
         <type>boolean</type>
       </attrib>
     </pattern>
@@ -9515,7 +9515,7 @@ END:VCALENDAR
         </ele>
         <ele>
           <name>in_use</name>
-          <summary>Whether any tasks are using the asset</summary>
+          <summary>Whether the asset is in use</summary>
           <pattern><t>boolean</t></pattern>
         </ele>
         <ele>


### PR DESCRIPTION
## What

In the GMP doc add `SOURCE/NAME` and `TYPE` to the `GET_ASSETS` response.

Also correct the summary of `IN_USE`, and correct multiple/optional flags of `HOSTS/ASSET` and `HOST/ROUTES`.

## Why

Elements were missing.

`IN_USE` was referring to tasks.

There can be multiple `ASSET`s in `OS/HOSTS`.

`HOSTS/ROUTES` is only sent when `@asset_id` is given.

## References

`SOURCE/NAME` was added in 186cce0fe1392f1e8a7ed79ac43372fd7da300e9.

`TYPE` was added in f14415d29032424407614b8acbae8f82e5ab2254.

## Examples
```xml
$ o m m '<get_assets type="host"/>'
<get_assets_response status="200" status_text="OK">
  <asset id="8c73d5af-e728-47a0-96e2-364d3dad7828">
    <identifiers>
      <identifier id="9d26b8ab-f5b6-495d-ad5d-b2156caec99c">
        ...
        <source id="991f910d-9ea4-4787-bab8-f4f4b479be5c">
          <type>User</type>
          <data></data>
          <deleted>0</deleted>
          <name>m</name>                         <!-- NAME -->
        </source>
      </identifier>
    </identifiers>
    <type>host</type>                            <!-- TYPE -->
    ...
  </asset>
```

```xml
time o m m '<get_assets type="os"/>'
<get_assets_response status="200" status_text="OK">
  <asset id="66539be2-8094-4bf0-a6ae-f3fe755a9f41">
    <os>
      ...
      <hosts>
        2
        <asset id="4512f4d4-7ec5-42d5-b40f-cc521936519d">                   <!-- Multiple ASSETs -->
          <name>xx.xx.xx.x1</name>
          <severity>
            <value>10.0</value>
          </severity>
        </asset>
        <asset id="9dc9ca41-cef6-488c-a92a-3ac4b9c87945">
          <name>xx.xx.xx.x2</name>
          <severity>
            <value>10.0</value>
          </severity>
        </asset>
      </hosts>
    </os>
  </asset>
```

```xml
$ o m m '<get_assets type="host" asset_id="4512f4d4-7ec5-42d5-b40f-cc521936519d"/>' 
<get_assets_response status="200" status_text="OK">
  <asset id="4512f4d4-7ec5-42d5-b40f-cc521936519d">
    <host>
      <routes>                                    <!-- ROUTES sent because @asset_id -->
        <route>
          <host id="" distance="0" same_source="0">
            <ip>...
```