### PR TITLE
Change: Make OSP VT update socket functions conditional on the OPENVASD feature flag

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -7699,19 +7699,6 @@ gvm_migrate_secinfo (int feed_type)
   return ret;
 }
 
-/**
- * @brief Update NVT cache using OSP.
- *
- * @param[in]  update_socket  Socket to use to contact ospd-openvas scanner.
- *
- * @return 0 success, -1 error, 1 VT integrity check failed.
- */
-int
-manage_update_nvts (const gchar *update_socket)
-{
-  return manage_update_nvt_cache (update_socket);
-}
-
 
 /* Wizards. */
 

--- a/src/manage.h
+++ b/src/manage.h
@@ -2882,6 +2882,9 @@ char *
 openvas_default_scanner_host ();
 
 int
+openvasd_scanner_exists ();
+
+int
 init_scanner_iterator (iterator_t*, get_data_t *);
 
 const char*

--- a/src/manage.h
+++ b/src/manage.h
@@ -2882,9 +2882,6 @@ char *
 openvas_default_scanner_host ();
 
 int
-openvasd_scanner_exists ();
-
-int
 init_scanner_iterator (iterator_t*, get_data_t *);
 
 const char*
@@ -4067,9 +4064,6 @@ nvts_feed_info (gchar **, gchar **, gchar **, gchar **);
 
 int
 nvts_check_feed (int *, int *, gchar **);
