### PR TITLE
Add: New option --max-concurrent-scan-updates

### DIFF
--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -109,6 +109,9 @@ File mode of the unix socket
 \fB--listen-owner=\fISTRING\fB\f1
 Owner of the unix socket
 .TP
+\fB--max-concurrent-scan-updates=\fINUMBER\fB\f1
+Maximum number of scan updates that can run at the same time. Default: 0 (unlimited). 
+.TP
 \fB--max-email-attachment-size=\fINUMBER\fB\f1
 Maximum size of alert email attachments, in bytes.
 .TP

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -263,6 +263,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </optdesc>
     </option>
     <option>
+      <p><opt>--max-concurrent-scan-updates=<arg>NUMBER</arg></opt></p>
+      <optdesc>
+        <p>
+          Maximum number of scan updates that can run at the same time.
+          Default: 0 (unlimited).
+        </p>
+      </optdesc>
+    </option>
+    <option>
       <p><opt>--max-email-attachment-size=<arg>NUMBER</arg></opt></p>
       <optdesc>
         <p>Maximum size of alert email attachments, in bytes.</p>

--- a/doc/gvmd.html
+++ b/doc/gvmd.html
@@ -217,6 +217,15 @@
       
     
     
+      <p><b>--max-concurrent-scan-updates=<em>NUMBER</em></b></p>
+      
+        <p>
+          Maximum number of scan updates that can run at the same time.
+          Default: 0 (unlimited).
+        </p>
+      
+    
+    
       <p><b>--max-email-attachment-size=<em>NUMBER</em></b></p>
       
         <p>Maximum size of alert email attachments, in bytes.</p>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,6 +109,7 @@ add_executable (manage-utils-test
 
                 debug_utils.c
                 gvmd.c gmpd.c
+                ipc.c
                 manage.c sql.c
                 manage_acl.c manage_configs.c manage_get.c
                 manage_license.c
@@ -140,6 +141,7 @@ add_executable (manage-test
 
                 debug_utils.c
                 gvmd.c gmpd.c
+                ipc.c
                 manage_utils.c sql.c
                 manage_acl.c manage_configs.c manage_get.c
                 manage_license.c
@@ -171,6 +173,7 @@ add_executable (manage-sql-test
 
                 debug_utils.c
                 gvmd.c gmpd.c
+                ipc.c
                 manage_utils.c manage.c sql.c
                 manage_acl.c manage_configs.c manage_get.c
                 manage_license.c
@@ -202,6 +205,7 @@ add_executable (gmp-tickets-test
 
                 debug_utils.c
                 gvmd.c gmpd.c
+                ipc.c
                 manage_utils.c manage.c sql.c
                 manage_acl.c manage_configs.c manage_get.c
                 manage_license.c
@@ -233,6 +237,7 @@ add_executable (utils-test
 
                 debug_utils.c
                 gvmd.c gmpd.c
+                ipc.c
                 manage_utils.c manage.c sql.c
                 manage_acl.c manage_configs.c manage_get.c
                 manage_license.c
@@ -281,6 +286,7 @@ add_executable (gvmd
                 main.c gvmd.c
                 debug_utils.c
                 gmpd.c
+                ipc.c
                 manage_utils.c manage.c sql.c
                 manage_acl.c manage_configs.c manage_get.c
                 manage_license.c

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1895,6 +1895,7 @@ gvmd (int argc, char** argv, char *env[])
   static gchar *broker_address = NULL;
   static gchar *feed_lock_path = NULL;
   static int feed_lock_timeout = 0;
+  static int max_concurrent_scan_updates = 0;
   static int mem_wait_retries = 30;
   static int min_mem_feed_update = 0;
   static int vt_ref_insert_size = VT_REF_INSERT_SIZE_DEFAULT;
@@ -2073,6 +2074,11 @@ gvmd (int argc, char** argv, char *env[])
           &listen_owner,
           "Owner of the unix socket",
           "<string>" },
+        { "max-concurrent-scan-updates", '\0', 0, G_OPTION_ARG_INT,
+          &max_concurrent_scan_updates,
+          "Maximum number of scan updates that can run at the same time."
+          " Default: 0 (unlimited).",
+          "<number>" },
         { "max-email-attachment-size", '\0', 0, G_OPTION_ARG_INT,
           &max_email_attachment_size,
           "Maximum size of alert email attachments, in bytes.",
@@ -2451,6 +2457,12 @@ gvmd (int argc, char** argv, char *env[])
     {
       g_debug ("Sentry support disabled");
     }
+
+  /* Set maximum number of concurrent scan updates */
+  set_max_concurrent_scan_updates (max_concurrent_scan_updates);
+
+  /* Initialize Inter-Process Communication */
+  init_semaphore_set ();
 
   /* Enable GNUTLS debugging if requested via env variable.  */
   {

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -102,6 +102,7 @@
 #include <gvm/util/ldaputils.h>
 
 #include "debug_utils.h"
+#include "ipc.h"
 #include "manage.h"
 #include "manage_sql_nvts.h"
 #include "manage_sql_secinfo.h"

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -49,10 +49,10 @@ static int semaphore_set = -1;
  * @brief Union type for values of semctl actions
  */
 union semun {
-    int              val;    ///< Value for SETVAL
-    struct semid_ds *buf;    ///< Buffer for IPC_STAT, IPC_SET
-    unsigned short  *array;  ///< Array for GETALL, SETALL
-    struct seminfo  *__buf;  ///< Buffer for IPC_INFO (Linux-specific)
+  int val;                ///< Value for SETVAL
+  struct semid_ds *buf;   ///< Buffer for IPC_STAT, IPC_SET
+  unsigned short *array;  ///< Array for GETALL, SETALL
+  struct seminfo *__buf;  ///< Buffer for IPC_INFO (Linux-specific)
 };
 
 /**

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -1,0 +1,160 @@
+/* Copyright (C) 2024 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file ipc.c
+ * @brief Inter-process communitcation (IPC)
+ */
+
+/**
+ * @brief Enable extra GNU functions.
+ *
+ * semtimedop needs this
+ */
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <sys/sem.h>
+
+#include "ipc.h"
+#include "manage.h"
+
+
+/**
+ * @brief System V semaphore set key for gvmd actions.
+ */
+static key_t semaphore_set_key = -1;
+
+/**
+ * @brief System V semaphore set id for gvmd actions.
+ */
+static int semaphore_set = -1;
+
+/**
+ * @brief Union type for values of semctl actions
+ */
+union semun {
+    int              val;    ///< Value for SETVAL
+    struct semid_ds *buf;    ///< Buffer for IPC_STAT, IPC_SET
+    unsigned short  *array;  ///< Array for GETALL, SETALL
+    struct seminfo  *__buf;  ///< Buffer for IPC_INFO (Linux-specific)
+};
+
+/**
+ * @brief Initializes the semaphore set for gvmd actions.
+ *
+ * Needs max_concurrent_scan_updates to be set.
+ *
+ * @return 0 success, -1 error
+ */
+int
+init_semaphore_set ()
+{
+  // Ensure semaphore set file exists
+  gchar *key_file_name = g_build_filename (GVM_STATE_DIR, "gvmd.sem", NULL);
+  FILE *key_file = fopen (key_file_name, "a");
+  union semun sem_value;
+  if (key_file == NULL)
+    {
+      g_warning ("%s: error creating semaphore file %s: %s",
+                 __func__, key_file_name, strerror (errno));
+      g_free (key_file_name);
+      return -1;
+    }
+  fclose (key_file);
+  semaphore_set_key = ftok (key_file_name, 0);
+  if (semaphore_set_key < 0)
+    {
+      g_warning ("%s: error creating semaphore key for file %s: %s",
+                 __func__, key_file_name, strerror (errno));
+      g_free (key_file_name);
+      return -1;
+    }
+
+  semaphore_set = semget (semaphore_set_key, 1, 0660 | IPC_CREAT);
+  if (semaphore_set < 0)
+    {
+      g_warning ("%s: error getting semaphore set: %s",
+                 __func__, strerror (errno));
+      g_free (key_file_name);
+      return -1;
+    }
+
+  g_debug ("%s: Semaphore set created for file '%s', key %x",
+             __func__, key_file_name, semaphore_set_key);
+  g_free (key_file_name);
+
+  sem_value.val = get_max_concurrent_scan_updates () ?: 1;
+  if (semctl (semaphore_set, SEMAPHORE_SCAN_UPDATE, SETVAL, sem_value) == -1)
+    {
+      g_warning ("%s: error initializing scan update semaphore: %s",
+                 __func__, strerror (errno));
+      return -1;
+    }
+
+  return 0;
+}
+
+/**
+ * @brief Performs a semaphore operation (signal or wait).
+ *
+ * A negative op_value will try to decrease the semaphore value
+ *  and wait if needed.
+ * A positive op_value will increase the semaphore value.
+ * Zero as op_value will wait for the semaphore value to become zero.
+ *
+ * (See semop from sys/sem.h)
+ *
+ * @param[in]  semaphore_index  The index of the semaphore in the gvmd set.
+ * @param[in]  op_value   The operation value
+ * @param[in]  timeout    Timeout in seconds, 0 for unlimited
+ *
+ * @return 0 success, 1 timed out, -1 error
+ */
+int
+semaphore_op (semaphore_index_t semaphore_index,
+              short int op_value,
+              time_t timeout)
+{
+  int ret;
+  struct sembuf op = {
+    sem_num: semaphore_index,
+    sem_op: op_value,
+    sem_flg: SEM_UNDO
+  };
+
+  struct timespec ts = {
+    tv_nsec: 0,
+    tv_sec: timeout,
+  };
+
+  ret = semtimedop (semaphore_set, &op, 1, timeout > 0 ? &ts : NULL);
+  if (ret)
+    {
+      if (errno == EAGAIN)
+        return 1;
+      else
+        {
+          g_warning ("%s: semaphore operation failed: %s",
+                     __func__, strerror (errno));
+          return -1;
+        }
+    }
+
+  return 0;
+}

--- a/src/ipc.h
+++ b/src/ipc.h
@@ -1,0 +1,37 @@
+/* Copyright (C) 2024 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file ipc.h
+ * @brief Headers for inter-process communitcation (IPC)
+ */
+
+#ifndef _GVMD_IPC_H
+#define _GVMD_IPC_H
+
+typedef enum {
+  SEMAPHORE_SCAN_UPDATE = 0
+} semaphore_index_t;
+
+int
+init_semaphore_set ();
+
+int
+semaphore_op (semaphore_index_t, short int, time_t);
+
+#endif /* not _GVMD_IPC_H */

--- a/src/manage.c
+++ b/src/manage.c
@@ -48,6 +48,7 @@
 
 #include "debug_utils.h"
 #include "gmp_base.h"
+#include "ipc.h"
 #include "manage.h"
 #include "manage_acl.h"
 #include "manage_configs.h"
@@ -75,7 +76,6 @@
 #include <string.h>
 #include <strings.h>
 #include <sys/file.h>
-#include <sys/sem.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -220,17 +220,6 @@ static int schedule_timeout = SCHEDULE_TIMEOUT_DEFAULT;
  *        lost in a running task.
  */
 static int scanner_connection_retry = SCANNER_CONNECTION_RETRY_DEFAULT;
-
-/**
- * @brief System V semaphore set key for gvmd actions.
- */
-static key_t semaphore_set_key = -1;
-
-/**
- * @brief System V semaphore set id for gvmd actions.
- */
-static int semaphore_set = -1;
-
 
 
 /* Certificate and key management. */
@@ -7921,121 +7910,4 @@ delete_resource (const char *type, const char *resource_id, int ultimate)
     return delete_tls_certificate (resource_id, ultimate);
   assert (0);
   return -1;
-}
-
-
-/* Inter-Process Communication */
-
-/**
- * @brief Union type for values of semctl actions
- */
-union semun {
-    int              val;    ///< Value for SETVAL
-    struct semid_ds *buf;    ///< Buffer for IPC_STAT, IPC_SET
-    unsigned short  *array;  ///< Array for GETALL, SETALL
-    struct seminfo  *__buf;  ///< Buffer for IPC_INFO (Linux-specific)
-};
-
-/**
- * @brief Initializes the semaphore set for gvmd actions.
- *
- * Needs max_concurrent_scan_updates to be set.
- *
- * @return 0 success, -1 error
- */
-int
-init_semaphore_set ()
-{
-  // Ensure semaphore set file exists
-  gchar *key_file_name = g_build_filename (GVM_STATE_DIR, "gvmd.sem", NULL);
-  FILE *key_file = fopen (key_file_name, "a");
-  union semun sem_value;
-  if (key_file == NULL)
-    {
-      g_warning ("%s: error creating semaphore file %s: %s",
-                 __func__, key_file_name, strerror (errno));
-      g_free (key_file_name);
-      return -1;
-    }
-  fclose (key_file);
-  semaphore_set_key = ftok (key_file_name, 0);
-  if (semaphore_set_key < 0)
-    {
-      g_warning ("%s: error creating semaphore key for file %s: %s",
-                 __func__, key_file_name, strerror (errno));
-      g_free (key_file_name);
-      return -1;
-    }
-
-  semaphore_set = semget (semaphore_set_key, 1, 0660 | IPC_CREAT);
-  if (semaphore_set < 0)
-    {
-      g_warning ("%s: error getting semaphore set: %s",
-                 __func__, strerror (errno));
-      g_free (key_file_name);
-      return -1;
-    }
-
-  g_debug ("%s: Semaphore set created for file '%s', key %x",
-             __func__, key_file_name, semaphore_set_key);
-  g_free (key_file_name);
-
-  sem_value.val = max_concurrent_scan_updates ?: 1;
-  if (semctl (semaphore_set, SEMAPHORE_SCAN_UPDATE, SETVAL, sem_value) == -1)
-    {
-      g_warning ("%s: error initializing scan update semaphore: %s",
-                 __func__, strerror (errno));
-      return -1;
-    }
-
-  return 0;
-}
-
-/**
- * @brief Performs a semaphore operation (signal or wait).
- *
- * A negative op_value will try to decrease the semaphore value
- *  and wait if needed.
- * A positive op_value will increase the semaphore value.
- * Zero as op_value will wait for the semaphore value to become zero.
- *
- * (See semop from sys/sem.h)
- *
- * @param[in]  semaphore_index  The index of the semaphore in the gvmd set.
- * @param[in]  op_value   The operation value
- * @param[in]  timeout    Timeout in seconds, 0 for unlimited
- *
- * @return 0 success, 1 timed out, -1 error
- */
-int
-semaphore_op (semaphore_index_t semaphore_index,
-              short int op_value,
-              time_t timeout)
-{
-  int ret;
-  struct sembuf op = {
-    sem_num: semaphore_index,
-    sem_op: op_value,
-    sem_flg: SEM_UNDO
-  };
-
-  struct timespec ts = {
-    tv_nsec: 0,
-    tv_sec: timeout,
-  };
-
-  ret = semtimedop (semaphore_set, &op, 1, timeout > 0 ? &ts : NULL);
-  if (ret)
-    {
-      if (errno == EAGAIN)
-        return 1;
-      else
-        {
-          g_warning ("%s: semaphore operation failed: %s",
-                     __func__, strerror (errno));
-          return -1;
-        }
-    }
-
-  return 0;
 }

--- a/src/manage.c
+++ b/src/manage.c
@@ -7930,17 +7930,18 @@ delete_resource (const char *type, const char *resource_id, int ultimate)
  * @brief Union type for values of semctl actions
  */
 union semun {
-    int              val;    /* Value for SETVAL */
-    struct semid_ds *buf;    /* Buffer for IPC_STAT, IPC_SET */
-    unsigned short  *array;  /* Array for GETALL, SETALL */
-    struct seminfo  *__buf;  /* Buffer for IPC_INFO
-                                (Linux-specific) */
+    int              val;    ///< Value for SETVAL
+    struct semid_ds *buf;    ///< Buffer for IPC_STAT, IPC_SET
+    unsigned short  *array;  ///< Array for GETALL, SETALL
+    struct seminfo  *__buf;  ///< Buffer for IPC_INFO (Linux-specific)
 };
 
 /**
  * @brief Initializes the semaphore set for gvmd actions.
  *
  * Needs max_concurrent_scan_updates to be set.
+ *
+ * @return 0 success, -1 error
  */
 int
 init_semaphore_set ()
@@ -7971,6 +7972,7 @@ init_semaphore_set ()
     {
       g_warning ("%s: error getting semaphore set: %s",
                  __func__, strerror (errno));
+      g_free (key_file_name);
       return -1;
     }
 
@@ -8001,6 +8003,9 @@ init_semaphore_set ()
  *
  * @param[in]  semaphore_index  The index of the semaphore in the gvmd set.
  * @param[in]  op_value   The operation value
+ * @param[in]  timeout    Timeout in seconds, 0 for unlimited
+ *
+ * @return 0 success, 1 timed out, -1 error
  */
 int
 semaphore_op (semaphore_index_t semaphore_index,

--- a/src/manage.h
+++ b/src/manage.h
@@ -3881,6 +3881,12 @@ void
 set_feed_lock_timeout (int);
 
 int
+get_max_concurrent_scan_updates ();
+
+void
+set_max_concurrent_scan_updates (int);
+
+int
 get_mem_wait_retries ();
 
 void
@@ -3982,5 +3988,18 @@ get_vt_verification_collation ();
 
 void
 set_vt_verification_collation (const char *);
+
+
+/* Inter-Process communication */
+
+typedef enum {
+  SEMAPHORE_SCAN_UPDATE = 0
+} semaphore_index_t;
+
+int
+init_semaphore_set ();
+
+int
+semaphore_op (semaphore_index_t, short int, time_t);
 
 #endif /* not _GVMD_MANAGE_H */

--- a/src/manage.h
+++ b/src/manage.h
@@ -3989,17 +3989,4 @@ get_vt_verification_collation ();
 void
 set_vt_verification_collation (const char *);
 
-
-/* Inter-Process communication */
-
-typedef enum {
-  SEMAPHORE_SCAN_UPDATE = 0
-} semaphore_index_t;
-
-int
-init_semaphore_set ();
-
-int
-semaphore_op (semaphore_index_t, short int, time_t);
-
 #endif /* not _GVMD_MANAGE_H */


### PR DESCRIPTION
## What
The new startup option --max-concurrent-scan-updates is added which allows limiting the number of scan updates which can run at the same time.

## Why
This can be used to limit the peak memory and CPU usage when running multiple scans at the same time.


## References
GEA-179
