### PR TITLE
Add missing runtime dependency postgres-client for container image

### DIFF
--- a/.github/runtime-dependencies.list
+++ b/.github/runtime-dependencies.list
@@ -64,6 +64,7 @@ libpq5
 msmtp
 msmtp-mta
 openssh-client
+postgresql-client
 postgresql-client-common
 python3
 rpm


### PR DESCRIPTION
## What

Add missing runtime dependency postgresql-client for container image

## Why

The `postgresql-client` package is required to provide the `psql` executable. Missed this package when streamlining the packages for being available on Debian oldstable, stable and testing. The `postgres-client` is a provides by the actual available versioned postgres client package e.g. on stable `postgresql-client-15`.

Requires a gvmd release to fix the `gvmd:stable` image.


## References

Fixes #2351 

https://forum.greenbone.net/t/gvmd-container-postgresql-client-version-package-error/20208

