### PR TITLE
Change: Handle timeout more like other VT prefs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 257)
+set (GVMD_DATABASE_VERSION 258)
 
 set (GVMD_SCAP_DATABASE_VERSION 22)
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -2828,19 +2828,12 @@ launch_osp_openvas_task (task_t task, target_t target, const char *scan_id,
                                 g_strdup (name),
                                 g_strdup (osp_value));
         }
-      /* Timeouts are stored as SERVER_PREFS, but are actually
-         script preferences. This prefs is converted into a
-         script preference to be sent to the scanner. */
       else if (name && value && g_str_has_prefix (name, "timeout."))
         {
-          char **oid = NULL;
-          osp_vt_single_t *osp_vt = NULL;
-
-          oid = g_strsplit (name, ".", 2);
-          osp_vt = g_hash_table_lookup (vts_hash_table, oid[1]);
-          if (osp_vt)
-            osp_vt_single_add_value (osp_vt, "0", value);
-          g_strfreev (oid);
+          /* Timeouts used to be stored as SERVER_PREFS, but were
+           * converted into a script preference to be sent to the scanner. */
+          g_warning ("%s: Timeout preference using obsolete format: %s",
+                     __func__, name);
         }
 
     }
@@ -6565,7 +6558,7 @@ get_nvt_xml (iterator_t *nvts, int details, int pref_count,
                              timeout ? timeout : "",
                              default_timeout ? default_timeout : "");
 
-          init_nvt_preference_iterator (&prefs, nvt_oid);
+          init_nvt_preference_iterator (&prefs, nvt_oid, FALSE);
           while (next (&prefs))
             buffer_config_preference_xml (buffer, &prefs, config, 1);
           cleanup_iterator (&prefs);

--- a/src/manage.h
+++ b/src/manage.h
@@ -2219,7 +2219,7 @@ void
 manage_nvt_preferences_enable ();
 
 void
-init_nvt_preference_iterator (iterator_t*, const char*);
+init_nvt_preference_iterator (iterator_t*, const char*, gboolean);
 
 const char*
 nvt_preference_iterator_name (iterator_t*);

--- a/src/manage_configs.h
+++ b/src/manage_configs.h
@@ -156,18 +156,6 @@ int
 manage_set_config_families (config_t, GPtrArray*, GPtrArray*, GPtrArray*, int,
                             gchar **);
 
-void
-init_config_timeout_iterator (iterator_t*, config_t);
-
-const char*
-config_timeout_iterator_oid (iterator_t *);
-
-const char*
-config_timeout_iterator_nvt_name (iterator_t *);
-
-const char*
-config_timeout_iterator_value (iterator_t *);
-
 gboolean
 configs_feed_dir_exists ();
 

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -3255,6 +3255,56 @@ migrate_256_to_257 ()
   return 0;
 }
 
