### PR TITLE
Fix: Made Verinice reports include attached reports.

### DIFF
--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -3997,18 +3997,18 @@ apply_report_format (gchar *report_format_id,
 
   rf_dependencies_string
     = sql_string ("SELECT value"
-                  "  FROM report_format_params"
-                  " WHERE report_format = %llu"
-                  "   AND type = %i",
-                  report_format,
-                  REPORT_FORMAT_PARAM_TYPE_REPORT_FORMAT_LIST);
+                  "  FROM report_config_params"
+                  "  WHERE report_config = %llu AND name = 'Attached report formats'",
+                  report_config);
 
   if (!rf_dependencies_string || !strcmp (rf_dependencies_string, ""))
     rf_dependencies_string
       = sql_string ("SELECT value"
-                   "  FROM report_config_params"
-                   "  WHERE report_config = %llu AND name = 'Attached report formats'",
-                   report_config);
+                    "  FROM report_format_params"
+                    "  WHERE report_format = %llu"
+                    "    AND type = %i",
+                    report_format,
+                    REPORT_FORMAT_PARAM_TYPE_REPORT_FORMAT_LIST);
 
   if (rf_dependencies_string)
     {

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -4003,6 +4003,13 @@ apply_report_format (gchar *report_format_id,
                   report_format,
                   REPORT_FORMAT_PARAM_TYPE_REPORT_FORMAT_LIST);
 
+  if (!rf_dependencies_string || !strcmp (rf_dependencies_string, ""))
+    rf_dependencies_string
+      = sql_string ("SELECT value"
+                   "  FROM report_config_params"
+                   "  WHERE report_config = %llu AND name = 'Attached report formats'",
+                   report_config);
+
   if (rf_dependencies_string)
     {
       gchar **rf_dependencies, **current_rf_dependency;


### PR DESCRIPTION
## What
It was not possible to export a "Verinice ISM" or "Verinice ISM all results" report correctly using a report config with attached report formats. That is working now.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This is a bug-fix.
<!-- Describe why are these changes necessary? -->

## References
GEA-840
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist
Tested manually on my local development system.
<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


