### PR TITLE
Remove resource_id field from get_permissions_data_t

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -1903,7 +1903,6 @@ get_overrides_data_reset (get_overrides_data_t *data)
 typedef struct
 {
   get_data_t get;     ///< Get args.
-  char *resource_id;  ///< Resource whose permissions to get.
 } get_permissions_data_t;
 
 /**
@@ -1914,8 +1913,6 @@ typedef struct
 static void
 get_permissions_data_reset (get_permissions_data_t *data)
 {
-  free (data->resource_id);
-
   get_data_reset (&data->get);
   memset (data, 0, sizeof (get_permissions_data_t));
 }
@@ -5471,8 +5468,6 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
             get_data_parse_attributes (&get_permissions_data->get, "permission",
                                        attribute_names,
                                        attribute_values);
-            append_attribute (attribute_names, attribute_values, "resource_id",
-                              &get_permissions_data->resource_id);
             set_client_state (CLIENT_GET_PERMISSIONS);
           }
         else if (strcasecmp ("GET_PREFERENCES", element_name) == 0)


### PR DESCRIPTION
## What

Remove stray field from `get_permissions_data_t`. This includes removing the parsing of `resource_id` for GET_PERMISSIONS. The command works the same, as the attribute has never been used.

## Why

Attribute is not used.

## References

Attribute was added when `GET_PERMISSIONS` was added, in a486de15899a8aee38b0ce0b5c3791cf4d09adb6. The idea was to allow filtering of permissions by resource ID. 11 years later I think it's safe to remove. We can add it back if the filtering is ever required.

