### PR TITLE
GMP doc: GET_FILTERS: fix duplicate FILTERS in HTML 

### DIFF
--- a/src/schema_formats/HTML/HTML.xsl
+++ b/src/schema_formats/HTML/HTML.xsl
@@ -579,12 +579,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </xsl:when>
       <xsl:when test="name() = 'e'">
         <li>
-          <xsl:variable name="element-name" select="text()"/>
+          <xsl:variable name="element-name-or-id" select="text()"/>
+          <!-- | appends right to left and [1] limits to one ele.
+               So if an ele with <id> is present it will override an ele with <name>. -->
           <xsl:variable name="new-line-element"
-                        select="$line-element/ele[name=$element-name]"/>
+                        select="($line-element/ele[id=$element-name-or-id]|$line-element/ele[name=$element-name-or-id])[1]"/>
           <xsl:choose>
             <xsl:when test="$new-line-element">
-              &lt;<b><xsl:value-of select="text()"/></b>&gt;
+              &lt;<b><xsl:value-of select="$new-line-element/name"/></b>&gt;
               <xsl:value-of select="$element-suffix"/>
               <xsl:if test="$new-line-element/type">
                 <div style="margin-left: 15px; display: inline;">(<xsl:apply-templates select="$new-line-element/type" mode="element"/>)</div>
@@ -611,6 +613,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
               </xsl:if>
             </xsl:when>
             <xsl:otherwise>
+              <xsl:variable name="element-name" select="text()"/>
               <xsl:variable name="global-element"
                             select="/protocol/element[name=$element-name]"/>
               &lt;<a href="#element_{$global-element/name}"><b><xsl:value-of select="text()"/></b></a>&gt;

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -11687,7 +11687,7 @@ END:VCALENDAR
         <any><e>filter</e></any>
         <e>filters</e>
         <e>sort</e>
-        <e>filters</e>
+        <e>filters2</e>
         <e>filter_count</e>
       </pattern>
       <ele>
@@ -11944,6 +11944,7 @@ END:VCALENDAR
         </ele>
       </ele>
       <ele>
+        <id>filters2</id>
         <name>filters</name>
         <pattern>
           <attrib>

--- a/src/schema_formats/rnc.xsl
+++ b/src/schema_formats/rnc.xsl
@@ -182,6 +182,10 @@ response
     <xsl:param name="parent"/>
     <xsl:variable name="name" select="text()"/>
     <xsl:choose>
+      <xsl:when test="$parent/ele[id=$name]">
+        <xsl:value-of select="$parent-name"/>
+        <xsl:value-of select="$parent/ele[id=$name]/name"/>
+      </xsl:when>
       <xsl:when test="$parent/ele[name=$name]">
         <xsl:value-of select="$parent-name"/>
         <xsl:value-of select="$name"/>


### PR DESCRIPTION
## What

In the GMP XML `E` in `PATTERN` currently refers to an `ELE` by `NAME`. Extend `E` to refer also to the `ELE` by `ID`. `ID` takes precedence over `NAME`.

Also select only one `ELE` for `E`.

Lastly, add an `ID` to the second FILTERS `ELE` in GET_FILTERS.

## Why

Adding the `ID` to FILTERS prevents the XSL from producing duplicate `FILTERS` elements in the HTML output.

Before, both `FILTERS` have same elements:
![shot](https://github.com/user-attachments/assets/ab43b273-ab83-419e-bb8f-b2f792c40a23)

After, correct:
![shot2](https://github.com/user-attachments/assets/738d36b7-5905-4aa1-b5c3-f25196609180)
