### PR TITLE
Change: Use SQL COPY for loading CVEs

### DIFF
--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -3914,7 +3914,7 @@ drop_indexes_cve ()
   sql ("DROP INDEX IF EXISTS scap2.cves_by_creation_time_idx");
   sql ("DROP INDEX IF EXISTS scap2.cves_by_modification_time_idx");
   sql ("DROP INDEX IF EXISTS scap2.cves_by_severity");
-  
+
   sql ("DROP INDEX IF EXISTS scap2.cpe_match_nodes_by_root_id");
 
   sql ("DROP INDEX IF EXISTS scap2.cpe_nodes_match_criteria_by_node_id");

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -3820,9 +3820,7 @@ manage_db_add_constraints (const gchar *name)
       sql ("ALTER TABLE scap2.affected_products"
            " ALTER cve SET NOT NULL,"
            " ALTER cpe SET NOT NULL,"
-           " ADD UNIQUE (cve, cpe),"
-           " ADD FOREIGN KEY(cve) REFERENCES cves(id),"
-           " ADD FOREIGN KEY(cpe) REFERENCES cpes(id);");
+           " ADD UNIQUE (cve, cpe);");
 
       sql ("ALTER TABLE scap2.epss_scores"
            " ALTER cve SET NOT NULL,"
@@ -3885,6 +3883,44 @@ drop_indexes_cpe ()
 }
 
 /**
+ * @brief Create the indexes for the CVEs tables in the scap2 schema.
+ */
+void
+create_indexes_cve ()
+{
+  sql ("CREATE UNIQUE INDEX cve_idx"
+       " ON scap2.cves (name);");
+  sql ("CREATE INDEX cves_by_creation_time_idx"
+       " ON scap2.cves (creation_time);");
+  sql ("CREATE INDEX cves_by_modification_time_idx"
+       " ON scap2.cves (modification_time);");
+  sql ("CREATE INDEX cves_by_severity"
+       " ON scap2.cves (severity);");
+
+  sql ("CREATE INDEX cpe_match_nodes_by_root_id"
+       " ON scap2.cpe_match_nodes(root_id);");
+
+  sql ("CREATE INDEX cpe_nodes_match_criteria_by_node_id"
+       " ON scap2.cpe_nodes_match_criteria(node_id);");
+}
+
+/**
+ * @brief Remove the indexes for the CVEs tables in the scap2 schema.
+ */
+void
+drop_indexes_cve ()
+{
+  sql ("DROP INDEX IF EXISTS scap2.cve_idx");
+  sql ("DROP INDEX IF EXISTS scap2.cves_by_creation_time_idx");
+  sql ("DROP INDEX IF EXISTS scap2.cves_by_modification_time_idx");
+  sql ("DROP INDEX IF EXISTS scap2.cves_by_severity");
+  
+  sql ("DROP INDEX IF EXISTS scap2.cpe_match_nodes_by_root_id");
+
+  sql ("DROP INDEX IF EXISTS scap2.cpe_nodes_match_criteria_by_node_id");
+}
+
+/**
  * @brief Init external database.
  *
  * @param[in]  name  Name.  Currently only "scap".
@@ -3896,22 +3932,9 @@ manage_db_init_indexes (const gchar *name)
 {
   if (strcasecmp (name, "scap") == 0)
     {
-      sql ("CREATE UNIQUE INDEX cve_idx"
-           " ON scap2.cves (name);");
-      sql ("CREATE INDEX cves_by_creation_time_idx"
-           " ON scap2.cves (creation_time);");
-      sql ("CREATE INDEX cves_by_modification_time_idx"
-           " ON scap2.cves (modification_time);");
-      sql ("CREATE INDEX cves_by_severity"
-           " ON scap2.cves (severity);");
-
       create_indexes_cpe ();
 
-      sql ("CREATE INDEX cpe_match_nodes_by_root_id"
-           " ON scap2.cpe_match_nodes(root_id);");
-
-      sql ("CREATE INDEX cpe_nodes_match_criteria_by_node_id"
-           " ON scap2.cpe_nodes_match_criteria(node_id);");
+      create_indexes_cve ();
 
       sql ("CREATE INDEX afp_cpe_idx"
            " ON scap2.affected_products (cpe);");

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -549,4 +549,10 @@ create_indexes_cpe ();
 void
 drop_indexes_cpe ();
 
+void
+create_indexes_cve ();
+
+void
+drop_indexes_cve ();
+
 #endif /* not _GVMD_MANAGE_SQL_H */

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -3762,7 +3762,7 @@ handle_cve_references (resource_t cve_db_id, char *cve_id,
   int ret = 0;
   cJSON *reference_item;
   static GHashTable *urls = NULL;
-  
+
   if (secinfo_fast_init && urls == NULL)
     urls = g_hash_table_new (g_str_hash, g_str_equal);
 
@@ -3816,7 +3816,7 @@ get_cve_configuration_fields (cJSON* configuration_item,
                               int *negate)
 {
   *nodes_array = cJSON_GetObjectItemCaseSensitive (configuration_item,
-                                                  "nodes");
+                                                   "nodes");
   if (!cJSON_IsArray (*nodes_array))
     {
       g_warning ("%s: 'nodes' field missing or not an array for %s.",
@@ -4169,7 +4169,7 @@ handle_cve_cpe_nodes_match_criteria (resource_t cve_db_id,
   if (vulnerable)
     {
       iterator_t cpe_matches;
-      gchar *quoted_match_criteria_id 
+      gchar *quoted_match_criteria_id
         = sql_quote (match_criteria_id);
 
       init_cpe_match_string_matches_iterator (
@@ -4402,7 +4402,7 @@ get_cve_json_fields (cJSON *vuln_item,
   cJSON *descriptions_json = NULL;
   cJSON *description_item_json = NULL;
   gboolean cvss_metric_is_primary = FALSE;
-  
+
   *cve_id = *vector = NULL;
   *published_time = *modified_time = 0;
   *score_dbl = SEVERITY_MISSING;
@@ -4907,7 +4907,7 @@ update_cve_json (const gchar *cve_path,
       sql_begin_immediate ();
       drop_indexes_cve ();
       if (secinfo_fast_init)
-        { 
+        {
           init_cve_copy_buffers (&cves_copy_buffer,
                                  &cve_refs_copy_buffer,
                                  &cpe_match_nodes_copy_buffer,

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -4068,8 +4068,8 @@ handle_cve_affected_product (resource_t cve_db_id,
       escaped_cpe_name_id = sql_copy_escape (match_cpe_name_id);
 
       g_hash_table_insert (hashed_cpes,
-                            g_strdup (match_cpe_name),
-                            GINT_TO_POINTER (*cpe_db_id_ptr));
+                           g_strdup (match_cpe_name),
+                           GINT_TO_POINTER (*cpe_db_id_ptr));
       if (db_copy_buffer_append_printf (cve_cpes_copy_buffer,
                                         "%s\t%s\t%lld\t%lld\t0\t%s\n",
                                         escaped_cpe_name,
@@ -4748,41 +4748,41 @@ init_cve_copy_buffers (db_copy_buffer_t *cves_buffer,
   int buffer_size = setting_secinfo_sql_buffer_threshold_bytes() / 6;
   db_copy_buffer_init
     (cves_buffer,
-      buffer_size,
-      "COPY scap2.cves ("
-      "  id, uuid, name, creation_time, modification_time,"
-      "  severity, description, cvss_vector, products"
-      ") FROM STDIN;");
+     buffer_size,
+     "COPY scap2.cves ("
+     "  id, uuid, name, creation_time, modification_time,"
+     "  severity, description, cvss_vector, products"
+     ") FROM STDIN;");
   db_copy_buffer_init
     (cve_refs_buffer,
-      buffer_size,
-      "COPY scap2.cve_references ("
-      "  cve_id, url, tags"
-      ") FROM STDIN;");
+     buffer_size,
+     "COPY scap2.cve_references ("
+     "  cve_id, url, tags"
+     ") FROM STDIN;");
   db_copy_buffer_init
     (cpe_match_nodes_buffer,
-      buffer_size,
-      "COPY scap2.cpe_match_nodes ("
-      "  id, root_id, cve_id, operator, negate"
-      ") FROM STDIN;");
+     buffer_size,
+     "COPY scap2.cpe_match_nodes ("
+     "  id, root_id, cve_id, operator, negate"
+     ") FROM STDIN;");
   db_copy_buffer_init
     (cpe_nodes_match_criteria_buffer,
-      buffer_size,
-      "COPY scap2.cpe_nodes_match_criteria ("
-      "  node_id, vulnerable, match_criteria_id"
-      ") FROM STDIN");
+     buffer_size,
+     "COPY scap2.cpe_nodes_match_criteria ("
+     "  node_id, vulnerable, match_criteria_id"
+     ") FROM STDIN");
   db_copy_buffer_init
     (cve_cpes_copy_buffer,
-      buffer_size,
-      "COPY scap2.cpes ("
-      "  uuid, name, creation_time, modification_time, deprecated, cpe_name_id"
-      ") FROM STDIN");
+     buffer_size,
+     "COPY scap2.cpes ("
+     "  uuid, name, creation_time, modification_time, deprecated, cpe_name_id"
+     ") FROM STDIN");
   db_copy_buffer_init
     (affected_products_copy_buffer,
-      buffer_size,
-      "COPY scap2.affected_products ("
-      "  cve, cpe"
-      ") FROM STDIN");
+     buffer_size,
+     "COPY scap2.affected_products ("
+     "  cve, cpe"
+     ") FROM STDIN");
 }
 
 /**


### PR DESCRIPTION
## What
When loading the CVEs with secinfo_fast_init enabled, COPY statements will be used to load the CVEs, including references, configurations and affected products.

## Why
This is much faster than using INSERT and UPDATE statements.

## References
GEA-928