### PR TITLE
Fix openvasd report results

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -9019,18 +9019,19 @@ handle_openvasd_scan (task_t task, report_t report, const char *scan_id)
 
               set_report_slave_progress (report, progress);
 
-              openvasd_parsed_results (connector, result_start,
-                                       result_end, &results);
-              result_start += g_slist_length (results);
-
-              gvm_sleep(1);
               openvasd_scan_status = openvasd_parsed_scan_status (connector);
               start_time = openvasd_scan_status->start_time;
               end_time = openvasd_scan_status->end_time;
-
               current_status = openvasd_scan_status->status;
               progress = openvasd_scan_status->progress;
               g_free (openvasd_scan_status);
+
+              gvm_sleep (1);
+
+              openvasd_parsed_results (connector, result_start,
+                                       result_end, &results);
+
+              result_start += g_slist_length (results);
 
               parse_openvasd_report (task, report, results, start_time,
                                      end_time);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -60110,25 +60110,31 @@ add_openvasd_result_to_report (openvasd_result_t res, gpointer *results_aux)
       res->detail_value && *res->detail_value)
     port = g_strdup ("general/Host_Details");
   else if (res->port > 0)
-    {
-      char buf[6];
-      snprintf(buf, sizeof(buf) , "%d", res->port);
-      port = g_strdup (buf);
-    }
+    port = g_strdup_printf ("%d/%s", res->port, res->protocol);
+  else
+    port = g_strdup_printf ("general/%s", res->protocol);
 
   /* Add report host if it doesn't exist. */
   manage_report_host_add (rep_aux->report, host, 0, 0);
   if (!strcmp (type, "host_detail"))
     {
       gchar *hash_value = NULL;
-      if (!check_host_detail_exists (rep_aux->report, host, "openvasd", "",
-                                     "openvasd Host Detail", res->detail_name,
-                                     res->detail_value, &hash_value,
+      if (!check_host_detail_exists (rep_aux->report, host,
+                                     res->detail_source_type,
+                                     res->detail_source_name,
+                                     res->detail_source_description,
+                                     res->detail_name,
+                                     res->detail_value,
+                                     &hash_value,
                                      rep_aux->hash_hostdetails))
         {
-          insert_report_host_detail (rep_aux->report, host, "openvasd", "",
-                                     "openvasd Host Detail", res->detail_name,
-                                     res->detail_value, hash_value);
+          insert_report_host_detail (rep_aux->report, host,
+                                     res->detail_source_type,
+                                     res->detail_source_name,
+                                     res->detail_source_description,
+                                     res->detail_name,
+                                     res->detail_value,
+                                     hash_value);
         }
       desc = res->message;
       g_free (hash_value);


### PR DESCRIPTION
## What

The order of the openvasd API calls changed to getting the status of the openvasd scans first, then getting the results.
Fix the parser on ports and hostdetail data in the openvasd results. 

## Why

This is needed to parse the openvasd results properly. 

## References

GEA-937

## Checklist

- [ ] Tests


