### PR TITLE
GMP doc: bring GET_FEEDS up to date

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -11342,7 +11342,7 @@ END:VCALENDAR
     <pattern>
       <attrib>
         <name>type</name>
-        <summary>Type of single feed to get: NVT, CERT or SCAP</summary>
+        <summary>Type of single feed to get: NVT, CERT, SCAP or GVMD_DATA</summary>
         <type>text</type>
       </attrib>
     </pattern>
@@ -11372,7 +11372,7 @@ END:VCALENDAR
         </pattern>
         <ele>
           <name>type</name>
-          <summary>The type of feed: NVT, CERT or SCAP</summary>
+          <summary>The type of feed: NVT, CERT, SCAP or GVMD_DATA</summary>
           <pattern>text</pattern>
         </ele>
         <ele>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -11406,16 +11406,10 @@ END:VCALENDAR
           <summary>Present if a sync of this type is underway</summary>
           <pattern>
             <e>timestamp</e>
-            <e>user</e>
           </pattern>
           <ele>
             <name>timestamp</name>
             <summary>Time sync started</summary>
-            <pattern>text</pattern>
-          </ele>
-          <ele>
-            <name>user</name>
-            <summary>Name of user who is performing sync</summary>
             <pattern>text</pattern>
           </ele>
         </ele>


### PR DESCRIPTION
## What

Add "GMVD_DATA" to the feed types, and remove `USER` from `CURRENTLY_SYNCING`.

## Why

Type was missing.

`USER` was removed from `CURRENTLY_SYNCING` in b6de74c37725cc06378805df9d7b21c74e9b5a69.

## Verify
```xml
$ o m m '<get_feeds type="GVMD_DATA"/>'
<get_feeds_response status="200" status_text="OK">
  <feed>
    <type>GVMD_DATA</type>
    <name>Greenbone Data Objects Feed</name>
    <version>202401230504</version>
    <description>Provided via feed-automation</description>
  </feed>
</get_feeds_response>
```
