### PR TITLE
GMP doc: add TEXT to AGGREGATE/OVERALL in GET_AGGREGATES

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -8115,6 +8115,7 @@ END:VCALENDAR
             <e>count</e>
             <e>c_count</e>
             <any><e>stats</e></any>
+            <any><e>text</e></any>
           </pattern>
           <ele>
             <name>count</name>
@@ -8168,6 +8169,18 @@ END:VCALENDAR
               <description>For overall this is always the same as sum.</description>
               <pattern><t>text</t></pattern>
             </ele>
+          </ele>
+          <ele>
+            <name>text</name>
+            <summary>The value of a simple text column</summary>
+            <pattern>
+              <attrib>
+                <name>name</name>
+                <summary>Name of the text column</summary>
+                <type>text</type>
+              </attrib>
+              text
+            </pattern>
           </ele>
         </ele>
         <ele>


### PR DESCRIPTION
## What

Add `TEXT` to `AGGREGATES/OVERALL` in the GMP doc for the response to `GET_AGGREGATES`.

## Why

The element was missing.

## References

`TEXT` was added to `GET_AGGREGATES` in be36b94840f1380cb6691e11a4ed21a70392bee4 in 2015. The element was added to the `GROUP` case in OMP.xml.in, but missed from the `OVERALL` case.

## Example
```xml
$ o m m '<get_aggregates type="os" data_column="average_severity"><data_column>average_severity_score</data_column><text_column>name</text_column><text_column>hosts</text_column></get_aggregates>'
<get_aggregates_response status_text="OK" status="200">
  <aggregate>
    <overall>
      ...
      <text column="name">cpe:/o:debian:debian_linux:12</text>
      <text column="hosts">2</text>
    </overall>
```