-
-int
-manage_update_nvts (const gchar *);
 
 int
 manage_rebuild (GSList *, const db_conn_info_t *);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -43181,22 +43181,6 @@ osp_get_details_from_iterator (iterator_t *iterator, char **desc,
 
 #if OPENVASD
 /**
- * @brief Checks if the default openvasd scanner exists.
- *
- * @return 0 if the scanner exists, 1 otherwise.
- */
-int
-openvasd_scanner_exists ()
-{
-  if (sql_int ("SELECT count(*) FROM scanners WHERE uuid = '%s';",
-               SCANNER_UUID_OPENVASD_DEFAULT) == 0)
-    {
-      return 1;
-    }
-  return 0;
-}
-
-/**
  * @brief Get an openvasd Scanner's get_scanner_preferences info.
  *
  * @param[in]   iterator    Scanner object iterator.

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -43181,6 +43181,22 @@ osp_get_details_from_iterator (iterator_t *iterator, char **desc,
 
 #if OPENVASD
 /**
+ * @brief Checks if the default openvasd scanner exists.
+ *
+ * @return 0 if the scanner exists, 1 otherwise.
+ */
+int
+openvasd_scanner_exists ()
+{
+  if (sql_int ("SELECT count(*) FROM scanners WHERE uuid = '%s';",
+               SCANNER_UUID_OPENVASD_DEFAULT) == 0)
+    {
+      return 1;
+    }
+  return 0;
+}
+
+/**
  * @brief Get an openvasd Scanner's get_scanner_preferences info.
  *
  * @param[in]   iterator    Scanner object iterator.

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1189,29 +1189,6 @@ nvts_feed_version_status ()
 }
 
 /**
- * @brief Update VTs via OSP or openvasd.
- *
- * Expect to be called in the child after a fork.
- *
- * @param[in]  update_socket  Socket to use to contact ospd-openvas scanner.
- *
- * @return 0 success, -1 error, 1 VT integrity check failed.
- */
-int
-manage_update_nvt_cache (const gchar *update_socket)
-{
-  int ret;
-
-#if OPENVASD
-      ret = manage_update_nvt_cache_openvasd ();
-#else
-      ret = manage_update_nvt_cache_osp (update_socket);
-#endif
-
-  return ret;
-}
-
-/**
  * @brief Sync NVTs if newer NVTs are available.
  *
  * @param[in]  fork_update_nvt_cache  Function to do the update.

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -1180,9 +1180,7 @@ int
 nvts_feed_version_status ()
 {
 #if OPENVASD
-  return nvts_feed_version_status_internal_openvasd (get_osp_vt_update_socket (),
-                                                     NULL,
-                                                     NULL);
+  return nvts_feed_version_status_internal_openvasd (NULL, NULL);
 #else
   return nvts_feed_version_status_internal_osp (get_osp_vt_update_socket (),
                                                 NULL,
@@ -1195,7 +1193,7 @@ nvts_feed_version_status ()
  *
  * Expect to be called in the child after a fork.
  *
- * @param[in]  update_socket  Socket to use to contact ospd-openvas or openvasd scanner.
+ * @param[in]  update_socket  Socket to use to contact ospd-openvas scanner.
  *
  * @return 0 success, -1 error, 1 VT integrity check failed.
  */
@@ -1204,8 +1202,8 @@ manage_update_nvt_cache (const gchar *update_socket)
 {
   int ret;
 
-#if OPENVASD == 1
-      ret = manage_update_nvt_cache_openvasd (update_socket);
+#if OPENVASD
+      ret = manage_update_nvt_cache_openvasd ();
 #else
       ret = manage_update_nvt_cache_osp (update_socket);
 #endif

--- a/src/manage_sql_nvts.h
+++ b/src/manage_sql_nvts.h
@@ -147,9 +147,6 @@ update_or_rebuild_nvts (int);
 int
 nvts_feed_version_status ();
 
-int
-manage_update_nvt_cache (const gchar *);
-
 char *
 nvt_family (const char *);
 

--- a/src/manage_sql_nvts_common.c
+++ b/src/manage_sql_nvts_common.c
@@ -82,66 +82,6 @@ insert_nvt_preferences_list (GList *nvt_preferences_list, int rebuild)
 }
 
 /**
- * @brief File socket for OSP NVT update.
- */
-static gchar *osp_vt_update_socket = NULL;
-
-/**
- * @brief Get the current file socket for OSP NVT update.
- *
- * @return The path of the file socket for OSP NVT update.
- */
-const gchar *
-get_osp_vt_update_socket ()
-{
-  return osp_vt_update_socket;
-}
-
-/**
- * @brief Set the file socket for OSP NVT update.
- *
- * @param new_socket The new path of the file socket for OSP NVT update.
- */
-void
-set_osp_vt_update_socket (const char *new_socket)
-{
-  if (new_socket)
-    {
-      g_free (osp_vt_update_socket);
-      osp_vt_update_socket = g_strdup (new_socket);
-    }
-}
-
-/**
- * @brief Check the files socket used for OSP NVT update.
- *
- * @return 0 success, 1 no socket found.
- */
-int
-check_osp_vt_update_socket ()
-{
-  if (get_osp_vt_update_socket () == NULL)
-    {
-      char *default_socket;
-
-      /* Try to get OSP VT update socket from default scanner. */
-
-      default_socket = openvas_default_scanner_host ();
-      if (default_socket == NULL)
-        return 1;
-
-      g_debug ("%s: Using OSP VT update socket from default OpenVAS"
-               " scanner: %s",
-               __func__,
-               default_socket);
-      set_osp_vt_update_socket (default_socket);
-      free (default_socket);
-    }
-
-  return 0;
-}
-
-/**
  * @brief Create an SQL batch.
  *
  * @param[in]  max  Max number of iterations.

--- a/src/manage_sql_nvts_common.h
+++ b/src/manage_sql_nvts_common.h
@@ -39,15 +39,6 @@
  */
 #define VT_SEV_INSERT_SIZE_DEFAULT 100000
 
-const char *
-get_osp_vt_update_socket ();
-
-void
-set_osp_vt_update_socket (const char *new_socket);
-
-int
-check_osp_vt_update_socket ();
-
 /**
  * @brief SQL batch.
  */

--- a/src/manage_sql_nvts_openvasd.c
+++ b/src/manage_sql_nvts_openvasd.c
@@ -584,12 +584,6 @@ nvts_feed_version_status_internal_openvasd (gchar **db_feed_version_out,
   if (scanner_feed_version_out)
     *scanner_feed_version_out = NULL;
 
-  if (openvasd_scanner_exists ())
-    {
-      g_warning ("No openvasd VT update client found.");
-      return -1;
-    }
-
   db_feed_version = nvts_feed_version ();
   g_debug ("%s: db_feed_version: %s", __func__, db_feed_version);
   if (db_feed_version_out && db_feed_version)

--- a/src/manage_sql_nvts_openvasd.c
+++ b/src/manage_sql_nvts_openvasd.c
@@ -241,7 +241,7 @@ move_buffer_data (struct FILESTREAM *filestream){
  *
  * @return 0 success, 1 VT integrity check failed, -1 error
  */
-int
+static int
 update_nvts_from_openvasd_vts (openvasd_connector_t connector,
                                const gchar *scanner_feed_version,
                                int rebuild)
@@ -380,7 +380,6 @@ update_nvts_from_openvasd_vts (openvasd_connector_t connector,
 /**
  * @brief Update VTs via openvasd.
  *
- * @param[in]  openvasd_uuid         UUID of openvasd to connect to.
  * @param[in]  db_feed_version       Feed version from meta table.
  * @param[in]  scanner_feed_version  Feed version from scanner.
  * @param[in]  rebuild               Whether to rebuild the NVT tables from scratch.
@@ -388,7 +387,7 @@ update_nvts_from_openvasd_vts (openvasd_connector_t connector,
  * @return 0 success, 1 VT integrity check failed, -1 error.
  */
 int
-update_nvt_cache_openvasd (gchar* openvasd_uuid, gchar *db_feed_version,
+update_nvt_cache_openvasd (gchar *db_feed_version,
                            gchar *scanner_feed_version, int rebuild)
 {
   openvasd_connector_t connector = NULL;
@@ -416,7 +415,7 @@ update_nvt_cache_openvasd (gchar* openvasd_uuid, gchar *db_feed_version,
   if (!connector)
     {
       g_warning ("%s: failed to connect to scanner (%s)", __func__,
-                 openvasd_uuid);
+                 SCANNER_UUID_OPENVASD_DEFAULT);
       return -1;
     }
 
@@ -568,15 +567,13 @@ nvts_feed_info_internal_from_openvasd (const gchar *scanner_uuid,
 /**
  * @brief Check VTs feed version status via openvasd, optionally get versions.
  *
- * @param[in]  update_socket  Socket to use to contact openvasd scanner.
  * @param[out] db_feed_version_out       Output of database feed version.
  * @param[out] scanner_feed_version_out  Output of scanner feed version.
  *
  * @return 0 VTs feed current, -1 error, 1 VT update needed.
  */
 int
-nvts_feed_version_status_internal_openvasd (const gchar *update_socket,
-                                            gchar **db_feed_version_out,
+nvts_feed_version_status_internal_openvasd (gchar **db_feed_version_out,
                                             gchar **scanner_feed_version_out)
 {
   gchar *db_feed_version = NULL;
@@ -586,6 +583,12 @@ nvts_feed_version_status_internal_openvasd (const gchar *update_socket,
     *db_feed_version_out = NULL;
   if (scanner_feed_version_out)
     *scanner_feed_version_out = NULL;
+
+  if (openvasd_scanner_exists ())
+    {
+      g_warning ("No openvasd VT update client found.");
+      return -1;
+    }
 
   db_feed_version = nvts_feed_version ();
   g_debug ("%s: db_feed_version: %s", __func__, db_feed_version);
@@ -622,12 +625,10 @@ nvts_feed_version_status_internal_openvasd (const gchar *update_socket,
  *
  * Expect to be called in the child after a fork.
  *
- * @param[in]  update_socket  Socket to use to contact openvasd scanner.
- *
  * @return 0 success, -1 error, 1 VT integrity check failed.
  */
 int
-manage_update_nvt_cache_openvasd (const gchar *update_socket)
+manage_update_nvt_cache_openvasd ()
 {
   gchar *db_feed_version, *scanner_feed_version;
   int ret;
@@ -639,8 +640,7 @@ manage_update_nvt_cache_openvasd (const gchar *update_socket)
 
   /* Try update VTs. */
 
-  ret = nvts_feed_version_status_internal_openvasd (update_socket,
-                                                    &db_feed_version,
+  ret = nvts_feed_version_status_internal_openvasd (&db_feed_version,
                                                     &scanner_feed_version);
   if (ret == 1)
     {
@@ -649,8 +649,7 @@ manage_update_nvt_cache_openvasd (const gchar *update_socket)
               scanner_feed_version, db_feed_version,
               sql_int ("SELECT count (*) FROM nvts;"));
 
-      ret = update_nvt_cache_openvasd (SCANNER_UUID_OPENVASD_DEFAULT,
-                                       db_feed_version,
+      ret = update_nvt_cache_openvasd (db_feed_version,
                                        scanner_feed_version, 0);
 
       g_free (db_feed_version);
@@ -677,10 +676,8 @@ update_or_rebuild_nvts_openvasd (int update)
   gchar *db_feed_version = NULL;
   gchar *scanner_feed_version = NULL;
   int ret = 0;
-  const char *update_socket = NULL;
 
-  ret = nvts_feed_version_status_internal_openvasd (update_socket,
-                                                    &db_feed_version,
+  ret = nvts_feed_version_status_internal_openvasd (&db_feed_version,
                                                     &scanner_feed_version);
   if (ret == -1)
     {
@@ -692,8 +689,7 @@ update_or_rebuild_nvts_openvasd (int update)
 
   if (update == 0)
     set_nvts_feed_version ("0");
-  ret = update_nvt_cache_openvasd (SCANNER_UUID_OPENVASD_DEFAULT,
-                                   db_feed_version,
+  ret = update_nvt_cache_openvasd (db_feed_version,
                                    scanner_feed_version, 0);
   if (ret != 0)
     ret = -1;

--- a/src/manage_sql_nvts_openvasd.h
+++ b/src/manage_sql_nvts_openvasd.h
@@ -28,24 +28,18 @@
 #include "manage_sql_nvts_common.h"
 
 int
-manage_update_nvt_cache_openvasd (const gchar *update_socket);
+manage_update_nvt_cache_openvasd ();
 
 int
-update_nvt_cache_openvasd(gchar *openvasd_uuid,
-                              gchar *db_feed_version,
-                              gchar *scanner_feed_version,
-                              int rebuild);
-int
 nvts_feed_info_internal_from_openvasd (const gchar *scanner_uuid,
-gchar **vts_version);
+                                       gchar **vts_version);
 
 int
 update_or_rebuild_nvts_openvasd (int update);
 
 int
-nvts_feed_version_status_internal_openvasd (const gchar *update_socket,
-                                   gchar **db_feed_version_out,
-                                   gchar **scanner_feed_version_out);
+nvts_feed_version_status_internal_openvasd (gchar **db_feed_version_out,
+                                            gchar **scanner_feed_version_out);
 
 #endif //MANAGE_NVTS_OPENVASD_H
 #endif

--- a/src/manage_sql_nvts_osp.c
+++ b/src/manage_sql_nvts_osp.c
@@ -549,6 +549,66 @@ update_nvts_from_osp_vts (element_t *get_vts_response,
 }
 
 /**
+ * @brief File socket for OSP NVT update.
+ */
+static gchar *openvas_vt_update_socket = NULL;
+
+/**
+ * @brief Get the current file socket for OSP NVT update.
+ *
+ * @return The path of the file socket for OSP NVT update.
+ */
+const gchar *
+get_osp_vt_update_socket ()
+{
+  return openvas_vt_update_socket;
+}
+
+/**
+ * @brief Set the file socket for OSP NVT update.
+ *
+ * @param new_socket The new path of the file socket for OSP NVT update.
+ */
+void
+set_osp_vt_update_socket (const char *new_socket)
+{
+  if (new_socket)
+    {
+      g_free (openvas_vt_update_socket);
+      openvas_vt_update_socket = g_strdup (new_socket);
+    }
+}
+
+/**
+ * @brief Check the files socket used for OSP NVT update.
+ *
+ * @return 0 success, 1 no socket found.
+ */
+int
+check_osp_vt_update_socket ()
+{
+  if (get_osp_vt_update_socket () == NULL)
+    {
+      char *default_socket;
+
+      /* Try to get OSP VT update socket from default scanner. */
+
+      default_socket = openvas_default_scanner_host ();
+      if (default_socket == NULL)
+        return 1;
+
+      g_debug ("%s: Using OSP VT update socket from default OpenVAS"
+               " scanner: %s",
+               __func__,
+               default_socket);
+      set_osp_vt_update_socket (default_socket);
+      free (default_socket);
+    }
+
+  return 0;
+}
+
+/**
  * @brief Get the VTs feed version from an OSP scanner.
  *
  * @param[in]  update_socket  Socket to use to contact ospd-openvas scanner.
@@ -919,3 +979,4 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
 
   return ret;
 }
+

--- a/src/manage_sql_nvts_osp.c
+++ b/src/manage_sql_nvts_osp.c
@@ -979,4 +979,3 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
 
   return ret;
 }
-

--- a/src/manage_sql_nvts_osp.h
+++ b/src/manage_sql_nvts_osp.h
@@ -26,6 +26,15 @@
 
 #include "manage_sql_nvts_common.h"
 
+const char *
+get_osp_vt_update_socket ();
+
+void
+set_osp_vt_update_socket (const char *new_socket);
+
+int
+check_osp_vt_update_socket ();
+
 int
 update_or_rebuild_nvts_osp (int update);
 


### PR DESCRIPTION

## What
I refactored the OSP VT update socket functions conditional on the OPENVASD feature flag

## Why

- Ensures consistent initialization by setting the default scanner before GVMD starts
- Allows controlled execution by checking that the openvasd scanner exists before updating the feed.

## References

GEA-937

## Checklist


- [ ] Tests


