### PR TITLE
Fix: Fixed signal when choosing an unsupported levels filter option.

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -22358,6 +22358,8 @@ where_levels_auto (const char *levels, const char *new_severity_sql)
       count++;
     }
 
+  // HIERHIERHIER
+
   if (count == 0)
     {
       g_string_free (levels_sql, TRUE);
@@ -23099,7 +23101,8 @@ results_extra_where (int trash, report_t report, const gchar* host,
   extra_where = g_strdup_printf("%s%s%s%s%s",
                                 report_clause ? report_clause : "",
                                 host_clause ? host_clause : "",
-                                levels_clause->str,
+                                (levels_clause && levels_clause->str) ?
+                                  levels_clause->str : "",
                                 min_qod_clause ? min_qod_clause : "",
                                 compliance_levels_clause ?: "");
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -22358,8 +22358,6 @@ where_levels_auto (const char *levels, const char *new_severity_sql)
       count++;
     }
 
-  // HIERHIERHIER
-
   if (count == 0)
     {
       g_string_free (levels_sql, TRUE);


### PR DESCRIPTION
## What
Fixed the signal that occurred when choosing an unsupported levels filter option (like d or x etc.) on the Scans > Results page.
 <!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This is a bug-fix.
<!-- Describe why are these changes necessary? -->

## References
GEA-671
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->
Tested manually on my local development system.
- [ ] Tests


