### PR TITLE
Flush trailing whitespace

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -5513,7 +5513,7 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
 
             append_attribute (attribute_names, attribute_values, "config_id",
                               &get_reports_data->config_id);
-            
+
             append_attribute (attribute_names, attribute_values, "format_id",
                               &get_reports_data->format_id);
 
@@ -5604,7 +5604,7 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
                                 "type", &typebuf))
               get_resource_names_data->type = g_ascii_strdown (typebuf, -1);
             set_client_state (CLIENT_GET_RESOURCE_NAMES);
-          }             
+          }
         else if (strcasecmp ("GET_RESULTS", element_name) == 0)
           {
             const gchar* attribute;
@@ -8451,7 +8451,7 @@ buffer_override_xml (GString *buffer, iterator_t *overrides,
       buffer_xml_append_printf (buffer,
                                 "<creation_time>%s</creation_time>",
                                 iso_if_time (get_iterator_creation_time (overrides)));
-                                    
+
       buffer_xml_append_printf (buffer,
                                 "<modification_time>%s</modification_time>",
                                 iso_if_time (get_iterator_modification_time (overrides)));
@@ -9353,9 +9353,9 @@ results_xml_append_nvt (iterator_t *results, GString *buffer, int cert_loaded)
  *
  */
 void
-buffer_diff(GString *buffer, const char *descr, const char *delta_descr) 
+buffer_diff(GString *buffer, const char *descr, const char *delta_descr)
 {
-  
+
   gchar *diff = strdiff (descr ? descr : "",
                   delta_descr ? delta_descr : "");
   if (diff)
@@ -9428,7 +9428,7 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
   report_t report;
   task_t selected_task;
   time_t creation_time;
-  
+
   comment = get_iterator_comment (results);
   name = get_iterator_name (results);
   host = result_iterator_host (results);
@@ -9503,7 +9503,7 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
     {
       const char *owner_name;
       time_t modification_time;
-     
+
       if (use_delta_fields)
         {
           owner_name = result_iterator_delta_owner_name (results);
@@ -9545,7 +9545,7 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
         {
           if (task == 0)
             selected_task = result_iterator_delta_task (results);
-          
+
           result_task_name = task_name(result_iterator_delta_task (results));
           result_report_id = report_uuid(result_iterator_delta_report (results));
         }
@@ -9553,7 +9553,7 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
         {
           if (task == 0)
             selected_task = result_iterator_task (results);
-          
+
           result_task_name = task_name (result_iterator_task (results));
           result_report_id = report_uuid (result_iterator_report (results));
         }
@@ -9674,14 +9674,14 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
       const char *nvt_version, *level;
       if (use_delta_fields)
         {
-          nvt_version = result_iterator_delta_nvt_version (results); 
+          nvt_version = result_iterator_delta_nvt_version (results);
           level = result_iterator_delta_level (results);
-        } 
+        }
       else
         {
           nvt_version = result_iterator_scan_nvt_version (results);
           level = result_iterator_level (results);
-        }     
+        }
       buffer_xml_append_printf
       (buffer,
         "<scan_nvt_version>%s</scan_nvt_version>"
@@ -9712,7 +9712,7 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
     {
       /* Only send the original severity if it has changed. */
       if (strncmp (original_severity,
-                    severity,          
+                    severity,
                     /* Avoid rounding differences. */
                     3))
         buffer_xml_append_printf (buffer,
@@ -9749,7 +9749,7 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
       if (delta_state)
         g_string_append_printf (buffer, "%s", delta_state);
 
-      if(delta_results) { 
+      if(delta_results) {
         /* delta reports version 1 */
         if (changed)
           {
@@ -9768,8 +9768,8 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
             g_free (delta_nl_descr);
           }
       } else {
-        /* delta reports version 2 */        
-        if (changed) 
+        /* delta reports version 2 */
+        if (changed)
           {
             gchar *delta_nl_descr;
             const char *delta_descr;
@@ -9812,8 +9812,8 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
       g_free (nl_descr_escaped);
     }
 
-  if (use_delta_fields 
-      ? result_iterator_delta_may_have_tickets (results) 
+  if (use_delta_fields
+      ? result_iterator_delta_may_have_tickets (results)
       : result_iterator_may_have_tickets (results))
     buffer_result_tickets_xml (buffer, result);
 
@@ -13304,7 +13304,7 @@ print_cpe_match_nodes_xml (resource_t node, GString *buffer)
       vee = cpe_match_string_iterator_version_end_excl (&cpe_match_ranges);
 
       xml_string_append (buffer,
-                         "<version_start_including>%s</version_start_including>", 
+                         "<version_start_including>%s</version_start_including>",
                          vsi ?: "");
       xml_string_append (buffer,
                          "<version_start_excluding>%s</version_start_excluding>",
@@ -15536,7 +15536,7 @@ print_report_config_params (gmp_parser_t *gmp_parser, GError **error,
 
           SENDF_TO_CLIENT_OR_FAIL
             ("</type><value using_default=\"%d\">%s",
-              report_config_param_iterator_using_default (&params), 
+              report_config_param_iterator_using_default (&params),
               value ? value : "");
           if (value)
             {
@@ -15711,27 +15711,27 @@ handle_get_report_configs (gmp_parser_t *gmp_parser, GError **error)
         {
           SEND_TO_CLIENT_OR_FAIL ("<orphan>1</orphan>");
         }
-      
-      SENDF_TO_CLIENT_OR_FAIL 
+
+      SENDF_TO_CLIENT_OR_FAIL
         ("<report_format id=\"%s\">",
           report_config_iterator_report_format_id (&report_configs)
         );
-      
+
       if (!orphan)
         {
-          SENDF_TO_CLIENT_OR_FAIL 
+          SENDF_TO_CLIENT_OR_FAIL
             ("<name>%s</name>",
               report_config_iterator_report_format_name (&report_configs)
             );
-            
+
           if (report_config_iterator_report_format_readable (&report_configs) == 0)
             {
               SENDF_TO_CLIENT_OR_FAIL ("<permissions/>");
             }
         }
-      
+
       SENDF_TO_CLIENT_OR_FAIL ("</report_format>");
-      
+
       print_report_config_params (gmp_parser, error,
                                   report_config_param_iterator_rowid (
                                     &report_configs
@@ -16114,16 +16114,16 @@ handle_get_report_formats (gmp_parser_t *gmp_parser, GError **error)
 }
 
 /**
- * @brief Assign resource iterator with an init iterator based on the type 
+ * @brief Assign resource iterator with an init iterator based on the type
  * in the get command data.
  *
  * @param[in]  resource_names_data   data for get_resource_names command.
  * @param[out] iterator              address of iterator function pointer.
- * 
+ *
  * @return 1 if type is invalid, else 0.
  */
 int
-select_resource_iterator (get_resource_names_data_t *resource_names_data, 
+select_resource_iterator (get_resource_names_data_t *resource_names_data,
                           int (**iterator) (iterator_t*, get_data_t *))
 {
     if (g_strcmp0 ("cpe", resource_names_data->type) == 0)
@@ -16173,7 +16173,7 @@ select_resource_iterator (get_resource_names_data_t *resource_names_data,
   else if (g_strcmp0 ("group", resource_names_data->type) == 0)
     {
       *iterator = (int (*) (iterator_t*, get_data_t *))init_group_iterator;
-    }                
+    }
   else if (g_strcmp0 ("note", resource_names_data->type) == 0)
     {
       *iterator = init_note_iterator_all;
@@ -16181,41 +16181,41 @@ select_resource_iterator (get_resource_names_data_t *resource_names_data,
   else if (g_strcmp0 ("override", resource_names_data->type) == 0)
     {
       *iterator = init_override_iterator_all;
-    }                
+    }
   else if (g_strcmp0 ("permission", resource_names_data->type) == 0)
     {
       *iterator = (int (*) (iterator_t*, get_data_t *))init_permission_iterator;
-    }                
+    }
   else if (g_strcmp0 ("port_list", resource_names_data->type) == 0)
     {
       *iterator = (int (*) (iterator_t*, get_data_t *))init_port_list_iterator;
-    }                
+    }
   else if (g_strcmp0 ("report", resource_names_data->type) == 0)
     {
       *iterator = (int (*) (iterator_t*, get_data_t *))init_report_iterator;
-      get_data_set_extra (&resource_names_data->get, 
+      get_data_set_extra (&resource_names_data->get,
                           "usage_type",
                           g_strdup ("scan"));
-    }                
+    }
   else if (g_strcmp0 ("audit_report", resource_names_data->type) == 0)
     {
       *iterator = (int (*) (iterator_t*, get_data_t *))init_report_iterator;
-      get_data_set_extra (&resource_names_data->get, 
+      get_data_set_extra (&resource_names_data->get,
                           "usage_type",
                           g_strdup ("audit"));
     }
   else if (g_strcmp0 ("report_config", resource_names_data->type) == 0)
     {
       *iterator = (int (*) (iterator_t*, get_data_t *))init_report_config_iterator;
-    }                
+    }
   else if (g_strcmp0 ("report_format", resource_names_data->type) == 0)
     {
       *iterator = (int (*) (iterator_t*, get_data_t *))init_report_format_iterator;
-    }                
+    }
   else if (g_strcmp0 ("role", resource_names_data->type) == 0)
     {
       *iterator = (int (*) (iterator_t*, get_data_t *))init_role_iterator;
-    }                
+    }
   else if (g_strcmp0 ("config", resource_names_data->type) == 0)
     {
       *iterator = (int (*) (iterator_t*, get_data_t *))init_config_iterator;
@@ -16233,15 +16233,15 @@ select_resource_iterator (get_resource_names_data_t *resource_names_data,
   else if (g_strcmp0 ("scanner", resource_names_data->type) == 0)
     {
       *iterator = (int (*) (iterator_t*, get_data_t *))init_scanner_iterator;
-    }                
+    }
   else if (g_strcmp0 ("schedule", resource_names_data->type) == 0)
     {
       *iterator = (int (*) (iterator_t*, get_data_t *))init_schedule_iterator;
-    }                
+    }
   else if (g_strcmp0 ("target", resource_names_data->type) == 0)
     {
       *iterator = (int (*) (iterator_t*, get_data_t *))init_target_iterator;
-    }                
+    }
   else if (g_strcmp0 ("task", resource_names_data->type) == 0)
     {
       *iterator = (int (*) (iterator_t*, get_data_t *))init_task_iterator;
@@ -16259,11 +16259,11 @@ select_resource_iterator (get_resource_names_data_t *resource_names_data,
   else if (g_strcmp0 ("tls_certificate", resource_names_data->type) == 0)
     {
       *iterator = (int (*) (iterator_t*, get_data_t *))init_tls_certificate_iterator;
-    } 
+    }
   else if (g_strcmp0 ("user", resource_names_data->type) == 0)
     {
       *iterator = (int (*) (iterator_t*, get_data_t *))init_user_iterator;
-    }         
+    }
   else
     {
       return 1;
@@ -16294,10 +16294,10 @@ handle_get_resource_names (gmp_parser_t *gmp_parser, GError **error)
       return;
     }
 
-  if ((((g_strcmp0 ("host", get_resource_names_data->type) == 0) 
+  if ((((g_strcmp0 ("host", get_resource_names_data->type) == 0)
           ||(g_strcmp0 ("os", get_resource_names_data->type) == 0))
        && (acl_user_may ("get_assets") == 0))
-      || ((g_strcmp0 ("result", get_resource_names_data->type) == 0) 
+      || ((g_strcmp0 ("result", get_resource_names_data->type) == 0)
           && (acl_user_may ("get_results") == 0))
       || (((g_strcmp0 ("report", get_resource_names_data->type) == 0)
            || (g_strcmp0 ("audit_report", get_resource_names_data->type) == 0))
@@ -16345,9 +16345,9 @@ handle_get_resource_names (gmp_parser_t *gmp_parser, GError **error)
         get_resource_names_data_reset (get_resource_names_data);
         set_client_state (CLIENT_AUTHENTIC);
         return;
-    }    
+    }
 
-  if (select_resource_iterator(get_resource_names_data, &init_resource_iterator)) 
+  if (select_resource_iterator(get_resource_names_data, &init_resource_iterator))
     {
       if (send_find_error_to_client ("get_resource_names", "type",
                                      get_resource_names_data->type, gmp_parser))
@@ -16372,7 +16372,7 @@ handle_get_resource_names (gmp_parser_t *gmp_parser, GError **error)
               error_send_to_client (error);
               return;
             }
-          break;          
+          break;
         case 2:
           if (send_find_error_to_client
                ("get_resource_names", "filter", get_resource_names_data->get.filt_id,
@@ -16391,7 +16391,7 @@ handle_get_resource_names (gmp_parser_t *gmp_parser, GError **error)
       set_client_state (CLIENT_AUTHENTIC);
       return;
     }
-  
+
   SEND_GET_START ("resource_name");
   SENDF_TO_CLIENT_OR_FAIL ("<type>%s</type>", get_resource_names_data->type);
 
@@ -16399,8 +16399,8 @@ handle_get_resource_names (gmp_parser_t *gmp_parser, GError **error)
     {
       GString *result;
       result = g_string_new ("");
-      
-      if(g_strcmp0 ("tls_certificate", get_resource_names_data->type) == 0) 
+
+      if(g_strcmp0 ("tls_certificate", get_resource_names_data->type) == 0)
         {
             buffer_xml_append_printf (result,
                                       "<resource id=\"%s\">"
@@ -16410,8 +16410,8 @@ handle_get_resource_names (gmp_parser_t *gmp_parser, GError **error)
                                         : "",
                                       tls_certificate_iterator_subject_dn (&resource)
                                         ? tls_certificate_iterator_subject_dn (&resource)
-                                        : "");          
-        } 
+                                        : "");
+        }
       else if (g_strcmp0 ("override", get_resource_names_data->type) == 0)
         {
             buffer_xml_append_printf (result,
@@ -16422,9 +16422,9 @@ handle_get_resource_names (gmp_parser_t *gmp_parser, GError **error)
                                           : "",
                                         override_iterator_nvt_name (&resource)
                                           ? override_iterator_nvt_name (&resource)
-                                          : "");          
+                                          : "");
         }
-      else 
+      else
         {
             buffer_xml_append_printf (result,
                                         "<resource id=\"%s\">"
@@ -20443,7 +20443,7 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
 
       case CLIENT_GET_RESOURCE_NAMES:
         handle_get_resource_names (gmp_parser, error);
-        break;        
+        break;
 
       case CLIENT_GET_RESULTS:
         handle_get_results (gmp_parser, error);

--- a/src/gmp_report_configs.c
+++ b/src/gmp_report_configs.c
@@ -38,7 +38,7 @@
 
 /**
  * @brief Collect params from entity.
- * 
+ *
  * @param[in] entity  Entity to check for param elements.
  *
  * @return Array of params
@@ -49,7 +49,7 @@ params_from_entity (entity_t entity)
   array_t *params;
   entities_t children;
   entity_t param_entity;
-  
+
   params = make_array ();
   children = entity->entities;
   while ((param_entity = first_entity (children)))
@@ -85,7 +85,7 @@ params_from_entity (entity_t entity)
           if (param_value)
             {
               const char *use_default_str;
-              
+
               param->value = g_strdup (entity_text (param_value));
               use_default_str = entity_attribute (param_value, "use_default");
               if (use_default_str)
@@ -100,7 +100,7 @@ params_from_entity (entity_t entity)
               report_config_param_data_free (param);
               continue;
             }
-            
+
 
           array_add (params, param);
         }
@@ -529,7 +529,7 @@ modify_report_config_run (gmp_parser_t *gmp_parser, GError **error)
                               comment ? comment->text : NULL,
                               params,
                               &error_message);
-  
+
   switch (ret)
     {
       case 0:

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -2474,7 +2474,7 @@ gvmd (int argc, char** argv, char *env[])
 
   /* Set number of retries waiting for memory */
   set_mem_wait_retries (mem_wait_retries);
-  
+
   /* Set minimum memory for feed updates */
   set_min_mem_feed_update (min_mem_feed_update);
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -3672,12 +3672,12 @@ fork_cve_scan_handler (task_t task, target_t target)
 
   gvm_hosts = gvm_hosts_new (hosts);
   free (hosts);
-  
+
   if (gvm_hosts_exclude (gvm_hosts, exclude_hosts ?: "") < 0)
     {
       set_task_interrupted (task,
                               "Failed to exclude hosts."
-                              "  Interrupting scan.");      
+                              "  Interrupting scan.");
       set_report_scan_run_status (global_current_report, TASK_STATUS_INTERRUPTED);
       gvm_hosts_free (gvm_hosts);
       free (exclude_hosts);
@@ -5480,12 +5480,12 @@ feed_sync_required ()
 
 /**
  * @brief Wait for memory
- * 
+ *
  * @param[in]  check_func  Function to check memory, should return 1 if enough.
  * @param[in]  retries     Number of retries.
  * @param[in]  min_mem     Minimum memory in MiB, for logging only
  * @param[in]  action      Short descriptor of action waiting for memory.
- * 
+ *
  * @return 0 if enough memory is available, 1 gave up
  */
 static int
@@ -6462,7 +6462,7 @@ get_nvt_xml (iterator_t *nvts, int details, int pref_count,
 
       if (nvt_iterator_epss_cve (nvts))
         {
-          buffer_xml_append_printf 
+          buffer_xml_append_printf
              (buffer,
               "<epss>"
               "<max_severity>"
@@ -6475,7 +6475,7 @@ get_nvt_xml (iterator_t *nvts, int details, int pref_count,
 
           if (nvt_iterator_has_epss_severity (nvts))
             {
-              buffer_xml_append_printf 
+              buffer_xml_append_printf
                  (buffer,
                   "<severity>%0.1f</severity>",
                   nvt_iterator_epss_severity (nvts));
@@ -6495,7 +6495,7 @@ get_nvt_xml (iterator_t *nvts, int details, int pref_count,
 
           if (nvt_iterator_has_max_epss_severity (nvts))
             {
-              buffer_xml_append_printf 
+              buffer_xml_append_printf
                  (buffer,
                   "<severity>%0.1f</severity>",
                   nvt_iterator_max_epss_severity (nvts));
@@ -6860,7 +6860,7 @@ set_mem_wait_retries (int new_retries)
 
 /**
  * @brief Check if the minimum memory for feed updates is available
- * 
+ *
  * @return 1 if minimum memory amount is available, 0 if not
  */
 int

--- a/src/manage.h
+++ b/src/manage.h
@@ -1416,7 +1416,7 @@ int
 init_result_get_iterator (iterator_t*, const get_data_t *, report_t,
                           const char*, const gchar *);
 int
-init_result_get_iterator_all (iterator_t* iterator, get_data_t *get);                         
+init_result_get_iterator_all (iterator_t* iterator, get_data_t *get);
 
 gboolean
 next_report (iterator_t*, report_t*);
@@ -1808,7 +1808,7 @@ manage_filter_controls (const gchar *, int *, int *, gchar **, int *);
 
 void
 manage_report_filter_controls (const gchar *, int *, int *, gchar **, int *,
-                               int *, gchar **, gchar **, gchar **, gchar **, 
+                               int *, gchar **, gchar **, gchar **, gchar **,
                                gchar **, int *, int *, int *, int *, gchar **);
 
 gchar *
@@ -2664,7 +2664,7 @@ init_override_iterator (iterator_t*, const get_data_t*, nvt_t, result_t,
                         task_t);
 
 int
-init_override_iterator_all (iterator_t* iterator, get_data_t *get);                        
+init_override_iterator_all (iterator_t* iterator, get_data_t *get);
 
 const char*
 override_iterator_nvt_oid (iterator_t*);

--- a/src/manage_configs.c
+++ b/src/manage_configs.c
@@ -343,7 +343,7 @@ should_sync_config_from_path (const char *path, gboolean rebuild,
   if (resource_id_deprecated ("config", uuid))
     {
       find_config_no_acl (uuid, config);
-      
+
       if (rebuild)
         {
           g_free (uuid);

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -871,13 +871,13 @@ manage_create_sql_functions ()
        "       OR qod2 is null"
        "  THEN RETURN 'new';"
        "  WHEN description1 != description2"
-       "       OR severity1 != severity2" 
+       "       OR severity1 != severity2"
        "       OR qod1 != qod2"
        "       OR hostname1 != hostname2"
        "       OR path1 != path2"
        "  THEN RETURN 'changed';"
        "  ELSE RETURN 'same';"
-       "  END CASE;" 
+       "  END CASE;"
        "END;"
        "$$ LANGUAGE plpgsql"
        " IMMUTABLE;");
@@ -890,7 +890,7 @@ manage_create_sql_functions ()
        "  WHEN port = 'package'"
        "  THEN RETURN 'general/tcp';"
        "  ELSE RETURN port;"
-       "  END CASE;" 
+       "  END CASE;"
        "END;"
        "$$ LANGUAGE plpgsql"
        " IMMUTABLE;");
@@ -913,7 +913,7 @@ manage_create_sql_functions ()
        "        AND description LIKE 'Compliant:%%YES%%') > 0"
        "  THEN RETURN 'yes';"
        "  ELSE RETURN 'undefined';"
-       "  END CASE;" 
+       "  END CASE;"
        "END;"
        "$$ LANGUAGE plpgsql"
        " IMMUTABLE;");
@@ -925,7 +925,7 @@ manage_create_sql_functions ()
        " DECLARE count integer := 0;"
        " BEGIN"
        "   WITH compliance_count AS"
-       "   (SELECT count(*) AS total FROM results WHERE report = report_id"                        
+       "   (SELECT count(*) AS total FROM results WHERE report = report_id"
        "        AND description LIKE 'Compliant:%%' || compliance || '%%')"
        "   SELECT total FROM compliance_count"
        "   INTO count;"
@@ -934,7 +934,7 @@ manage_create_sql_functions ()
        " $$ LANGUAGE plpgsql"
        " IMMUTABLE;");
 
- /* Functions in SQL. */       
+ /* Functions in SQL. */
 
   if (sql_int ("SELECT (EXISTS (SELECT * FROM information_schema.tables"
                "                WHERE table_catalog = '%s'"
@@ -1996,7 +1996,7 @@ create_indexes_nvt ()
        "                     'nvts', 'cvss_base');");
   sql ("SELECT create_index ('nvts_by_solution_type',"
        "                     'nvts', 'solution_type');");
-  
+
   sql ("SELECT create_index ('vt_refs_by_vt_oid',"
        "                     'vt_refs', 'vt_oid');");
 
@@ -3569,7 +3569,7 @@ manage_db_init (const gchar *name)
 
       sql ("CREATE TABLE scap2.cpe_matches"
            " (id SERIAL PRIMARY KEY,"
-           "  match_criteria_id text,"               
+           "  match_criteria_id text,"
            "  cpe_name_id text,"
            "  cpe_name text);");
 

--- a/src/manage_port_lists.c
+++ b/src/manage_port_lists.c
@@ -280,7 +280,7 @@ should_sync_port_list_from_path (const char *path, gboolean rebuild,
   if (resource_id_deprecated ("port_list", uuid))
     {
       find_port_list_no_acl (uuid, port_list);
-      
+
       if (rebuild)
         {
           return 1;

--- a/src/manage_report_configs.c
+++ b/src/manage_report_configs.c
@@ -54,7 +54,7 @@ find_report_config_with_permission (const char *uuid,
 
 /**
  * @brief Free a report config parameter data struct.
- * 
+ *
  * @param[in]  param  The parameter to free.
  */
 void

--- a/src/manage_report_formats.c
+++ b/src/manage_report_formats.c
@@ -645,7 +645,7 @@ should_sync_report_format_from_path (const char *path,
   if (resource_id_deprecated ("report_format", uuid))
     {
       find_report_format_no_acl (uuid, report_format);
-      
+
       if (rebuild)
         {
           g_free (uuid);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -294,7 +294,7 @@ cache_all_permissions_for_users (GArray*);
 static void
 report_cache_counts (report_t, int, int, const char*);
 
-static gchar * 
+static gchar *
 reports_extra_where (int, const char *, const char *);
 
 static int
@@ -2037,8 +2037,8 @@ filter_control_str (keyword_t **point, const char *column, gchar **string)
  * @param[out]  compliance_levels   String describing compliance levels
  *                             to include in count (for example, "yniu" for
  *                             "yes" (compliant), "n" for "no" (not compliant),
- *                             "i" for "incomplete" and "u" for "undefined" 
- *                              (without compliance information). 
+ *                             "i" for "incomplete" and "u" for "undefined"
+ *                              (without compliance information).
  *                              All levels if NULL.
  * @param[out]  delta_states   String describing delta states to include in count
  *                             (for example, "sngc" Same, New, Gone and Changed).
@@ -2056,9 +2056,9 @@ manage_report_filter_controls (const gchar *filter, int *first, int *max,
                                gchar **sort_field, int *sort_order,
                                int *result_hosts_only, gchar **min_qod,
                                gchar **levels, gchar **compliance_levels,
-                               gchar **delta_states, gchar **search_phrase, 
-                               int *search_phrase_exact, int *notes, 
-                               int *overrides, int *apply_overrides, 
+                               gchar **delta_states, gchar **search_phrase,
+                               int *search_phrase_exact, int *notes,
+                               int *overrides, int *apply_overrides,
                                gchar **zone)
 {
   keyword_t **point;
@@ -16177,7 +16177,7 @@ check_db_versions ()
   else
     {
       int supported;
-      
+
       supported = manage_scap_db_supported_version ();
       if (scap_db_version != supported)
         {
@@ -21863,7 +21863,7 @@ report_compliance_by_uuid (const char *report_id,
                    " WHERE report = %llu"
                    " AND description NOT LIKE 'Compliant:%%';",
                    report);
-    }    
+    }
 
   g_free (quoted_uuid);
 }
@@ -22277,7 +22277,7 @@ report_iterator_opts_table (int override, int min_qod)
  * @brief Return SQL WHERE for restricting a SELECT to compliance statuses.
  *
  * @param[in]  compliance  String describing compliance statuses of reports
- *                         to include (for example, "yniu" for yes (compliant), 
+ *                         to include (for example, "yniu" for yes (compliant),
  *                         no (not compliant), i (incomplete) and u (undefined))
  *                         All compliance statuses if NULL.
  *
@@ -22351,7 +22351,7 @@ reports_extra_where (int trash, const gchar *filter, const char *usage_type)
     {
       trash_clause = g_strdup_printf (" AND (SELECT hidden FROM tasks"
                                       "      WHERE tasks.id = task)"
-                                      "     = 2");    
+                                      "     = 2");
     }
   else
     {
@@ -22460,7 +22460,7 @@ init_report_iterator (iterator_t* iterator, const get_data_t *get)
   extra_tables = report_iterator_opts_table (overrides, min_qod);
   usage_type = get_data_get_extra (get, "usage_type");
 
-  extra_where = reports_extra_where (get->trash, 
+  extra_where = reports_extra_where (get->trash,
                                      filter ? filter : get->filter,
                                      usage_type);
 
@@ -22616,7 +22616,7 @@ where_levels_auto (const char *levels, const char *new_severity_sql)
 /**
  * @brief Return SQL WHERE for restricting a SELECT to compliance levels.
  *
- * @param[in]  levels  String describing compliance levels to include in 
+ * @param[in]  levels  String describing compliance levels to include in
  *                     report (for example, "yniu" for "yes, "no", "incomplete"
  *                     and "undefined").  All levels if NULL.
  *
@@ -23620,14 +23620,14 @@ init_result_get_iterator_severity (iterator_t* iterator, const get_data_t *get,
  * @param[in]  apply_overrides   Whether to apply overrides.
  * @param[in]  dynamic_severity  Whether to use dynamic severity.
  * @param[in]  nvts_table        NVTS table.
- * @param[in]  results_table     Results table. 
+ * @param[in]  results_table     Results table.
  *
  * @return SQL clause for FROM.
  */
 static gchar *
-result_iterator_lateral (int apply_overrides, 
-                         int dynamic_severity, 
-                         const char *results_table, 
+result_iterator_lateral (int apply_overrides,
+                         int dynamic_severity,
+                         const char *results_table,
                          const char *nvts_table)
 {
   if (apply_overrides && dynamic_severity)
@@ -23642,11 +23642,11 @@ result_iterator_lateral (int apply_overrides,
       "                         ov_old_severity)"
       "                   LIMIT 1),"
       "                  (SELECT curr_severity FROM curr LIMIT 1))"
-      " AS new_severity)", 
+      " AS new_severity)",
       results_table,
       nvts_table,
       results_table,
-      results_table, 
+      results_table,
       results_table);
 
   if (apply_overrides)
@@ -23832,7 +23832,7 @@ result_count (const get_data_t *get, report_t report, const char* host)
 
   opts_tables = result_iterator_opts_table (apply_overrides, dynamic_severity);
 
-  lateral_clause = result_iterator_lateral (apply_overrides, 
+  lateral_clause = result_iterator_lateral (apply_overrides,
                                             dynamic_severity,
                                             "results",
                                             "nvts");
@@ -26215,19 +26215,19 @@ report_compliance_from_counts (const int* yes_count,
  * @param[in]   get                  Get data.
  * @param[out]  f_compliance_yes     Compliant results count after filtering.
  * @param[out]  f_compliance_no      Incompliant results count after filtering.
- * @param[out]  f_compliance_incomplete  Incomplete results count 
+ * @param[out]  f_compliance_incomplete  Incomplete results count
  *                                       after filtering.
- * @param[out]  f_compliance_undefined   Undefined results count 
+ * @param[out]  f_compliance_undefined   Undefined results count
  *                                       after filtering.
  *
  * @return 0 on success, -1 on error.
  */
 static int
-report_compliance_f_counts (report_t report, 
-                            const get_data_t* get, 
-                            int* f_compliance_yes, 
-                            int* f_compliance_no, 
-                            int* f_compliance_incomplete, 
+report_compliance_f_counts (report_t report,
+                            const get_data_t* get,
+                            int* f_compliance_yes,
+                            int* f_compliance_no,
+                            int* f_compliance_incomplete,
                             int* f_compliance_undefined)
 {
   if (report == 0)
@@ -26262,7 +26262,7 @@ report_compliance_f_counts (report_t report,
       else if (strcasecmp (compliance, "no") == 0)
         {
           no_count++;
-        }      
+        }
       else if (strcasecmp (compliance, "incomplete") == 0)
         {
           incomplete_count++;
@@ -26270,7 +26270,7 @@ report_compliance_f_counts (report_t report,
       else if (strcasecmp (compliance, "undefined") == 0)
         {
           undefined_count++;
-        }      
+        }
 
     }
 
@@ -26301,11 +26301,11 @@ report_compliance_f_counts (report_t report,
  * @return 0 on success, -1 on error.
  */
 static int
-report_compliance_counts (report_t report, 
+report_compliance_counts (report_t report,
                           const get_data_t* get,
-                          int* compliance_yes, 
+                          int* compliance_yes,
                           int* compliance_no,
-                          int* compliance_incomplete, 
+                          int* compliance_incomplete,
                           int* compliance_undefined)
 {
   if (report == 0)
@@ -26313,7 +26313,7 @@ report_compliance_counts (report_t report,
 
   report_compliance_by_uuid (report_uuid(report),
                              compliance_yes,
-                             compliance_no, 
+                             compliance_no,
                              compliance_incomplete,
                              compliance_undefined);
 
@@ -27550,7 +27550,7 @@ print_report_host_details_xml (report_host_t report_host, FILE *stream,
  * @return 0 on success, -1 error.
  */
 static int
-print_report_host_tls_certificates_xml (report_host_t report_host, 
+print_report_host_tls_certificates_xml (report_host_t report_host,
                                         const char *host_ip,
                                         FILE *stream)
 {
@@ -27572,14 +27572,14 @@ print_report_host_tls_certificates_xml (report_host_t report_host,
                  "        OR source_description = 'SSL Certificate')",
                  report_host);
 
-  while (next (&tls_certs)) 
+  while (next (&tls_certs))
     {
       const char *certificate_prefixed, *certificate_b64;
       gsize certificate_size;
       unsigned char *certificate;
       const char *scanner_fpr_prefixed, *scanner_fpr;
       gchar *quoted_scanner_fpr;
-      char *ssldetails;       
+      char *ssldetails;
       iterator_t ports;
       gboolean valid;
       time_t now;
@@ -27642,7 +27642,7 @@ print_report_host_tls_certificates_xml (report_host_t report_host,
 
       now = time (NULL);
 
-      if((expiration_time >= now || expiration_time == -1) 
+      if((expiration_time >= now || expiration_time == -1)
          && (activation_time <= now || activation_time == -1))
         {
           valid = TRUE;
@@ -27692,7 +27692,7 @@ print_report_host_tls_certificates_xml (report_host_t report_host,
       g_free (serial);
 
       free (hostname);
-    
+
       init_iterator (&ports,
                      "SELECT value FROM report_host_details"
                      " WHERE report_host = %llu"
@@ -27700,7 +27700,7 @@ print_report_host_tls_certificates_xml (report_host_t report_host,
                      "   AND value LIKE '%%:%%:%s'",
                      report_host,
                      quoted_scanner_fpr);
-     
+
       PRINT (stream, "<ports>");
 
       while (next (&ports))
@@ -27719,10 +27719,10 @@ print_report_host_tls_certificates_xml (report_host_t report_host,
       PRINT (stream, "</ports>");
 
       PRINT (stream, "</tls_certificate>");
-      
+
       g_free (quoted_scanner_fpr);
-      cleanup_iterator (&ports);   
-    
+      cleanup_iterator (&ports);
+
     }
     cleanup_iterator (&tls_certs);
 
@@ -28331,7 +28331,7 @@ init_delta_iterator (report_t report, iterator_t *results, report_t delta,
                                   " ON results.nvt = nvts.oid %s,"
                                   " LATERAL %s AS lateral_new_severity",
                                   opts_tables,
-                                  lateral_clause);                                                         
+                                  lateral_clause);
 
   g_free (lateral_clause);
 
@@ -28355,24 +28355,24 @@ init_delta_iterator (report_t report, iterator_t *results, report_t delta,
 
   extra_with = g_strdup_printf(" comparison AS ("
     " WITH r1a as (SELECT results.id, description, host, report, port,"
-    "              severity, nvt, results.qod, results.uuid, hostname," 
+    "              severity, nvt, results.qod, results.uuid, hostname,"
     "              path, r1_lateral.new_severity as new_severity "
     "       FROM results "
     "       LEFT JOIN (SELECT cvss_base, oid AS nvts_oid FROM nvts)"
     "       AS nvts_cols"
     "       ON nvts_cols.nvts_oid = results.nvt"
-    "       %s, LATERAL %s AS r1_lateral" 
+    "       %s, LATERAL %s AS r1_lateral"
     "       WHERE report = %llu),"
-    " r2a as (SELECT results.*, r2_lateral.new_severity AS new_severity" 
-    "        FROM results" 
+    " r2a as (SELECT results.*, r2_lateral.new_severity AS new_severity"
+    "        FROM results"
     "        LEFT JOIN (SELECT cvss_base, oid AS nvts_oid FROM nvts)"
-    "        AS nvts_cols" 
-    "        ON nvts_cols.nvts_oid = results.nvt" 
-    "        %s, LATERAL %s AS r2_lateral" 
+    "        AS nvts_cols"
+    "        ON nvts_cols.nvts_oid = results.nvt"
+    "        %s, LATERAL %s AS r2_lateral"
     "        WHERE report = %llu),"
     " r1 as (SELECT DISTINCT ON (r1a.id) r1a.*, r2a.id as r2id, row_number() over w1 as r1_rank"
     "        FROM r1a LEFT JOIN r2a ON r1a.host = r2a.host"
-    "        AND normalize_port(r1a.port) = normalize_port(r2a.port)" 
+    "        AND normalize_port(r1a.port) = normalize_port(r2a.port)"
     "        AND r1a.nvt = r2a.nvt "
     "        AND (r1a.new_severity = 0) = (r2a.new_severity = 0)"
     "        AND (r1a.description = r2a.description)"
@@ -28381,15 +28381,15 @@ init_delta_iterator (report_t report, iterator_t *results, report_t delta,
     "        ORDER BY r1a.id),"
     " r2 as (SELECT DISTINCT ON (r2a.id) r2a.*, r1a.id as r1id, row_number() over w2 as r2_rank"
     "        FROM r2a LEFT JOIN r1a ON r2a.host = r1a.host"
-    "        AND normalize_port(r2a.port) = normalize_port(r1a.port)" 
+    "        AND normalize_port(r2a.port) = normalize_port(r1a.port)"
     "        AND r2a.nvt = r1a.nvt "
     "        AND (r2a.new_severity = 0) = (r1a.new_severity = 0)"
     "        AND (r2a.description = r1a.description)"
     "        WINDOW w2 AS (PARTITION BY r2a.host, normalize_port(r2a.port),"
     "                      r2a.nvt, r2a.new_severity = 0, r1a.id is null ORDER BY r1a.id)"
     "        ORDER BY r2a.id)"
-    " (SELECT r1.id AS result1_id," 
-    " r2.id AS result2_id," 
+    " (SELECT r1.id AS result1_id,"
+    " r2.id AS result2_id,"
     " compare_results("
     "  r1.description,"
     "  r2.description,"
@@ -28413,13 +28413,13 @@ init_delta_iterator (report_t report, iterator_t *results, report_t delta,
     " r2.owner AS delta_owner,"
     " r2.path AS delta_path,"
     " r2.host AS delta_host,"
-      RESULT_HOSTNAME_SQL("r2.hostname", "r2.host", "r2.report") 
+      RESULT_HOSTNAME_SQL("r2.hostname", "r2.host", "r2.report")
     "   AS delta_hostname,"
     " r2.nvt_version AS delta_nvt_version"
     " FROM r1"
     " FULL OUTER JOIN r2"
     " ON r1.host = r2.host"
-    " AND normalize_port(r1.port) = normalize_port(r2.port)" 
+    " AND normalize_port(r1.port) = normalize_port(r2.port)"
     " AND r1.nvt = r2.nvt "
     " AND (r1.new_severity = 0) = (r2.new_severity = 0)"
     " AND ((r1id IS NULL AND r2id IS NULL) OR"
@@ -28613,12 +28613,12 @@ print_report_delta_xml (FILE *out, iterator_t *results,
                         0,
                         state,
                         NULL,
-                        (strcmp (state, "changed") == 0), 
+                        (strcmp (state, "changed") == 0),
                         -1,
                         0,  /* Lean. */
                         0); /* Delta fields. */
- 
-    if (fprintf (out, "%s", buffer->str) < 0) 
+
+    if (fprintf (out, "%s", buffer->str) < 0)
       {
         g_string_free (buffer, TRUE);
         g_tree_destroy (ports);
@@ -28810,8 +28810,8 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
                                      &first_result, &max_results, &sort_field,
                                      &sort_order, &result_hosts_only,
                                      &min_qod, &levels, &compliance_levels,
-                                     &delta_states, &search_phrase, 
-                                     &search_phrase_exact, &notes, 
+                                     &delta_states, &search_phrase,
+                                     &search_phrase_exact, &notes,
                                      &overrides, &apply_overrides, &zone);
     }
   else
@@ -28822,7 +28822,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
                                      &first_result, &max_results, &sort_field,
                                      &sort_order, &result_hosts_only,
                                      &min_qod, &levels, &compliance_levels,
-                                     &delta_states, &search_phrase, 
+                                     &delta_states, &search_phrase,
                                      &search_phrase_exact, &notes, &overrides,
                                      &apply_overrides, &zone);
     }
@@ -28944,7 +28944,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
       if (strcmp (tsk_usage_type, "audit"))
         {
           if (delta == 0)
-            {         
+            {
               int total_holes, total_infos, total_logs;
               int total_warnings, total_false_positives;
               get_data_t *all_results_get;
@@ -28980,7 +28980,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
               filtered_result_count = holes + infos + logs + warnings
                                       + false_positives;
 
-            }          
+            }
         }
       /* Get report run status. */
 
@@ -29845,7 +29845,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
             {
               report_host_t report_host = host_iterator_report_host(&hosts);
 
-              if (print_report_host_tls_certificates_xml(report_host, 
+              if (print_report_host_tls_certificates_xml(report_host,
                                                          result_host,
                                                          out))
                 {
@@ -29865,15 +29865,15 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
       const char *host;
       iterator_t hosts;
       init_report_host_iterator (&hosts, report, NULL, 0);
-      
+
       PRINT (out, "<tls_certificates>");
-      
+
       while (next (&hosts))
         {
           report_host_t report_host = host_iterator_report_host(&hosts);
           host = host_iterator_host (&hosts);
 
-          if (print_report_host_tls_certificates_xml(report_host, 
+          if (print_report_host_tls_certificates_xml(report_host,
                                                      host,
                                                      out))
             {
@@ -47631,7 +47631,7 @@ modify_filter (const char *filter_id, const char *name, const char *comment,
     return 4;
 
   db_type = type_db_name (type);
-  if (db_type && !((strcmp (db_type, "") == 0) || valid_type (db_type))) 
+  if (db_type && !((strcmp (db_type, "") == 0) || valid_type (db_type)))
     {
       if (!valid_subtype (type))
         return 3;
@@ -56024,7 +56024,7 @@ tag_add_resources_list (tag_t tag, const char *type, array_t *uuids,
     resource_permission = g_strdup ("get_info");
   else if (type_is_asset_subtype (type))
     resource_permission = g_strdup ("get_assets");
-  else if (type_is_report_subtype (type)) 
+  else if (type_is_report_subtype (type))
     {
       resource_permission = g_strdup ("get_reports");
       type = g_strdup("report");
@@ -56336,7 +56336,7 @@ tag_remove_resources_filter (tag_t tag, const char *type, const char *filter)
             g_free (resources_get.filter);
             g_free (resources_get.type);
             if (resources_get.extra_params)
-              g_hash_table_destroy (resources_get.extra_params);           
+              g_hash_table_destroy (resources_get.extra_params);
             return -1;
         }
     }
@@ -56345,7 +56345,7 @@ tag_remove_resources_filter (tag_t tag, const char *type, const char *filter)
   g_free (resources_get.filter);
   g_free (resources_get.type);
   if (resources_get.extra_params)
-      g_hash_table_destroy (resources_get.extra_params);  
+      g_hash_table_destroy (resources_get.extra_params);
 
   ret = 2;
   while (next (&resources))
@@ -56462,11 +56462,11 @@ create_tag (const char * name, const char * comment, const char * value,
   if (strcmp (lc_resource_type, "")
       && valid_db_resource_type (lc_resource_type) == 0)
     {
-      if (!valid_subtype (lc_resource_type)) 
+      if (!valid_subtype (lc_resource_type))
         {
           g_free (lc_resource_type);
           sql_rollback ();
-          return -1;          
+          return -1;
         }
     }
 
@@ -56700,7 +56700,7 @@ modify_tag (const char *tag_id, const char *name, const char *comment,
       if (!valid_subtype (lc_resource_type))
         {
           sql_rollback ();
-          return -1;          
+          return -1;
         }
     }
 
@@ -57672,7 +57672,7 @@ type_extra_where (const char *type, int trash, const char *filter,
         usage_type = g_hash_table_lookup (extra_params, "usage_type");
       else
         usage_type = NULL;
-      
+
       extra_where = reports_extra_where (trash, filter, usage_type);
     }
   else if (strcasecmp (type, "RESULT") == 0)
@@ -57809,9 +57809,9 @@ type_build_select (const char *type, const char *columns_str,
 
       original = opts_table;
 
-      lateral_clause = result_iterator_lateral (overrides, 
-                                                dynamic, 
-                                                "results", 
+      lateral_clause = result_iterator_lateral (overrides,
+                                                dynamic,
+                                                "results",
                                                 "nvts");
 
       opts_table = g_strdup_printf (" LEFT OUTER JOIN result_vt_epss"

--- a/src/manage_sql_report_configs.c
+++ b/src/manage_sql_report_configs.c
@@ -242,7 +242,7 @@ create_report_config (const char *name, const char *comment,
   g_free (quoted_comment);
   g_free (quoted_report_format_id);
 
-  for (int i = 0; g_ptr_array_index (params, i); i++) 
+  for (int i = 0; g_ptr_array_index (params, i); i++)
     {
       report_config_param_data_t *param;
       param = g_ptr_array_index (params, i);
@@ -266,7 +266,7 @@ create_report_config (const char *name, const char *comment,
 
 /**
  * @brief Modify a report config.
- * 
+ *
  * @param[in]   report_config_id  UUID of report config to modify.
  * @param[in]   new_name          Name of report config.
  * @param[in]   new_comment       Comment of report config.
@@ -352,7 +352,7 @@ modify_report_config (const char *report_config_id,
           return 3;
         }
 
-      for (int i = 0; g_ptr_array_index (params, i); i++) 
+      for (int i = 0; g_ptr_array_index (params, i); i++)
         {
           report_config_param_data_t *param;
           param = g_ptr_array_index (params, i);
@@ -797,7 +797,7 @@ report_config_iterator_report_format_readable (iterator_t* iterator)
 
   if (iterator->done) return 0;
 
-  report_format_id 
+  report_format_id
     = report_config_iterator_report_format_id (iterator);
 
   if (report_format_id)
@@ -855,7 +855,7 @@ init_report_config_param_iterator (iterator_t *iterator,
                                    int trash)
 {
   report_format_t report_format;
-  
+
   report_format = report_config_report_format (report_config);
 
   init_iterator (iterator,

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -2409,10 +2409,10 @@ report_format_param_type_min (report_format_t report_format, const char *name)
 
 /**
  * @brief Checks if the value of a report format param is a valid option.
- * 
+ *
  * @param[in]  param  The report format param to check.
  * @param[in]  value  The value to check.
- * 
+ *
  * @return 1 if the value is one of the allowed options, 0 if not.
  */
 static int
@@ -2983,7 +2983,7 @@ report_format_iterator_trust_time (iterator_t* iterator)
  *
  * @return Time report format was verified.
  */
-int 
+int
 report_format_iterator_configurable (iterator_t* iterator)
 {
   int ret;

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -291,7 +291,7 @@ inserts_check_size (inserts_t *inserts)
       inserts->statements_size += inserts->statement->len;
       inserts->statement = NULL;
       inserts->current_chunk_size = 0;
-      
+
       if (inserts->max_statements_size
           && inserts-> statements_size >= inserts->max_statements_size)
         {
@@ -1019,7 +1019,7 @@ init_cert_bund_adv_info_iterator (iterator_t* iterator, get_data_t *get,
 }
 
 /**
- * @brief Initialise an CERT-Bund advisory (cert_bund_adv) info iterator not 
+ * @brief Initialise an CERT-Bund advisory (cert_bund_adv) info iterator not
  *        limited to a name.
  *
  * @param[in]  iterator        Iterator.
@@ -1243,7 +1243,7 @@ init_dfn_cert_adv_info_iterator (iterator_t* iterator, get_data_t *get,
 }
 
 /**
- * @brief Initialise an DFN-CERT advisory (dfn_cert_adv) info iterator 
+ * @brief Initialise an DFN-CERT advisory (dfn_cert_adv) info iterator
  *        not limited to a name.
  *
  * @param[in]  iterator        Iterator.
@@ -2389,7 +2389,7 @@ handle_json_cpe_item (inserts_t *inserts, inserts_t *deprecated_by_inserts,
                                   quoted_name,
                                   quoted_deprecated_by_id);
 
-          deprecated_by_inserts->current_chunk_size++;   
+          deprecated_by_inserts->current_chunk_size++;
           g_free (quoted_deprecated_by_id);
         }
     }
@@ -2473,7 +2473,7 @@ handle_json_cpe_refs (inserts_t *inserts, cJSON *product_item)
       type = json_object_item_string (refs_item, "type");
       quoted_ref = sql_quote (ref ? ref : "");
       quoted_type = sql_quote (type ? type : "");
-      
+
       first = inserts_check_size (inserts);
 
       g_string_append_printf (inserts->statement,
@@ -2485,7 +2485,7 @@ handle_json_cpe_refs (inserts_t *inserts, cJSON *product_item)
 
       inserts->current_chunk_size++;
       g_free (quoted_ref);
-      g_free (quoted_type); 
+      g_free (quoted_type);
     }
   g_free (quoted_name);
 
@@ -3005,7 +3005,7 @@ insert_cve_products (element_t list, resource_t cve,
 
       product_element = element_next (product_element);
     }
-  
+
   /* Add new CPEs. */
 
   first_product = first_affected = 1;
@@ -3031,7 +3031,7 @@ insert_cve_products (element_t list, resource_t cve,
 
   if (first_product == 0)
     {
-      /* Run the SQL for inserting new CPEs and add them to hashed_cpes 
+      /* Run the SQL for inserting new CPEs and add them to hashed_cpes
        * so they can be looked up quickly when adding affected_products.
        */
       iterator_t inserted_cpes;
@@ -3414,7 +3414,7 @@ handle_cve_configurations (resource_t cve_db_id, char * cve_id,
       resource_t id, root_id;
       char *config_operator;
       int negate;
-      
+
       nodes_array = cJSON_GetObjectItemCaseSensitive (configuration_item,
                                                       "nodes");
       if (!cJSON_IsArray (nodes_array))
@@ -3444,7 +3444,7 @@ handle_cve_configurations (resource_t cve_db_id, char * cve_id,
               g_warning ("%s: operator missing for %s.", __func__, cve_id);
               return -1;
             }
-          
+
           negate = json_object_item_boolean (node_item, "negate", 0);
 
           cJSON *cpe_matches_array;
@@ -3463,7 +3463,7 @@ handle_cve_configurations (resource_t cve_db_id, char * cve_id,
             root_id = id;
 
           set_root_id (id, root_id);
-          
+
           cJSON *cpe_match_item;
           cJSON_ArrayForEach (cpe_match_item, cpe_matches_array)
             {
@@ -3505,7 +3505,7 @@ handle_cve_configurations (resource_t cve_db_id, char * cve_id,
                     g_string_append_printf (software, "%s ", cpe_matches_cpe_name (&cpe_matches));
                   cleanup_iterator (&cpe_matches);
                 }
-              g_free (quoted_match_criteria_id);          
+              g_free (quoted_match_criteria_id);
             }
         }
     }
@@ -3584,7 +3584,7 @@ handle_json_cve_item (cJSON *item)
     }
 
   gboolean cvss_metric_found = FALSE;
-  
+
   const char *cvss_metric_keys[] = {
     "cvssMetricV40",
     "cvssMetricV31",
@@ -4127,7 +4127,7 @@ handle_json_cpe_match_string (inserts_t *inserts, inserts_t *matches_inserts,
     quoted_version_start_incl = g_strdup ("NULL");
   else
     quoted_version_start_incl = g_strdup_printf ("'%s'", ver_se);
-    
+
   ver_se = json_object_item_string (match_string, "versionStartExcluding");
   if (ver_se == NULL)
     quoted_version_start_excl = g_strdup ("NULL");
@@ -4171,7 +4171,7 @@ handle_json_cpe_match_string (inserts_t *inserts, inserts_t *matches_inserts,
   g_free (quoted_version_end_excl);
 
   matches_array = cJSON_GetObjectItemCaseSensitive (match_string, "matches");
-  
+
   if (cJSON_IsArray (matches_array) && cJSON_GetArraySize (matches_array) > 0)
     {
       cJSON *match_item;
@@ -4339,9 +4339,9 @@ update_scap_cpe_match_strings ()
 
       inserts_init (&matches_inserts, 10,
                 setting_secinfo_sql_buffer_threshold_bytes (),
-                "INSERT INTO scap2.cpe_matches" 
+                "INSERT INTO scap2.cpe_matches"
                 "  (match_criteria_id, cpe_name_id, cpe_name)"
-                "  VALUES ",              
+                "  VALUES ",
                 "");
 
       gvm_json_pull_parser_next (&parser, &event);
@@ -4376,7 +4376,7 @@ update_scap_cpe_match_strings ()
               gvm_json_pull_event_cleanup (&event);
               gvm_json_pull_parser_cleanup (&parser);
               fclose (cpe_match_strings_file);
-              return -1;            
+              return -1;
             }
           cJSON_Delete (cpe_match_string_item);
           gvm_json_pull_parser_next (&parser, &event);
@@ -4447,7 +4447,7 @@ if (failure_condition) {                                          \
 
 /**
  * @brief Updates the base EPSS scores table in the SCAP database.
- * 
+ *
  * @return 0 success, -1 error.
  */
 static int
@@ -5311,7 +5311,7 @@ update_vt_scap_extra_data ()
        " WHERE epss_candidates.vt_oid = nvts.oid"
        "   AND epss_candidates.rank = 1;");
 }
- 
+
 /**
  * @brief Update CERT data that depends on SCAP.
  */

--- a/src/manage_sql_tls_certificates.c
+++ b/src/manage_sql_tls_certificates.c
@@ -1747,9 +1747,9 @@ cleanup_tls_certificate_encoding ()
       if (g_utf8_validate (subject_dn, -1, NULL) == FALSE
           || g_utf8_validate (issuer_dn, -1, NULL) == FALSE)
         {
-          gchar *quoted_subject_dn 
+          gchar *quoted_subject_dn
             = sql_ascii_escape_and_quote (subject_dn, NULL);
-          gchar *quoted_issuer_dn 
+          gchar *quoted_issuer_dn
             = sql_ascii_escape_and_quote (issuer_dn, NULL);
 
           sql ("UPDATE tls_certificates"

--- a/src/sql_pg.c
+++ b/src/sql_pg.c
@@ -607,7 +607,7 @@ sql_rollback ()
  *
  * @param[in]  table         The table to lock.
  * @param[in]  lock_timeout  The lock timeout in milliseconds, 0 for unlimited.
- * 
+ *
  * @return 1 if locked, 0 if failed / timed out.
  */
 int
@@ -615,10 +615,10 @@ sql_table_lock_wait (const char *table, int lock_timeout)
 {
   int old_lock_timeout = sql_int ("SHOW lock_timeout;");
   sql ("SET LOCAL lock_timeout = %d;", lock_timeout);
-  
+
   // This requires the gvmd functions to be defined first.
   int ret = sql_int ("SELECT try_exclusive_lock_wait ('%s');", table);
-  
+
   sql ("SET LOCAL lock_timeout = %d;", old_lock_timeout);
   return ret;
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -1029,7 +1029,7 @@ wait_for_pid (pid_t pid, const char *context)
 
 /**
  * @brief Get the available physical memory in bytes.
- * 
+ *
  * @return The available memory
  */
 guint64
@@ -1041,7 +1041,7 @@ phys_mem_available ()
 
 /**
  * @brief Get the total physical memory in bytes.
- * 
+ *
  * @return The total memory
  */
 guint64

--- a/src/utils_tests.c
+++ b/src/utils_tests.c
@@ -109,25 +109,25 @@ Ensure (utils, gvm_sleep_sleep_for_1)
   assert_that (timespec_subtract (&end, &start), is_greater_than (NANOSECONDS - 1));
 }
 
-Ensure (utils, strescape_check_utf_8_no_exceptions) 
+Ensure (utils, strescape_check_utf_8_no_exceptions)
 {
   const char *utf8_input = "Äöü\n123\\UTF-8\x04";
   const char *utf8_expected = "Äöü\\n123\\\\UTF-8\\004";
   const char *cp850_input = "\x8E\x94\x81\n123\\CP850\x04";
   const char *cp850_expected = "\\216\\224\\201\\n123\\\\CP850\\004";
-  
+
   assert_that (g_utf8_validate (utf8_input, -1, NULL), is_true);
   gchar *output = strescape_check_utf8 (utf8_input, NULL);
-  assert_that (output, is_equal_to_string (utf8_expected)); 
+  assert_that (output, is_equal_to_string (utf8_expected));
   g_free (output);
 
   assert_that (g_utf8_validate (cp850_input, -1, NULL), is_false);
   output = strescape_check_utf8 (cp850_input, NULL);
-  assert_that (output, is_equal_to_string (cp850_expected)); 
+  assert_that (output, is_equal_to_string (cp850_expected));
   g_free (output);
 }
 
-Ensure (utils, strescape_check_utf_8_with_exceptions) 
+Ensure (utils, strescape_check_utf_8_with_exceptions)
 {
   const char *utf8_input = "Äöü\n123\\UTF-8\x04";
   const char *utf8_expected = "Äöü\n123\\\\UTF-8\\004";
@@ -136,12 +136,12 @@ Ensure (utils, strescape_check_utf_8_with_exceptions)
 
   assert_that (g_utf8_validate (utf8_input, -1, NULL), is_true);
   gchar *output = strescape_check_utf8 (utf8_input, "\t\n\r");
-  assert_that (output, is_equal_to_string (utf8_expected)); 
+  assert_that (output, is_equal_to_string (utf8_expected));
   g_free (output);
 
   assert_that (g_utf8_validate (cp850_input, -1, NULL), is_false);
   output = strescape_check_utf8 (cp850_input, "\t\n\r");
-  assert_that (output, is_equal_to_string (cp850_expected)); 
+  assert_that (output, is_equal_to_string (cp850_expected));
   g_free (output);
 }
 
@@ -164,7 +164,7 @@ main (int argc, char **argv)
   add_test_with_context (suite, utils, parse_iso_time_tz_with_z);
   add_test_with_context (suite, utils, parse_iso_time_tz_with_fallback_tz);
   add_test_with_context (suite, utils, parse_iso_time_tz_variants);
-  
+
   add_test_with_context (suite, utils, strescape_check_utf_8_no_exceptions);
   add_test_with_context (suite, utils, strescape_check_utf_8_with_exceptions);
 


### PR DESCRIPTION
## What

Remove all spaces from the ends of lines.

## Why

I was reviewing #2317 earlier and the trailing whitespace changes got in the way.

## How

```sh
# show
PKG=gvmd; SRC=$HOME/fresh/main; cd $SRC/$PKG && find . -type f -name \*.[ch] -exec egrep -l " +$" {} \;
# flush
PKG=gvmd; SRC=$HOME/fresh/main; cd $SRC/$PKG && find . -type f -name \*.[ch] -print0 | xargs -0 sed --in-place='' -E "s/[ ]+$//"
```

## References

See #2323 for an idea on how to keep the space out.