+/**
+ * @brief Migrate the database from version 256 to version 257.
+ *
+ * @return 0 success, -1 error.
+ */
+int
+migrate_257_to_258 ()
+{
+  sql_begin_immediate ();
+
+  /* Ensure that the database is currently version 257. */
+
+  if (manage_db_version () != 257)
+    {
+      sql_rollback ();
+      return -1;
+    }
+
+  /* Update the database. */
+
+  // Change timeout config preferences to normal VT preferences
+
+  sql ("UPDATE config_preferences SET"
+       " type = 'PLUGINS_PREFS',"
+       " name = substring(name, 9) || ':0:entry:timeout',"
+       " pref_nvt = substring(name, 9),"
+       " pref_id = 0,"
+       " pref_type = 'entry',"
+       " pref_name = 'timeout'"
+       " WHERE name LIKE 'timeout.%%' AND type = 'SERVER_PREFS';");
+
+
+  sql ("UPDATE config_preferences_trash SET"
+       " type = 'PLUGINS_PREFS',"
+       " name = substring(name, 9) || ':0:entry:timeout',"
+       " pref_nvt = substring(name, 9),"
+       " pref_id = 0,"
+       " pref_type = 'entry',"
+       " pref_name = 'timeout'"
+       " WHERE name LIKE 'timeout.%%' AND type = 'SERVER_PREFS';");
+
+  /* Set the database version to 258. */
+
+  set_db_version (258);
+
+  sql_commit ();
+
+  return 0;
+}
+
 #undef UPDATE_DASHBOARD_SETTINGS
 
 /**
@@ -3318,6 +3368,7 @@ static migrator_t database_migrators[] = {
   {255, migrate_254_to_255},
   {256, migrate_255_to_256},
   {257, migrate_256_to_257},
+  {258, migrate_257_to_258},
   /* End marker. */
   {-1, NULL}};
 

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -1747,9 +1747,11 @@ manage_nvt_preference_add (const char *name, const char *value,
  *
  * @param[in]  iterator  Iterator.
  * @param[in]  oid       OID of NVT, NULL for all preferences.
+ * @param[in]  include_timeout  Whether to include the timeout preference.
  */
 void
-init_nvt_preference_iterator (iterator_t* iterator, const char *oid)
+init_nvt_preference_iterator (iterator_t* iterator, const char *oid,
+                              gboolean include_timeout)
 {
   if (oid)
     {
@@ -1762,7 +1764,7 @@ init_nvt_preference_iterator (iterator_t* iterator, const char *oid)
                      " AND name != 'nasl_no_signature_check'"
                      " AND name != 'network_targets'"
                      " AND name != 'ntp_save_sessions'"
-                     " AND name != '%s:0:entry:timeout'"
+                     " %s%s%s"
                      " AND name NOT %s 'server_info_%%'"
                      /* Task preferences. */
                      " AND name != 'max_checks'"
@@ -1770,7 +1772,9 @@ init_nvt_preference_iterator (iterator_t* iterator, const char *oid)
                      " ORDER BY name ASC",
                      sql_ilike_op (),
                      quoted_oid,
-                     quoted_oid,
+                     include_timeout ? "" : "AND name != '",
+                     include_timeout ? "" : quoted_oid,
+                     include_timeout ? "" : "'",
                      sql_ilike_op ());
       g_free (quoted_oid);
     }
@@ -1782,13 +1786,15 @@ init_nvt_preference_iterator (iterator_t* iterator, const char *oid)
                    " AND name != 'nasl_no_signature_check'"
                    " AND name != 'network_targets'"
                    " AND name != 'ntp_save_sessions'"
-                   " AND name NOT %s '%%:0:entry:timeout'"
+                   " %s%s%s"
                    " AND name NOT %s 'server_info_%%'"
                    /* Task preferences. */
                    " AND name != 'max_checks'"
                    " AND name != 'max_hosts'"
                    " ORDER BY name ASC",
-                   sql_ilike_op (),
+                   include_timeout ? "" : "AND name NOT ",
+                   include_timeout ? "" : sql_ilike_op (),
+                   include_timeout ? "" : " '%:0:entry:timeout'",
                    sql_ilike_op ());
 }
 
