### PR TITLE
Add: New Kerberos credential type

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -4416,6 +4416,8 @@ credential_full_type (const char* abbreviation)
     return NULL;
   else if (strcasecmp (abbreviation, "cc") == 0)
     return "client certificate";
+  else if (strcasecmp (abbreviation, "krb5") == 0)
+    return "Kerberos 5";
   else if (strcasecmp (abbreviation, "pw") == 0)
     return "password only";
   else if (strcasecmp (abbreviation, "snmp") == 0)

--- a/src/manage.h
+++ b/src/manage.h
@@ -2293,7 +2293,7 @@ int
 create_credential (const char*, const char*, const char*, const char*,
                    const char*, const char*, const char*, const char*,
                    const char*, const char*, const char*, const char*,
-                   const char*, credential_t*);
+                   const char*, const char*, const char*, credential_t*);
 
 int
 copy_credential (const char*, const char*, const char*,
@@ -2303,7 +2303,7 @@ int
 modify_credential (const char*, const char*, const char*, const char*,
                    const char*, const char*, const char*, const char*,
                    const char*, const char*, const char*, const char*,
-                   const char*);
+                   const char*, const char*, const char*);
 
 int
 delete_credential (const char *, int);
@@ -2343,6 +2343,12 @@ credential_iterator_privacy_password (iterator_t*);
 
 const char*
 credential_iterator_public_key (iterator_t*);
