### PR TITLE
CA certificates

### DIFF
--- a/.docker/setup-mta.sh
+++ b/.docker/setup-mta.sh
@@ -16,7 +16,4 @@ if [ -n "$MTA_HOST" ]; then
     [ -n "$MTA_LOGFILE" ] && echo "logfile $MTA_LOGFILE" >> $CONFIG
     chown gvmd:mail $CONFIG
     chmod 750 $CONFIG
-    echo "installing ca-certificates for tls verification"
-    apt-get update && apt-get install -y ca-certificates
-    update-ca-certificates
 fi

--- a/.docker/setup-mta.sh
+++ b/.docker/setup-mta.sh
@@ -16,4 +16,7 @@ if [ -n "$MTA_HOST" ]; then
     [ -n "$MTA_LOGFILE" ] && echo "logfile $MTA_LOGFILE" >> $CONFIG
     chown gvmd:mail $CONFIG
     chmod 750 $CONFIG
+    echo "installing ca-certificates for tls verification"
+    apt-get update && apt-get install -y ca-certificates
+    update-ca-certificates
 fi

--- a/.github/runtime-dependencies.list
+++ b/.github/runtime-dependencies.list
@@ -49,6 +49,10 @@
 # Required for set up certificates for GVM
 # gnutls-bin
 
+# MTA TLS verification"
+# ca-certificates
+
+ca-certificates
 dpkg
 fakeroot
 nsis


### PR DESCRIPTION
## What

Install CA certificates when MTA is setup for successful TLS verification.

## Why

A secure SMTP configuration requires a successful TLS verification. This silently fails without `ca-certificates` installed.

## References

#2316


