### PR TITLE
Change: Rename the cpe match strings feed file

### DIFF
--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -4245,7 +4245,7 @@ update_scap_cpe_match_strings ()
   inserts_t inserts, matches_inserts;
 
   current_json_path = g_build_filename (GVM_SCAP_DATA_DIR,
-                                        "cpe_match_strings.json.gz",
+                                        "nvd_cpe_matches.json.gz",
                                         NULL);
   int fd = open(current_json_path, O_RDONLY);
 
@@ -4253,7 +4253,7 @@ update_scap_cpe_match_strings ()
   {
     g_free (current_json_path);
     current_json_path = g_build_filename (GVM_SCAP_DATA_DIR,
-                                          "cpe_match_strings.json",
+                                          "nvd_cpe_matches.json",
                                           NULL);
     fd = open(current_json_path, O_RDONLY);
   }

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -4245,7 +4245,7 @@ update_scap_cpe_match_strings ()
   inserts_t inserts, matches_inserts;
 
   current_json_path = g_build_filename (GVM_SCAP_DATA_DIR,
-                                        "nvd_cpe_matches.json.gz",
+                                        "nvd-cpe-matches.json.gz",
                                         NULL);
   int fd = open(current_json_path, O_RDONLY);
 
@@ -4253,7 +4253,7 @@ update_scap_cpe_match_strings ()
   {
     g_free (current_json_path);
     current_json_path = g_build_filename (GVM_SCAP_DATA_DIR,
-                                          "nvd_cpe_matches.json",
+                                          "nvd-cpe-matches.json",
                                           NULL);
     fd = open(current_json_path, O_RDONLY);
   }


### PR DESCRIPTION
## What
Rename the cpe match strings feed file

## Why
Name is inconsistent with the feed file. 
Current feed file name is `nvd_cpe_matches` but requested to be renamed to `nvd-cpe-matches` for consistency with other feed files.