### PR TITLE
Fix: Limit query size for affected products update

### DIFF
--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -13,6 +13,12 @@ It manages the storage of any vulnerability management configurations and of the
 \fB-h, --help\f1
 Show help options.
 .TP
+\fB--affected-products-query-size=\fINUMBER\fB\f1
+Sets the number of CVEs to process per query when updating the affected products. Defaults to 1000. 
+.TP
+\fB--auth-timeout=\fITIMEOUT\fB\f1
+Sets the authentication timeout time for the cached authentication. Defaults to 15 minutes. 
+.TP
 \fB--broker-address=\fIADDRESS\fB\f1
 Sets the address for the publish-subscribe message (MQTT) broker. Defaults to localhost:9138. Set to empty to disable. 
 .TP

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -53,6 +53,24 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </optdesc>
     </option>
     <option>
+      <p><opt>--affected-products-query-size=<arg>NUMBER</arg></opt></p>
+      <optdesc>
+        <p>
+          Sets the number of CVEs to process per query when updating
+          the affected products. Defaults to 1000.
+        </p>
+      </optdesc>
+    </option>
+    <option>
+      <p><opt>--auth-timeout=<arg>TIMEOUT</arg></opt></p>
+      <optdesc>
+        <p>
+          Sets the authentication timeout time for the cached authentication.
+          Defaults to 15 minutes.
+        </p>
+      </optdesc>
+    </option>
+    <option>
       <p><opt>--broker-address=<arg>ADDRESS</arg></opt></p>
       <optdesc>
         <p>

--- a/doc/gvmd.html
+++ b/doc/gvmd.html
@@ -37,6 +37,20 @@
       
     
     
+      <p><b>--affected-products-query-size=<em>NUMBER</em></b></p>
+      
+        <p>Sets the number of CVEs to process per query when updating
+          the affected products. Defaults to 1000.</p>
+      
+    
+    
+      <p><b>--auth-timeout=<em>TIMEOUT</em></b></p>
+      
+        <p>Sets the authentication timeout time for the cached authentication.
+          Defaults to 15 minutes.</p>
+      
+    
+    
       <p><b>--broker-address=<em>ADDRESS</em></b></p>
       
         <p>Sets the address for the publish-subscribe message (MQTT) broker.

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1865,6 +1865,8 @@ gvmd (int argc, char** argv, char *env[])
   static gchar *scanner_key_priv = NULL;
   static int scanner_connection_retry = SCANNER_CONNECTION_RETRY_DEFAULT;
   static int schedule_timeout = SCHEDULE_TIMEOUT_DEFAULT;
+  static int affected_products_query_size
+    = AFFECTED_PRODUCTS_QUERY_SIZE_DEFAULT;
   static int secinfo_commit_size = SECINFO_COMMIT_SIZE_DEFAULT;
   static gchar *delete_scanner = NULL;
   static gchar *verify_scanner = NULL;
@@ -1911,6 +1913,12 @@ gvmd (int argc, char** argv, char *env[])
   GOptionContext *option_context;
   static GOptionEntry option_entries[]
     = {
+        { "affected-products-query-size", '\0', 0, G_OPTION_ARG_INT,
+          &affected_products_query_size,
+          "Sets the number of CVEs to process per query when updating"
+          " the affected products. Defaults to "
+          G_STRINGIFY (AFFECTED_PRODUCTS_QUERY_SIZE_DEFAULT) ".",
+          "<number>" },
         { "auth-timeout", '\0', 0, G_OPTION_ARG_INT,
           &auth_timeout,
           "Sets the authentication timeout time for the cached authentication."
@@ -2363,6 +2371,8 @@ gvmd (int argc, char** argv, char *env[])
   set_scanner_connection_retry (scanner_connection_retry);
 
   /* Set SQL sizes */
+
+  set_affected_products_query_size (affected_products_query_size);
 
   set_secinfo_commit_size (secinfo_commit_size);
 

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -3781,6 +3781,8 @@ manage_db_init_indexes (const gchar *name)
            " ON scap2.cpes (severity);");
       sql ("CREATE INDEX cpes_by_uuid"
            " ON scap2.cpes (uuid);");
+      sql ("CREATE INDEX cpes_by_cpe_name_id"
+           " ON scap2.cpes(cpe_name_id);");
 
       sql ("CREATE INDEX afp_cpe_idx"
            " ON scap2.affected_products (cpe);");

--- a/src/manage_sql_secinfo.h
+++ b/src/manage_sql_secinfo.h
@@ -166,6 +166,11 @@
  }
 
 /**
+ * @brief Default for affected_products_query_size.
+ */
+#define AFFECTED_PRODUCTS_QUERY_SIZE_DEFAULT 1000
+
+/**
  * @brief Default for secinfo_commit_size.
  */
 #define SECINFO_COMMIT_SIZE_DEFAULT 0
@@ -190,6 +195,9 @@ check_cert_db_version ();
 
 int
 get_secinfo_commit_size ();
+
+void
+set_affected_products_query_size (int);
 
 void
 set_secinfo_commit_size (int);


### PR DESCRIPTION
## What
The update of the affected products is now limited to 1000 CVEs per SQL query. This number can be changed with the --affected-products-query-size option.
Also, an index has been added to make the queries a little faster.

## Why
This is meant to prevent the WAL from becoming very large during the affected products update.

## References
GEA-872
#2353
