### PR TITLE
Change: Run gvmd in foreground in the docker container.

### DIFF
--- a/.docker/start-gvmd.sh
+++ b/.docker/start-gvmd.sh
@@ -18,7 +18,7 @@
 
 [ -z "$USER" ] && USER="admin"
 [ -z "$PASSWORD" ] && PASSWORD="admin"
-[ -z "$GVMD_ARGS" ] && GVMD_ARGS="--listen-mode=666"
+[ -z "$GVMD_ARGS" ] && GVMD_ARGS="-f --listen-mode=666"
 [ -z "$GVMD_USER" ] && GVMD_USER="gvmd"
 [ -z "$PGRES_DATA" ] && PGRES_DATA="/var/lib/postgresql"
 


### PR DESCRIPTION
## What
Run gvmd in foreground in the docker container.

## Why
To keep the container alive after removing the tail command in #2324 

## References
GEA-420
