### PR TITLE
Doc: Drop mention of obsolete dependency on xml-twig-tools in Dockerfile

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -72,9 +72,6 @@ ARG DEBIAN_FRONTEND=noninteractive
 # s/mime email encryption
 # gpgsm
 
-# Loading scap and cert data
-# xml-twig-tools
-
 # Required for set up certificates for GVM
 # gnutls-bin
 


### PR DESCRIPTION
## What
In #2142 the dependency itself has been dropped but it was missed to remove the relevant comment as well.

## Why
Don't mention an unnecessary dependency

## References
- #2142 
- greenbone/docs#524