### PR TITLE
Fix: Handle schemas in SCAP rebuild correctly

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -13367,7 +13367,9 @@ print_cpe_match_nodes_xml (resource_t node, GString *buffer)
                          vee ?: "");
 
       iterator_t cpe_matches;
-      init_cpe_match_string_matches_iterator (&cpe_matches, match_criteria_id);
+      init_cpe_match_string_matches_iterator (
+        &cpe_matches, match_criteria_id, NULL
+      );
       xml_string_append (buffer, "<matched_cpes>");
 
       while (next (&cpe_matches))

--- a/src/manage.h
+++ b/src/manage.h
@@ -1751,7 +1751,7 @@ int
 cpe_match_string_iterator_vulnerable (iterator_t*);
 
 void
-init_cpe_match_string_matches_iterator (iterator_t*, const char *);
+init_cpe_match_string_matches_iterator (iterator_t*, const char *, const char*);
 
 const char*
 cpe_matches_cpe_name_id (iterator_t*);

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -1834,7 +1834,7 @@ create_view_vulns ()
          "       severity, "
          G_STRINGIFY (QOD_DEFAULT) " AS qod,"
          "       'cve' AS type"
-         " FROM cves"
+         " FROM scap.cves"
          " WHERE uuid in (SELECT * FROM used_nvts)");
   else
     sql ("CREATE OR REPLACE VIEW vulns AS"

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -20661,15 +20661,18 @@ DEF_ACCESS (cpe_match_string_iterator_version_end_excl, 7);
  *
  * @param[in]  iterator           Iterator.
  * @param[in]  match_criteria_id  The match criteria id to get the matches for.
+ * @param[in]  schema             Schema name, NULL for the default "scap".
  */
 void
 init_cpe_match_string_matches_iterator (iterator_t* iterator,
-                                       const char *match_criteria_id)
+                                        const char *match_criteria_id,
+                                        const char *schema)
 {
   init_iterator (iterator,
                  "SELECT cpe_name_id, cpe_name"
-                 " FROM scap.cpe_matches"
+                 " FROM %s.cpe_matches"
                  " WHERE match_criteria_id = '%s'",
+                 schema ? schema : "scap",
                  match_criteria_id);
 }
 

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -3500,7 +3500,11 @@ handle_cve_configurations (resource_t cve_db_id, char * cve_id,
               if (vulnerable)
                 {
                   iterator_t cpe_matches;
-                  init_cpe_match_string_matches_iterator (&cpe_matches, quoted_match_criteria_id);
+                  init_cpe_match_string_matches_iterator (
+                    &cpe_matches,
+                    quoted_match_criteria_id,
+                    "scap2"
+                  );
                   while (next (&cpe_matches))
                     g_string_append_printf (software, "%s ", cpe_matches_cpe_name (&cpe_matches));
                   cleanup_iterator (&cpe_matches);


### PR DESCRIPTION
## What
The SCAP rebuild will now use the "scap2" schema for the "cpe_matches" table and create_view_vulns explicitly uses the "scap.cves".

## Why
This fixes the SCAP rebuild either not working at all for old, missing or empty "scap" schemas or using using outdated CPE match data.

## References
GEA-800


