### PR TITLE
Speed up CPEs and CPE match strings update by using COPY statements

### DIFF
--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -217,6 +217,9 @@ Time out tasks that are more than TIME minutes overdue. -1 to disable, 0 for min
 \fB--secinfo-commit-size=\fINUMBER\fB\f1
 During CERT and SCAP sync, commit updates to the database every NUMBER items, 0 for unlimited.
 .TP
+\fB--secinfo-fast_init=\fINUMBER\fB\f1
+Whether to prefer faster SQL with less checks for non-incremental SecInfo updates. 0 to use statements with more checks, 1 to use faster statements, default: 1
+.TP
 \fB-c, --unix-socket=\fIFILENAME\fB\f1
 Listen on UNIX socket at FILENAME.
 .TP

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -509,6 +509,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </optdesc>
     </option>
     <option>
+      <p><opt>--secinfo-fast_init=<arg>NUMBER</arg></opt></p>
+      <optdesc>
+        <p>Whether to prefer faster SQL with less checks for non-incremental
+           SecInfo updates. 0 to use statements with more checks, 1 to use
+           faster statements, default: 1</p>
+      </optdesc>
+    </option>
+    <option>
       <p><opt>-c, --unix-socket=<arg>FILENAME</arg></opt></p>
       <optdesc>
         <p>Listen on UNIX socket at FILENAME.</p>

--- a/doc/gvmd.html
+++ b/doc/gvmd.html
@@ -451,6 +451,14 @@
       
     
     
+      <p><b>--secinfo-fast-init=<em>NUMBER</em></b></p>
+      
+        <p>Whether to prefer faster SQL with less checks for non-incremental
+           SecInfo updates. 0 to use statements with more checks, 1 to use
+           faster statements, default: 1</p>
+      
+    
+    
       <p><b>--slave-commit-size=<em>NUMBER</em></b></p>
       
         <p>During slave updates, commit after every NUMBER updated results and

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1867,6 +1867,7 @@ gvmd (int argc, char** argv, char *env[])
   static int schedule_timeout = SCHEDULE_TIMEOUT_DEFAULT;
   static int affected_products_query_size
     = AFFECTED_PRODUCTS_QUERY_SIZE_DEFAULT;
+  static int secinfo_fast_init = SECINFO_FAST_INIT_DEFAULT;
   static int secinfo_commit_size = SECINFO_COMMIT_SIZE_DEFAULT;
   static gchar *delete_scanner = NULL;
   static gchar *verify_scanner = NULL;
@@ -2242,6 +2243,13 @@ gvmd (int argc, char** argv, char *env[])
           "During CERT and SCAP sync, commit updates to the database every"
           " <number> items, 0 for unlimited, default: "
           G_STRINGIFY (SECINFO_COMMIT_SIZE_DEFAULT), "<number>" },
