### PR TITLE
GMP doc: update GET_NVTS

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -13793,25 +13793,25 @@ handle_get_nvts (gmp_parser_t *gmp_parser, GError **error)
          (XML_ERROR_SYNTAX ("get_nvts",
                             "Too many parameters at once"));
       else if ((get_nvts_data->details == 0)
-                && get_nvts_data->preference_count)
+               && get_nvts_data->preference_count)
         SEND_TO_CLIENT_OR_FAIL
          (XML_ERROR_SYNTAX ("get_nvts",
                             "The preference_count attribute"
                             " requires the details attribute"));
       else if ((get_nvts_data->details == 0)
-                && get_nvts_data->preferences)
+               && get_nvts_data->preferences)
         SEND_TO_CLIENT_OR_FAIL
          (XML_ERROR_SYNTAX ("get_nvts",
                             "The preferences attribute"
                             " requires the details attribute"));
       else if ((get_nvts_data->details == 0)
-                && get_nvts_data->skip_cert_refs)
+               && get_nvts_data->skip_cert_refs)
         SEND_TO_CLIENT_OR_FAIL
          (XML_ERROR_SYNTAX ("get_nvts",
                             "The skip_cert_refs attribute"
                             " requires the details attribute"));
       else if ((get_nvts_data->details == 0)
-                && get_nvts_data->skip_tags)
+               && get_nvts_data->skip_tags)
         SEND_TO_CLIENT_OR_FAIL
          (XML_ERROR_SYNTAX ("get_nvts",
                             "The skip_tags attribute"
@@ -13825,14 +13825,14 @@ handle_get_nvts (gmp_parser_t *gmp_parser, GError **error)
       else if (((get_nvts_data->details == 0)
                 || ((get_nvts_data->config_id == NULL)
                     && (get_nvts_data->preferences_config_id == NULL)))
-                && get_nvts_data->timeout)
+               && get_nvts_data->timeout)
         SEND_TO_CLIENT_OR_FAIL
          (XML_ERROR_SYNTAX ("get_nvts",
                             "The timeout attribute"
                             " requires the details and config_id"
                             " attributes"));
       else if (get_nvts_data->nvt_oid
-                && find_nvt (get_nvts_data->nvt_oid, &nvt))
+               && find_nvt (get_nvts_data->nvt_oid, &nvt))
         SEND_TO_CLIENT_OR_FAIL
           (XML_INTERNAL_ERROR ("get_nvts"));
       else if (get_nvts_data->nvt_oid && nvt == 0)
@@ -13846,15 +13846,15 @@ handle_get_nvts (gmp_parser_t *gmp_parser, GError **error)
             }
         }
       else if (get_nvts_data->config_id
-                && get_nvts_data->preferences_config_id)
+               && get_nvts_data->preferences_config_id)
         SEND_TO_CLIENT_OR_FAIL
          (XML_ERROR_SYNTAX ("get_nvts",
                             "config_id and"
                             " preferences_config_id both given"));
       else if (get_nvts_data->config_id
-                && find_config_with_permission (get_nvts_data->config_id,
-                                                &config,
-                                                NULL))
+               && find_config_with_permission (get_nvts_data->config_id,
+                                               &config,
+                                               NULL))
         SEND_TO_CLIENT_OR_FAIL
           (XML_INTERNAL_ERROR ("get_nvts"));
       else if (get_nvts_data->config_id && (config == 0))
@@ -13868,19 +13868,19 @@ handle_get_nvts (gmp_parser_t *gmp_parser, GError **error)
             }
         }
       else if (get_nvts_data->preferences_config_id
-                && find_config_with_permission
+               && find_config_with_permission
                     (get_nvts_data->preferences_config_id,
-                    &preferences_config,
-                    NULL))
+                     &preferences_config,
+                     NULL))
         SEND_TO_CLIENT_OR_FAIL
           (XML_INTERNAL_ERROR ("get_nvts"));
       else if (get_nvts_data->preferences_config_id
-                && (preferences_config == 0))
+               && (preferences_config == 0))
         {
           if (send_find_error_to_client
                 ("get_nvts", "config",
-                get_nvts_data->preferences_config_id,
-                gmp_parser))
+                 get_nvts_data->preferences_config_id,
+                 gmp_parser))
             {
               error_send_to_client (error);
               return;
@@ -13896,16 +13896,16 @@ handle_get_nvts (gmp_parser_t *gmp_parser, GError **error)
             " status_text=\"" STATUS_OK_TEXT "\">");
 
           init_nvt_iterator (&nvts,
-                              nvt,
-                              get_nvts_data->nvt_oid
-                              /* Presume the NVT is in the config (if
-                                * a config was given). */
-                              ? 0
-                              : config,
-                              get_nvts_data->family,
-                              NULL,
-                              get_nvts_data->sort_order,
-                              get_nvts_data->sort_field);
+                             nvt,
+                             get_nvts_data->nvt_oid
+                             /* Presume the NVT is in the config (if
+                              * a config was given). */
+                             ? 0
+                             : config,
+                             get_nvts_data->family,
+                             NULL,
+                             get_nvts_data->sort_order,
+                             get_nvts_data->sort_field);
           if (preferences_config)
             config = preferences_config;
           if (get_nvts_data->details)
