### PR TITLE
GMP doc: make key/package/cert element optional in GET_CREDENTIALS

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -10755,11 +10755,13 @@ END:VCALENDAR
           <o><e>certificate_info</e></o>
           <o><e>scanners</e></o>
           <o><e>targets</e></o>
-          <or>
-            <e>public_key</e>
-            <e>package</e>
-            <e>certificate</e>
-          </or>
+          <o>
+            <or>
+              <e>public_key</e>
+              <e>package</e>
+              <e>certificate</e>
+            </or>
+          </o>
         </pattern>
         <ele>
           <name>owner</name>


### PR DESCRIPTION
## What

In the GMP doc add an optional marker to the `OR` in GET_CREDENTIALS that produced "One of `PUBLIC_KEY`, `PACKAGE`, `CERTIFICATE`".

## Why

All three of these elements may be left out entirely by leaving the `filter` attribute out of the request.

## Verify

```
$ o m m '<get_credentials credential_id="5e337463-30e5-4335-988a-800532f56123"/>' | grep '\(public_key\|package\|certificate\)'
$ o m m '<get_credentials format="pem" credential_id="5e337463-30e5-4335-988a-800532f56123"/>' | grep '\(public_key\|package\|certificate\)'
    <certificate>-----BEGIN CERTIFICATE-----
    -----END CERTIFICATE-----</certificate>
```

