### PR TITLE
Change: Differentiate report formats of scan and audit reports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 256)
+set (GVMD_DATABASE_VERSION 257)
 
 set (GVMD_SCAP_DATABASE_VERSION 22)
 

--- a/src/gmp_report_formats.c
+++ b/src/gmp_report_formats.c
@@ -157,6 +157,7 @@ params_options_free (array_t *params_options)
  * @param[out] params            Address for params.
  * @param[out] params_options    Address for param options.
  * @param[out] deprecated        Address for deprecation status.
+ * @param[out] report_type       Address for report type.
  */
 void
 parse_report_format_entity (entity_t report_format,
@@ -165,7 +166,7 @@ parse_report_format_entity (entity_t report_format,
                             char **summary, char **description,
                             char **signature, array_t **files,
                             array_t **params, array_t **params_options,
-                            char **deprecated)
+                            char **deprecated, char **report_type)
 {
   entity_t file, param_entity;
   entities_t children;
@@ -181,6 +182,18 @@ parse_report_format_entity (entity_t report_format,
   *signature = child_or_null (report_format, "signature");
   if (deprecated)
     *deprecated = child_or_null (report_format, "deprecated");
+  if (report_type)
+    *report_type = child_or_null (report_format, "report_type");
+
+  if (*report_type == NULL)
+    *report_type = "scan";
+  else if (strcmp (*report_type, "scan") && strcmp (*report_type, "audit")
+           && strcmp (*report_type, "all"))
+    {
+      g_warning ("report_type for report format %s is invalid.",
+                 *report_format_id);
+      *report_type = "scan";
+    }
 
   *files = make_array ();
   *params = make_array ();
@@ -362,7 +375,7 @@ create_report_format_run (gmp_parser_t *gmp_parser, GError **error)
       && (report_format = entity_child (get_report_formats_response, "report_format")))
     {
       char *import_name, *content_type, *extension, *summary, *description;
-      char *signature;
+      char *signature, *report_type;
       const char *report_format_id;
       array_t *files, *params, *params_options;
 
@@ -371,7 +384,8 @@ create_report_format_run (gmp_parser_t *gmp_parser, GError **error)
       parse_report_format_entity (report_format, &report_format_id,
                                   &import_name, &content_type, &extension,
                                   &summary, &description, &signature, &files,
-                                  &params, &params_options, NULL);
+                                  &params, &params_options, NULL,
+                                  &report_type);
 
       /* Check data, then create report format. */
 
@@ -410,6 +424,7 @@ create_report_format_run (gmp_parser_t *gmp_parser, GError **error)
                                          params,
                                          params_options,
                                          signature,
+                                         report_type,
                                          &new_report_format))
         {
           case -1:

--- a/src/gmp_report_formats.c
+++ b/src/gmp_report_formats.c
@@ -186,13 +186,13 @@ parse_report_format_entity (entity_t report_format,
     *report_type = child_or_null (report_format, "report_type");
 
   if (*report_type == NULL)
-    *report_type = "scan";
+    *report_type = "all";
   else if (strcmp (*report_type, "scan") && strcmp (*report_type, "audit")
            && strcmp (*report_type, "all"))
     {
       g_warning ("report_type for report format %s is invalid.",
                  *report_format_id);
-      *report_type = "scan";
+      *report_type = "all";
     }
 
   *files = make_array ();

--- a/src/gmp_report_formats.h
+++ b/src/gmp_report_formats.h
@@ -43,6 +43,7 @@ params_options_free (array_t *);
 void
 parse_report_format_entity (entity_t, const char **, char **, char **,
                             char **, char **, char **, char **,
-                            array_t **, array_t **, array_t **, char **);
+                            array_t **, array_t **, array_t **, char **,
+                            char **);
 
 #endif /* not _GVMD_GMP_REPORT_FORMATS_H */

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -3241,10 +3241,10 @@ migrate_256_to_257 ()
   // Add new columns
 
   sql ("ALTER TABLE report_formats ADD COLUMN"
-       " report_type text DEFAULT 'scan';");
+       " report_type text DEFAULT 'all';");
 
   sql ("ALTER TABLE report_formats_trash ADD COLUMN"
-       " report_type text DEFAULT 'scan';");
+       " report_type text DEFAULT 'all';");
 
   /* Set the database version to 257. */
 

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -3218,6 +3218,43 @@ migrate_255_to_256 ()
   return 0;
 }
 
