### PR TITLE
GMP doc: GET_REPORTS: remove stray FILTER elements

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -18269,9 +18269,6 @@ END:VCALENDAR
           </attrib>
           <e>term</e>
           <o><e>name</e></o>
-          <any><e>filter</e></any>
-          <o><e>host</e></o>
-          <o><e>delta</e></o>
           <e>keywords</e>
         </pattern>
         <ele>
@@ -18283,61 +18280,6 @@ END:VCALENDAR
           <name>name</name>
           <summary>Filter name, if applicable</summary>
           <pattern>text</pattern>
-        </ele>
-        <ele>
-          <name>filter</name>
-          <summary>A severity level that is included in the report</summary>
-          <pattern>
-            <alts>
-              <alt>High</alt>
-              <alt>Medium</alt>
-              <alt>Low</alt>
-              <alt>Log</alt>
-            </alts>
-          </pattern>
-        </ele>
-        <ele>
-          <name>host</name>
-          <summary>Single host selected for delta report</summary>
-          <pattern>
-            <e>ip</e>
-          </pattern>
-          <ele>
-            <name>ip</name>
-            <summary>IP address of the host</summary>
-            <pattern>text</pattern>
-          </ele>
-        </ele>
-        <ele>
-          <name>delta</name>
-          <summary>Delta states</summary>
-          <pattern>
-            text
-            <e>changed</e>
-            <e>gone</e>
-            <e>new</e>
-            <e>same</e>
-          </pattern>
-          <ele>
-            <name>changed</name>
-            <summary>Whether changed results are included</summary>
-            <pattern><t>boolean</t></pattern>
-          </ele>
-          <ele>
-            <name>gone</name>
-            <summary>Whether results that have vanished are included</summary>
-            <pattern><t>boolean</t></pattern>
-          </ele>
-          <ele>
-            <name>new</name>
-            <summary>Whether new results are included</summary>
-            <pattern><t>boolean</t></pattern>
-          </ele>
-          <ele>
-            <name>same</name>
-            <summary>Whether results that are equal are included</summary>
-            <pattern><t>boolean</t></pattern>
-          </ele>
         </ele>
         <ele>
           <name>keywords</name>


### PR DESCRIPTION
## What

Remove the elements `FILTER`, `HOST` and `DELTA` from `GET_REPORTS_RESPONSE/FILTERS` in the GMP doc.

## Why

These elements only appear in `GET_REPORTS_RESPONSE/REPORT/REPORT/FILTERS`.

## References

The elements were accidentally added to the doc in ae7857b4f22034ba3de1cb8eae954e6e79f4b582 on 2016-02-22.

Note that these elements already existed in the doc for `REPORT/FILTERS` under `ELEMENT/REPORT`. For example, `HOST` and `DELTA` were added there in c07711b48b396d12c541f74213358c301ae8426b in 2011-12-21 (and `FILTER` even earlier).

## Example
```xml
$ o m m '<get_reports/>'
<get_reports_response status="200" status_text="OK">
  <report id="3aafe571-86cb-4ecb-afc8-b405cb3c5519" ...>
    <report id="3aafe571-86cb-4ecb-afc8-b405cb3c5519">
      <filters id="">
        <term>apply_overrides=0 min_qod=70 levels=hmlgdf first=1 rows=10 sort=name</term>
        <filter>High</filter>
        <filter>Medium</filter>
        <filter>Low</filter>
        <filter>Log</filter>
        <filter>False Positive</filter>
        <keywords>...</keywords>
      </filters>
      ...
    </report>
  </report>
  ...
  <filters id="">
    <term>apply_overrides=0 min_qod=70 first=1 rows=10 sort=name</term>
    <keywords>...</keywords>
  </filters>
  <sort>
    <field>name
    <order>ascending</order></field>
  </sort>
  <reports start="1" max="1000" />
  <report_count>11
  <filtered>11</filtered>
  <page>10</page></report_count>
</get_reports_response>
```