### PR TITLE
Support building against PostgreSQL 17

### DIFF
--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -87,7 +87,7 @@ set(PostgreSQL_ROOT_DIR_MESSAGE "Set the PostgreSQL_ROOT system variable to wher
 
 
 set(PostgreSQL_KNOWN_VERSIONS ${PostgreSQL_ADDITIONAL_VERSIONS}
-    "16" "15" "14" "13" "12" "11" "10" "9.6" "9.5" "9.4" "9.3" "9.2" "9.1" "9.0" "8.4" "8.3" "8.2" "8.1" "8.0")
+    "17" "16" "15" "14" "13" "12" "11" "10" "9.6" "9.5" "9.4" "9.3" "9.2" "9.1" "9.0" "8.4" "8.3" "8.2" "8.1" "8.0")
 
 # Define additional search paths for root directories.
 set( PostgreSQL_ROOT_DIRECTORIES


### PR DESCRIPTION


## What

Support building against PostgreSQL 17

As a side note, it's a bit funny that the FindPostgreSQL.cmake file shipped with cmake and Debian testing also doesn't support PostgreSQL 17 yet. That means still having our own cmake file is a good thing.

## Why

PostgreSQL 17 is in Debian testing/trixie. Thus we need to support it.

## References

https://github.com/greenbone/gvmd/actions/runs/12932770250/job/36069777597?pr=2347
https://github.com/greenbone/pg-gvm/pull/83
