### PR TITLE
Add: The table scap.affected_products is filled for the new JSON feed.

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -20511,7 +20511,7 @@ init_cpe_match_nodes_iterator (iterator_t* iterator, const char *criteria)
                  " JOIN scap.cpe_nodes_match_criteria c"
                  " ON n.id = c.node_id"
                  " JOIN scap.cpe_match_strings r"
-                 " ON c.match_criteria = r.match_criteria_id"
+                 " ON c.match_criteria_id = r.match_criteria_id"
                  " WHERE criteria like '%s%%';",
                  quoted_criteria);
   g_free (quoted_criteria);

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -4047,10 +4047,8 @@ update_scap_cves ()
  * @brief Update SCAP affected products.
  *
  * Assume that the databases are attached.
- *
- * @return 0 success, -1 error.
  */
-static int
+static void
 update_scap_affected_products ()
 {
   g_info ("Updating affected products");
@@ -4064,8 +4062,6 @@ update_scap_affected_products ()
        "      AND scap2.cpe_nodes_match_criteria.match_criteria_id ="
        "            scap2.cpe_matches.match_criteria_id"
        "      AND scap2.cpe_matches.cpe_name_id = scap2.cpes.cpe_name_id;");
-
-  return 0;
 }
 
 /**
@@ -5634,11 +5630,7 @@ update_scap (gboolean reset_scap_db)
   g_debug ("%s: update affected_products", __func__);
   setproctitle ("Syncing SCAP: Updating affected products");
 
-  if (update_scap_affected_products () == -1)
-    {
-      abort_scap_update ();
-      return -1;
-    }
+  update_scap_affected_products ();
 
   g_debug ("%s: updating user defined data", __func__);
 


### PR DESCRIPTION
## What
This PR contains the filling of the table scap.affected_products from already filled tables of the db
and a small bug-fix for the CVE scan.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
The table scap.affected_products is needed amongst others to get the severity score in CPE SecInfo.
<!-- Describe why are these changes necessary? -->

## References
GEA-627
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


