### PR TITLE
Change: start moving alert code to dedicated files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -308,7 +308,7 @@ add_executable (gvmd
                 gmpd.c
                 ipc.c
                 manage_utils.c manage.c sql.c
-                manage_acl.c manage_configs.c manage_get.c
+                manage_acl.c manage_alerts.c manage_configs.c manage_get.c
                 manage_license.c
                 manage_port_lists.c manage_preferences.c
                 manage_report_configs.c

--- a/src/manage.c
+++ b/src/manage.c
@@ -1399,40 +1399,6 @@ report_t global_current_report = (report_t) 0;
 /* Alerts. */
 
 /**
- * @brief Frees a alert_report_data_t struct, including contained data.
- *
- * @param[in]  data   The struct to free.
- */
-void
-alert_report_data_free (alert_report_data_t *data)
-{
-  if (data == NULL)
-    return;
-
-  alert_report_data_reset (data);
-  g_free (data);
-}
-
-/**
- * @brief Frees content of an alert_report_data_t, but not the struct itself.
- *
- * @param[in]  data   The struct to free.
- */
-void
-alert_report_data_reset (alert_report_data_t *data)
-{
-  if (data == NULL)
-    return;
-
-  g_free (data->content_type);
-  g_free (data->local_filename);
-  g_free (data->remote_filename);
-  g_free (data->report_format_name);
-
-  memset (data, 0, sizeof (alert_report_data_t));
-}
-
-/**
  * @brief Get the name of an alert condition.
  *
  * @param[in]  condition  Condition.

--- a/src/manage.h
+++ b/src/manage.h
@@ -427,22 +427,6 @@ set_resource_id_deprecated (const char *, const char *, gboolean);
 /* Events and Alerts. */
 
 /**
- * @brief Data about a report sent by an alert.
- */
-typedef struct {
-  gchar *local_filename;          ///< Path to the local report file.
-  gchar *remote_filename;         ///< Path or filename to send to / as.
-  gchar *content_type;            ///< The MIME content type of the report.
-  gchar *report_format_name;      ///< Name of the report format used.
-} alert_report_data_t;
-
-void
-alert_report_data_free (alert_report_data_t *);
-
-void
-alert_report_data_reset (alert_report_data_t *);
-
-/**
  * @brief Default format string for alert email, when including report.
  */
 #define ALERT_MESSAGE_INCLUDE                                                 \

--- a/src/manage_alerts.c
+++ b/src/manage_alerts.c
@@ -1,0 +1,66 @@
+/* Copyright (C) 2020-2022 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file manage_sql_alerts.c
+ * @brief GVM management layer: Alert SQL
+ *
+ * Alert SQL for the GVM management layer.
+ */
+
+#include "manage_alerts.h"
+
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md manage"
+
+/**
+ * @brief Frees a alert_report_data_t struct, including contained data.
+ *
+ * @param[in]  data   The struct to free.
+ */
+void
+alert_report_data_free (alert_report_data_t *data)
+{
+  if (data == NULL)
+    return;
+
+  alert_report_data_reset (data);
+  g_free (data);
+}
+
+/**
+ * @brief Frees content of an alert_report_data_t, but not the struct itself.
+ *
+ * @param[in]  data   The struct to free.
+ */
+void
+alert_report_data_reset (alert_report_data_t *data)
+{
+  if (data == NULL)
+    return;
+
+  g_free (data->content_type);
+  g_free (data->local_filename);
+  g_free (data->remote_filename);
+  g_free (data->report_format_name);
+
+  memset (data, 0, sizeof (alert_report_data_t));
+}

--- a/src/manage_alerts.h
+++ b/src/manage_alerts.h
@@ -1,0 +1,40 @@
+/* Copyright (C) 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _GVMD_MANAGE_ALERTS_H
+#define _GVMD_MANAGE_ALERTS_H
+
+#include <glib.h>
+
+/**
+ * @brief Data about a report sent by an alert.
+ */
+typedef struct {
+  gchar *local_filename;          ///< Path to the local report file.
+  gchar *remote_filename;         ///< Path or filename to send to / as.
+  gchar *content_type;            ///< The MIME content type of the report.
+  gchar *report_format_name;      ///< Name of the report format used.
+} alert_report_data_t;
+
+void
+alert_report_data_free (alert_report_data_t *);
+
+void
+alert_report_data_reset (alert_report_data_t *);
+
+#endif /* not _GVMD_MANAGE_ALERTS_H */

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -34,6 +34,7 @@
 #include "manage.h"
 #include "debug_utils.h"
 #include "manage_sql.h"
+#include "manage_alerts.h"
 #include "manage_port_lists.h"
 #include "manage_report_formats.h"
 #include "manage_sql_secinfo.h"


### PR DESCRIPTION
## What

Move the first few pieces of alert code from `manage.c` to new file `manage_alerts.c`.

## Why

Aiming to reduce the size of `manage.c` and `manage_sql.c`.

A start at organizing the alerts code like other resources (ports_lists etc).

## Test

These functions are only used by the vFire alert. I hacked the alert script to check if it was getting the right values. Looks OK.

