### PR TITLE
Fix: Use g_string_free in update_scap_affected_products

### DIFF
--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -4119,7 +4119,7 @@ update_scap_affected_products ()
       exec_affected_products_sql (cve_ids_buffer->str);
       g_debug ("%s: Products of %d CVEs processed", __func__, count);
     }
-  g_free (cve_ids_buffer);
+  g_string_free (cve_ids_buffer, TRUE);
 
   g_info ("Updating affected products ... done");
 }


### PR DESCRIPTION
## What
Use g_string_free in update_scap_affected_products

## Why

<!-- Describe why are these changes necessary? -->

## References

https://github.com/greenbone/gvmd/commit/6408bc120311a128dddb69aaeb46f360188ac007#commitcomment-151971953

