### PR TITLE
Add: New --min-mem-feed-update option

### DIFF
--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -121,8 +121,14 @@ Maximum size of user-defined message text in alert emails, in bytes.
 \fB--max-ips-per-target=\fINUMBER\fB\f1
 Maximum number of IPs per target.
 .TP
+\fB--mem-wait-retries=\fINUMBER\fB\f1
+How often to try waiting for available memory. Default: 30. Each retry will wait for 10 seconds. 
+.TP
 \fB-m, --migrate\f1
 Migrate the database and exit.
+.TP
+\fB--min-mem-feed-update=\fINUMBER\fB\f1
+Minimum memory in MiB for feed updates. Default: 0. Feed updates are skipped if less physical memory is available. 
 .TP
 \fB--modify-scanner=\fISCANNER-UUID\fB\f1
 Modify scanner SCANNER-UUID and exit.

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -288,9 +288,27 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </optdesc>
     </option>
     <option>
+      <p><opt>--mem-wait-retries=<arg>NUMBER</arg></opt></p>
+      <optdesc>
+        <p>
+          How often to try waiting for available memory. Default: 30.
+          Each retry will wait for 10 seconds.
+        </p>
+      </optdesc>
+    </option>
+    <option>
       <p><opt>-m, --migrate</opt></p>
       <optdesc>
         <p>Migrate the database and exit.</p>
+      </optdesc>
+    </option>
+    <option>
+      <p><opt>--min-mem-feed-update=<arg>NUMBER</arg></opt></p>
+      <optdesc>
+        <p>
+          Minimum memory in MiB for feed updates. Default: 0.
+          Feed updates are skipped if less physical memory is available.
+        </p>
       </optdesc>
     </option>
     <option>

--- a/doc/gvmd.html
+++ b/doc/gvmd.html
@@ -242,9 +242,27 @@
       
     
     
+      <p><b>--mem-wait-retries=<em>NUMBER</em></b></p>
+      
+        <p>
+          How often to try waiting for available memory. Default: 30.
+           Each retry will wait for 10 seconds.
+        </p>
+      
+    
+    
       <p><b>-m, --migrate</b></p>
       
         <p>Migrate the database and exit.</p>
+      
+    
+    
+      <p><b>--min-mem-feed-update=<em>NUMBER</em></b></p>
+      
+        <p>
+          Minimum memory in MiB for feed updates. Default: 0.
+          Feed updates are skipped if less physical memory is available.
+        </p>
       
     
     

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1895,6 +1895,8 @@ gvmd (int argc, char** argv, char *env[])
   static gchar *broker_address = NULL;
   static gchar *feed_lock_path = NULL;
   static int feed_lock_timeout = 0;
+  static int mem_wait_retries = 30;
+  static int min_mem_feed_update = 0;
   static int vt_ref_insert_size = VT_REF_INSERT_SIZE_DEFAULT;
   static int vt_sev_insert_size = VT_SEV_INSERT_SIZE_DEFAULT;
   static gchar *vt_verification_collation = NULL;
@@ -2088,10 +2090,20 @@ gvmd (int argc, char** argv, char *env[])
           &max_ips_per_target,
           "Maximum number of IPs per target.",
           "<number>" },
+        { "mem-wait-retries", '\0', 0, G_OPTION_ARG_INT,
+          &mem_wait_retries,
+          "How often to try waiting for available memory. Default: 30."
+          " Each retry will wait for 10 seconds.",
+          "<number>" },
         { "migrate", 'm', 0, G_OPTION_ARG_NONE,
           &migrate_database,
           "Migrate the database and exit.",
           NULL },
+        { "min-mem-feed-update", '\0', 0, G_OPTION_ARG_INT,
+          &min_mem_feed_update,
+          "Minimum memory in MiB for feed updates. Default: 0."
+          " Feed updates are skipped if less physical memory is available.",
+          "<number>" },
         { "modify-scanner", '\0', 0, G_OPTION_ARG_STRING,
           &modify_scanner,
           "Modify scanner <scanner-uuid> and exit.",
@@ -2446,6 +2458,12 @@ gvmd (int argc, char** argv, char *env[])
         gnutls_global_set_log_level (atoi (s));
       }
   }
+
+  /* Set number of retries waiting for memory */
+  set_mem_wait_retries (mem_wait_retries);
+  
+  /* Set minimum memory for feed updates */
+  set_min_mem_feed_update (min_mem_feed_update);
 
   /* Set relay mapper */
   if (relay_mapper)

--- a/src/manage.h
+++ b/src/manage.h
@@ -3870,6 +3870,21 @@ get_feed_lock_timeout ();
 void
 set_feed_lock_timeout (int);
 
+int
+get_mem_wait_retries ();
+
+void
+set_mem_wait_retries (int);
+
+int
+check_min_mem_feed_update ();
+
+int
+get_min_mem_feed_update ();
+
+void
+set_min_mem_feed_update (int);
+
 void
 write_sync_start (int);
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -959,3 +959,26 @@ wait_for_pid (pid_t pid, const char *context)
         }
     }
 }
+
+/**
+ * @brief Get the available physical memory in bytes.
+ * 
+ * @return The available memory
+ */
+guint64
+phys_mem_available ()
+{
+  return (unsigned long long)(sysconf(_SC_AVPHYS_PAGES))
+    * sysconf(_SC_PAGESIZE);
+}
+
+/**
+ * @brief Get the total physical memory in bytes.
+ * 
+ * @return The total memory
+ */
+guint64
+phys_mem_total ()
+{
+  return sysconf(_SC_PHYS_PAGES) * sysconf(_SC_PAGESIZE);
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -103,4 +103,10 @@ fork_with_handlers ();
 void
 wait_for_pid (pid_t, const char *);
 
+guint64
+phys_mem_available ();
+
+guint64
+phys_mem_total ();
+
 #endif /* not _GVMD_UTILS_H */


### PR DESCRIPTION
## What
A new option is added which will make the automatic feed update wait until a minimum amount of physical memory is available.

## Why
Additionally, the --mem-wait-retries can be used to set the number of retries waiting for memory to be available in each process.

## References
GEA-179

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


