### PR TITLE
Change: Extend get_feeds GMP command.

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -12996,15 +12996,11 @@ handle_get_feeds (gmp_parser_t *gmp_parser, GError **error)
 
   if (feed_owner_uuid != NULL && strlen (feed_owner_uuid) > 0)
     feed_owner_set = TRUE;
-  else
-    g_warning ("%s: No feed owner set.", __func__);
 
   setting_value (SETTING_UUID_FEED_IMPORT_ROLES, &feed_roles);
 
   if (feed_roles != NULL && strlen (feed_roles) > 0)
     feed_import_roles_set = TRUE;
-  else
-    g_warning ("%s: No feed import roles set.", __func__);
 
   if (feed_owner_uuid != NULL && strcmp (feed_owner_uuid, current_credentials.uuid) == 0)
     feed_resources_access = TRUE;
@@ -13031,13 +13027,11 @@ handle_get_feeds (gmp_parser_t *gmp_parser, GError **error)
                           " status=\"" STATUS_OK "\""
                           " status_text=\"" STATUS_OK_TEXT "\">");
 
-  SENDF_TO_CLIENT_OR_FAIL ("<feed_owner_set>%s</feed_owner_set>",
-                           feed_owner_set ? "1" : "0");
-
-  SENDF_TO_CLIENT_OR_FAIL ("<feed_roles_set>%s</feed_roles_set>",
-                           feed_import_roles_set ? "1" : "0");
-
-  SENDF_TO_CLIENT_OR_FAIL ("<feed_resources_access>%s</feed_resources_access>",
+  SENDF_TO_CLIENT_OR_FAIL ("<feed_owner_set>%s</feed_owner_set>"
+                           "<feed_roles_set>%s</feed_roles_set>"
+                           "<feed_resources_access>%s</feed_resources_access>",
+                           feed_owner_set ? "1" : "0",
+                           feed_import_roles_set ? "1" : "0",
                            feed_resources_access ? "1" : "0");
 
   if ((get_feeds_data->type == NULL)

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -12976,6 +12976,7 @@ static void
 handle_get_feeds (gmp_parser_t *gmp_parser, GError **error)
 {
   assert (current_credentials.username);
+  assert (current_credentials.uuid);
 
   if (acl_user_may ("get_feeds") == 0)
     {
@@ -12986,9 +12987,58 @@ handle_get_feeds (gmp_parser_t *gmp_parser, GError **error)
       return;
     }
 
+  char *feed_owner_uuid, *feed_roles;
+  gboolean feed_owner_set, feed_import_roles_set, feed_resources_access;
+
+  feed_owner_set = feed_import_roles_set = feed_resources_access = FALSE;
+
+  setting_value (SETTING_UUID_FEED_IMPORT_OWNER, &feed_owner_uuid);
+
+  if (feed_owner_uuid != NULL && strlen (feed_owner_uuid) > 0)
+    feed_owner_set = TRUE;
+  else
+    g_warning ("%s: No feed owner set.", __func__);
+
+  setting_value (SETTING_UUID_FEED_IMPORT_ROLES, &feed_roles);
+
+  if (feed_roles != NULL && strlen (feed_roles) > 0)
+    feed_import_roles_set = TRUE;
+  else
+    g_warning ("%s: No feed import roles set.", __func__);
+
+  if (feed_owner_uuid != NULL && strcmp (feed_owner_uuid, current_credentials.uuid) == 0)
+    feed_resources_access = TRUE;
+  else if (feed_roles != NULL)
+    {
+      gchar **roles = g_strsplit (feed_roles, ",", -1);
+      gchar **role = roles;
+      while (*role)
+      {
+        if (acl_user_has_role (current_credentials.uuid, *role))
+          {
+            feed_resources_access = TRUE;
+            break;
+          }
+        role++;
+      }
+      g_strfreev (roles);
+    }
+
+  free (feed_roles);
+  free (feed_owner_uuid);
+
   SEND_TO_CLIENT_OR_FAIL ("<get_feeds_response"
                           " status=\"" STATUS_OK "\""
                           " status_text=\"" STATUS_OK_TEXT "\">");
+
+  SENDF_TO_CLIENT_OR_FAIL ("<feed_owner_set>%s</feed_owner_set>",
+                           feed_owner_set ? "1" : "0");
+
+  SENDF_TO_CLIENT_OR_FAIL ("<feed_roles_set>%s</feed_roles_set>",
+                           feed_import_roles_set ? "1" : "0");
+
+  SENDF_TO_CLIENT_OR_FAIL ("<feed_resources_access>%s</feed_resources_access>",
+                           feed_resources_access ? "1" : "0");
 
   if ((get_feeds_data->type == NULL)
       || (strcasecmp (get_feeds_data->type, "nvt") == 0))

--- a/src/manage_acl.c
+++ b/src/manage_acl.c
@@ -462,6 +462,35 @@ acl_user_is_user (const char *uuid)
   return ret;
 }
 
+/**
+ * @brief Check whether a user has a given role.
+ *
+ * @param[in]  user_uuid  UUID of the user.
+ * @param[in]  role_uuid  UUID of the role.
+ *
+ * @return 1 if user has the given role, else 0.
+ */
+int
+acl_user_has_role (const char *user_uuid, const char *role_uuid)
+{
+  int ret;
+  gchar *quoted_role_uuid, *quoted_user_uuid;
+
+  quoted_role_uuid = sql_quote (role_uuid);
+  quoted_user_uuid = sql_quote (user_uuid);
+
+  ret = sql_int ("SELECT count (*) FROM role_users"
+                 " WHERE role = (SELECT id FROM roles"
+                 "               WHERE uuid = '%s')"
+                 " AND \"user\" = (SELECT id FROM users WHERE uuid = '%s');",
+                 quoted_role_uuid, quoted_user_uuid);
+
+  g_free (quoted_role_uuid);
+  g_free (quoted_user_uuid);
+  return ret;
+}
+
+
 /* TODO This is only predicatable for unique fields like "id".  If the field
  *      is "name" then "SELECT ... format" will choose arbitrarily between
  *      the resources that have the same name. */

--- a/src/manage_acl.h
+++ b/src/manage_acl.h
@@ -156,6 +156,9 @@ int
 acl_user_is_observer (const char *);
 
 int
+acl_user_has_role (const char *, const char *);
+
+int
 acl_user_owns (const char *, resource_t, int);
 
 int

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -11525,8 +11525,26 @@ END:VCALENDAR
           <type>text</type>
           <required>1</required>
         </attrib>
+        <e>feed_owner_set</e>
+        <e>feed_roles_set</e>
+        <e>feed_resources_access</e>
         <any><e>feed</e></any>
       </pattern>
+      <ele>
+        <name>feed_owner_set</name>
+        <summary>Whether the feed owner is set</summary>
+        <pattern><t>boolean</t></pattern>
+      </ele>
+      <ele>
+        <name>feed_roles_set</name>
+        <summary>Whether the feed roles are set</summary>
+        <pattern><t>boolean</t></pattern>
+      </ele>
+      <ele>
+        <name>feed_resources_access</name>
+        <summary>Whether the user has access to feed resources</summary>
+        <pattern><t>boolean</t></pattern>
+      </ele>
       <ele>
         <name>feed</name>
         <pattern>
@@ -11590,6 +11608,9 @@ END:VCALENDAR
       </request>
       <response>
         <get_feeds_response status_text="OK" status="200">
+          <feed_owner_set>1</feed_owner_set>
+          <feed_roles_set>1</feed_roles_set>
+          <feed_resources_access>1</feed_resources_access>
           <feed>
             <type>NVT</type>
             <name>Greenbone Security Feed</name>


### PR DESCRIPTION
## What

Added information on whether the feed owner and feed import roles are set and whether the user has access to feed resources.

## Why
To provide a more descriptive feedback to the user in GSA if the scanning is not possible. 

## References
GEA-704