+/**
+ * @brief Migrate the database from version 256 to version 257.
+ *
+ * @return 0 success, -1 error.
+ */
+int
+migrate_256_to_257 ()
+{
+  sql_begin_immediate ();
+
+  /* Ensure that the database is currently version 256. */
+
+  if (manage_db_version () != 256)
+    {
+      sql_rollback ();
+      return -1;
+    }
+
+  /* Update the database. */
+
+  // Add new columns
+
+  sql ("ALTER TABLE report_formats ADD COLUMN"
+       " report_type text DEFAULT 'scan';");
+
+  sql ("ALTER TABLE report_formats_trash ADD COLUMN"
+       " report_type text DEFAULT 'scan';");
+
+  /* Set the database version to 257. */
+
+  set_db_version (257);
+
+  sql_commit ();
+
+  return 0;
+}
+
 #undef UPDATE_DASHBOARD_SETTINGS
 
 /**
@@ -3280,6 +3317,7 @@ static migrator_t database_migrators[] = {
   {254, migrate_253_to_254},
   {255, migrate_254_to_255},
   {256, migrate_255_to_256},
+  {257, migrate_256_to_257},
   /* End marker. */
   {-1, NULL}};
 

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -2979,6 +2979,7 @@ create_tables ()
        "  trust_time integer,"
        "  flags integer,"
        "  predefined integer,"
+       "  report_type text,"
        "  creation_time integer,"
        "  modification_time integer);");
 
@@ -3005,6 +3006,7 @@ create_tables ()
         * Feed ("predefined") report formats are not given a new UUID because
         * they are not created if they already exist in the trash. */
        "  original_uuid text,"
+       "  report_type text,"
        "  creation_time integer,"
        "  modification_time integer);");
 

--- a/src/manage_report_formats.c
+++ b/src/manage_report_formats.c
@@ -395,7 +395,7 @@ update_report_format_from_file (report_format_t report_format,
   entity_t entity;
   array_t *files, *params, *params_options;
   char *name, *content_type, *extension, *summary, *description, *signature;
-  char *deprecated;
+  char *deprecated, *report_type;
   const char *report_format_id;
 
   g_debug ("%s: updating %s", __func__, path);
@@ -410,13 +410,13 @@ update_report_format_from_file (report_format_t report_format,
   parse_report_format_entity (entity, &report_format_id, &name,
                               &content_type, &extension, &summary,
                               &description, &signature, &files, &params,
-                              &params_options, &deprecated);
+                              &params_options, &deprecated, &report_type);
 
   /* Update the report format. */
 
   update_report_format (report_format, report_format_id, name, content_type,
                         extension, summary, description, signature, files,
-                        params, params_options, deprecated);
+                        params, params_options, deprecated, report_type);
 
   /* Cleanup. */
 
@@ -487,7 +487,7 @@ create_report_format_from_file (const gchar *path)
   entity_t report_format;
   array_t *files, *params, *params_options;
   char *name, *content_type, *extension, *summary, *description, *signature;
-  char *deprecated;
+  char *deprecated, *report_type;
   const char *report_format_id;
   report_format_t new_report_format;
 
@@ -503,7 +503,7 @@ create_report_format_from_file (const gchar *path)
   parse_report_format_entity (report_format, &report_format_id, &name,
                               &content_type, &extension, &summary,
                               &description, &signature, &files, &params,
-                              &params_options, &deprecated);
+                              &params_options, &deprecated, &report_type);
 
   /* Handle deprecation status */
 
