### PR TITLE
Fix: Correctly use test conditions in .docker/setup-mta.sh

### DIFF
--- a/.docker/setup-mta.sh
+++ b/.docker/setup-mta.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 
 # Make any changes only when MTA_HOST has been set
-if [ -n MTA_HOST ]; then
+if [ -n "$MTA_HOST" ]; then
     echo "setting up configuration file for mail agent"
     CONFIG="/etc/msmtprc"
     echo "host $MTA_HOST" > $CONFIG
-    [ -n MTA_PORT ] && echo "port $MTA_PORT" >> $CONFIG
-    [ -n MTA_TLS ] && echo "tls $MTA_TLS" >> $CONFIG
-    [ -n MTA_STARTTLS ] && echo "tls_starttls $MTA_STARTTLS" >> $CONFIG
-    [ -n MTA_TLS_CERTCHECK ] && echo "tls_certcheck $MTA_TLS_CERTCHECK" >> $CONFIG
-    [ -n MTA_AUTH ] && echo "auth $MTA_AUTH" >> $CONFIG
-    [ -n MTA_USER ] && echo "user $MTA_USER" >> $CONFIG
-    [ -n MTA_FROM ] && echo "from $MTA_FROM" >> $CONFIG
-    [ -n MTA_PASSWORD ] && echo "password $MTA_PASSWORD" >> $CONFIG
-    [ -n MTA_LOGFILE ] && echo "logfile $MTA_LOGFILE" >> $CONFIG
+    [ -n "$MTA_PORT" ] && echo "port $MTA_PORT" >> $CONFIG
+    [ -n "$MTA_TLS" ] && echo "tls $MTA_TLS" >> $CONFIG
+    [ -n "$MTA_STARTTLS" ] && echo "tls_starttls $MTA_STARTTLS" >> $CONFIG
+    [ -n "$MTA_TLS_CERTCHECK" ] && echo "tls_certcheck $MTA_TLS_CERTCHECK" >> $CONFIG
+    [ -n "$MTA_AUTH" ] && echo "auth $MTA_AUTH" >> $CONFIG
+    [ -n "$MTA_USER" ] && echo "user $MTA_USER" >> $CONFIG
+    [ -n "$MTA_FROM" ] && echo "from $MTA_FROM" >> $CONFIG
+    [ -n "$MTA_PASSWORD" ] && echo "password $MTA_PASSWORD" >> $CONFIG
+    [ -n "$MTA_LOGFILE" ] && echo "logfile $MTA_LOGFILE" >> $CONFIG
     chown gvmd:mail $CONFIG
     chmod 750 $CONFIG
 fi


### PR DESCRIPTION
Replacement for #2286 to work around CI.

## What

Added dollar signs to have the tests actually look at variable values and not
for the plain strings which leads to them being always true!

## Why

`shellcheck setup-mta.sh`:
```

In setup-mta.sh line 4:
if [ -n MTA_HOST ]; then
        ^------^ SC2157 (error): Argument to -n is always true due to literal strings.


In setup-mta.sh line 8:
    [ -n MTA_PORT ] && echo "port $MTA_PORT" >> $CONFIG
         ^------^ SC2157 (error): Argument to -n is always true due to literal strings.


In setup-mta.sh line 9:
    [ -n MTA_TLS ] && echo "tls $MTA_TLS" >> $CONFIG
         ^-----^ SC2157 (error): Argument to -n is always true due to literal strings.


In setup-mta.sh line 10:
    [ -n MTA_STARTTLS ] && echo "tls_starttls $MTA_STARTTLS" >> $CONFIG
         ^----------^ SC2157 (error): Argument to -n is always true due to literal strings.


In setup-mta.sh line 11:
    [ -n MTA_TLS_CERTCHECK ] && echo "tls_certcheck $MTA_TLS_CERTCHECK" >> $CONFIG
         ^---------------^ SC2157 (error): Argument to -n is always true due to literal strings.


In setup-mta.sh line 12:
    [ -n MTA_AUTH ] && echo "auth $MTA_AUTH" >> $CONFIG
         ^------^ SC2157 (error): Argument to -n is always true due to literal strings.


In setup-mta.sh line 13:
    [ -n MTA_USER ] && echo "user $MTA_USER" >> $CONFIG
         ^------^ SC2157 (error): Argument to -n is always true due to literal strings.


In setup-mta.sh line 14:
    [ -n MTA_FROM ] && echo "from $MTA_FROM" >> $CONFIG
         ^------^ SC2157 (error): Argument to -n is always true due to literal strings.


In setup-mta.sh line 15:
    [ -n MTA_PASSWORD ] && echo "password $MTA_PASSWORD" >> $CONFIG
         ^----------^ SC2157 (error): Argument to -n is always true due to literal strings.


In setup-mta.sh line 16:
    [ -n MTA_LOGFILE ] && echo "logfile $MTA_LOGFILE" >> $CONFIG
         ^---------^ SC2157 (error): Argument to -n is always true due to literal strings.

For more information:
  https://www.shellcheck.net/wiki/SC2157 -- Argument to -n is always true due...
```


