### PR TITLE
Use gvm-libs base image for CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis-c.yml
+++ b/.github/workflows/codeql-analysis-c.yml
@@ -19,7 +19,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    container: ${{ vars.IMAGE_REGISTRY }}/greenbone/gvmd-build:stable
+    container: ${{ vars.SELF_HOSTED_REGISTRY }}/community/gvm-libs:stable
 
     strategy:
       fail-fast: false
@@ -29,7 +29,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-
+    - name: Install build dependencies
+      run: sh .github/install-dependencies.sh .github/build-dependencies.list
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:


### PR DESCRIPTION
## What
Instead of using the now obsolete gvmd-build image, the CodeQL workflow now uses the gvm-libs image and installs the build dependencies from a the list file.

## Why
Without this the CodeQL workflow fails when a newer gvm-libs version is required. 