### PR TITLE
Add: The table scap.affected_products is filled for the new JSON feed.

### DIFF
--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -3513,7 +3513,7 @@ manage_db_init (const gchar *name)
            "  creation_time integer,"
            "  modification_time integer,"
            "  cvss_vector text,"
-           "  products text,"
+           "  products text DEFAULT '',"
            "  severity DOUBLE PRECISION DEFAULT 0);");
 
       sql ("CREATE TABLE scap2.cpes"
@@ -3650,11 +3650,12 @@ manage_db_init_indexes (const gchar *name)
            " ON scap2.cpes (severity);");
       sql ("CREATE INDEX cpes_by_uuid"
            " ON scap2.cpes (uuid);");
-
       sql ("CREATE INDEX afp_cpe_idx"
            " ON scap2.affected_products (cpe);");
       sql ("CREATE INDEX afp_cve_idx"
            " ON scap2.affected_products (cve);");
+      sql ("CREATE INDEX cpe_by_pattern_name ON scap2.cpes"
+           " USING btree(name text_pattern_ops);");
 
       sql ("CREATE INDEX epss_scores_by_cve"
            " ON scap2.epss_scores (cve);");


### PR DESCRIPTION
## What
Now the table scap.affected_products is filled from a new separate JSON feed file for the new JSON feed.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
It is needed amongst others to get the severity score in CPE SecInfo.
<!-- Describe why are these changes necessary? -->

## References
GEA-627
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


