### PR TITLE
GMP doc: add details attribute to GET_CREDENTIALS

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -10683,6 +10683,11 @@ END:VCALENDAR
         <type>uuid</type>
       </attrib>
       <attrib>
+        <name>details</name>
+        <summary>Whether to include certificate info</summary>
+        <type>boolean</type>
+      </attrib>
+      <attrib>
         <name>scanners</name>
         <summary>Whether to include a list of scanners using the credentials</summary>
         <type>boolean</type>


### PR DESCRIPTION
## What

Add attribute `details` to command `GET_CREDENTIALS` in the GMP doc.

## Why

Attribute was missing.

## Verify

```xml
$ o m m '<get_credentials credential_id="b9e540ed-92d5-4dba-b1af-201ada28e58d"/>' | grep certificate
    <name>cc: certificate</name>
    <full_type>client certificate</full_type>

$ o m m '<get_credentials credential_id="b9e540ed-92d5-4dba-b1af-201ada28e58d" details="1"/>' | grep certificate
    <name>cc: certificate</name>
    <full_type>client certificate</full_type>
    <certificate_info>
    </certificate_info>
````