### PR TITLE
Fix: Add missing log domain for ipc

### DIFF
--- a/src/ipc.c
+++ b/src/ipc.c
@@ -34,6 +34,11 @@
 #include "ipc.h"
 #include "manage.h"
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md   main"
 
 /**
  * @brief System V semaphore set key for gvmd actions.


### PR DESCRIPTION
## What
Add missing log domain for ipc.

## Why
It was missing.

## References
GEA-684


