### PR TITLE
Change: Retry on deadlocks in sql_x

### DIFF
--- a/src/sql.c
+++ b/src/sql.c
@@ -394,7 +394,7 @@ sql_x (char* sql, va_list args, sql_stmt_t** stmt_return)
           sql_finalize (*stmt_return);
           continue;
         }
-      else if (ret == -5)
+      if (ret == -5)
         {
           if (deadlock_amount++ > DEADLOCK_THRESHOLD)
             {


### PR DESCRIPTION
## What
The sql_x function (and thus functions using it like sql_string) now also retries executing the statement in case of a deadlock like the sql function.

## Why
This addresses an issue with queries of the auth_cache aborting if there are too many concurrent ones.

## References
GEA-655

