### PR TITLE
Fix: Optimized "gvmd --get-users" and "gvmd --get-roles" command.

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -144,6 +144,8 @@ manage_reset_currents ();
 
 /* Commands. */
 
+#define MAX_LOCK_RETRIES 16
+
 /**
  * @brief A command.
  */

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -17275,11 +17275,14 @@ init_manage_internal (GSList *log_config,
 
   /* Load the NVT cache into memory. */
 
-  if (nvti_cache == NULL)
+  if (nvti_cache == NULL && !skip_update_nvti_cache ())
     update_nvti_cache ();
 
+  if (skip_update_nvti_cache ())
+    avoid_db_check_inserts = TRUE;
+
   if (skip_db_check == 0)
-    /* Requires NVT cache. */
+    /* Requires NVT cache if avoid_db_check_inserts == FALSE */
     check_db_configs (avoid_db_check_inserts);
 
   sql_close ();

--- a/src/utils.c
+++ b/src/utils.c
@@ -58,6 +58,9 @@
  */
 #define G_LOG_DOMAIN "md manage"
 
+/* Flag if to skip the update of the nvti cache or not. */
+static gboolean skip_upd_nvti_cache = FALSE;
+
 
 /* Sleep. */
 
@@ -751,6 +754,30 @@ lockfile_locked (const gchar *lockfile_basename)
   if ((ret == 0) && lockfile_unlock (&lockfile))
     return -1;
   return ret;
+}
+
+/**
+ * @brief Set Flag if to run update_nvti_cache () or not.
+ *            The default value of the flag is FALSE.
+ *
+ * @param[in]  skip_upd_nvti_c  Value for the flag if to
+ *                              skip the cache update or not.
+ */
+void
+set_skip_update_nvti_cache (gboolean skip_upd_nvti_c)
+{
+  skip_upd_nvti_cache = skip_upd_nvti_c;
+}
+
+/**
+ * @brief Check if to run update_nvti_cache () or not.
+ *
+ * @return TRUE skip update, FALSE don't skip update
+ */
+gboolean
+skip_update_nvti_cache ()
+{
+  return skip_upd_nvti_cache;
 }
 
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -85,8 +85,7 @@ lockfile_unlock (lockfile_t *);
 int
 lockfile_locked (const gchar *);
 
-void
-set_skip_update_nvti_cache (gboolean);
+void set_skip_update_nvti_cache (gboolean);
 
 gboolean
 skip_update_nvti_cache ();

--- a/src/utils.h
+++ b/src/utils.h
@@ -85,6 +85,12 @@ lockfile_unlock (lockfile_t *);
 int
 lockfile_locked (const gchar *);
 
+void
+set_skip_update_nvti_cache (gboolean);
+
+gboolean
+skip_update_nvti_cache ();
+
 int
 is_uuid (const char *);
 


### PR DESCRIPTION
## What
Optimized the "gvmd --get-users" and the "gvmd --get-roles" command by skipping the update of the nvti cache in those cases.
Also added a retry loop around "lockfile_lock_nb (...)" so that commands like "gvmd --get-users" don't fail if another gvmd process is starting up.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This is a bug-fix / optimization.
<!-- Describe why are these changes necessary? -->

## References
GEA-789
GEA-806
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist
Tested manually on my local development system.
<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


