### PR TITLE
Remove delta reports feature toggle and non-default-code

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -28262,7 +28262,7 @@ print_report_host_xml (FILE *stream,
 }
 
 /**
- * @brief Init v2 delta iterator for print_report_xml.
+ * @brief Init delta iterator for print_report_xml.
  *
  * @param[in]  report         The report.
  * @param[in]  results        Report result iterator.
@@ -28274,9 +28274,9 @@ print_report_host_xml (FILE *stream,
  * @return 0 on success, -1 error.
  */
 static int
-init_v2_delta_iterator (report_t report, iterator_t *results, report_t delta, 
-                      const get_data_t *get, const char *term,
-                      const char *sort_field)
+init_delta_iterator (report_t report, iterator_t *results, report_t delta,
+                     const get_data_t *get, const char *term,
+                     const char *sort_field)
 {
   int ret;
   static const char *filter_columns[] = RESULT_ITERATOR_FILTER_COLUMNS;
@@ -28465,7 +28465,7 @@ init_v2_delta_iterator (report_t report, iterator_t *results, report_t delta,
 }
 
 /**
- * @brief Print v2 delta results for print_report_xml.
+ * @brief Print delta results for print_report_xml.
  *
  * @param[in]  out            File stream to write to.
  * @param[in]  results        Report result iterator.
@@ -28504,7 +28504,7 @@ init_v2_delta_iterator (report_t report, iterator_t *results, report_t delta,
  * @return 0 on success, -1 error.
  */
 static int
-print_v2_report_delta_xml (FILE *out, iterator_t *results,
+print_report_delta_xml (FILE *out, iterator_t *results,
                         const char *delta_states,
                         int first_result, int max_results, task_t task,
                         int notes, int notes_details, int overrides,
@@ -29380,7 +29380,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
 
   if (delta && get->details)
     {
-      if (init_v2_delta_iterator (report, &results, delta,
+      if (init_delta_iterator (report, &results, delta,
                                   get, term, sort_field))
         {
           g_free (term);
@@ -29448,27 +29448,27 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
 
   if (delta && get->details)
     {
-      if (print_v2_report_delta_xml (out, &results, delta_states,
-                                    ignore_pagination ? 0 : first_result,
-                                    ignore_pagination ? -1 : max_results,
-                                    task, notes,
-                                    notes_details, overrides,
-                                    overrides_details, sort_order,
-                                    sort_field, result_hosts_only,
-                                    &orig_filtered_result_count,
-                                    &filtered_result_count,
-                                    &orig_f_holes, &f_holes,
-                                    &orig_f_infos, &f_infos,
-                                    &orig_f_logs, &f_logs,
-                                    &orig_f_warnings, &f_warnings,
-                                    &orig_f_false_positives,
-                                    &f_false_positives,
-                                    &f_compliance_yes,
-                                    &f_compliance_no,
-                                    &f_compliance_incomplete,
-                                    &f_compliance_undefined,
-                                    &f_compliance_count,
-                                    result_hosts))
+      if (print_report_delta_xml (out, &results, delta_states,
+                                  ignore_pagination ? 0 : first_result,
+                                  ignore_pagination ? -1 : max_results,
+                                  task, notes,
+                                  notes_details, overrides,
+                                  overrides_details, sort_order,
+                                  sort_field, result_hosts_only,
+                                  &orig_filtered_result_count,
+                                  &filtered_result_count,
+                                  &orig_f_holes, &f_holes,
+                                  &orig_f_infos, &f_infos,
+                                  &orig_f_logs, &f_logs,
+                                  &orig_f_warnings, &f_warnings,
+                                  &orig_f_false_positives,
+                                  &f_false_positives,
+                                  &f_compliance_yes,
+                                  &f_compliance_no,
+                                  &f_compliance_incomplete,
+                                  &f_compliance_undefined,
+                                  &f_compliance_count,
+                                  result_hosts))
         goto failed_delta_report;
     }
   else if (get->details)

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -138,11 +138,6 @@
 #define SETTING_UUID_FEED_IMPORT_ROLES "ff000362-338f-11ea-9051-28d24461215b"
 
 /**
- * @brief UUID of 'Delta Reports Version' setting.
- */
-#define SETTING_UUID_DELTA_REPORTS_VERSION "985a0c05-2140-4e66-9989-ce9a0906a5a9"
-
-/**
  * @brief UUID of 'SecInfo SQL Buffer Threshold' setting.
  */
 #define SETTING_UUID_SECINFO_SQL_BUFFER_THRESHOLD "316275a9-3629-49ad-9cea-5b3ab155b93f"

--- a/src/manage_sql_tests.c
+++ b/src/manage_sql_tests.c
@@ -61,104 +61,6 @@ Ensure (manage_sql, validate_results_port_validates)
   FAIL ("udp");
 }
 
-#define CMP(one, two, ret) assert_that (streq_ignore_ws (one, two), is_equal_to (ret))
-
-#define EQ2(one, two) CMP(one, two, 1); CMP(two, one, 1)
-#define EQ(string) CMP(string, string, 1)
-
-Ensure (manage_sql, streq_ignore_ws_finds_equal)
-{
-  EQ ("abc");
-  EQ (" abc");
-  EQ ("abc ");
-  EQ ("ab c");
-  EQ ("");
-  EQ (".");
-  EQ (" abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+-=_)(*&^%$#@!~\"':}{<>?");
-  EQ ("three little words");
-}
-
-Ensure (manage_sql, streq_ignore_ws_finds_equal_despite_ws)
-{
-  EQ2 ("abc", " abc");
-  EQ2 ("abc", "abc ");
-  EQ2 ("abc", "ab c");
-  EQ2 ("abc", " a b    c ");
-
-  EQ2 ("abc", "\nabc");
-  EQ2 ("abc", "abc\n");
-  EQ2 ("abc", "ab\nc");
-  EQ2 ("abc", "\na\nb\n\n\n\nc\n");
-
-  EQ2 ("abc", "\tabc");
-  EQ2 ("abc", "abc\t");
-  EQ2 ("abc", "ab\tc");
-  EQ2 ("abc", "\ta\tb\t\t\t\tc\t");
-
-  EQ2 ("abcd", "\ta\nb \t\nc  \t\t\n\nd\t\n ");
-
-  EQ2 ("", " ");
-  EQ2 ("", "\t");
-  EQ2 ("", "\n");
-  EQ2 ("", "  ");
-  EQ2 ("", "\t\t");
-  EQ2 ("", "\n\n");
-  EQ2 ("", " \n\t  \n\n\t\t");
-
-  EQ2 (" \n\t  \n\n\t\t", " \n\t  \n\n\t\t");
-}
-
-#define DIFF(one, two) CMP(one, two, 0); CMP(two, one, 0)
-
-Ensure (manage_sql, streq_ignore_ws_finds_diff)
-{
-  DIFF ("abc", "abcd");
-  DIFF ("abc", "dabc");
-  DIFF ("abc", "abdc");
-  DIFF ("abc", "xyz");
-  DIFF ("abc", "");
-  DIFF ("abc", ".");
-  DIFF ("abc", "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+-=_)(*&^%$#@!~\"':}{<>?");
-}
-
-Ensure (manage_sql, streq_ignore_ws_finds_diff_incl_ws)
-{
-  DIFF ("zabc", " abc");
-  DIFF ("zabc", "abc ");
-  DIFF ("zabc", "ab c");
-  DIFF ("zabc", " a b    c ");
-
-  DIFF ("zabc", "\nabc");
-  DIFF ("zabc", "abc\n");
-  DIFF ("zabc", "ab\nc");
-  DIFF ("zabc", "\na\nb\n\n\n\nc\n");
-
-  DIFF ("zabc", "\tabc");
-  DIFF ("zabc", "abc\t");
-  DIFF ("zabc", "ab\tc");
-  DIFF ("zabc", "\ta\tb\t\t\t\tc\t");
-
-  DIFF ("zabcd", "\ta\nb \t\nc  \t\t\n\nd\t\n ");
-
-  DIFF ("a", " ");
-  DIFF ("a", "\t");
-  DIFF ("a", "\n");
-  DIFF ("a", "  ");
-  DIFF ("a", "\t\t");
-  DIFF ("a", "\n\n");
-  DIFF ("a", " \n\t  \n\n\t\t");
-
-  DIFF ("a \n\t  \n\n\t\t", " \n\t  \n\n\t\t");
-  DIFF (" \n\t  \na\n\t\t", " \n\t  \n\n\t\t");
-  DIFF (" \n\t  \n\n\t\ta", " \n\t  \n\n\t\t");
-}
-
-Ensure (manage_sql, streq_ignore_ws_handles_null)
-{
-  EQ (NULL);
-  DIFF ("abc", NULL);
-}
-
 /* Test suite. */
 
 int
@@ -169,12 +71,6 @@ main (int argc, char **argv)
   suite = create_test_suite ();
 
   add_test_with_context (suite, manage_sql, validate_results_port_validates);
-
-  add_test_with_context (suite, manage_sql, streq_ignore_ws_finds_equal);
-  add_test_with_context (suite, manage_sql, streq_ignore_ws_finds_equal_despite_ws);
-  add_test_with_context (suite, manage_sql, streq_ignore_ws_finds_diff);
-  add_test_with_context (suite, manage_sql, streq_ignore_ws_finds_diff_incl_ws);
-  add_test_with_context (suite, manage_sql, streq_ignore_ws_handles_null);
 
   if (argc > 1)
     return run_single_test (suite, argv[1], create_text_reporter ());


### PR DESCRIPTION
## What
Remove delta reports feature toggle and non-default-code (v1)

## Why
No need to maintain v1 code any more. Delta reports v2 was enabled by default in GEA-271.

## References
GEA-701


