### PR TITLE
GMP doc: update GET_REPORT_CONFIGS

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -16665,6 +16665,7 @@ END:VCALENDAR
             <e>type</e>
             <e>value</e>
             <e>default</e>
+            <o><e>options</e></o>
           </pattern>
           <ele>
             <name>name</name>
@@ -16677,7 +16678,6 @@ END:VCALENDAR
             <pattern>
               <o><e>min</e></o>
               <o><e>max</e></o>
-              <o><e>options</e></o>
               <alts>
                 <alt>boolean</alt>
                 <alt>integer</alt>
@@ -16697,16 +16697,6 @@ END:VCALENDAR
               <name>max</name>
               <summary>Maximum</summary>
               <pattern>text</pattern>
-            </ele>
-            <ele>
-              <name>options</name>
-              <summary>Selection options</summary>
-              <pattern><any><e>option</e></any></pattern>
-              <ele>
-                <name>option</name>
-                <summary>Option value</summary>
-                <pattern>text</pattern>
-              </ele>
             </ele>
           </ele>
           <ele>
@@ -16737,6 +16727,16 @@ END:VCALENDAR
             <name>default</name>
             <summary>The fallback value of the param</summary>
             <pattern>text</pattern>
+          </ele>
+          <ele>
+            <name>options</name>
+            <summary>Selection options</summary>
+            <pattern><any><e>option</e></any></pattern>
+            <ele>
+              <name>option</name>
+              <summary>Option value</summary>
+              <pattern>text</pattern>
+            </ele>
           </ele>
         </ele>
         <ele>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -16726,7 +16726,27 @@ END:VCALENDAR
           <ele>
             <name>default</name>
             <summary>The fallback value of the param</summary>
-            <pattern>text</pattern>
+            <pattern>
+              text
+              <any><e>report_format</e></any>
+            </pattern>
+            <ele>
+              <name>report_format</name>
+              <summary>Report format info if type is report_format_list</summary>
+              <pattern>
+                <attrib>
+                  <name>id</name>
+                  <type>uuid</type>
+                  <required>1</required>
+                </attrib>
+                <e>name</e>
+              </pattern>
+              <ele>
+                <name>name</name>
+                <summary>Name of the report format if available</summary>
+                <pattern>text</pattern>
+              </ele>
+            </ele>
           </ele>
           <ele>
             <name>options</name>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -16519,7 +16519,6 @@ END:VCALENDAR
           <o><e>user_tags</e></o>
           <e>report_format</e>
           <o><e>orphan</e></o>
-          <o><e>alerts</e></o>
           <any><e>param</e></any>
         </pattern>
         <ele>
@@ -16658,36 +16657,6 @@ END:VCALENDAR
           <pattern>
             <t>boolean</t>
           </pattern>
-        </ele>
-        <ele>
-          <name>alerts</name>
-          <summary>Alerts using the report config</summary>
-          <pattern>
-            <any><e>alert</e></any>
-          </pattern>
-          <ele>
-            <name>alert</name>
-            <pattern>
-              <attrib>
-                <name>id</name>
-                <type>uuid</type>
-                <summary>UUID of the alert</summary>
-                <required>1</required>
-              </attrib>
-              <e>name</e>
-              <o><e>permissions</e></o>
-            </pattern>
-            <ele>
-              <name>name</name>
-              <summary>Name of the alert</summary>
-              <pattern><t>name</t></pattern>
-            </ele>
-            <ele>
-              <name>permissions</name>
-              <summary>Permissions the user has on the alert</summary>
-              <pattern></pattern>
-            </ele>
-          </ele>
         </ele>
         <ele>
           <name>param</name>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -16703,6 +16703,12 @@ END:VCALENDAR
             <name>value</name>
             <summary>The value of the param</summary>
             <pattern>
+              <attrib>
+                <name>using_default</name>
+                <summary>Whether this is the default value</summary>
+                <type>boolean</type>
+                <required>1</required>
+              </attrib>
               <any><e>report_format</e></any>
             </pattern>
             <ele>


### PR DESCRIPTION
## What

In the GMP doc for GET_REPORT_CONFIGS:

1. Remove `ALERTS`.
2. Move `OPTIONS` up one level.
3. Add `REPORT_FORMAT` to `DEFAULT`.
4. Add attribute `using_default` to `VALUE`.

## Why

1. Alerts are not sent by the command. This looks like a copy paste error from GET_REPORT_FORMATS, which does send alerts.
2. `OPTIONS` was inside `TYPE` but they are siblings.
3. `DEFAULT` may contain `REPORT_FORMATS` when type is `report_format_list`.
4. Attribute `using_default` was missing.

## Verify
```xml
$ # 1 Zero ALERT elements:
$ o m m '<get_report_configs/>' | grep alerts | wc -l
0

$ o m m '<get_report_configs/>'
<get_report_configs_response status="200" status_text="OK">
  <report_config id="66b89581-141b-47d2-a478-cbde5e8f8339">
    <param>
      <name>test_param_selection</name>
      <type>
        selection
        <min>0</min>
        <max>0</max>
      </type>
      <value using_default="1">a</value>                         <!--==== 4 using_default ===========-->
      <default>a</default>
      <options>                                                  <!--==== 2 OPTIONS outside TYPE ====-->
        <option>a</option>
        <option>b</option>
        <option>c</option>
      </options>
    </param>
    <param>
      <name>test_param_rf_list</name>
      <type>report_format_list
      <min>0</min>
      <max>0</max></type>
      <value using_default="1">
        bbb5f18f-7e9e-4319-b4ad-5eb474e70d1a,5057e5cc-b825-11e4-9d0e-28d24461215b
        <report_format id="bbb5f18f-7e9e-4319-b4ad-5eb474e70d1a">
          <name>aa</name>
        </report_format>
        <report_format id="5057e5cc-b825-11e4-9d0e-28d24461215b">
          <name>Anonymous XML</name>
        </report_format>
      </value>
      <default>
        bbb5f18f-7e9e-4319-b4ad-5eb474e70d1a,5057e5cc-b825-11e4-9d0e-28d24461215b

        <!--==== 3 REPORT_FORMAT inside DEFAULT ====-->

        <report_format id="bbb5f18f-7e9e-4319-b4ad-5eb474e70d1a">
          <name>aa</name>
        </report_format>
        <report_format id="5057e5cc-b825-11e4-9d0e-28d24461215b">
          <name>Anonymous XML</name>
        </report_format>
      </default>
    </param>
  </report_config>
```