### PR TITLE
Fix: Move misplaced comma in LSC_FAMILY_LIST

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -1145,8 +1145,8 @@ user_has_super (const char *, user_t);
   " 'SuSE Local Security Checks',"                 \
   " 'VMware Local Security Checks',"               \
   " 'Ubuntu Local Security Checks',"               \
-  " 'Windows : Microsoft Bulletins'"               \
-  " 'Windows Local Security Checks',"
+  " 'Windows : Microsoft Bulletins',"              \
+  " 'Windows Local Security Checks'"
 
 /**
  * @brief Whole only families.


### PR DESCRIPTION
## What
Move misplaced comma in LSC_FAMILY_LIST

## Why
The misplaced comma caused SQL errors when loading results