@@ -528,6 +528,7 @@ create_report_format_from_file (const gchar *path)
                                        params_options,
                                        signature,
                                        1,
+                                       report_type,
                                        &new_report_format))
     {
       case 0:

--- a/src/manage_report_formats.h
+++ b/src/manage_report_formats.h
@@ -43,7 +43,8 @@ typedef struct
 int
 create_report_format (const char *, const char *, const char *, const char *,
                       const char *, const char *, array_t *, array_t *,
-                      array_t *, const char *, report_format_t *);
+                      array_t *, const char *, const char *,
+                      report_format_t *);
 
 int
 copy_report_format (const char *, const char *, report_format_t*);
@@ -72,6 +73,9 @@ report_format_content_type (report_format_t);
 
 char *
 report_format_extension (report_format_t);
+
+char *
+report_format_report_type (report_format_t);
 
 int
 report_format_global (report_format_t);
@@ -118,6 +122,9 @@ report_format_iterator_extension (iterator_t *);
 
 const char*
 report_format_iterator_content_type (iterator_t *);
+
+const char*
+report_format_iterator_report_type (iterator_t *);
 
 const char*
 report_format_iterator_description (iterator_t *);

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -843,6 +843,7 @@ add_report_format_params (report_format_t report_format, array_t *params,
  *                             params.  Each item of an inner array is a string,
  *                             the text of an option in a selection.
  * @param[in]   predefined     Whether report format is from the feed.
+ * @param[in]   report_type    Type of the report.
  * @param[in]   signature      Signature.
  * @param[out]  report_format  Created report format.
  *
@@ -859,12 +860,12 @@ create_report_format_internal (int check_access, int may_exist, int active,
                                const char *summary, const char *description,
                                array_t *files, array_t *params,
                                array_t *params_options, const char *signature,
-                               int predefined,
+                               int predefined, const char * report_type,
                                report_format_t *report_format)
 {
   gchar *quoted_name, *quoted_summary, *quoted_description, *quoted_extension;
   gchar *quoted_content_type, *quoted_signature, *file_name, *dir;
-  gchar *candidate_name, *new_uuid, *uuid_actual;
+  gchar *candidate_name, *new_uuid, *uuid_actual, *quoted_report_type;
   report_format_t report_format_rowid;
   int index, num, ret;
   gchar *format_signature = NULL;
@@ -1126,15 +1127,17 @@ create_report_format_internal (int check_access, int may_exist, int active,
   quoted_extension = extension ? sql_quote (extension) : NULL;
   quoted_content_type = content_type ? sql_quote (content_type) : NULL;
   quoted_signature = signature ? sql_quote (signature) : NULL;
+  quoted_report_type = report_type ? sql_quote (report_type) : NULL;
   g_free (format_signature);
 
   sql ("INSERT INTO report_formats"
        " (uuid, name, owner, summary, description, extension, content_type,"
-       "  signature, trust, trust_time, flags, predefined, creation_time,"
+       "  signature, trust, trust_time, flags, predefined,"
+       "  report_type, creation_time,"
        "  modification_time)"
        " VALUES ('%s', '%s',"
        " (SELECT id FROM users WHERE users.uuid = '%s'),"
-       " '%s', '%s', '%s', '%s', '%s', %i, %i, %i, %i, m_now (), m_now ());",
+       " '%s', '%s', '%s', '%s', '%s', %i, %i, %i, %i, '%s', m_now (), m_now ());",
        new_uuid ? new_uuid : uuid,
        quoted_name,
        current_credentials.uuid,
@@ -1146,7 +1149,8 @@ create_report_format_internal (int check_access, int may_exist, int active,
        format_trust,
        time (NULL),
        active ? REPORT_FORMAT_FLAG_ACTIVE : 0,
-       predefined ? 1 : 0);
+       predefined ? 1 : 0,
+       quoted_report_type ? quoted_report_type : "");
 
   g_free (new_uuid);
   g_free (quoted_summary);
@@ -1155,6 +1159,7 @@ create_report_format_internal (int check_access, int may_exist, int active,
   g_free (quoted_content_type);
   g_free (quoted_signature);
   g_free (quoted_name);
+  g_free (quoted_report_type);
 
   /* Add params to database. */
 
@@ -1195,6 +1200,7 @@ create_report_format_internal (int check_access, int may_exist, int active,
  *                             params.  Each item of an inner array is a string,
  *                             the text of an option in a selection.
  * @param[in]   signature      Signature.
+ * @param[in]   report_type    Type of the report.
  * @param[out]  report_format  Created report format.
  *
  * @return 0 success, 2 empty file name, 3 param value
@@ -1208,7 +1214,8 @@ create_report_format (const char *uuid, const char *name,
                       const char *content_type, const char *extension,
                       const char *summary, const char *description,
                       array_t *files, array_t *params, array_t *params_options,
-                      const char *signature, report_format_t *report_format)
+                      const char *signature, const char* report_type,
+                      report_format_t *report_format)
 {
   return create_report_format_internal (1, /* Check permission. */
                                         1, /* Allow existing report format. */
@@ -1218,6 +1225,7 @@ create_report_format (const char *uuid, const char *name,
                                         summary, description, files, params,
                                         params_options, signature,
                                         0, /* Predefined. */
+                                        report_type,
                                         report_format);
 }
 
@@ -1239,6 +1247,7 @@ create_report_format (const char *uuid, const char *name,
  *                             the text of an option in a selection.
  * @param[in]   signature      Signature.
  * @param[in]   predefined     Whether report format is from the feed.
+ * @param[in]   report_type    Type of the report.
  * @param[out]  report_format  Created report format.
  *
  * @return 0 success, 1 report format exists, 2 empty file name, 3 param value
@@ -1253,7 +1262,8 @@ create_report_format_no_acl (const char *uuid, const char *name,
                              const char *summary, const char *description,
                              array_t *files, array_t *params,
                              array_t *params_options, const char *signature,
-                             int predefined, report_format_t *report_format)
+                             int predefined, const char *report_type,
+                             report_format_t *report_format)
 {
   return create_report_format_internal (0, /* Check permission. */
                                         0, /* Allow existing report format. */
@@ -1262,7 +1272,8 @@ create_report_format_no_acl (const char *uuid, const char *name,
                                         uuid, name, content_type, extension,
                                         summary, description, files, params,
                                         params_options, signature,
-                                        predefined, report_format);
+                                        predefined, report_type,
+                                        report_format);
 }
 
 /**
@@ -1407,7 +1418,7 @@ copy_report_format (const char* name, const char* source_uuid,
 
   ret = copy_resource_lock ("report_format", name, NULL, source_uuid,
                             "extension, content_type, summary, description,"
-                            " signature, trust, trust_time, flags",
+                            " signature, trust, trust_time, flags, report_type",
                             1, &new, &old);
   if (ret)
     {
@@ -1881,11 +1892,13 @@ delete_report_format (const char *report_format_id, int ultimate)
       sql ("INSERT INTO report_formats_trash"
            " (uuid, owner, name, extension, content_type, summary,"
            "  description, signature, trust, trust_time, flags, original_uuid,"
-           "  predefined, creation_time, modification_time)"
+           "  predefined, report_type, creation_time,"
+           "  modification_time)"
            " SELECT"
            "  %s, owner, name, extension, content_type, summary,"
            "  description, signature, trust, trust_time, flags, uuid,"
-           "  predefined, creation_time, modification_time"
+           "  predefined, report_type, creation_time,"
+           "  modification_time"
            " FROM report_formats"
            " WHERE id = %llu;",
            report_format_predefined (report_format) ? "uuid" : "make_uuid ()",
@@ -2007,11 +2020,11 @@ restore_report_format (const char *report_format_id)
   sql ("INSERT INTO report_formats"
        " (uuid, owner, name, extension, content_type, summary,"
        "  description, signature, trust, trust_time, flags,"
-       "  predefined, creation_time, modification_time)"
+       "  predefined, report_type, creation_time, modification_time)"
        " SELECT"
        "  original_uuid, owner, name, extension, content_type, summary,"
        "  description, signature, trust, trust_time, flags,"
-       "  predefined, creation_time, modification_time"
+       "  predefined, report_type, creation_time, modification_time"
        " FROM report_formats_trash"
        " WHERE id = %llu;",
        resource);
@@ -2271,6 +2284,21 @@ char *
 report_format_extension (report_format_t report_format)
 {
   return sql_string ("SELECT extension FROM report_formats WHERE id = %llu;",
+                     report_format);
+}
+
+/**
+ * @brief Return the report type of a report format.
+ *
+ * @param[in]  report_format  Report format.
+ *
+ * @return Newly allocated report type.
+ */
+char *
+report_format_report_type (report_format_t report_format)
+{
+  return sql_string ("SELECT report_type FROM report_formats"
+                     " WHERE id = %llu;",
                      report_format);
 }
 
@@ -2743,7 +2771,7 @@ report_format_trust (report_format_t report_format)
 #define REPORT_FORMAT_ITERATOR_FILTER_COLUMNS                                 \
  { ANON_GET_ITERATOR_FILTER_COLUMNS, "name", "extension", "content_type",     \
    "summary", "description", "trust", "trust_time", "active", "predefined",   \
-   "configurable", NULL }
+   "configurable", "report_type", NULL }
 
 /**
  * @brief Report Format iterator columns.
@@ -2779,6 +2807,7 @@ report_format_trust (report_format_t report_format)
    },                                                                   \
    { "flags & 1", "active", KEYWORD_TYPE_INTEGER },                     \
    { "predefined", NULL, KEYWORD_TYPE_INTEGER },                        \
+   { "report_type", NULL, KEYWORD_TYPE_STRING },                        \
    { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                                 \
  }
 
@@ -2817,6 +2846,7 @@ report_format_trust (report_format_t report_format)
    },                                                                   \
    { "flags & 1", "active", KEYWORD_TYPE_INTEGER },                     \
    { "predefined", NULL, KEYWORD_TYPE_INTEGER },                        \
+   { "report_type", NULL, KEYWORD_TYPE_STRING },                        \
    { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                                 \
  }
 
@@ -3006,6 +3036,16 @@ report_format_iterator_active (iterator_t* iterator)
   return (iterator_int64 (iterator, GET_ITERATOR_COLUMN_COUNT + 8)
           & REPORT_FORMAT_FLAG_ACTIVE) ? 1 : 0;
 }
+
+/**
+ * @brief Get the report type from a report format iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return Report type, or NULL if iteration is complete.  Freed by
+ *         cleanup_iterator.
+ */
+DEF_ACCESS (report_format_iterator_report_type, GET_ITERATOR_COLUMN_COUNT + 10);
 
 /**
  * @brief Initialise a Report Format alert iterator.
@@ -4428,6 +4468,7 @@ delete_report_format_dirs_user (const gchar *user_id, iterator_t *rows)
  * @param[in]  params           New params.
  * @param[in]  params_options   Options for new params.
  * @param[in]  deprecated       New deprecation status.
+ * @param[in]  report_type      New report type.
  */
 void
 update_report_format (report_format_t report_format, const gchar *report_id,
@@ -4435,11 +4476,12 @@ update_report_format (report_format_t report_format, const gchar *report_id,
                       const gchar *content_type, const gchar *extension,
                       const gchar *summary, const gchar *description,
                       const gchar *signature, array_t *files, array_t *params,
-                      array_t *params_options, const char *deprecated)
+                      array_t *params_options, const char *deprecated,
+                      const char *report_type)
 {
   int ret;
   gchar *quoted_name, *quoted_content_type, *quoted_extension, *quoted_summary;
-  gchar *quoted_description, *quoted_signature;
+  gchar *quoted_description, *quoted_signature, *quoted_report_type;
 
   sql_begin_immediate ();
 
@@ -4449,10 +4491,12 @@ update_report_format (report_format_t report_format, const gchar *report_id,
   quoted_summary = sql_quote (summary ? summary : "");
   quoted_description = sql_quote (description ? description : "");
   quoted_signature = sql_quote (signature ? signature : "");
+  quoted_report_type = sql_quote (report_type ? report_type : "");
   sql ("UPDATE report_formats"
        " SET name = '%s', content_type = '%s', extension = '%s',"
        "     summary = '%s', description = '%s', signature = '%s',"
-       "     predefined = 1, modification_time = m_now ()"
+       "     predefined = 1, report_type = '%s',"
+       "     modification_time = m_now ()"
        " WHERE id = %llu;",
        quoted_name,
        quoted_content_type,
@@ -4460,6 +4504,7 @@ update_report_format (report_format_t report_format, const gchar *report_id,
        quoted_summary,
        quoted_description,
        quoted_signature,
+       quoted_report_type,
        report_format);
   g_free (quoted_name);
   g_free (quoted_content_type);
@@ -4467,6 +4512,7 @@ update_report_format (report_format_t report_format, const gchar *report_id,
   g_free (quoted_summary);
   g_free (quoted_description);
   g_free (quoted_signature);
+  g_free (quoted_report_type);
 
   /* Replace the params. */
 

--- a/src/manage_sql_report_formats.h
+++ b/src/manage_sql_report_formats.h
@@ -37,7 +37,7 @@ int
 create_report_format_no_acl (const char *, const char *, const char *,
                              const char *, const char *, const char *,
                              array_t *, array_t *, array_t *, const char *,
-                             int, report_format_t *);
+                             int, const char *, report_format_t *);
 
 const char**
 report_format_filter_columns ();
@@ -71,7 +71,7 @@ void
 update_report_format (report_format_t, const gchar *, const gchar *,
                       const gchar *, const gchar *, const gchar *,
                       const gchar *, const gchar *, array_t *, array_t *,
-                      array_t *, const gchar *);
+                      array_t *, const gchar *, const gchar *);
 
 int
 report_format_updated_in_feed (report_format_t, const gchar *);

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -17537,6 +17537,17 @@ END:VCALENDAR
             <type>boolean</type>
             <summary>Whether the report format was created from the feed</summary>
           </column>
+          <column>
+            <name>report_type</name>
+            <type>
+              <alts>
+                <alt>scan</alt>
+                <alt>audit</alt>
+                <alt>all</alt>
+              </alts>
+            </type>
+            <summary>The type of the report compatible with the report format</summary>
+          </column>
         </filter_keywords>
       </attrib>
       <attrib>
@@ -17622,6 +17633,7 @@ END:VCALENDAR
           <e>active</e>
           <e>predefined</e>
           <e>configurable</e>
+          <e>report_type</e>
           <o><e>deprecated</e></o>
           <any><e>param</e></any>
         </pattern>
@@ -17934,6 +17946,17 @@ END:VCALENDAR
           <name>configurable</name>
           <summary>Whether the report format can be used with a report config</summary>
           <pattern><t>boolean</t></pattern>
+        </ele>
+        <ele>
+          <name>report_type</name>
+          <summary>The type of the report compatible with the report format</summary>
+          <pattern>
+            <alts>
+              <alt>scan</alt>
+              <alt>audit</alt>
+              <alt>all</alt>
+            </alts>
+          </pattern>
         </ele>
         <ele>
           <name>deprecated</name>


### PR DESCRIPTION
## What

Differentiate between report formats for scan and audit reports based on the new field `report_type` added to the report formats.

GMP command `get_report` will now reject a report format when not consistent with the report type and `get_report_formats` will return the `report_type` for a report format.

Report formats can now be filtered using `report_type` with values `scan`, `audit` or `all`.

Requires [#168](https://github.com/greenbone/report-formats/pull/168)

## Why
To restrict the use of report formats to the appropriate report type.

## References
GEA-873


