### PR TITLE
Remove stray details checks from GET_ASSETS

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -11905,7 +11905,7 @@ handle_get_assets (gmp_parser_t *gmp_parser, GError **error)
                                       (&details));
           cleanup_iterator (&details);
 
-          if (get_assets_data->details || get_assets_data->get.id)
+          if (get_assets_data->get.id)
             {
               routes_xml = host_routes_xml (asset);
               g_string_append (result, routes_xml);
@@ -11922,9 +11922,6 @@ handle_get_assets (gmp_parser_t *gmp_parser, GError **error)
       g_string_free (result, TRUE);
     }
   cleanup_iterator (&assets);
-
-  if (get_assets_data->details == 1)
-    SEND_TO_CLIENT_OR_FAIL ("<details>1</details>");
 
   filtered = get_assets_data->get.id
               ? 1


### PR DESCRIPTION
## What

Remove checks of `get_assets_data->details` from `handle_get_assets`.

## Why

The `details` attribute is stored in `get_assets_data->get.details`. These checks on `get_assets_data->details` are probably copy-paste errors from GET_INFO. This works in GET_INFO because GET_INFO explicitly sets `get_info_data->details` alongside `get_info_data->get.details`.

As a result the `DETAILS` element has never been returned from GET_ASSETS. It's also missing from the docs. That's OK.

Similarly, `ROUTES` is only returned from GET_ASSETS when an `asset_id` attribute is given, regardless of the value of the `details` attribute. Also OK.

## Verify

`ROUTES` is controlled by `asset_id` alone:
```xml
$ o m m '<get_assets type="host" details="1" asset_id="4512f4d4-7ec5-42d5-b40f-cc521936519d"/>' | grep routes
      <routes>
      </routes>
$ o m m '<get_assets type="host" details="1"/>' | grep routes
$ o m m '<get_assets type="host" asset_id="4512f4d4-7ec5-42d5-b40f-cc521936519d"/>' | grep routes
      <routes>
      </routes>
$ o m m '<get_assets type="host"/>' | grep routes
```
`DETAILS` is never sent:
```xml
$ o m m '<get_assets type="os"/>' | grep details
$ o m m '<get_assets type="host"/>' | grep details
$ o m m '<get_assets type="os" details="1"/>' | grep details
$ o m m '<get_assets type="host" details="1"/>' | grep details
```

## References

Check for `DETAILS` element added when GET_ASSETS originally added in aaceac736d412ed03874214963be2985c7b58fca in 2015.

Check for `ROUTES` element added in 21663160d6a3a64415630affafb3701d353cfd46 in 2016.
