### PR TITLE
Fix: add LIBDIR to SYSTEMD_SERVICE_DIR config

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -15,9 +15,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-
 if (NOT SYSTEMD_SERVICE_DIR)
-  set (SYSTEMD_SERVICE_DIR "/lib/systemd/system")
+  set (SYSTEMD_SERVICE_DIR "${LIBDIR}/systemd/system")
 endif (NOT SYSTEMD_SERVICE_DIR)
 
 if (NOT LOGROTATE_DIR)


### PR DESCRIPTION
## What

Prefix the `SYSTEMD_SERVICE_DIR` config path with `LIBDIR`.

## Why

The default install was always putting the systemd files in `/lib`.

For one this can cause permission problems, for example if you're installing to your home dir.

Note that it's still possible to specify an exact location by passing -DSYSTEMD_SERVICE_DIR to cmake.

## Verify

On main, before the PR:
```console
#### 1 plain
$ cmake MANY_ARGS && make install
-- Installing: /lib/systemd/system/gvmd.service
CMake Error at config/cmake_install.cmake:54 (file):
  file INSTALL cannot copy file
  "/home/matt/fresh/main/build/gvmd/config/gvmd.service" to
  "/lib/systemd/system/gvmd.service": Permission denied.
Call Stack (most recent call first):
  cmake_install.cmake:424 (include)
make: *** [Makefile:130: install] Error 1

#### 2 specify LIBDIR
$ cmake -DLIBDIR=/tmp/ MANY_ARGS && make install
-- Installing: /lib/systemd/system/gvmd.service
CMake Error at config/cmake_install.cmake:54 (file):
  file INSTALL cannot copy file
  "/home/matt/fresh/main/build/gvmd/config/gvmd.service" to
  "/lib/systemd/system/gvmd.service": Permission denied.
Call Stack (most recent call first):
  cmake_install.cmake:424 (include)
make: *** [Makefile:130: install] Error 1
```
With the PR:
```console
#### plain
$ cmake MANY_ARGS && make install
-- Installing: /home/matt/alts/main/lib/systemd/system/gvmd.service
Compilation finished at Tue Oct  8 11:12:02

#### specify LIBDIR
$ cmake -DLIBDIR=/tmp/ MANY_ARGS && make install
-- Installing: /tmp/systemd/system/gvmd.service
Compilation finished at Tue Oct  8 11:12:57
```

## References

Closes #2296.