### PR TITLE
Fix: Add missing EPSS columns for "no CVEs" case

### DIFF
--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -1849,9 +1849,11 @@ create_view_result_vt_epss ()
          "    epss_score,"
          "    epss_percentile,"
          "    epss_cve,"
+         "    epss_severity,"
          "    max_epss_score,"
          "    max_epss_percentile,"
-         "    max_epss_cve"
+         "    max_epss_cve,"
+         "    max_epss_severity"
          "  FROM nvts);");
 
   sql ("SELECT create_index ('result_vt_epss_by_vt_id',"


### PR DESCRIPTION
## What
The materialized view result_vt_epss now also has the columns epss_severity and max_epss_severity in case there are no CVEs present when the view is created.

## Why
This fixes SQL errors resulting from those missing columns.

## References
closes #2273
https://forum.greenbone.net/t/get-reports-via-gmp-fails-with-database-issue/18785