+        { "secinfo-fast-init", '\0', 0, G_OPTION_ARG_INT,
+          &secinfo_fast_init,
+          "Whether to prefer faster SQL with less checks for non-incremental"
+          " SecInfo updates."
+          " 0 to use statements with more checks, 1 to use faster statements,"
+          " default: "
+          G_STRINGIFY (SECINFO_FAST_INIT_DEFAULT), "<number>" },
         { "set-encryption-key", '\0', 0, G_OPTION_ARG_STRING,
           &set_encryption_key,
           "Set the encryption key with the given UID as the new default"
@@ -2370,7 +2378,9 @@ gvmd (int argc, char** argv, char *env[])
   /* Set the connection auto retry */
   set_scanner_connection_retry (scanner_connection_retry);
 
-  /* Set SQL sizes */
+  /* Set SQL sizes and related options */
+
+  set_secinfo_fast_init (secinfo_fast_init);
 
   set_affected_products_query_size (affected_products_query_size);
 

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -3849,6 +3849,40 @@ manage_db_add_constraints (const gchar *name)
 }
 
 /**
+ * @brief Create the indexes for the CPEs table in the scap2 schema.
+ */
+void
+create_cpe_indexes ()
+{
+  sql ("CREATE UNIQUE INDEX cpe_idx"
+       " ON scap2.cpes (name);");
+  sql ("CREATE INDEX cpes_by_creation_time_idx"
+       " ON scap2.cpes (creation_time);");
+  sql ("CREATE INDEX cpes_by_modification_time_idx"
+       " ON scap2.cpes (modification_time);");
+  sql ("CREATE INDEX cpes_by_severity"
+       " ON scap2.cpes (severity);");
+  sql ("CREATE INDEX cpes_by_uuid"
+       " ON scap2.cpes (uuid);");
+  sql ("CREATE INDEX cpes_by_cpe_name_id"
+       " ON scap2.cpes(cpe_name_id);");
+}
+
+/**
+ * @brief Remove the indexes for the CPEs table in the scap2 schema.
+ */
+void
+drop_cpe_indexes ()
+{
+  sql ("DROP INDEX IF EXISTS scap2.cpe_idx");
+  sql ("DROP INDEX IF EXISTS scap2.cpes_by_creation_time_idx");
+  sql ("DROP INDEX IF EXISTS scap2.cpes_by_modification_time_idx");
+  sql ("DROP INDEX IF EXISTS scap2.cpes_by_severity");
+  sql ("DROP INDEX IF EXISTS scap2.cpes_by_uuid");
+  sql ("DROP INDEX IF EXISTS scap2.cpes_by_cpe_name_id");
+}
+
+/**
  * @brief Init external database.
  *
  * @param[in]  name  Name.  Currently only "scap".
@@ -3869,18 +3903,7 @@ manage_db_init_indexes (const gchar *name)
       sql ("CREATE INDEX cves_by_severity"
            " ON scap2.cves (severity);");
 
-      sql ("CREATE UNIQUE INDEX cpe_idx"
-           " ON scap2.cpes (name);");
-      sql ("CREATE INDEX cpes_by_creation_time_idx"
-           " ON scap2.cpes (creation_time);");
-      sql ("CREATE INDEX cpes_by_modification_time_idx"
-           " ON scap2.cpes (modification_time);");
-      sql ("CREATE INDEX cpes_by_severity"
-           " ON scap2.cpes (severity);");
-      sql ("CREATE INDEX cpes_by_uuid"
-           " ON scap2.cpes (uuid);");
-      sql ("CREATE INDEX cpes_by_cpe_name_id"
-           " ON scap2.cpes(cpe_name_id);");
+      create_cpe_indexes ();
 
       sql ("CREATE INDEX cpe_match_nodes_by_root_id"
            " ON scap2.cpe_match_nodes(root_id);");

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -3852,7 +3852,7 @@ manage_db_add_constraints (const gchar *name)
  * @brief Create the indexes for the CPEs table in the scap2 schema.
  */
 void
