### PR TITLE
Fix: adjusted the logrotate config file with proper permissions

### DIFF
--- a/config/gvmd.logrotate.in
+++ b/config/gvmd.logrotate.in
@@ -4,5 +4,7 @@ ${GVM_LOG_DIR}/gvmd.log {
 	notifempty
 	sharedscripts
 	copytruncate
+	su gvm gvm
+	create 0640 gvm gvm
 }
 


### PR DESCRIPTION
Cherry picked from greenbone/gvmd/pull/2263:

## What

This will add proper permissions to the logrotate configuration file, which is placed into the `/etc/logrotate.d/gvmd` during the make build process. 

## Why

It was pointed out from [this forum post]((https://forum.greenbone.net/t/logrotate-debian/18706/7)) that the logs do not have the correct permission configuration for logrotate.

## References

[Forum post with discussion](https://forum.greenbone.net/t/logrotate-debian/18706/7)

## Checklist

- [ *] Tests - Tested and works on Ubuntu 22.04
