### PR TITLE
Made the filter on the vulnerabilities page work for report_ids.

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -56305,7 +56305,7 @@ vuln_iterator_extra_with (const gchar *task_id, const gchar *report_id,
   if (report_id && strcmp (report_id, ""))
     {
       report_t report = 0;
-      find_report_with_permission (task_id, &report, "get_reports");
+      find_report_with_permission (report_id, &report, "get_reports");
       g_string_append_printf (ret, " AND results.report = %llu", report);
     }
 


### PR DESCRIPTION
## What
The filter on the vulnerabilities page did not work for report_ids as it was expected.
Now the filter also works for report_ids.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->
## Why
This is a bug-fix.
<!-- Describe why are these changes necessary? -->

## References
GEA-862
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist
Tested manually on my local development system.
<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


