### PR TITLE
Fix: Rollback on create_credential privkey error

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -35916,7 +35916,10 @@ create_credential (const char* name, const char* comment, const char* login,
       if (key_private)
         key_private_truncated = truncate_private_key (key_private);
       else
-        return 3;
+        {
+          sql_rollback ();
+          return 3;
+        }
 
       generated_key_public = gvm_ssh_public_from_private
                                 (key_private_truncated
@@ -35926,6 +35929,7 @@ create_credential (const char* name, const char* comment, const char* login,
       if (generated_key_public == NULL)
         {
           g_free (key_private_truncated);
+          sql_rollback ();
           return 3;
         }
       g_free (generated_key_public);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -35760,6 +35760,7 @@ create_credential (const char* name, const char* comment, const char* login,
   else
     {
       g_warning ("%s: Cannot determine type of new credential", __func__);
+      sql_rollback ();
       return 18;
     }
 


### PR DESCRIPTION
## What
If the private key checks in create_credential fail, the SQL transaction is now rolled back.

## Why
This fixes SQL transaction errors and possible incomplete credentials being created if there are multiple GMP commands per connection and one of them is create_credential failing because of the private key.

## References
GEA-736

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


