### PR TITLE
Remove: Drop obsolete comment from prod Dockerfile

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -72,9 +72,6 @@ ARG DEBIAN_FRONTEND=noninteractive
 # s/mime email encryption
 # gpgsm
 
-# Loading scap and cert data
-# xml-twig-tools
-
 # Required for set up certificates for GVM
 # gnutls-bin
 


### PR DESCRIPTION
## What

xml split tool from xml-twig-tools packages isn't used anymore. Therefore the comment is obsolete.

## References

Replaces #2321
