### PR TITLE
Fix: Remove stray setting UUIDs

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -53047,9 +53047,7 @@ modify_setting (const gchar *uuid, const gchar *name,
                || strcmp (uuid, SETTING_UUID_PREFERRED_LANG) == 0
                || strcmp (uuid, SETTING_UUID_ROWS_PER_PAGE) == 0
                || strcmp (uuid, SETTING_UUID_USER_INTERFACE_DATE_FORMAT) == 0
-               || strcmp (uuid, SETTING_UUID_USER_INTERFACE_TIME_FORMAT) == 0
-               || strcmp (uuid, "02e294fa-061b-11e6-ae64-28d24461215b") == 0
-               || strcmp (uuid, "5a9046cc-0628-11e6-ba53-28d24461215b") == 0))
+               || strcmp (uuid, SETTING_UUID_USER_INTERFACE_TIME_FORMAT) == 0))
     {
       gsize value_size;
       gchar *value, *quoted_uuid, *quoted_value;


### PR DESCRIPTION
## What

Remove stray checks for UUIDs from `modify_setting`.

## Why

I added these two Asset settings in 2016 in 1f5133bf1b7167e3c02c635abe5e708157c2a576. I removed the settings the next day in f3ddd9b61c1001efb153e367a67a65972ddae7cf but I forgot to remove the UUID checks.

