### PR TITLE
Change: Update gvm-libs image in prod.Dockerfile and build.Dockerfile

### DIFF
--- a/.docker/build.Dockerfile
+++ b/.docker/build.Dockerfile
@@ -2,7 +2,7 @@
 ARG GVM_LIBS_VERSION=oldstable
 
 # We want gvm-libs to be ready so we use the build docker image of gvm-libs
-FROM greenbone/gvm-libs:$GVM_LIBS_VERSION
+FROM registry.community.greenbone.net/community/gvm-libs:${GVM_LIBS_VERSION}
 
 # This will make apt-get install without question
 ARG DEBIAN_FRONTEND=noninteractive

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -20,7 +20,7 @@ RUN mkdir /build && \
     cmake -DCMAKE_BUILD_TYPE=Release $FEATURE_TOGGLE /source && \
     make DESTDIR=/install install
 
-FROM greenbone/gvm-libs:${GVM_LIBS_VERSION}
+FROM registry.community.greenbone.net/community/gvm-libs:${GVM_LIBS_VERSION}
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## What

Update gvm-libs image in prod.Dockerfile and build.Dockerfile

## Why

In the next release gvm-libs will be pushed to a new registry, therefore the reference needs to be updated.

## References

https://jira.greenbone.net/browse/DEVOPS-1229

## Checklist

- [ ] Tests