-create_cpe_indexes ()
+create_indexes_cpe ()
 {
   sql ("CREATE UNIQUE INDEX cpe_idx"
        " ON scap2.cpes (name);");
@@ -3872,7 +3872,7 @@ create_cpe_indexes ()
  * @brief Remove the indexes for the CPEs table in the scap2 schema.
  */
 void
-drop_cpe_indexes ()
+drop_indexes_cpe ()
 {
   sql ("DROP INDEX IF EXISTS scap2.cpe_idx");
   sql ("DROP INDEX IF EXISTS scap2.cpes_by_creation_time_idx");
@@ -3903,7 +3903,7 @@ manage_db_init_indexes (const gchar *name)
       sql ("CREATE INDEX cves_by_severity"
            " ON scap2.cves (severity);");
 
-      create_cpe_indexes ();
+      create_indexes_cpe ();
 
       sql ("CREATE INDEX cpe_match_nodes_by_root_id"
            " ON scap2.cpe_match_nodes(root_id);");

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -544,9 +544,9 @@ int
 cleanup_ids_for_table (const char *);
 
 void
-create_cpe_indexes ();
+create_indexes_cpe ();
 
 void
-drop_cpe_indexes ();
+drop_indexes_cpe ();
 
 #endif /* not _GVMD_MANAGE_SQL_H */

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -543,4 +543,10 @@ cleanup_nvt_sequences ();
 int
 cleanup_ids_for_table (const char *);
 
+void
+create_cpe_indexes ();
+
+void
+drop_cpe_indexes ();
+
 #endif /* not _GVMD_MANAGE_SQL_H */

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -2789,6 +2789,11 @@ update_scap_cpes_from_json_file (const gchar *path, gboolean use_copy)
           gvm_json_pull_parser_cleanup (&parser);
           cJSON_Delete (entry);
           fclose (cpe_file);
+          if (use_copy)
+            db_copy_buffer_cleanup (&copy_buffer);
+          else 
+            inserts_free (&inserts);
+          inserts_free (&deprecated_by_inserts);
           sql_commit ();
           return -1;
         }
@@ -2803,6 +2808,11 @@ update_scap_cpes_from_json_file (const gchar *path, gboolean use_copy)
           gvm_json_pull_parser_cleanup (&parser);
           cJSON_Delete (entry);
           fclose (cpe_file);
+          if (use_copy)
+            db_copy_buffer_cleanup (&copy_buffer);
+          else 
+            inserts_free (&inserts);
+          inserts_free (&deprecated_by_inserts);
           sql_commit ();
           return -1;
         }
@@ -2817,6 +2827,11 @@ update_scap_cpes_from_json_file (const gchar *path, gboolean use_copy)
           sql_commit ();
           gvm_json_pull_parser_cleanup (&parser);
           fclose (cpe_file);
+          if (use_copy)
+            db_copy_buffer_cleanup (&copy_buffer);
+          else 
+            inserts_free (&inserts);
+          inserts_free (&deprecated_by_inserts);
           return -1;
         }
     }
@@ -2892,6 +2907,10 @@ update_scap_cpes_from_json_file (const gchar *path, gboolean use_copy)
           gvm_json_pull_parser_cleanup (&parser);
           cJSON_Delete (entry);
           fclose (cpe_file);
+          if (use_copy)
+            db_copy_buffer_cleanup (&copy_buffer);
+          else
+            inserts_free (&inserts);
           sql_commit ();
           return -1;
         }
@@ -2902,6 +2921,10 @@ update_scap_cpes_from_json_file (const gchar *path, gboolean use_copy)
           gvm_json_pull_parser_cleanup (&parser);
           cJSON_Delete (entry);
           fclose (cpe_file);
+          if (use_copy)
+            db_copy_buffer_cleanup (&copy_buffer);
+          else
+            inserts_free (&inserts);
           sql_commit ();
           return -1;
         }
@@ -2915,6 +2938,10 @@ update_scap_cpes_from_json_file (const gchar *path, gboolean use_copy)
           sql_commit ();
           gvm_json_pull_parser_cleanup (&parser);
           fclose (cpe_file);
+          if (use_copy)
+            db_copy_buffer_cleanup (&copy_buffer);
+          else
+            inserts_free (&inserts);
           return -1;
         }
     }

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -82,6 +82,12 @@ static int affected_products_query_size = AFFECTED_PRODUCTS_QUERY_SIZE_DEFAULT;
 static int secinfo_commit_size = SECINFO_COMMIT_SIZE_DEFAULT;
 
 /**
+ * @brief Whether to prefer faster SQL with less checks for non-incremental
+ *        SecInfo updates.
+ */
+static int secinfo_fast_init = SECINFO_FAST_INIT_DEFAULT;
+
+/**
  * @brief Maximum number of rows in a EPSS INSERT.
  */
 #define EPSS_MAX_CHUNK_SIZE 10000
