### PR TITLE
Use definitions more consistently for setting UUIDs

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -16176,12 +16176,12 @@ check_db_settings ()
          "  1000);");
 
   if (sql_int ("SELECT count(*) FROM settings"
-               " WHERE uuid = '77ec2444-e7f2-4a80-a59b-f4237782d93f'"
+               " WHERE uuid = '" SETTING_UUID_DYNAMIC_SEVERITY "'"
                " AND " ACL_IS_GLOBAL () ";")
       == 0)
     sql ("INSERT into settings (uuid, owner, name, comment, value)"
          " VALUES"
-         " ('77ec2444-e7f2-4a80-a59b-f4237782d93f', NULL, 'Dynamic Severity',"
+         " ('" SETTING_UUID_DYNAMIC_SEVERITY "', NULL, 'Dynamic Severity',"
          "  'Whether to use dynamic severity scores by default.',"
          "  '0');");
 
@@ -53042,7 +53042,7 @@ modify_setting (const gchar *uuid, const gchar *name,
   if (uuid && (strcmp (uuid, SETTING_UUID_ROWS_PER_PAGE) == 0
                || strcmp (uuid, SETTING_UUID_EXCERPT_SIZE) == 0
                || strcmp (uuid, SETTING_UUID_PREFERRED_LANG) == 0
-               || strcmp (uuid, "77ec2444-e7f2-4a80-a59b-f4237782d93f") == 0
+               || strcmp (uuid, SETTING_UUID_DYNAMIC_SEVERITY) == 0
                || strcmp (uuid, "7eda49c5-096c-4bef-b1ab-d080d87300df") == 0
                || strcmp (uuid, "578a1c14-e2dc-45ef-a591-89d31391d007") == 0
                || strcmp (uuid, "02e294fa-061b-11e6-ae64-28d24461215b") == 0
@@ -53148,7 +53148,7 @@ modify_setting (const gchar *uuid, const gchar *name,
             }
         }
 
-      if (strcmp (uuid, "77ec2444-e7f2-4a80-a59b-f4237782d93f") == 0)
+      if (strcmp (uuid, SETTING_UUID_DYNAMIC_SEVERITY) == 0)
         {
           /* Dynamic Severity */
           current_credentials.dynamic_severity = atoi (value);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -16145,12 +16145,12 @@ static void
 check_db_settings ()
 {
   if (sql_int ("SELECT count(*) FROM settings"
-               " WHERE uuid = '6765549a-934e-11e3-b358-406186ea4fc5'"
+               " WHERE uuid = '" SETTING_UUID_PREFERRED_LANG "'"
                " AND " ACL_IS_GLOBAL () ";")
       == 0)
     sql ("INSERT into settings (uuid, owner, name, comment, value)"
          " VALUES"
-         " ('6765549a-934e-11e3-b358-406186ea4fc5', NULL,"
+         " ('" SETTING_UUID_PREFERRED_LANG "', NULL,"
          "  'User Interface Language',"
          "  'Preferred language to be used in client user interfaces.',"
          "  'Browser Language');");
@@ -53041,7 +53041,7 @@ modify_setting (const gchar *uuid, const gchar *name,
 
   if (uuid && (strcmp (uuid, SETTING_UUID_ROWS_PER_PAGE) == 0
                || strcmp (uuid, SETTING_UUID_EXCERPT_SIZE) == 0
-               || strcmp (uuid, "6765549a-934e-11e3-b358-406186ea4fc5") == 0
+               || strcmp (uuid, SETTING_UUID_PREFERRED_LANG) == 0
                || strcmp (uuid, "77ec2444-e7f2-4a80-a59b-f4237782d93f") == 0
                || strcmp (uuid, "7eda49c5-096c-4bef-b1ab-d080d87300df") == 0
                || strcmp (uuid, "578a1c14-e2dc-45ef-a591-89d31391d007") == 0
@@ -53100,7 +53100,7 @@ modify_setting (const gchar *uuid, const gchar *name,
             }
         }
 
-      if (strcmp (uuid, "6765549a-934e-11e3-b358-406186ea4fc5") == 0)
+      if (strcmp (uuid, SETTING_UUID_PREFERRED_LANG) == 0)
         {
           GRegex *languages_regex;
           gboolean match;

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -16240,12 +16240,12 @@ check_db_settings ()
          "  '10.0');");
 
   if (sql_int ("SELECT count(*) FROM settings"
-               " WHERE uuid = 'a09285b0-2d47-49b6-a4ef-946ee71f1d5c'"
+               " WHERE uuid = '" SETTING_UUID_AUTO_CACHE_REBUILD "'"
                " AND " ACL_IS_GLOBAL () ";")
       == 0)
     sql ("INSERT into settings (uuid, owner, name, comment, value)"
          " VALUES"
-         " ('a09285b0-2d47-49b6-a4ef-946ee71f1d5c', NULL,"
+         " ('" SETTING_UUID_AUTO_CACHE_REBUILD "', NULL,"
          "  'Auto Cache Rebuild',"
          "  'Whether to rebuild report caches on changes affecting severity.',"
          "  '1');");
@@ -52732,7 +52732,7 @@ setting_auto_cache_rebuild_int ()
 {
   return sql_int ("SELECT coalesce"
                   "        ((SELECT value FROM settings"
-                  "          WHERE uuid = 'a09285b0-2d47-49b6-a4ef-946ee71f1d5c'"
+                  "          WHERE uuid = '" SETTING_UUID_AUTO_CACHE_REBUILD "'"
                   "          AND " ACL_USER_OWNS () ""
                   "          ORDER BY coalesce (owner, 0) DESC LIMIT 1),"
                   "         '1');",
@@ -53047,7 +53047,7 @@ modify_setting (const gchar *uuid, const gchar *name,
                || strcmp (uuid, SETTING_UUID_AUTO_REFRESH) == 0
                || strcmp (uuid, "02e294fa-061b-11e6-ae64-28d24461215b") == 0
                || strcmp (uuid, "5a9046cc-0628-11e6-ba53-28d24461215b") == 0
-               || strcmp (uuid, "a09285b0-2d47-49b6-a4ef-946ee71f1d5c") == 0
+               || strcmp (uuid, SETTING_UUID_AUTO_CACHE_REBUILD) == 0
                || strcmp (uuid, "11deb7ff-550b-4950-aacf-06faeb7c61b9") == 0
                || strcmp (uuid, "d9857b7c-1159-4193-9bc0-18fae5473a69") == 0))
     {
@@ -53175,7 +53175,7 @@ modify_setting (const gchar *uuid, const gchar *name,
             current_credentials.default_severity = severity_dbl;
         }
 
-      if (strcmp (uuid, "a09285b0-2d47-49b6-a4ef-946ee71f1d5c") == 0)
+      if (strcmp (uuid, SETTING_UUID_AUTO_CACHE_REBUILD) == 0)
         {
           int value_int;
           /* Auto Cache Rebuild */

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -16207,12 +16207,12 @@ check_db_settings ()
          "  '%%T-%%U');");
 
   if (sql_int ("SELECT count(*) FROM settings"
-               " WHERE uuid = '0872a6ed-4f85-48c5-ac3f-a5ef5e006745'"
+               " WHERE uuid = '" SETTING_UUID_FILE_LIST "'"
                " AND " ACL_IS_GLOBAL () ";")
       == 0)
     sql ("INSERT into settings (uuid, owner, name, comment, value)"
          " VALUES"
-         " ('0872a6ed-4f85-48c5-ac3f-a5ef5e006745', NULL,"
+         " ('" SETTING_UUID_FILE_LIST "', NULL,"
          "  'List Export File Name',"
          "  'File name format string for the export of resource lists.',"
          "  '%%T-%%D');");
@@ -53250,7 +53250,7 @@ modify_setting (const gchar *uuid, const gchar *name,
   /* Export file name format */
   if (uuid
       && (strcmp (uuid, SETTING_UUID_FILE_DETAILS) == 0
-          || strcmp (uuid, "0872a6ed-4f85-48c5-ac3f-a5ef5e006745") == 0
+          || strcmp (uuid, SETTING_UUID_FILE_LIST) == 0
           || strcmp (uuid, "e1a2ae0b-736e-4484-b029-330c9e15b900") == 0))
     {
       gsize value_size;
@@ -53259,7 +53259,7 @@ modify_setting (const gchar *uuid, const gchar *name,
       assert (current_credentials.uuid);
       if (strcmp (uuid, SETTING_UUID_FILE_DETAILS) == 0)
         setting_name = "Details Export File Name";
-      else if (strcmp (uuid, "0872a6ed-4f85-48c5-ac3f-a5ef5e006745") == 0)
+      else if (strcmp (uuid, SETTING_UUID_FILE_LIST) == 0)
         setting_name = "List Export File Name";
       else if (strcmp (uuid, "e1a2ae0b-736e-4484-b029-330c9e15b900") == 0)
         setting_name = "Report Export File Name";

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -53039,17 +53039,17 @@ modify_setting (const gchar *uuid, const gchar *name,
       return ret;
     }
 
-  if (uuid && (strcmp (uuid, SETTING_UUID_ROWS_PER_PAGE) == 0
+  if (uuid && (strcmp (uuid, SETTING_UUID_AUTO_CACHE_REBUILD) == 0
+               || strcmp (uuid, SETTING_UUID_AUTO_REFRESH) == 0
+               || strcmp (uuid, SETTING_UUID_DEFAULT_SEVERITY) == 0
+               || strcmp (uuid, SETTING_UUID_DYNAMIC_SEVERITY) == 0
                || strcmp (uuid, SETTING_UUID_EXCERPT_SIZE) == 0
                || strcmp (uuid, SETTING_UUID_PREFERRED_LANG) == 0
-               || strcmp (uuid, SETTING_UUID_DYNAMIC_SEVERITY) == 0
-               || strcmp (uuid, SETTING_UUID_DEFAULT_SEVERITY) == 0
-               || strcmp (uuid, SETTING_UUID_AUTO_REFRESH) == 0
-               || strcmp (uuid, "02e294fa-061b-11e6-ae64-28d24461215b") == 0
-               || strcmp (uuid, "5a9046cc-0628-11e6-ba53-28d24461215b") == 0
-               || strcmp (uuid, SETTING_UUID_AUTO_CACHE_REBUILD) == 0
+               || strcmp (uuid, SETTING_UUID_ROWS_PER_PAGE) == 0
+               || strcmp (uuid, SETTING_UUID_USER_INTERFACE_DATE_FORMAT) == 0
                || strcmp (uuid, SETTING_UUID_USER_INTERFACE_TIME_FORMAT) == 0
-               || strcmp (uuid, SETTING_UUID_USER_INTERFACE_DATE_FORMAT) == 0))
+               || strcmp (uuid, "02e294fa-061b-11e6-ae64-28d24461215b") == 0
+               || strcmp (uuid, "5a9046cc-0628-11e6-ba53-28d24461215b") == 0))
     {
       gsize value_size;
       gchar *value, *quoted_uuid, *quoted_value;

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -53048,7 +53048,7 @@ modify_setting (const gchar *uuid, const gchar *name,
                || strcmp (uuid, "02e294fa-061b-11e6-ae64-28d24461215b") == 0
                || strcmp (uuid, "5a9046cc-0628-11e6-ba53-28d24461215b") == 0
                || strcmp (uuid, SETTING_UUID_AUTO_CACHE_REBUILD) == 0
-               || strcmp (uuid, "11deb7ff-550b-4950-aacf-06faeb7c61b9") == 0
+               || strcmp (uuid, SETTING_UUID_USER_INTERFACE_TIME_FORMAT) == 0
                || strcmp (uuid, "d9857b7c-1159-4193-9bc0-18fae5473a69") == 0))
     {
       gsize value_size;
@@ -53187,7 +53187,7 @@ modify_setting (const gchar *uuid, const gchar *name,
             }
         }
 
-      if (strcmp (uuid, "11deb7ff-550b-4950-aacf-06faeb7c61b9") == 0)
+      if (strcmp (uuid, SETTING_UUID_USER_INTERFACE_TIME_FORMAT) == 0)
         {
           /* User Interface Time Format */
           if (strcmp (value, "12") && strcmp (value, "24")

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -16186,12 +16186,12 @@ check_db_settings ()
          "  '0');");
 
   if (sql_int ("SELECT count(*) FROM settings"
-               " WHERE uuid = '578a1c14-e2dc-45ef-a591-89d31391d007'"
+               " WHERE uuid = '" SETTING_UUID_AUTO_REFRESH "'"
                " AND " ACL_IS_GLOBAL () ";")
       == 0)
     sql ("INSERT into settings (uuid, owner, name, comment, value)"
          " VALUES"
-         " ('578a1c14-e2dc-45ef-a591-89d31391d007', NULL, 'Auto-Refresh',"
+         " ('" SETTING_UUID_AUTO_REFRESH "', NULL, 'Auto-Refresh',"
          "  'The delay between automatic page refreshs in seconds.',"
          "  '0');");
 
@@ -53044,7 +53044,7 @@ modify_setting (const gchar *uuid, const gchar *name,
                || strcmp (uuid, SETTING_UUID_PREFERRED_LANG) == 0
                || strcmp (uuid, SETTING_UUID_DYNAMIC_SEVERITY) == 0
                || strcmp (uuid, SETTING_UUID_DEFAULT_SEVERITY) == 0
-               || strcmp (uuid, "578a1c14-e2dc-45ef-a591-89d31391d007") == 0
+               || strcmp (uuid, SETTING_UUID_AUTO_REFRESH) == 0
                || strcmp (uuid, "02e294fa-061b-11e6-ae64-28d24461215b") == 0
                || strcmp (uuid, "5a9046cc-0628-11e6-ba53-28d24461215b") == 0
                || strcmp (uuid, "a09285b0-2d47-49b6-a4ef-946ee71f1d5c") == 0

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -16196,12 +16196,12 @@ check_db_settings ()
          "  '0');");
 
   if (sql_int ("SELECT count(*) FROM settings"
-               " WHERE uuid = 'a6ac88c5-729c-41ba-ac0a-deea4a3441f2'"
+               " WHERE uuid = '" SETTING_UUID_FILE_DETAILS "'"
                " AND " ACL_IS_GLOBAL () ";")
       == 0)
     sql ("INSERT into settings (uuid, owner, name, comment, value)"
          " VALUES"
-         " ('a6ac88c5-729c-41ba-ac0a-deea4a3441f2', NULL,"
+         " ('" SETTING_UUID_FILE_DETAILS "', NULL,"
          "  'Details Export File Name',"
          "  'File name format string for the export of resource details.',"
          "  '%%T-%%U');");
@@ -53249,7 +53249,7 @@ modify_setting (const gchar *uuid, const gchar *name,
 
   /* Export file name format */
   if (uuid
-      && (strcmp (uuid, "a6ac88c5-729c-41ba-ac0a-deea4a3441f2") == 0
+      && (strcmp (uuid, SETTING_UUID_FILE_DETAILS) == 0
           || strcmp (uuid, "0872a6ed-4f85-48c5-ac3f-a5ef5e006745") == 0
           || strcmp (uuid, "e1a2ae0b-736e-4484-b029-330c9e15b900") == 0))
     {
@@ -53257,7 +53257,7 @@ modify_setting (const gchar *uuid, const gchar *name,
       gchar *value, *quoted_value;
 
       assert (current_credentials.uuid);
-      if (strcmp (uuid, "a6ac88c5-729c-41ba-ac0a-deea4a3441f2") == 0)
+      if (strcmp (uuid, SETTING_UUID_FILE_DETAILS) == 0)
         setting_name = "Details Export File Name";
       else if (strcmp (uuid, "0872a6ed-4f85-48c5-ac3f-a5ef5e006745") == 0)
         setting_name = "List Export File Name";

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -16218,12 +16218,12 @@ check_db_settings ()
          "  '%%T-%%D');");
 
   if (sql_int ("SELECT count(*) FROM settings"
-               " WHERE uuid = 'e1a2ae0b-736e-4484-b029-330c9e15b900'"
+               " WHERE uuid = '" SETTING_UUID_FILE_REPORT "'"
                " AND " ACL_IS_GLOBAL () ";")
       == 0)
     sql ("INSERT into settings (uuid, owner, name, comment, value)"
          " VALUES"
-         " ('e1a2ae0b-736e-4484-b029-330c9e15b900', NULL,"
+         " ('" SETTING_UUID_FILE_REPORT "', NULL,"
          "  'Report Export File Name',"
          "  'File name format string for the export of reports.',"
          "  '%%T-%%U');");
@@ -53251,7 +53251,7 @@ modify_setting (const gchar *uuid, const gchar *name,
   if (uuid
       && (strcmp (uuid, SETTING_UUID_FILE_DETAILS) == 0
           || strcmp (uuid, SETTING_UUID_FILE_LIST) == 0
-          || strcmp (uuid, "e1a2ae0b-736e-4484-b029-330c9e15b900") == 0))
+          || strcmp (uuid, SETTING_UUID_FILE_REPORT) == 0))
     {
       gsize value_size;
       gchar *value, *quoted_value;
@@ -53261,7 +53261,7 @@ modify_setting (const gchar *uuid, const gchar *name,
         setting_name = "Details Export File Name";
       else if (strcmp (uuid, SETTING_UUID_FILE_LIST) == 0)
         setting_name = "List Export File Name";
-      else if (strcmp (uuid, "e1a2ae0b-736e-4484-b029-330c9e15b900") == 0)
+      else if (strcmp (uuid, SETTING_UUID_FILE_REPORT) == 0)
         setting_name = "Report Export File Name";
       else
         return -1;

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -53049,7 +53049,7 @@ modify_setting (const gchar *uuid, const gchar *name,
                || strcmp (uuid, "5a9046cc-0628-11e6-ba53-28d24461215b") == 0
                || strcmp (uuid, SETTING_UUID_AUTO_CACHE_REBUILD) == 0
                || strcmp (uuid, SETTING_UUID_USER_INTERFACE_TIME_FORMAT) == 0
-               || strcmp (uuid, "d9857b7c-1159-4193-9bc0-18fae5473a69") == 0))
+               || strcmp (uuid, SETTING_UUID_USER_INTERFACE_DATE_FORMAT) == 0))
     {
       gsize value_size;
       gchar *value, *quoted_uuid, *quoted_value;
@@ -53198,7 +53198,7 @@ modify_setting (const gchar *uuid, const gchar *name,
             }
         }
 
-      if (strcmp (uuid, "d9857b7c-1159-4193-9bc0-18fae5473a69") == 0)
+      if (strcmp (uuid, SETTING_UUID_USER_INTERFACE_DATE_FORMAT) == 0)
         {
           /* User Interface Date Format */
           if (strcmp (value, "wmdy") && strcmp (value, "wdmy")

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -16229,12 +16229,12 @@ check_db_settings ()
          "  '%%T-%%U');");
 
   if (sql_int ("SELECT count(*) FROM settings"
-               " WHERE uuid = '7eda49c5-096c-4bef-b1ab-d080d87300df'"
+               " WHERE uuid = '" SETTING_UUID_DEFAULT_SEVERITY "'"
                " AND " ACL_IS_GLOBAL () ";")
       == 0)
     sql ("INSERT into settings (uuid, owner, name, comment, value)"
          " VALUES"
-         " ('7eda49c5-096c-4bef-b1ab-d080d87300df', NULL,"
+         " ('" SETTING_UUID_DEFAULT_SEVERITY "', NULL,"
          "  'Default Severity',"
          "  'Severity to use if none is specified or available from SecInfo.',"
          "  '10.0');");
@@ -53043,7 +53043,7 @@ modify_setting (const gchar *uuid, const gchar *name,
                || strcmp (uuid, SETTING_UUID_EXCERPT_SIZE) == 0
                || strcmp (uuid, SETTING_UUID_PREFERRED_LANG) == 0
                || strcmp (uuid, SETTING_UUID_DYNAMIC_SEVERITY) == 0
-               || strcmp (uuid, "7eda49c5-096c-4bef-b1ab-d080d87300df") == 0
+               || strcmp (uuid, SETTING_UUID_DEFAULT_SEVERITY) == 0
                || strcmp (uuid, "578a1c14-e2dc-45ef-a591-89d31391d007") == 0
                || strcmp (uuid, "02e294fa-061b-11e6-ae64-28d24461215b") == 0
                || strcmp (uuid, "5a9046cc-0628-11e6-ba53-28d24461215b") == 0
@@ -53161,7 +53161,7 @@ modify_setting (const gchar *uuid, const gchar *name,
           current_credentials.excerpt_size = atoi (value);
         }
 
-      if (strcmp (uuid, "7eda49c5-096c-4bef-b1ab-d080d87300df") == 0)
+      if (strcmp (uuid, SETTING_UUID_DEFAULT_SEVERITY) == 0)
         {
           double severity_dbl;
           /* Default Severity */
@@ -59642,7 +59642,7 @@ manage_optimize (GSList *log_config, const db_conn_info_t *database,
       sql ("UPDATE results"
           " SET severity"
           "       = (SELECT CAST (value AS real) FROM settings"
-          "           WHERE uuid = '7eda49c5-096c-4bef-b1ab-d080d87300df'"
+          "           WHERE uuid = '" SETTING_UUID_DEFAULT_SEVERITY "'"
           "             AND (settings.owner = results.owner"
           "                  OR settings.owner IS NULL)"
           "          ORDER BY settings.owner DESC LIMIT 1)"

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -111,6 +111,11 @@
 /**
  * @brief UUID of setting.
  */
+#define SETTING_UUID_DYNAMIC_SEVERITY "77ec2444-e7f2-4a80-a59b-f4237782d93f"
+
+/**
+ * @brief UUID of setting.
+ */
 #define SETTING_UUID_PREFERRED_LANG "6765549a-934e-11e3-b358-406186ea4fc5"
 
 /**

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -111,6 +111,11 @@
 /**
  * @brief UUID of setting.
  */
+#define SETTING_UUID_AUTO_REFRESH "578a1c14-e2dc-45ef-a591-89d31391d007"
+
+/**
+ * @brief UUID of setting.
+ */
 #define SETTING_UUID_DEFAULT_SEVERITY "7eda49c5-096c-4bef-b1ab-d080d87300df"
 
 /**

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -111,6 +111,11 @@
 /**
  * @brief UUID of setting.
  */
+#define SETTING_UUID_AUTO_CACHE_REBUILD "a09285b0-2d47-49b6-a4ef-946ee71f1d5c"
+
+/**
+ * @brief UUID of setting.
+ */
 #define SETTING_UUID_AUTO_REFRESH "578a1c14-e2dc-45ef-a591-89d31391d007"
 
 /**

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -111,6 +111,11 @@
 /**
  * @brief UUID of setting.
  */
+#define SETTING_UUID_DEFAULT_SEVERITY "7eda49c5-096c-4bef-b1ab-d080d87300df"
+
+/**
+ * @brief UUID of setting.
+ */
 #define SETTING_UUID_DYNAMIC_SEVERITY "77ec2444-e7f2-4a80-a59b-f4237782d93f"
 
 /**

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -159,6 +159,11 @@
 #define SETTING_UUID_FILE_DETAILS "a6ac88c5-729c-41ba-ac0a-deea4a3441f2"
 
 /**
+ * @brief UUID of setting.
+ */
+#define SETTING_UUID_FILE_LIST "0872a6ed-4f85-48c5-ac3f-a5ef5e006745"
+
+/**
  * @brief UUID of 'Debian LSC Package Maintainer' setting.
  */
 #define SETTING_UUID_LSC_DEB_MAINTAINER "2fcbeac8-4237-438f-b52a-540a23e7af97"

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -109,6 +109,11 @@
 #define SCANNER_UUID_CVE "6acd0832-df90-11e4-b9d5-28d24461215b"
 
 /**
+ * @brief UUID of setting.
+ */
+#define SETTING_UUID_PREFERRED_LANG "6765549a-934e-11e3-b358-406186ea4fc5"
+
+/**
  * @brief UUID of 'Rows Per Page' setting.
  */
 #define SETTING_UUID_ROWS_PER_PAGE "5f5a8712-8017-11e1-8556-406186ea4fc5"

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -154,6 +154,11 @@
 #define SETTING_UUID_FEED_IMPORT_ROLES "ff000362-338f-11ea-9051-28d24461215b"
 
 /**
+ * @brief UUID of setting.
+ */
+#define SETTING_UUID_FILE_DETAILS "a6ac88c5-729c-41ba-ac0a-deea4a3441f2"
+
+/**
  * @brief UUID of 'Debian LSC Package Maintainer' setting.
  */
 #define SETTING_UUID_LSC_DEB_MAINTAINER "2fcbeac8-4237-438f-b52a-540a23e7af97"

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -119,34 +119,14 @@
 #define SETTING_UUID_AUTO_REFRESH "578a1c14-e2dc-45ef-a591-89d31391d007"
 
 /**
+ * @brief UUID of 'CVE-CPE Matching Version' setting.
+ */
+#define SETTING_UUID_CVE_CPE_MATCHING_VERSION "2e8a8ccc-219f-4a82-824a-3ad88b6d4029"
+
+/**
  * @brief UUID of setting.
  */
 #define SETTING_UUID_DEFAULT_SEVERITY "7eda49c5-096c-4bef-b1ab-d080d87300df"
-
-/**
- * @brief UUID of setting.
- */
-#define SETTING_UUID_DYNAMIC_SEVERITY "77ec2444-e7f2-4a80-a59b-f4237782d93f"
-
-/**
- * @brief UUID of setting.
- */
-#define SETTING_UUID_PREFERRED_LANG "6765549a-934e-11e3-b358-406186ea4fc5"
-
-/**
- * @brief UUID of 'Rows Per Page' setting.
- */
-#define SETTING_UUID_ROWS_PER_PAGE "5f5a8712-8017-11e1-8556-406186ea4fc5"
-
-/**
- * @brief UUID of 'Max Rows Per Page' setting.
- */
-#define SETTING_UUID_MAX_ROWS_PER_PAGE "76374a7a-0569-11e6-b6da-28d24461215b"
-
-/**
- * @brief UUID of 'Note/Override Excerpt Size' setting.
- */
-#define SETTING_UUID_EXCERPT_SIZE "9246a0f6-c6ad-44bc-86c2-557a527c8fb3"
 
 /**
  * @brief UUID of 'Default CA Cert' setting.
@@ -154,9 +134,14 @@
 #define SETTING_UUID_DEFAULT_CA_CERT "9ac801ea-39f8-11e6-bbaa-28d24461215b"
 
 /**
- * @brief UUID of 'Debian LSC Package Maintainer' setting.
+ * @brief UUID of setting.
  */
-#define SETTING_UUID_LSC_DEB_MAINTAINER "2fcbeac8-4237-438f-b52a-540a23e7af97"
+#define SETTING_UUID_DYNAMIC_SEVERITY "77ec2444-e7f2-4a80-a59b-f4237782d93f"
+
+/**
+ * @brief UUID of 'Note/Override Excerpt Size' setting.
+ */
+#define SETTING_UUID_EXCERPT_SIZE "9246a0f6-c6ad-44bc-86c2-557a527c8fb3"
 
 /**
  * @brief UUID of 'Feed Import Owner' setting.
@@ -169,14 +154,29 @@
 #define SETTING_UUID_FEED_IMPORT_ROLES "ff000362-338f-11ea-9051-28d24461215b"
 
 /**
+ * @brief UUID of 'Debian LSC Package Maintainer' setting.
+ */
+#define SETTING_UUID_LSC_DEB_MAINTAINER "2fcbeac8-4237-438f-b52a-540a23e7af97"
+
+/**
+ * @brief UUID of 'Max Rows Per Page' setting.
+ */
+#define SETTING_UUID_MAX_ROWS_PER_PAGE "76374a7a-0569-11e6-b6da-28d24461215b"
+
+/**
+ * @brief UUID of setting.
+ */
+#define SETTING_UUID_PREFERRED_LANG "6765549a-934e-11e3-b358-406186ea4fc5"
+
+/**
+ * @brief UUID of 'Rows Per Page' setting.
+ */
+#define SETTING_UUID_ROWS_PER_PAGE "5f5a8712-8017-11e1-8556-406186ea4fc5"
+
+/**
  * @brief UUID of 'SecInfo SQL Buffer Threshold' setting.
  */
 #define SETTING_UUID_SECINFO_SQL_BUFFER_THRESHOLD "316275a9-3629-49ad-9cea-5b3ab155b93f"
-
-/**
- * @brief UUID of 'User Interface Time Format' setting.
- */
-#define SETTING_UUID_USER_INTERFACE_TIME_FORMAT "11deb7ff-550b-4950-aacf-06faeb7c61b9"
 
 /**
  * @brief UUID of 'User Interface Date Format' setting.
@@ -184,9 +184,9 @@
 #define SETTING_UUID_USER_INTERFACE_DATE_FORMAT "d9857b7c-1159-4193-9bc0-18fae5473a69"
 
 /**
- * @brief UUID of 'CVE-CPE Matching Version' setting.
+ * @brief UUID of 'User Interface Time Format' setting.
  */
-#define SETTING_UUID_CVE_CPE_MATCHING_VERSION "2e8a8ccc-219f-4a82-824a-3ad88b6d4029"
+#define SETTING_UUID_USER_INTERFACE_TIME_FORMAT "11deb7ff-550b-4950-aacf-06faeb7c61b9"
 
 /**
  * @brief Trust constant for error.

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -164,6 +164,11 @@
 #define SETTING_UUID_FILE_LIST "0872a6ed-4f85-48c5-ac3f-a5ef5e006745"
 
 /**
+ * @brief UUID of setting.
+ */
+#define SETTING_UUID_FILE_REPORT "e1a2ae0b-736e-4484-b029-330c9e15b900"
+
+/**
  * @brief UUID of 'Debian LSC Package Maintainer' setting.
  */
 #define SETTING_UUID_LSC_DEB_MAINTAINER "2fcbeac8-4237-438f-b52a-540a23e7af97"


### PR DESCRIPTION
## What

Use definitions (like `SETTING_UUID_PREFERRED_LANG`) more consistently for setting UUIDs.

Note that I've left the filter settings like `Alerts Filter` as literal UUIDs, because there are many of them and they're only used in `modify_setting`.

## Why

 - Some of the settings were already using definitions, so it made those look special some how.
 - Easier to change in future.
 - Using a name makes it easier to see what the setting is.