+
+const char*
+credential_iterator_kdc (iterator_t*);
+
+const char*
+credential_iterator_realm (iterator_t*);
 
 const char*
 credential_iterator_private_key (iterator_t*);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -35670,6 +35670,8 @@ validate_credential_username_for_format (const gchar *username,
  * @param[in]  auth_algorithm     SNMP authentication algorithm, or NULL.
  * @param[in]  privacy_password   SNMP privacy password.
  * @param[in]  privacy_algorithm  SNMP privacy algorithm.
+ * @param[in]  kdc             Kerberos KDC (key distribution centers).
+ * @param[in]  realm           Kerberos realm.
  * @param[in]  given_type      Credential type or NULL.
  * @param[in]  allow_insecure  Whether to allow insecure uses.
  * @param[out] credential      Created Credential.
@@ -35683,6 +35685,7 @@ validate_credential_username_for_format (const gchar *username,
  *         14 privacy algorithm missing,
  *         15 invalid auth algorithm, 16 invalid privacy algorithm,
  *         17 invalid certificate, 18 cannot determine type,
+ *         19 key distribution center missing, 20 realm missing,
  *         99 permission denied, -1 error.
  */
 int
@@ -35692,6 +35695,7 @@ create_credential (const char* name, const char* comment, const char* login,
                    const char* certificate, const char* community,
                    const char* auth_algorithm, const char* privacy_password,
                    const char* privacy_algorithm,
+                   const char* kdc, const char *realm,
                    const char* given_type, const char* allow_insecure,
                    credential_t *credential)
 {
@@ -35738,7 +35742,8 @@ create_credential (const char* name, const char* comment, const char* login,
           && strcmp (given_type, "snmp")
           && strcmp (given_type, "smime")
           && strcmp (given_type, "up")
-          && strcmp (given_type, "usk"))
+          && strcmp (given_type, "usk")
+          && strcmp (given_type, "krb5"))
         {
           sql_rollback ();
           return 4;
@@ -35753,6 +35758,8 @@ create_credential (const char* name, const char* comment, const char* login,
     quoted_type = g_strdup ("cc");
   else if (login && key_private)
     quoted_type = g_strdup ("usk");
+  else if (login && given_password && (realm || kdc))
+    quoted_type = g_strdup ("krb5");
   else if (login && given_password)
     quoted_type = g_strdup ("up");
   else if (login && key_private == NULL && given_password == NULL)
@@ -35773,7 +35780,8 @@ create_credential (const char* name, const char* comment, const char* login,
       && (strcmp (quoted_type, "cc") == 0
           || strcmp (quoted_type, "pgp") == 0
           || strcmp (quoted_type, "smime") == 0
-          || strcmp (quoted_type, "snmp") == 0))
+          || strcmp (quoted_type, "snmp") == 0
+          || strcmp (quoted_type, "krb5") == 0))
     ret = 10; // Type does not support autogenerate
 
   using_snmp_v3 = 0;
@@ -35787,7 +35795,8 @@ create_credential (const char* name, const char* comment, const char* login,
     ret = 5;
   else if (given_password == NULL && auto_generate == 0
            && (strcmp (quoted_type, "up") == 0
-               || strcmp (quoted_type, "pw") == 0))
+               || strcmp (quoted_type, "pw") == 0
+               || strcmp (quoted_type, "krb5") == 0))
       // (username) password requires a password
     ret = 6;
   else if (key_private == NULL && auto_generate == 0
@@ -35801,6 +35810,12 @@ create_credential (const char* name, const char* comment, const char* login,
   else if (key_public == NULL && auto_generate == 0
            && strcmp (quoted_type, "pgp") == 0)
     ret = 9;
+  else if (kdc == NULL && auto_generate == 0
+           && strcmp (quoted_type, "krb5") == 0)
+    ret = 19;
+  else if (realm == NULL && auto_generate == 0
+           && strcmp (quoted_type, "krb5") == 0)
+    ret = 20;
   else if (strcmp (quoted_type, "snmp") == 0)
     {
       if (login || given_password || auth_algorithm
@@ -35876,9 +35891,10 @@ create_credential (const char* name, const char* comment, const char* login,
                            "username", login);
     }
 
+  if (kdc)
+    set_credential_data (new_credential, "kdc", kdc);
   if (key_public)
     set_credential_data (new_credential, "public_key", key_public);
-
   if (certificate)
     {
       gchar *certificate_truncated;
@@ -35899,6 +35915,8 @@ create_credential (const char* name, const char* comment, const char* login,
   if (privacy_algorithm)
     set_credential_data (new_credential,
                          "privacy_algorithm", privacy_algorithm);
+  if (realm)
+    set_credential_data (new_credential, "realm", realm);
 
   g_free (quoted_type);
 
@@ -36177,6 +36195,8 @@ copy_credential (const char* name, const char* comment,
  * @param[in]   auth_algorithm      Authentication algorithm of Credential.
  * @param[in]   privacy_password    Privacy password of Credential.
  * @param[in]   privacy_algorithm   Privacy algorithm of Credential.
+ * @param[in]   kdc                 Kerberos KDC (key distribution centers).
+ * @param[in]   realm               Kerberos realm.
  * @param[in]   allow_insecure      Whether to allow insecure use.
  *
  * @return 0 success, 1 failed to find credential, 2 credential with new name
@@ -36196,6 +36216,7 @@ modify_credential (const char *credential_id,
                    const char* certificate,
                    const char* community, const char* auth_algorithm,
                    const char* privacy_password, const char* privacy_algorithm,
+                   const char* kdc, const char* realm,
                    const char* allow_insecure)
 {
   credential_t credential;
@@ -36471,6 +36492,15 @@ modify_credential (const char *credential_id,
         {
           set_credential_data (credential, "secret", "");
         }
+      else if (strcmp (type, "krb5") == 0)
+        {
+          if (password)
+            set_credential_password (credential, password);
+          if (kdc)
+            set_credential_data (credential, "kdc", kdc);
+          if (realm)
+            set_credential_data (credential, "realm", realm);
+        }
       else
         {
           g_warning ("%s: Unknown credential type: %s", __func__, type);
@@ -36665,6 +36695,14 @@ delete_credential (const char *credential_id, int ultimate)
    { "(SELECT value FROM credentials_data"                                    \
      " WHERE credential = credentials.id AND type = 'public_key')",           \
      NULL,                                                                    \
+     KEYWORD_TYPE_STRING },                                                   \
+   { "(SELECT value FROM credentials_data"                                    \
+     " WHERE credential = credentials.id AND type = 'kdc')"       ,           \
+     "kdc",                                                                   \
+     KEYWORD_TYPE_STRING },                                                   \
+   { "(SELECT value FROM credentials_data"                                    \
+     " WHERE credential = credentials.id AND type = 'realm')",                \
+     "realm",                                                                 \
      KEYWORD_TYPE_STRING },                                                   \
    /* private data */                                                         \
    { "(SELECT value FROM credentials_data"                                    \
@@ -37248,20 +37286,20 @@ credential_iterator_encrypted_data (iterator_t* iterator, const char* type)
 
   if (iterator->done)
     return NULL;
-  secret = iterator_string (iterator, GET_ITERATOR_COLUMN_COUNT + 7);
+  secret = iterator_string (iterator, GET_ITERATOR_COLUMN_COUNT + 9);
   if (type == NULL)
     {
       g_warning ("%s: NULL data type given", __func__);
       return NULL;
     }
   else if (strcmp (type, "password") == 0)
-    unencrypted = iterator_string (iterator, GET_ITERATOR_COLUMN_COUNT + 8);
+    unencrypted = iterator_string (iterator, GET_ITERATOR_COLUMN_COUNT + 10);
   else if (strcmp (type, "private_key") == 0)
-    unencrypted  = iterator_string (iterator, GET_ITERATOR_COLUMN_COUNT + 9);
-  else if (strcmp (type, "community") == 0)
-    unencrypted  = iterator_string (iterator, GET_ITERATOR_COLUMN_COUNT + 10);
-  else if (strcmp (type, "privacy_password") == 0)
     unencrypted  = iterator_string (iterator, GET_ITERATOR_COLUMN_COUNT + 11);
+  else if (strcmp (type, "community") == 0)
+    unencrypted  = iterator_string (iterator, GET_ITERATOR_COLUMN_COUNT + 12);
+  else if (strcmp (type, "privacy_password") == 0)
+    unencrypted  = iterator_string (iterator, GET_ITERATOR_COLUMN_COUNT + 13);
   else
     {
       g_warning ("%s: unknown data type \"%s\"", __func__, type);
@@ -37361,6 +37399,27 @@ DEF_ACCESS (credential_iterator_privacy_algorithm,
  */
 DEF_ACCESS (credential_iterator_public_key,
             GET_ITERATOR_COLUMN_COUNT + 6);
+
+/**
+ * @brief Get the key distribution center from an LSC credential iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return Key distribution center, or NULL if iteration is complete.  Freed by
+ *         cleanup_iterator.
+ */
+DEF_ACCESS (credential_iterator_kdc,
+            GET_ITERATOR_COLUMN_COUNT + 7);
+
+/**
+ * @brief Get the realm from an LSC credential iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return Realm, or NULL if iteration is complete.  Freed by cleanup_iterator.
+ */
+DEF_ACCESS (credential_iterator_realm,
+            GET_ITERATOR_COLUMN_COUNT + 8);
 
 /**
  * @brief Get the password from a Credential iterator.

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -3987,12 +3987,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <o><e>copy</e></o>
       <o><e>allow_insecure</e></o>
       <o><e>certificate</e></o>
+      <o><e>kdc</e></o>
       <o><e>key</e></o>
       <o><e>login</e></o>
       <o><e>password</e></o>
       <o><e>auth_algorithm</e></o>
       <o><e>community</e></o>
       <o><e>privacy</e></o>
+      <o><e>realm</e></o>
       <o><e>type</e></o>
     </pattern>
     <ele>
@@ -4027,6 +4029,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <pattern>
         text
       </pattern>
+    </ele>
+    <ele>
+      <name>kdc</name>
+      <pattern>text</pattern>
+      <summary>The Kerberos KDC (key distribution center(s))</summary>
     </ele>
     <ele>
       <name>key</name>
@@ -4115,10 +4122,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </ele>
     </ele>
     <ele>
+      <name>realm</name>
+      <pattern>text</pattern>
+      <summary>The Kerberos realm</summary>
+    </ele>
+    <ele>
       <name>type</name>
       <summary>The type of credential to create</summary>
       <description>
         <p>cc: Client certificate</p>
+        <p>krb5: Kerberos 5</p>
         <p>pgp: PGP encryption key</p>
         <p>pw: Password only</p>
         <p>smime: S/MIME certificate</p>
@@ -4129,6 +4142,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <pattern>
         <alts>
           <alt>cc</alt>
+          <alt>krb5</alt>
           <alt>pgp</alt>
           <alt>pw</alt>
           <alt>smime</alt>
@@ -10911,6 +10925,8 @@ END:VCALENDAR
               <e>certificate</e>
             </or>
           </o>
+          <o><e>kdc</e></o>
+          <o><e>realm</e></o>
         </pattern>
         <ele>
           <name>owner</name>
@@ -11037,6 +11053,7 @@ END:VCALENDAR
           <summary>The type of the credential</summary>
           <description>
             <p>cc: Client certificate</p>
+            <p>krb5: Kerberos 5</p>
             <p>pgp: PGP encryption key</p>
             <p>pw: Password only</p>
             <p>smime: S/MIME certificate</p>
@@ -11047,6 +11064,7 @@ END:VCALENDAR
           <pattern>
             <alts>
               <alt>cc</alt>
+              <alt>krb5</alt>
               <alt>pgp</alt>
               <alt>pw</alt>
               <alt>smime</alt>
@@ -11198,6 +11216,16 @@ END:VCALENDAR
         <ele>
           <name>certificate</name>
           <pattern>text</pattern>
+        </ele>
+        <ele>
+          <name>kdc</name>
+          <pattern>text</pattern>
+          <summary>The Kerberos KDC (key distribution center(s))</summary>
+        </ele>
+        <ele>
+          <name>realm</name>
+          <pattern>text</pattern>
+          <summary>The Kerberos realm</summary>
         </ele>
       </ele>
       <ele>
@@ -26744,12 +26772,14 @@ END:VCALENDAR
       <o><e>name</e></o>
       <o><e>allow_insecure</e></o>
       <o><e>certificate</e></o>
+      <o><e>kdc</e></o>
       <o><e>key</e></o>
       <o><e>login</e></o>
       <o><e>password</e></o>
       <o><e>community</e></o>
       <o><e>auth_algorithm</e></o>
       <o><e>privacy</e></o>
+      <o><e>realm</e></o>
     </pattern>
     <ele>
       <name>name</name>
@@ -26776,6 +26806,11 @@ END:VCALENDAR
       <pattern>
         text
       </pattern>
+    </ele>
+    <ele>
+      <name>kdc</name>
+      <pattern>text</pattern>
+      <summary>The Kerberos KDC (key distribution center(s))</summary>
     </ele>
     <ele>
       <name>key</name>
@@ -26862,6 +26897,11 @@ END:VCALENDAR
           text
         </pattern>
       </ele>
+    </ele>
+    <ele>
+      <name>realm</name>
+      <pattern>text</pattern>
+      <summary>The Kerberos realm</summary>
     </ele>
     <response>
       <pattern>


### PR DESCRIPTION
## What
The new type "krb5" is added to the create_credential, modify_credential and get_credentials commands.

## Why
This will later be usable in scan targets for Kerberos 5 authentication.

## References
GEA-774
