### PR TITLE
Change: move skip_update_nvti_cache functions out of utils

### DIFF
--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -68,6 +68,11 @@ create_tables_nvt (const gchar *);
 /* NVT related global options */
 
 /**
+ * @brief Whether to skip the update of the nvti cache.
+ */
+static gboolean skip_upd_nvti_cache = FALSE;
+
+/**
  * @brief Max number of rows inserted per statement.
  */
 static int vt_ref_insert_size = VT_REF_INSERT_SIZE_DEFAULT;
@@ -79,6 +84,31 @@ static int vt_sev_insert_size = VT_SEV_INSERT_SIZE_DEFAULT;
 
 
 /* NVT's. */
+
+/**
+ * @brief Set flag if to run update_nvti_cache () or not.
+ *
+ * The default value of the flag is FALSE.
+ *
+ * @param[in]  skip_upd_nvti_c  Value for the flag if to
+ *                              skip the cache update or not.
+ */
+void
+set_skip_update_nvti_cache (gboolean skip_upd_nvti_c)
+{
+  skip_upd_nvti_cache = skip_upd_nvti_c;
+}
+
+/**
+ * @brief Check if to run update_nvti_cache () or not.
+ *
+ * @return TRUE skip update, FALSE don't skip update
+ */
+gboolean
+skip_update_nvti_cache ()
+{
+  return skip_upd_nvti_cache;
+}
 
 /**
  * @brief Set the VT ref insert size.

--- a/src/manage_sql_nvts.h
+++ b/src/manage_sql_nvts.h
@@ -130,6 +130,12 @@
  }
 
 void
+set_skip_update_nvti_cache (gboolean);
+
+gboolean
+skip_update_nvti_cache ();
+
+void
 set_vt_ref_insert_size (int);
 
 void

--- a/src/utils.c
+++ b/src/utils.c
@@ -58,9 +58,6 @@
  */
 #define G_LOG_DOMAIN "md manage"
 
-/* Flag if to skip the update of the nvti cache or not. */
-static gboolean skip_upd_nvti_cache = FALSE;
-
 
 /* Sleep. */
 
@@ -754,30 +751,6 @@ lockfile_locked (const gchar *lockfile_basename)
   if ((ret == 0) && lockfile_unlock (&lockfile))
     return -1;
   return ret;
-}
-
-/**
- * @brief Set Flag if to run update_nvti_cache () or not.
- *            The default value of the flag is FALSE.
- *
- * @param[in]  skip_upd_nvti_c  Value for the flag if to
- *                              skip the cache update or not.
- */
-void
-set_skip_update_nvti_cache (gboolean skip_upd_nvti_c)
-{
-  skip_upd_nvti_cache = skip_upd_nvti_c;
-}
-
-/**
- * @brief Check if to run update_nvti_cache () or not.
- *
- * @return TRUE skip update, FALSE don't skip update
- */
-gboolean
-skip_update_nvti_cache ()
-{
-  return skip_upd_nvti_cache;
 }
 
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -85,11 +85,6 @@ lockfile_unlock (lockfile_t *);
 int
 lockfile_locked (const gchar *);
 
-void set_skip_update_nvti_cache (gboolean);
-
-gboolean
-skip_update_nvti_cache ();
-
 int
 is_uuid (const char *);
 


### PR DESCRIPTION
## What

Move `skip_update_nvti_cache` and `set_skip_update_nvti_cache` out of `utils.c`.

## Why

`utils.c` is for generic utilities. Stuff that could be used in any project. These are NVT related functions.

## References

Added in /pull/2337.
