### PR TITLE
Remove redundant note and override ID fields

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -1874,7 +1874,6 @@ get_nvt_families_data_reset (get_nvt_families_data_t *data)
 typedef struct
 {
   get_data_t get;      ///< Get args.
-  char *override_id;   ///< ID of override to get.
   char *nvt_oid;       ///< OID of NVT to which to limit listing.
   char *task_id;       ///< ID of task to which to limit listing.
   int result;          ///< Boolean.  Whether to include associated results.
@@ -1888,7 +1887,6 @@ typedef struct
 static void
 get_overrides_data_reset (get_overrides_data_t *data)
 {
-  free (data->override_id);
   free (data->nvt_oid);
   free (data->task_id);
 
@@ -5428,9 +5426,6 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
             get_data_parse_attributes (&get_overrides_data->get, "override",
                                        attribute_names,
                                        attribute_values);
-
-            append_attribute (attribute_names, attribute_values, "override_id",
-                              &get_overrides_data->override_id);
 
             append_attribute (attribute_names, attribute_values, "nvt_oid",
                               &get_overrides_data->nvt_oid);
@@ -14048,12 +14043,12 @@ handle_get_overrides (gmp_parser_t *gmp_parser, GError **error)
   nvt_t nvt = 0;
   task_t task = 0;
 
-  if (get_overrides_data->override_id && get_overrides_data->nvt_oid)
+  if (get_overrides_data->get.id && get_overrides_data->nvt_oid)
     SEND_TO_CLIENT_OR_FAIL
      (XML_ERROR_SYNTAX ("get_overrides",
                         "Only one of NVT and the override_id attribute"
                         " may be given"));
-  else if (get_overrides_data->override_id
+  else if (get_overrides_data->get.id
             && get_overrides_data->task_id)
     SEND_TO_CLIENT_OR_FAIL
      (XML_ERROR_SYNTAX ("get_overrides",

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -1793,7 +1793,6 @@ get_info_data_reset (get_info_data_t *data)
 typedef struct
 {
   get_data_t get;        ///< Get args.
-  char *note_id;         ///< ID of single note to get.
   char *nvt_oid;         ///< OID of NVT to which to limit listing.
   char *task_id;         ///< ID of task to which to limit listing.
   int result;            ///< Boolean.  Whether to include associated results.
@@ -1807,7 +1806,6 @@ typedef struct
 static void
 get_notes_data_reset (get_notes_data_t *data)
 {
-  free (data->note_id);
   free (data->nvt_oid);
   free (data->task_id);
 
@@ -5332,7 +5330,7 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
                                attribute_names,
                                attribute_values);
             set_client_state (CLIENT_GET_LICENSE);
-          }      
+          }
         else if (strcasecmp ("GET_NOTES", element_name) == 0)
           {
             const gchar* attribute;
@@ -5340,9 +5338,6 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
             get_data_parse_attributes (&get_notes_data->get, "note",
                                        attribute_names,
                                        attribute_values);
-
-            append_attribute (attribute_names, attribute_values, "note_id",
-                              &get_notes_data->note_id);
 
             append_attribute (attribute_names, attribute_values, "nvt_oid",
                               &get_notes_data->nvt_oid);
@@ -13648,12 +13643,12 @@ handle_get_notes (gmp_parser_t *gmp_parser, GError **error)
   nvt_t nvt = 0;
   task_t task = 0;
 
-  if (get_notes_data->note_id && get_notes_data->nvt_oid)
+  if (get_notes_data->get.id && get_notes_data->nvt_oid)
     SEND_TO_CLIENT_OR_FAIL
      (XML_ERROR_SYNTAX ("get_notes",
                         "Only one of NVT and the note_id attribute"
                         " may be given"));
-  else if (get_notes_data->note_id && get_notes_data->task_id)
+  else if (get_notes_data->get.id && get_notes_data->task_id)
     SEND_TO_CLIENT_OR_FAIL
      (XML_ERROR_SYNTAX ("get_notes",
                         "Only one of the note_id and task_id"


### PR DESCRIPTION
## What

Remove the fields `note_id` and `override_id` from `get_notes_data_t` and `get_overrides_data_t`.

## Why

These attributes are already available as `get.id`. For example, for GET_NOTES `get_data_parse_attributes` parsed `note_id` and puts it in `get.id` in `get_notes_data`.

## Verify

Same behaviour before and after PR:
```xml
$ o m m '<get_overrides override_id="xxx" task_id="yyy"/>'
<get_overrides_response status="400" status_text="Only one of the override_id and task_id attributes may be given" />

$ o m m '<get_notes note_id="xxx" task_id="yyy"/>'
<get_notes_response status="400" status_text="Only one of the note_id and task_id attributes may be given" />

$ o m m '<get_overrides override_id="xxx" nvt_oid="yyy"/>'
<get_overrides_response status="400" status_text="Only one of NVT and the override_id attribute may be given" />

$ o m m '<get_notes note_id="xxx" nvt_oid="yyy"/>'
<get_notes_response status="400" status_text="Only one of NVT and the note_id attribute may be given" />

$ o m m '<get_overrides override_id="d8e604b6-a078-446a-8d75-b36c90218d69"/>'
<get_overrides_response status="200" status_text="OK">
  <override id="d8e604b6-a078-446a-8d75-b36c90218d69">
  <filtered>1</filtered>

$ o m m '<get_notes note_id="99fa36e8-7d80-402d-83bf-8037b8313f9f"/>'
<get_notes_response status="200" status_text="OK">
  <note id="99fa36e8-7d80-402d-83bf-8037b8313f9f">
  <filtered>1</filtered>
```