@@ -13921,7 +13921,7 @@ handle_get_nvts (gmp_parser_t *gmp_parser, GError **error)
                 if (get_nvts_data->preferences && (timeout == NULL))
                   timeout = config_nvt_timeout
                               (config,
-                              nvt_iterator_oid (&nvts));
+                               nvt_iterator_oid (&nvts));
 
                 if (get_nvts_data->preference_count)
                   {

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -14618,6 +14618,7 @@ END:VCALENDAR
             <pattern>
               <e>nvt</e>
               <e>name</e>
+              <e>hr_name</e>
               <e>id</e>
               <e>type</e>
               <e>value</e>
@@ -14645,6 +14646,11 @@ END:VCALENDAR
               <name>name</name>
               <summary>The name of the preference</summary>
               <pattern>text</pattern>
+            </ele>
+            <ele>
+              <name>hr_name</name>
+              <summary>The human readable name of the preference</summary>
+              <pattern><t>name</t></pattern>
             </ele>
             <ele>
               <name>id</name>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -14200,10 +14200,6 @@ END:VCALENDAR
         NVT information.  If the manager cannot access a list of available
         NVTs at that time, it will reply with the 503 response.
       </p>
-      <p>
-        NVT categories: 0 init, 1 scanner, 2 settings, 3 infos, 4 attack, 5 mixed,
-        6 destructive attack, 7 denial, 8 kill host, 9 flood, 10 end, and 11 unknown.
-      </p>
     </description>
     <pattern>
       <attrib>
@@ -14324,7 +14320,36 @@ END:VCALENDAR
         <ele>
           <name>category</name>
           <summary>The category of the NVT</summary>
-          <pattern><t>integer</t></pattern>
+          <description>
+            <p>0: init</p>
+            <p>1: scanner</p>
+            <p>2: settings</p>
+            <p>3: infos</p>
+            <p>4: attack</p>
+            <p>5: mixed</p>
+            <p>6: destructive attack</p>
+            <p>7: denial</p>
+            <p>8: kill host</p>
+            <p>9: flood</p>
+            <p>10: end</p>
+            <p>11: unknown</p>
+          </description>
+          <pattern>
+            <alts>
+              <alt>0</alt>
+              <alt>1</alt>
+              <alt>2</alt>
+              <alt>3</alt>
+              <alt>4</alt>
+              <alt>5</alt>
+              <alt>6</alt>
+              <alt>7</alt>
+              <alt>8</alt>
+              <alt>9</alt>
+              <alt>10</alt>
+              <alt>11</alt>
+            </alts>
+          </pattern>
         </ele>
         <ele>
           <name>creation_time</name>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -14296,7 +14296,6 @@ END:VCALENDAR
               <e>creation_time</e>
               <e>modification_time</e>
               <e>category</e>
-              <e>summary</e>
               <e>family</e>
               <e>cvss_base</e>
               <e>severities</e>
@@ -14406,11 +14405,6 @@ END:VCALENDAR
               <pattern>text</pattern>
             </ele>
           </ele>
-        </ele>
-        <ele>
-          <name>summary</name>
-          <summary>Short description of the NVT</summary>
-          <pattern>text</pattern>
         </ele>
         <ele>
           <name>family</name>
@@ -14719,7 +14713,6 @@ END:VCALENDAR
             <creation_time>2011-01-14T10:12:23+01:00</creation_time>
             <modification_time>2012-09-19T20:56:15+02:00</modification_time>
             <category>3</category>
-            <summary>Find what is listening on which port</summary>
             <family>Service detection</family>
             <cvss_base></cvss_base>
             <severities score="0"/>


### PR DESCRIPTION
## What

In the GMP doc for `GET_NVTS`:

1. Add `HR_NAME`
2. Move the list of categories from the command description into the `CATEGORY` element of the response.
3. Remove `SUMMARY`

## Why

1. `HR_NAME` was missing.
2. Having the categories as an `ALT` list is more precise, and matches the other commands better, like the list of credentials types in `CREATE_CREDENTIAL`.
3. `SUMMARY` was removed.

## References

`HR_NAME` was added in 52f3c3a19b72148507ea46b516d040f152ec61e1.

`SUMMARY` was removed in 883cf5bf6dd40cc3a2cf17d89f289e9f9ee43d97.

## Verify

`HR_NAME` is present:
```xml
$ o m m '<get_nvts nvt_oid="1.3.6.1.4.1.25623.1.0.14259" details="1" preferences="1"/>'
<get_nvts_response status="200" status_text="OK">
  <nvt oid="1.3.6.1.4.1.25623.1.0.14259">
    <preferences>
      <preference>
        <hr_name>Min RTT Timeout (ms) :</hr_name>
```

`SUMMARY` element is gone (but summary tag remains):
```xml
o m m '<get_nvts nvt_oid="1.3.6.1.4.1.25623.1.0.14259" details="1" preferences="1"/>' | grep -i summary
    <tags>cvss_base_vector=AV:N/AC:L/Au:N/C:N/I:N/A:N|summary=This
```