@@ -2327,28 +2333,8 @@ config_insert_preferences (config_t config,
         gchar *quoted_value;
 
         if (preference->name == NULL) return -4;
-        if (strcmp (preference->name, "Timeout") == 0)
-          {
-            gchar *quoted_nvt_oid;
 
-            /* Special Timeout preference. */
-
-            if (preference->nvt_oid == NULL)
-              return -4;
-
-            quoted_nvt_oid = sql_quote (preference->nvt_oid);
-            quoted_value = sql_quote (preference->value);
-
-            sql ("INSERT into config_preferences (config, type, name, value)"
-                 " VALUES (%llu, 'SERVER_PREFS', 'timeout.%s', '%s');",
-                 config,
-                 quoted_nvt_oid,
-                 quoted_value);
-
-            g_free (quoted_nvt_oid);
-            g_free (quoted_value);
-          }
-        else if (preference->type)
+        if (preference->type)
           {
             gchar *quoted_type, *quoted_nvt_oid, *quoted_preference_name;
             gchar *quoted_preference_id;
@@ -2367,7 +2353,13 @@ config_insert_preferences (config_t config,
 
             quoted_nvt_oid = sql_quote (preference->nvt_oid ?: "");
             quoted_preference_id = sql_quote (preference->id ?: "");
-            quoted_preference_name = sql_quote (preference->name);
+
+            // Special handling of "Timeout" preference
+            if (strcmp (preference->name, "Timeout") == 0)
+              quoted_preference_name = g_strdup ("timeout");
+            else
+              quoted_preference_name = sql_quote (preference->name);
+
             quoted_type
               = g_str_has_prefix (preference->type, "osp_")
                   ? sql_quote (preference->type + strlen ("osp_"))
@@ -2736,8 +2728,8 @@ config_nvt_timeout (config_t config, const char *oid)
 {
   return sql_string ("SELECT value FROM config_preferences"
                      " WHERE config = %llu"
-                     " AND type = 'SERVER_PREFS'"
-                     " AND name = 'timeout.%s';",
+                     " AND type = 'PLUGINS_PREFS'"
+                     " AND name = '%s:0:entry:timeout';",
                      config,
                      oid);
 }
@@ -3465,16 +3457,16 @@ init_preference_iterator (iterator_t* iterator,
                  " FROM config_preferences, nvt_preferences"
                  " WHERE config_preferences.config = %llu"
                  " AND config_preferences.type = '%s'"
-                 " AND (config_preferences.name = nvt_preferences.name"
-                 "      OR config_preferences.name LIKE 'timeout.%%')"
                  " AND config_preferences.name != 'max_checks'"
                  " AND config_preferences.name != 'max_hosts'"
                  " UNION"
                  " SELECT nvt_preferences.name, nvt_preferences.value"
                  " FROM nvt_preferences"
                  " LEFT JOIN config_preferences"
-                 "      ON config_preferences.config = %llu AND config_preferences.name = nvt_preferences.name"
-                 " WHERE config_preferences.id IS NULL AND nvt_preferences.name %s",
+                 "      ON config_preferences.config = %llu"
+                 "         AND config_preferences.name = nvt_preferences.name"
+                 " WHERE config_preferences.id IS NULL"
+                 "   AND nvt_preferences.name %s",
                  config,
                  quoted_section,
                  config,
@@ -4160,62 +4152,6 @@ config_task_iterator_readable (iterator_t* iterator)
   if (iterator->done) return 0;
   return iterator_int (iterator, 2);
 }
-
-/**
- * @brief Initialise a config timeout iterator.
- *
- * Iterate over all timeout preferences of NVTs that have timeouts.
- *
- * @param[in]  iterator   Iterator.
- * @param[in]  config     Config.
- */
-void
-init_config_timeout_iterator (iterator_t* iterator, config_t config)
-{
-  init_iterator (iterator,
-                 "SELECT name, substr (name, 9),"
-                 "       (SELECT name FROM nvts"
-                 "        WHERE oid = substr (config_preferences.name, 9)),"
-                 "       value"
-                 " FROM config_preferences"
-                 " WHERE config = %llu"
-                 " AND substr (name, 1, 8) = 'timeout.'"
-                 /* Ensure that the NVT pref comes first, in case an
-                  * error in the GSA added the NVT pref as a Scanner
-                  * pref. */
-                 " ORDER BY type",
-                 config);
-}
-
-/**
- * @brief Get the NVT OID from a config timeout iterator.
- *
- * @param[in]  iterator  Iterator.
- *
- * @return NVT OID, or NULL if iteration is complete.  Freed by
- *         cleanup_iterator.
- */
-DEF_ACCESS (config_timeout_iterator_oid, 1);
-
-/**
- * @brief Get the NVT OID from a config timeout iterator.
- *
- * @param[in]  iterator  Iterator.
- *
- * @return NVT OID, or NULL if iteration is complete.  Freed by
- *         cleanup_iterator.
- */
-DEF_ACCESS (config_timeout_iterator_nvt_name, 2);
-
-/**
- * @brief Get the value from a config timeout iterator.
- *
- * @param[in]  iterator  Iterator.
- *
- * @return Timeout value, or NULL if iteration is complete.  Freed by
- *         cleanup_iterator.
- */
-DEF_ACCESS (config_timeout_iterator_value, 3);
 
 /**
  * @brief Update the cached count and growing information in a config.


### PR DESCRIPTION
## What
The timeout preferences of VTs in configs/policies are now handled more like normal VT preferences instead of a scanner ones, which is also more consistent with default preferences of the VTs themselves.

## Why
This simplifies the special handling needed and fixes timeouts in the config being overwritten by their default values.

## References
GEA-799