### PR TITLE
GMP doc: GET_REPORT_FORMATS: remove PERMISSIONS

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -17293,17 +17293,11 @@ END:VCALENDAR
                 <required>1</required>
               </attrib>
               <e>name</e>
-              <o><e>permissions</e></o>
             </pattern>
             <ele>
               <name>name</name>
               <summary>Name of the alert</summary>
               <pattern><t>name</t></pattern>
-            </ele>
-            <ele>
-              <name>permissions</name>
-              <summary>Permissions the user has on the permission</summary>
-              <pattern></pattern>
             </ele>
           </ele>
         </ele>
@@ -17328,17 +17322,11 @@ END:VCALENDAR
                 <required>1</required>
               </attrib>
               <e>name</e>
-              <o><e>permissions</e></o>
             </pattern>
             <ele>
               <name>name</name>
               <summary>Name of the report config</summary>
               <pattern><t>name</t></pattern>
-            </ele>
-            <ele>
-              <name>permissions</name>
-              <summary>Permissions the user has on the report config</summary>
-              <pattern></pattern>
             </ele>
           </ele>
         </ele>


### PR DESCRIPTION
## What

In the GMP doc, remove `PERMISSIONS` from `ALERTS` and `REPORT_CONFIGS` in command `GET_REPORT_FORMATS`.

## Why

These elements are not present, even when details="1".

## Verify

```xml
o m m '<get_report_formats report_configs="1" alerts="1" details="1"/>'
<get_report_formats_response status="200" status_text="OK">
  <report_format id="a3810a62-1f62-11e1-9219-406186ea4fc5">
    <alerts>
      <alert id="e4b4cacb-1081-4a9c-bdee-760988c6a39f">
        <name>uses rf</name>
      </alert>
    </alerts>
    ...
  </report_format>
  <report_format id="a3810a62-1f62-11e1-9219-406186ea4fc6">
    <report_configs>
      <report_config id="66b89581-141b-47d2-a478-cbde5e8f8339">
        <name>test</name>
      </report_config>
      <report_config id="7865d67d-eeff-4dce-9536-4175f2794a9e">
        <name>test2</name>
      </report_config>
      <report_config id="63b82cff-1587-4aeb-9164-8510576578d8">
        <name>test3</name>
      </report_config>
    </report_configs>
    ...
```