@@ -3199,7 +3205,7 @@ update_scap_cpes ()
 
   g_info ("Updating CPEs");
 
-  ret = update_scap_cpes_from_json_file (full_path, TRUE);
+  ret = update_scap_cpes_from_json_file (full_path, secinfo_fast_init);
 
   g_free (full_path);
 
@@ -4638,7 +4644,7 @@ update_scap_cpe_match_strings ()
   gvm_json_pull_parser_t parser;
   inserts_t inserts, matches_inserts;
   db_copy_buffer_t copy_buffer, matches_copy_buffer;
-  gboolean use_copy = TRUE;
+  gboolean use_copy = secinfo_fast_init;
 
   current_json_path = g_build_filename (GVM_SCAP_DATA_DIR,
                                         "nvd-cpe-matches.json.gz",
@@ -6269,4 +6275,18 @@ set_secinfo_commit_size (int new_commit_size)
     secinfo_commit_size = 0;
   else
     secinfo_commit_size = new_commit_size;
+}
+
+/**
+ * @brief Set the SecInfo fast initialization option.
+ *
+ * @param new_fast_init The new SecInfo fast initialization option.
+ */
+void
+set_secinfo_fast_init (int new_fast_init)
+{
+  if (new_fast_init < 0)
+    secinfo_fast_init = SECINFO_FAST_INIT_DEFAULT;
+  else
+    secinfo_fast_init = new_fast_init;
 }

--- a/src/manage_sql_secinfo.h
+++ b/src/manage_sql_secinfo.h
@@ -171,6 +171,11 @@
 #define AFFECTED_PRODUCTS_QUERY_SIZE_DEFAULT 1000
 
 /**
+ * @brief Default for secinfo_copy.
+ */
+#define SECINFO_FAST_INIT_DEFAULT 1
+
+/**
  * @brief Default for secinfo_commit_size.
  */
 #define SECINFO_COMMIT_SIZE_DEFAULT 0
@@ -201,6 +206,9 @@ set_affected_products_query_size (int);
 
 void
 set_secinfo_commit_size (int);
+
+void
+set_secinfo_fast_init (int);
 
 void
 update_scap_extra ();

--- a/src/sql.h
+++ b/src/sql.h
@@ -167,4 +167,13 @@ iterator_column_name (iterator_t *, int);
 int
 iterator_column_count (iterator_t *);
 
+int
+sql_copy_write_str (const char *, int);
+
+int
+sql_copy_end ();
+
+gchar *
+sql_copy_escape (const char *);
+
 #endif /* not _GVMD_SQL_H */

--- a/src/sql_pg.c
+++ b/src/sql_pg.c
@@ -980,7 +980,7 @@ sql_copy_escape (const char *str)
           g_string_append (escaped, "\\t");
           break;
         case '\v':
-          g_string_append (escaped, "\\r");
+          g_string_append (escaped, "\\v");
           break;
         default:
           g_string_append_c (escaped, str[i]);

--- a/src/sql_pg.c
+++ b/src/sql_pg.c
@@ -951,6 +951,9 @@ sql_copy_end ()
 gchar *
 sql_copy_escape (const char *str)
 {
+  if (str == NULL)
+    return NULL;
+
   gssize i;
   gssize len = strlen (str);
   GString *escaped = g_string_sized_new (len);
@@ -958,6 +961,9 @@ sql_copy_escape (const char *str)
   for (i = 0; i < len; i++) {
     switch (str[i])
       {
+        case '\\':
+          g_string_append (escaped, "\\\\");
+          break;
         case '\b':
           g_string_append (escaped, "\\b");
           break;


### PR DESCRIPTION
## What
The CPE and CPE match strings are now updated using COPY statements unless this is disabled with the option
`--secinfo-fast-init=0`. 

## Why
This can significantly increase the speed of updating these SCAP SecInfo types.

## References
GEA-886



