### PR TITLE
Fix: Prevent sporadic signals when loading reports.

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -527,9 +527,12 @@ get_certificate_info (const gchar* certificate, gssize certificate_len,
           gchar *buffer;
           gnutls_x509_crt_get_dn (gnutls_cert, NULL, &buffer_size);
           buffer = g_malloc (buffer_size);
-          gnutls_x509_crt_get_dn (gnutls_cert, buffer, &buffer_size);
-
-          if (escape_dns)
+          if (gnutls_x509_crt_get_dn (gnutls_cert, buffer, &buffer_size))
+            {
+              *subject = g_strdup ("");
+              g_free (buffer);
+            }
+          else if (escape_dns)
             {
               *subject = strescape_check_utf8 (buffer, NULL);
               g_free (buffer);
@@ -544,9 +547,12 @@ get_certificate_info (const gchar* certificate, gssize certificate_len,
           gchar *buffer;
           gnutls_x509_crt_get_issuer_dn (gnutls_cert, NULL, &buffer_size);
           buffer = g_malloc (buffer_size);
-          gnutls_x509_crt_get_issuer_dn (gnutls_cert, buffer, &buffer_size);
-
-          if (escape_dns)
+          if (gnutls_x509_crt_get_issuer_dn (gnutls_cert, buffer, &buffer_size))
+            {
+              *issuer = g_strdup ("");
+              g_free (buffer);
+            }
+          else if (escape_dns)
             {
               *issuer = strescape_check_utf8 (buffer, NULL);
               g_free (buffer);


### PR DESCRIPTION
## What
Now the returned error code of the functions gnutls_x509_crt_get_dn (..) and gnutls_x509_crt_get_issuer_dn (..) is considered to prevent the sporadic occurrence of signals when loading reports.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This is a bug-fix.
<!-- Describe why are these changes necessary? -->

## References
GEA-866
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->
Because the bug could not be reproduced on our systems the (positive) effect of the change could not be tested.


