### PR TITLE
Fix: Remove tail command from gvmd startup script.

### DIFF
--- a/.docker/start-gvmd.sh
+++ b/.docker/start-gvmd.sh
@@ -49,6 +49,4 @@ gvmd --modify-setting 78eceaec-3385-11ea-b237-28d24461215b --value "$uid"
 
 echo "starting gvmd"
 gvmd $GVMD_ARGS ||
-    (cat /var/log/gvm/gvmd.log && exit 1)
-
-tail -f /var/log/gvm/gvmd.log
+    (echo "Starting gvmd failed" && exit 1)


### PR DESCRIPTION
## What
Remove the `tail` command for `gvmd.log`

## Why
Messages are now logged to `stderr` by default. See #2313. This fixes the issue with `tail` not able to open the log file.


