### PR TITLE
GMP doc: GET_FILTERS: fix summary of IN_USE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,7 +402,7 @@ install (FILES src/alert_methods/vFire/alert
          DESTINATION ${GVMD_DATA_DIR}/global_alert_methods/159f79a5-fce8-4ec5-aa49-7d17a77739a3/
          PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 
- install (CODE "file (MAKE_DIRECTORY \$ENV{DESTDIR}${GVMD_DATA_DIR}/wizards)")
+install (CODE "file (MAKE_DIRECTORY \$ENV{DESTDIR}${GVMD_DATA_DIR}/wizards)")
 
 install (FILES src/wizards/quick_first_scan.xml
                src/wizards/get_tasks_deep.xml

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -11759,7 +11759,7 @@ END:VCALENDAR
         </ele>
         <ele>
           <name>in_use</name>
-          <summary>Whether any tasks are using the filter</summary>
+          <summary>Whether any alerts are using the filter</summary>
           <pattern><t>boolean</t></pattern>
         </ele>
         <ele>


### PR DESCRIPTION
## What

Fix `SUMMARY`.

## Why

`IN_USE` is 1 if an alert is using the filter.

## References

See `filter_in_use` in [manage_sql.c](https://github.com/greenbone/gvmd/blob/main/src/manage_sql.c#L47779).
