### PR TITLE
GMP doc: GET_LICENSE: add missing SENSOR reference

### DIFF
--- a/src/manage_license.c
+++ b/src/manage_license.c
@@ -82,8 +82,7 @@ manage_update_license_file (const char *new_license, char **error_msg)
                  __func__, broker_address);
       return 1;
     }
-  else
-    g_debug ("%s: Connected to %s\n", __func__, broker_address);
+  g_debug ("%s: Connected to %s\n", __func__, broker_address);
 
   ret = theia_new_modify_license_cmd ((char *) new_license, &modify_license_cmd);
 
@@ -105,13 +104,11 @@ manage_update_license_file (const char *new_license, char **error_msg)
       free (client);
       return 2;
     }
-  else
-    g_debug ("%s: Sent modify.license command"
-             " (message_id: %s, group_id: %s)\n",
-             __func__,
-             modify_license_cmd->message->id,
-             modify_license_cmd->message->group_id);
-
+  g_debug ("%s: Sent modify.license command"
+           " (message_id: %s, group_id: %s)\n",
+           __func__,
+           modify_license_cmd->message->id,
+           modify_license_cmd->message->group_id);
 
   ret = theia_client_get_info_response (client, THEIA_LICENSE_INFO_TOPIC,
                                         "modified.license",
@@ -127,8 +124,7 @@ manage_update_license_file (const char *new_license, char **error_msg)
       free (client);
       return 3;
     }
-  else
-    g_debug ("%s: Received modified.license response", __func__);
+  g_debug ("%s: Received modified.license response", __func__);
 
   if (failure_modify_license_info)
     {
@@ -142,11 +138,8 @@ manage_update_license_file (const char *new_license, char **error_msg)
       free (client);
       return 5;
     }
-  else
-    {
-    g_message ("%s: Uploaded new license file (%lu bytes)",
-               __func__, strlen (new_license));
-    }
+  g_message ("%s: Uploaded new license file (%lu bytes)",
+             __func__, strlen (new_license));
 
   theia_client_disconnect (client);
   theia_modified_license_info_free (modified_license_info);
@@ -207,8 +200,7 @@ manage_get_license (gchar **status,
                  __func__, broker_address);
       return 1;
     }
-  else
-    g_debug ("%s: Connected to %s\n", __func__, broker_address);
+  g_debug ("%s: Connected to %s\n", __func__, broker_address);
 
   ret = theia_new_get_license_cmd (&get_license_cmd);
   if (ret)
@@ -229,13 +221,11 @@ manage_get_license (gchar **status,
       free (client);
       return 2;
     }
-  else
-    g_debug ("%s: Sent get.license command"
-             " (message_id: %s, group_id: %s)\n",
-             __func__,
-             get_license_cmd->message->id,
-             get_license_cmd->message->group_id);
-
+  g_debug ("%s: Sent get.license command"
+           " (message_id: %s, group_id: %s)\n",
+           __func__,
+           get_license_cmd->message->id,
+           get_license_cmd->message->group_id);
 
   ret = theia_client_get_info_response (client, THEIA_LICENSE_INFO_TOPIC,
                                         "got.license", NULL,
@@ -250,8 +240,7 @@ manage_get_license (gchar **status,
       free (client);
       return 3;
     }
-  else
-    g_debug ("%s: Received got.license response", __func__);
+  g_debug ("%s: Received got.license response", __func__);
 
   theia_client_disconnect (client);
 

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -13579,6 +13579,7 @@ END:VCALENDAR
             <pattern>
               <e>model</e>
               <e>model_type</e>
+              <e>sensor</e>
             </pattern>
             <ele>
               <name>model</name>


### PR DESCRIPTION
## What

In the GMP doc for GET_LICENSE, add missing reference `SENSOR` to the `PATTERN` of `APPLIANCE`.

Also clean some `else`s that were making the code harder to follow.

## Why

`SENSOR` was missing from the doc.

## References

The element for `SENSOR` was added to the doc in 5b274d1705e2d9b483baa7727eefdc85adf1a025, just the reference in `PATTERN` was missing.

## Confirm

Using [libtheia-dummy](https://git.sr.ht/~mattmundell/libtheia-dummy):

```xml
$ o m m '<get_license/>'
<get_license_response status="200" status_text="OK">
  <license>
    <status>200</status>
    <content>
      ...
      <appliance>
        <model>Model9</model>
        <model_type>Type11</model_type>
        <sensor>1</sensor>                <!-- HERE -->
      </appliance>
```