### PR TITLE
Add windows and hce local security check families

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -1145,7 +1145,8 @@ user_has_super (const char *, user_t);
   " 'SuSE Local Security Checks',"                 \
   " 'VMware Local Security Checks',"               \
   " 'Ubuntu Local Security Checks',"               \
-  " 'Windows : Microsoft Bulletins'"
+  " 'Windows : Microsoft Bulletins'"               \
+  " 'Windows Local Security Checks',"
 
 /**
  * @brief Whole only families.
@@ -1173,6 +1174,7 @@ user_has_super (const char *, user_t);
     "Solaris Local Security Checks",               \
     "SuSE Local Security Checks",                  \
     "Ubuntu Local Security Checks",                \
+    "Windows Local Security Checks",               \
     NULL }
 
 gboolean

--- a/src/manage.h
+++ b/src/manage.h
@@ -1127,6 +1127,7 @@ user_has_super (const char *, user_t);
   " 'FortiOS Local Security Checks',"              \
   " 'FreeBSD Local Security Checks',"              \
   " 'Gentoo Local Security Checks',"               \
+  " 'HCE Local Security Checks',"                  \
   " 'HP-UX Local Security Checks',"                \
   " 'Huawei EulerOS Local Security Checks',"       \
   " 'JunOS Local Security Checks',"                \
@@ -1158,6 +1159,7 @@ user_has_super (const char *, user_t);
     "Fedora Local Security Checks",                \
     "FreeBSD Local Security Checks",               \
     "Gentoo Local Security Checks",                \
+    "HCE Local Security Checks",                   \
     "HP-UX Local Security Checks",                 \
     "Huawei EulerOS Local Security Checks",        \
     "Mageia Linux Local Security Checks",          \


### PR DESCRIPTION
## What

Adds two families: Windows Local Security Check and HCE Local Security Check.

## Why
In order to mirror the available families provided by VT

## References
https://jira.greenbone.net/browse/GEA-941
https://jira.greenbone.net/browse/GEA-942



