### PR TITLE
GMP doc: GET_REPORTS: fix typo in attribute name

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -18162,7 +18162,7 @@ END:VCALENDAR
         <type>uuid</type>
       </attrib>
       <attrib>
-        <name>format_id</name>
+        <name>config_id</name>
         <summary>ID of requested report config</summary>
         <type>uuid</type>
       </attrib>


### PR DESCRIPTION
## What

Fix name of attribute in GET_REPORTS GMP doc.

## Why

`format_id` was appearing twice.



