### PR TITLE
Change: Set affected-products-query-size to 20000

### DIFF
--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -14,7 +14,7 @@ It manages the storage of any vulnerability management configurations and of the
 Show help options.
 .TP
 \fB--affected-products-query-size=\fINUMBER\fB\f1
-Sets the number of CVEs to process per query when updating the affected products. Defaults to 1000. 
+Sets the number of CVEs to process per query when updating the affected products. Defaults to 20000.
 .TP
 \fB--auth-timeout=\fITIMEOUT\fB\f1
 Sets the authentication timeout time for the cached authentication. Defaults to 15 minutes. 

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -57,7 +57,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <optdesc>
         <p>
           Sets the number of CVEs to process per query when updating
-          the affected products. Defaults to 1000.
+          the affected products. Defaults to 20000.
         </p>
       </optdesc>
     </option>

--- a/doc/gvmd.html
+++ b/doc/gvmd.html
@@ -40,7 +40,7 @@
       <p><b>--affected-products-query-size=<em>NUMBER</em></b></p>
       
         <p>Sets the number of CVEs to process per query when updating
-          the affected products. Defaults to 1000.</p>
+          the affected products. Defaults to 20000.</p>
       
     
     

--- a/src/manage_sql_secinfo.h
+++ b/src/manage_sql_secinfo.h
@@ -168,7 +168,7 @@
 /**
  * @brief Default for affected_products_query_size.
  */
-#define AFFECTED_PRODUCTS_QUERY_SIZE_DEFAULT 1000
+#define AFFECTED_PRODUCTS_QUERY_SIZE_DEFAULT 20000
 
 /**
  * @brief Default for secinfo_copy.


### PR DESCRIPTION
## What
The default value for the --affected-products-query-size option is increased to 20000.

## Why
Tests have shown this to increase the speed of the affected products update while still keeping the memory/disk usage limited.

## References
GEA-899
