### PR TITLE
Add: Add log message when gvmd is ready to accept GMP connections

### DIFF
--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1419,6 +1419,7 @@ serve_and_schedule ()
       exit (EXIT_FAILURE);
     }
   sigmask_normal = &sigmask_current;
+  g_info ("gvmd is ready to accept GMP connections");
   while (1)
     {
       int ret, nfds;


### PR DESCRIPTION
## What

I have added a new log message when the gvmd is ready to accept GMP connections.

## Why

This is needed for understanding if gvmd is not ready or gsad is not configured correctly.

## References


## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


