### PR TITLE
Change: move db_conn_info_t to SQL layer

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -27,6 +27,7 @@
 #include "iterator.h"
 #include "manage_configs.h"
 #include "manage_get.h"
+#include "sql.h"
 #include "utils.h"
 
 #include <stdio.h>
@@ -44,16 +45,6 @@
 #if OPENVASD
 #include <gvm/openvasd/openvasd.h>
 #endif
-
-/**
- * @brief Data structure for info used to connect to the database
- */
-typedef struct {
-  gchar *name; ///< The database name
-  gchar *host; ///< The database host or socket directory
-  gchar *port; ///< The database port or socket file extension
-  gchar *user; ///< The database user name
-} db_conn_info_t;
 
 /**
  * @brief OID of ping_host.nasl

--- a/src/sql.c
+++ b/src/sql.c
@@ -28,6 +28,7 @@
  */
 
 #include "sql.h"
+#include "utils.h"
 
 #include <assert.h>
 #include <errno.h>

--- a/src/sql.h
+++ b/src/sql.h
@@ -25,9 +25,18 @@
 #define _GVMD_SQL_H
 
 #include "iterator.h"
-#include "manage.h"
 
 #include <glib.h>
+
+/**
+ * @brief Data structure for info used to connect to the database
+ */
+typedef struct {
+  gchar *name; ///< The database name
+  gchar *host; ///< The database host or socket directory
+  gchar *port; ///< The database port or socket file extension
+  gchar *user; ///< The database user name
+} db_conn_info_t;
 
 /* Helpers. */
 


### PR DESCRIPTION
## What

Move `db_conn_info_t` to `sql.c`.

## Why

This keeps sql.c as a self contained SQL interface. It was a bit weird to be including `manage.h` in `sql.c` just for a db type.

## References

Added in 8e1fca3e7a5ecff08a41bf5de81fb66cd2f75610 in /pull/1308.


