### PR TITLE
Add scanner relay fields, deprecate relay-mapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ include (CPack)
 
 ## Variables
 
-set (GVMD_DATABASE_VERSION 258)
+set (GVMD_DATABASE_VERSION 259)
 
 set (GVMD_SCAP_DATABASE_VERSION 22)
 

--- a/doc/gvmd.8
+++ b/doc/gvmd.8
@@ -14,7 +14,7 @@ It manages the storage of any vulnerability management configurations and of the
 Show help options.
 .TP
 \fB--affected-products-query-size=\fINUMBER\fB\f1
-Sets the number of CVEs to process per query when updating the affected products. Defaults to 20000.
+Sets the number of CVEs to process per query when updating the affected products. Defaults to 20000. 
 .TP
 \fB--auth-timeout=\fITIMEOUT\fB\f1
 Sets the authentication timeout time for the cached authentication. Defaults to 15 minutes. 
@@ -175,7 +175,7 @@ The types must be "all" or a comma-separated of the following: "configs", "port_
 Rebuild all SCAP data. 
 .TP
 \fB--relay-mapper=\fIFILE\fB\f1
-Executable for mapping scanner hosts to relays. Use an empty string to explicitly disable. If the option is not given, $PATH is checked for gvm-relay-mapper. 
+Executable for automatically mapping scanner hosts to relays. If the option is empty or not given, automatic mapping is disabled. This option is deprecated and relays should be set explictly in the relay_... fields of scanners. 
 .TP
 \fB--role=\fIROLE\fB\f1
 Role for --create-user and --get-users.
@@ -202,6 +202,12 @@ Name for --modify-scanner.
 .TP
 \fB--scanner-port=\fISCANNER-PORT\fB\f1
 Scanner port for --create-scanner and --modify-scanner.
+.TP
+\fB--scanner-relay-host=\fISCANNER-HOST\fB\f1
+Scanner relay host or socket for --create-scanner and --modify-scanner. 
+.TP
+\fB--scanner-relay-port=\fISCANNER-PORT\fB\f1
+Scanner relay port for --create-scanner and --modify-scanner.
 .TP
 \fB--scanner-type=\fISCANNER-TYPE\fB\f1
 Scanner type for --create-scanner and --modify-scanner.

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -421,9 +421,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <option>
       <p><opt>--relay-mapper=<arg>FILE</arg></opt></p>
       <optdesc>
-        <p>Executable for mapping scanner hosts to relays.
-          Use an empty string to explicitly disable.
-          If the option is not given, $PATH is checked for gvm-relay-mapper.
+        <p>
+          Executable for automatically mapping scanner hosts to relays.
+          If the option is empty or not given, automatic mapping
+          is disabled. This option is deprecated and relays should be
+           set explictly in the relay_... fields of scanners.
         </p>
       </optdesc>
     </option>

--- a/doc/gvmd.8.xml
+++ b/doc/gvmd.8.xml
@@ -480,6 +480,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </optdesc>
     </option>
     <option>
+      <p><opt>--scanner-relay-host=<arg>SCANNER-HOST</arg></opt></p>
+      <optdesc>
+        <p>
+          Scanner relay host or socket for --create-scanner and
+          --modify-scanner.
+        </p>
+      </optdesc>
+    </option>
+    <option>
+      <p><opt>--scanner-relay-port=<arg>SCANNER-PORT</arg></opt></p>
+      <optdesc>
+        <p>Scanner relay port for --create-scanner and --modify-scanner.</p>
+      </optdesc>
+    </option>
+    <option>
       <p><opt>--scanner-type=<arg>SCANNER-TYPE</arg></opt></p>
       <optdesc>
         <p>Scanner type for --create-scanner and --modify-scanner.</p>

--- a/doc/gvmd.html
+++ b/doc/gvmd.html
@@ -370,9 +370,10 @@
     
       <p><b>--relay-mapper=<em>FILE</em></b></p>
       
-        <p>Executable for mapping scanner hosts to relays.
-          Use an empty string to explicitly disable.
-          If the option is not given, $PATH is checked for gvm-relay-mapper.
+        <p>Executable for automatically mapping scanner hosts to relays.
+           If the option is empty or not given, automatic mapping
+           is disabled. This option is deprecated and relays should be
+           set explictly in the relay_... fields of scanners.
         </p>
       
     

--- a/doc/gvmd.html
+++ b/doc/gvmd.html
@@ -429,6 +429,19 @@
       
     
     
+      <p><b>--scanner-relay-host=<em>SCANNER-HOST</em></b></p>
+      
+        <p>Scanner relay host or socket for --create-scanner and
+           --modify-scanner.</p>
+      
+    
+    
+      <p><b>--scanner-relay-port=<em>SCANNER-PORT</em></b></p>
+      
+        <p>Scanner relay port for --create-scanner and --modify-scanner.</p>
+      
+    
+    
       <p><b>--scanner-type=<em>SCANNER-TYPE</em></b></p>
       
         <p>Scanner type for --create-scanner and --modify-scanner.</p>

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -873,6 +873,8 @@ typedef struct
   char *type;               ///< Type of new scanner.
   char *ca_pub;             ///< CA Certificate of new scanner.
   char *credential_id;      ///< UUID of credential for new scanner.
+  char *relay_host;         ///< Relay host of new scanner.
+  char *relay_port;         ///< Relay port of new scanner.
 } create_scanner_data_t;
 
 /**
@@ -891,6 +893,8 @@ create_scanner_data_reset (create_scanner_data_t *data)
   free (data->type);
   free (data->ca_pub);
   free (data->credential_id);
+  free (data->relay_host);
+  free (data->relay_port);
 
   memset (data, 0, sizeof (create_scanner_data_t));
 }
@@ -2744,6 +2748,8 @@ typedef struct
   char *scanner_id;         ///< scanner UUID.
   char *ca_pub;             ///< CA Certificate of scanner.
   char *credential_id;      ///< UUID of credential of scanner.
+  char *relay_host;         ///< Relay host of scanner.
+  char *relay_port;         ///< Relay port of scanner.
 } modify_scanner_data_t;
 
 /**
@@ -2762,6 +2768,8 @@ modify_scanner_data_reset (modify_scanner_data_t *data)
   g_free (data->scanner_id);
   free (data->ca_pub);
   free (data->credential_id);
+  g_free (data->relay_host);
+  g_free (data->relay_port);
 
   memset (data, 0, sizeof (modify_scanner_data_t));
 }
@@ -4266,6 +4274,8 @@ typedef enum
   CLIENT_CREATE_SCANNER_TYPE,
   CLIENT_CREATE_SCANNER_CA_PUB,
   CLIENT_CREATE_SCANNER_CREDENTIAL,
+  CLIENT_CREATE_SCANNER_RELAY_HOST,
+  CLIENT_CREATE_SCANNER_RELAY_PORT,
   CLIENT_CREATE_SCHEDULE,
   CLIENT_CREATE_SCHEDULE_COMMENT,
   CLIENT_CREATE_SCHEDULE_COPY,
@@ -4506,6 +4516,8 @@ typedef enum
   CLIENT_MODIFY_SCANNER_TYPE,
   CLIENT_MODIFY_SCANNER_CA_PUB,
   CLIENT_MODIFY_SCANNER_CREDENTIAL,
+  CLIENT_MODIFY_SCANNER_RELAY_HOST,
+  CLIENT_MODIFY_SCANNER_RELAY_PORT,
   CLIENT_MODIFY_SCHEDULE,
   CLIENT_MODIFY_SCHEDULE_COMMENT,
   CLIENT_MODIFY_SCHEDULE_ICALENDAR,
@@ -6107,6 +6119,10 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
                               &create_scanner_data->credential_id);
             set_client_state (CLIENT_CREATE_SCANNER_CREDENTIAL);
           }
+        else if (strcasecmp ("RELAY_HOST", element_name) == 0)
+          set_client_state (CLIENT_CREATE_SCANNER_RELAY_HOST);
+        else if (strcasecmp ("RELAY_PORT", element_name) == 0)
+          set_client_state (CLIENT_CREATE_SCANNER_RELAY_PORT);
         ELSE_READ_OVER;
 
       case CLIENT_CREATE_SCHEDULE:
@@ -6517,6 +6533,16 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
             append_attribute (attribute_names, attribute_values, "id",
                               &modify_scanner_data->credential_id);
             set_client_state (CLIENT_MODIFY_SCANNER_CREDENTIAL);
+          }
+        else if (strcasecmp ("RELAY_HOST", element_name) == 0)
+          {
+            gvm_append_string (&modify_scanner_data->relay_host, "");
+            set_client_state (CLIENT_MODIFY_SCANNER_RELAY_HOST);
+          }
+        else if (strcasecmp ("RELAY_PORT", element_name) == 0)
+          {
+            gvm_append_string (&modify_scanner_data->relay_port, "");
+            set_client_state (CLIENT_MODIFY_SCANNER_RELAY_PORT);
           }
         ELSE_READ_OVER;
 
@@ -16892,11 +16918,15 @@ handle_get_scanners (gmp_parser_t *gmp_parser, GError **error)
        ("<host>%s</host>"
         "<port>%d</port>"
         "<type>%d</type>"
-        "<ca_pub>%s</ca_pub>",
+        "<ca_pub>%s</ca_pub>"
+        "<relay_host>%s</relay_host>"
+        "<relay_port>%d</relay_port>",
         scanner_iterator_host (&scanners) ?: "",
         scanner_iterator_port (&scanners) ?: 0,
         scanner_iterator_type (&scanners),
-        scanner_iterator_ca_pub (&scanners) ?: "");
+        scanner_iterator_ca_pub (&scanners) ?: "",
+        scanner_iterator_relay_host (&scanners) ?: "",
+        scanner_iterator_relay_port (&scanners) ?: 0);
 
       if (get_scanners_data->get.details)
         {
@@ -19597,9 +19627,10 @@ handle_create_scanner (gmp_parser_t *gmp_parser, GError **error)
            (create_scanner_data->name, create_scanner_data->comment,
             create_scanner_data->host, create_scanner_data->port,
             create_scanner_data->type, &new_scanner,
-            create_scanner_data->ca_pub, create_scanner_data->credential_id))
+            create_scanner_data->ca_pub, create_scanner_data->credential_id,
+            create_scanner_data->relay_host, create_scanner_data->relay_port))
     {
-      case 0:
+      case CREATE_SCANNER_SUCCESS:
         {
           char *uuid = scanner_uuid (new_scanner);
           SENDF_TO_CLIENT_OR_FAIL
@@ -19608,17 +19639,24 @@ handle_create_scanner (gmp_parser_t *gmp_parser, GError **error)
           g_free (uuid);
           break;
         }
-      case 1:
+      case CREATE_SCANNER_ALREADY_EXISTS:
         SEND_TO_CLIENT_OR_FAIL
          (XML_ERROR_SYNTAX ("create_scanner", "Scanner exists already"));
         log_event_fail ("scanner", "Scanner", NULL, "created");
         break;
-      case 2:
+      case CREATE_SCANNER_MISSING_TYPE:
         SEND_TO_CLIENT_OR_FAIL
-         (XML_ERROR_SYNTAX ("create_scanner", "Invalid entity value"));
+         (XML_ERROR_SYNTAX ("create_scanner",
+                            "Scanner requires a TYPE"));
         log_event_fail ("scanner", "Scanner", NULL, "created");
         break;
-      case 3:
+      case CREATE_SCANNER_MISSING_HOST:
+        SEND_TO_CLIENT_OR_FAIL
+         (XML_ERROR_SYNTAX ("create_scanner",
+                            "Scanner requires a HOST"));
+        log_event_fail ("scanner", "Scanner", NULL, "created");
+        break;
+      case CREATE_SCANNER_CREDENTIAL_NOT_FOUND:
         if (send_find_error_to_client ("create_scanner", "credential",
                                        create_scanner_data->credential_id,
                                        gmp_parser))
@@ -19628,32 +19666,61 @@ handle_create_scanner (gmp_parser_t *gmp_parser, GError **error)
           }
         log_event_fail ("scanner", "Scanner", NULL, "created");
         break;
-      case 4:
-        SEND_TO_CLIENT_OR_FAIL
-         (XML_ERROR_SYNTAX ("create_scanner",
-                            "Credential must be of type 'up'"
-                            " (username + password)"));
-        log_event_fail ("scanner", "Scanner", NULL, "created");
-        break;
-      case 5:
+      case CREATE_SCANNER_CREDENTIAL_NOT_CC:
         SEND_TO_CLIENT_OR_FAIL
          (XML_ERROR_SYNTAX ("create_scanner",
                             "Credential must be of type 'cc'"
                             " (client certificate)"));
         log_event_fail ("scanner", "Scanner", NULL, "created");
         break;
-      case 6:
+      case CREATE_SCANNER_INVALID_TYPE:
         SEND_TO_CLIENT_OR_FAIL
          (XML_ERROR_SYNTAX ("create_scanner",
-                            "Scanner type requires a credential"));
+                            "Invalid scanner TYPE"));
         log_event_fail ("scanner", "Scanner", NULL, "created");
         break;
-      case 99:
+      case CREATE_SCANNER_INVALID_PORT:
+        SEND_TO_CLIENT_OR_FAIL
+         (XML_ERROR_SYNTAX ("create_scanner",
+                            "Scanner PORT must be a valid port number"
+                            " (1 - 65535)"
+                            " if HOST is not a UNIX socket path"));
+        log_event_fail ("scanner", "Scanner", NULL, "created");
+        break;
+      case CREATE_SCANNER_INVALID_HOST:
+        SEND_TO_CLIENT_OR_FAIL
+         (XML_ERROR_SYNTAX ("create_scanner",
+                            "Scanner HOST must be a valid hostname,"
+                            " IP address or UNIX socket path."));
+        log_event_fail ("scanner", "Scanner", NULL, "created");
+        break;
+      case CREATE_SCANNER_INVALID_RELAY_PORT:
+        SEND_TO_CLIENT_OR_FAIL
+         (XML_ERROR_SYNTAX ("create_scanner",
+                            "Scanner RELAY_PORT must be a valid port number"
+                            " (1 - 65535)"
+                            " if RELAY_HOST is not a UNIX socket path"));
+        log_event_fail ("scanner", "Scanner", NULL, "created");
+        break;
+      case CREATE_SCANNER_INVALID_RELAY_HOST:
+        SEND_TO_CLIENT_OR_FAIL
+         (XML_ERROR_SYNTAX ("create_scanner",
+                            "Scanner RELAY_HOST must be a valid hostname,"
+                            " IP address, UNIX socket path or empty."));
+        log_event_fail ("scanner", "Scanner", NULL, "created");
+        break;
+      case CREATE_SCANNER_UNIX_SOCKET_UNSUPPORTED:
+        SEND_TO_CLIENT_OR_FAIL
+         (XML_ERROR_SYNTAX ("create_scanner",
+                            "Scanner type does not support UNIX sockets."));
+        log_event_fail ("scanner", "Scanner", NULL, "created");
+        break;
+      case CREATE_SCANNER_PERMISSION_DENIED:
         SEND_TO_CLIENT_OR_FAIL
          (XML_ERROR_SYNTAX ("create_scanner", "Permission denied"));
         log_event_fail ("scanner", "Scanner", NULL, "created");
         break;
-      case -1:
+      case CREATE_SCANNER_INTERNAL_ERROR:
         SEND_TO_CLIENT_OR_FAIL (XML_INTERNAL_ERROR ("create_scanner"));
         log_event_fail ("scanner", "Scanner", NULL, "created");
         break;
@@ -19698,14 +19765,15 @@ handle_modify_scanner (gmp_parser_t *gmp_parser, GError **error)
            (modify_scanner_data->scanner_id, modify_scanner_data->name,
             modify_scanner_data->comment, modify_scanner_data->host,
             modify_scanner_data->port, modify_scanner_data->type,
-            modify_scanner_data->ca_pub, modify_scanner_data->credential_id))
+            modify_scanner_data->ca_pub, modify_scanner_data->credential_id,
+            modify_scanner_data->relay_host, modify_scanner_data->relay_port))
     {
-      case 0:
+      case MODIFY_SCANNER_SUCCESS:
         SENDF_TO_CLIENT_OR_FAIL (XML_OK ("modify_scanner"));
         log_event ("scanner", "Scanner", modify_scanner_data->scanner_id,
                    "modified");
         break;
-      case 1:
+      case MODIFY_SCANNER_NOT_FOUND:
         if (send_find_error_to_client ("modify_scanner", "scanner",
                                        modify_scanner_data->scanner_id,
                                        gmp_parser))
@@ -19716,26 +19784,20 @@ handle_modify_scanner (gmp_parser_t *gmp_parser, GError **error)
         log_event_fail ("scanner", "Scanner", modify_scanner_data->scanner_id,
                         "modified");
         break;
-      case 2:
+      case MODIFY_SCANNER_ALREADY_EXISTS:
         SEND_TO_CLIENT_OR_FAIL
          (XML_ERROR_SYNTAX ("modify_scanner",
                             "Scanner with new name exists already"));
         log_event_fail ("scanner", "Scanner", modify_scanner_data->scanner_id,
                         "modified");
         break;
-      case 3:
+      case MODIFY_SCANNER_MISSING_ID:
         SEND_TO_CLIENT_OR_FAIL
          (XML_ERROR_SYNTAX ("modify_scanner", "Missing scanner_id"));
         log_event_fail ("scanner", "Scanner", modify_scanner_data->scanner_id,
                         "modified");
         break;
-      case 4:
-        SEND_TO_CLIENT_OR_FAIL
-         (XML_ERROR_SYNTAX ("modify_scanner", "Invalid value"));
-        log_event_fail ("scanner", "Scanner", modify_scanner_data->scanner_id,
-                        "modified");
-        break;
-      case 5:
+      case MODIFY_SCANNER_CREDENTIAL_NOT_FOUND:
         if (send_find_error_to_client ("create_scanner", "credential",
                                        modify_scanner_data->credential_id,
                                        gmp_parser))
@@ -19746,7 +19808,7 @@ handle_modify_scanner (gmp_parser_t *gmp_parser, GError **error)
         log_event_fail ("scanner", "Scanner", modify_scanner_data->scanner_id,
                         "modified");
         break;
-      case 6:
+      case MODIFY_SCANNER_CREDENTIAL_NOT_CC:
         SEND_TO_CLIENT_OR_FAIL
          (XML_ERROR_SYNTAX ("modify_scanner",
                             "Credential must be of type 'cc'"
@@ -19754,29 +19816,61 @@ handle_modify_scanner (gmp_parser_t *gmp_parser, GError **error)
         log_event_fail ("scanner", "Scanner", modify_scanner_data->scanner_id,
                         "modified");
         break;
-      case 7:
+      case MODIFY_SCANNER_INVALID_TYPE:
         SEND_TO_CLIENT_OR_FAIL
          (XML_ERROR_SYNTAX ("modify_scanner",
-                            "Credential must be of type 'up'"
-                            " (username + password)"));
+                            "Invalid scanner TYPE"));
         log_event_fail ("scanner", "Scanner", modify_scanner_data->scanner_id,
                         "modified");
         break;
-      case 8:
+      case MODIFY_SCANNER_INVALID_PORT:
         SEND_TO_CLIENT_OR_FAIL
          (XML_ERROR_SYNTAX ("modify_scanner",
-                            "Scanner type requires a credential"));
+                            "Scanner PORT must be a valid port number"
+                            " (1 - 65535)"
+                            " if HOST is not a UNIX socket path"));
         log_event_fail ("scanner", "Scanner", modify_scanner_data->scanner_id,
                         "modified");
         break;
-      case 99:
+      case MODIFY_SCANNER_INVALID_HOST:
+        SEND_TO_CLIENT_OR_FAIL
+         (XML_ERROR_SYNTAX ("modify_scanner",
+                            "Scanner HOST must be a valid hostname,"
+                            " IP address or UNIX socket path."));
+        log_event_fail ("scanner", "Scanner", modify_scanner_data->scanner_id,
+                        "modified");
+        break;
+      case MODIFY_SCANNER_INVALID_RELAY_PORT:
+        SEND_TO_CLIENT_OR_FAIL
+         (XML_ERROR_SYNTAX ("modify_scanner",
+                            "Scanner RELAY_PORT must be a valid port number"
+                            " (1 - 65535)"
+                            " if RELAY_HOST is not a UNIX socket path"));
+        log_event_fail ("scanner", "Scanner", modify_scanner_data->scanner_id,
+                        "modified");
+        break;
+      case MODIFY_SCANNER_INVALID_RELAY_HOST:
+        SEND_TO_CLIENT_OR_FAIL
+         (XML_ERROR_SYNTAX ("modify_scanner",
+                            "Scanner RELAY_HOST must be a valid hostname,"
+                            " IP address, UNIX socket path or empty."));
+        log_event_fail ("scanner", "Scanner", modify_scanner_data->scanner_id,
+                        "modified");
+        break;
+      case MODIFY_SCANNER_UNIX_SOCKET_UNSUPPORTED:
+        SEND_TO_CLIENT_OR_FAIL
+         (XML_ERROR_SYNTAX ("modify_scanner",
+                            "Scanner type does not support UNIX sockets."));
+        log_event_fail ("scanner", "Scanner", modify_scanner_data->scanner_id,
+                        "modified");
+        break;
+      case MODIFY_SCANNER_PERMISSION_DENIED:
         SEND_TO_CLIENT_OR_FAIL
          (XML_ERROR_SYNTAX ("modify_scanner", "Permission denied"));
         log_event_fail ("scanner", "Scanner", modify_scanner_data->scanner_id,
                         "modified");
         break;
       default:
-      case -1:
         SEND_TO_CLIENT_OR_FAIL (XML_INTERNAL_ERROR ("modify_scanner"));
         log_event_fail ("scanner", "Scanner", modify_scanner_data->scanner_id,
                         "modified");
@@ -22991,6 +23085,8 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
       CLOSE (CLIENT_CREATE_SCANNER, TYPE);
       CLOSE (CLIENT_CREATE_SCANNER, CA_PUB);
       CLOSE (CLIENT_CREATE_SCANNER, CREDENTIAL);
+      CLOSE (CLIENT_CREATE_SCANNER, RELAY_HOST);
+      CLOSE (CLIENT_CREATE_SCANNER, RELAY_PORT);
 
       case CLIENT_CREATE_SCHEDULE:
         {
@@ -25780,6 +25876,8 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
       CLOSE (CLIENT_MODIFY_SCANNER, NAME);
       CLOSE (CLIENT_MODIFY_SCANNER, CA_PUB);
       CLOSE (CLIENT_MODIFY_SCANNER, CREDENTIAL);
+      CLOSE (CLIENT_MODIFY_SCANNER, RELAY_HOST);
+      CLOSE (CLIENT_MODIFY_SCANNER, RELAY_PORT);
 
       case CLIENT_MODIFY_SCHEDULE:
         {
@@ -28151,6 +28249,12 @@ gmp_xml_handle_text (/* unused */ GMarkupParseContext* context,
       APPEND (CLIENT_CREATE_SCANNER_CA_PUB,
               &create_scanner_data->ca_pub);
 
+      APPEND (CLIENT_CREATE_SCANNER_RELAY_HOST,
+              &create_scanner_data->relay_host);
+
+      APPEND (CLIENT_CREATE_SCANNER_RELAY_PORT,
+              &create_scanner_data->relay_port);
+
 
       APPEND (CLIENT_CREATE_SCHEDULE_COMMENT,
               &create_schedule_data->comment);
@@ -28478,6 +28582,12 @@ gmp_xml_handle_text (/* unused */ GMarkupParseContext* context,
 
       APPEND (CLIENT_MODIFY_SCANNER_CA_PUB,
               &modify_scanner_data->ca_pub);
+
+      APPEND (CLIENT_MODIFY_SCANNER_RELAY_HOST,
+              &modify_scanner_data->relay_host);
+
+      APPEND (CLIENT_MODIFY_SCANNER_RELAY_PORT,
+              &modify_scanner_data->relay_port);
 
 
       APPEND (CLIENT_MODIFY_SCHEDULE_COMMENT,

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1870,6 +1870,8 @@ gvmd (int argc, char** argv, char *env[])
   static gchar *scanner_credential = NULL;
   static gchar *scanner_key_pub = NULL;
   static gchar *scanner_key_priv = NULL;
+  static gchar *scanner_relay_host = NULL;
+  static gchar *scanner_relay_port = NULL;
   static int scanner_connection_retry = SCANNER_CONNECTION_RETRY_DEFAULT;
   static int schedule_timeout = SCHEDULE_TIMEOUT_DEFAULT;
   static int affected_products_query_size
@@ -2233,6 +2235,15 @@ gvmd (int argc, char** argv, char *env[])
           "Scanner port for --create-scanner and --modify-scanner."
           " Default is " G_STRINGIFY (GVMD_PORT) ".",
           "<scanner-port>" },
+        { "scanner-relay-host", '\0', 0, G_OPTION_ARG_STRING,
+          &scanner_relay_host,
+          "Scanner relay host or socket for --create-scanner and"
+          " --modify-scanner.",
+          "<scanner-relay-host>" },
+        { "scanner-relay-port", '\0', 0, G_OPTION_ARG_STRING,
+          &scanner_relay_port,
+          "Scanner relay port for --create-scanner and --modify-scanner.",
+          "<scanner-relay-port>" },
         { "scanner-type", '\0', 0, G_OPTION_ARG_STRING,
           &scanner_type,
           "Scanner type for --create-scanner and --modify-scanner."
@@ -2894,7 +2905,8 @@ gvmd (int argc, char** argv, char *env[])
       ret = manage_create_scanner (log_config, &database, create_scanner,
                                    scanner_host, scanner_port, stype,
                                    scanner_ca_pub, scanner_credential,
-                                   scanner_key_pub, scanner_key_priv);
+                                   scanner_key_pub, scanner_key_priv,
+                                   scanner_relay_host, scanner_relay_port);
       g_free (stype);
       log_config_free ();
       if (ret)
@@ -2943,7 +2955,8 @@ gvmd (int argc, char** argv, char *env[])
       ret = manage_modify_scanner (log_config, &database, modify_scanner,
                                    scanner_name, scanner_host, scanner_port,
                                    stype, scanner_ca_pub, scanner_credential,
-                                   scanner_key_pub, scanner_key_priv);
+                                   scanner_key_pub, scanner_key_priv,
+                                   scanner_relay_host, scanner_relay_port);
       g_free (stype);
       log_config_free ();
       if (ret)

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -2188,10 +2188,10 @@ gvmd (int argc, char** argv, char *env[])
           NULL },
         { "relay-mapper", '\0', 0, G_OPTION_ARG_FILENAME,
           &relay_mapper,
-          "Executable for mapping scanner hosts to relays."
-          " Use an empty string to explicitly disable."
-          " If the option is not given, $PATH is checked for"
-          " gvm-relay-mapper.",
+          "Executable for automatically mapping scanner hosts to relays."
+          " If the option is empty or not given, automatic mapping"
+          " is disabled. This option is deprecated and relays should be"
+          " set explictly in the relay_... fields of scanners.",
           "<file>" },
         { "role", '\0', 0, G_OPTION_ARG_STRING,
           &role,
@@ -2517,36 +2517,22 @@ gvmd (int argc, char** argv, char *env[])
   set_min_mem_feed_update (min_mem_feed_update);
 
   /* Set relay mapper */
-  if (relay_mapper)
+  if (relay_mapper && strcmp (relay_mapper, ""))
     {
-      if (strcmp (relay_mapper, ""))
-        {
-          if (gvm_file_exists (relay_mapper) == 0)
-            g_warning ("Relay mapper '%s' not found.", relay_mapper);
-          else if (gvm_file_is_readable (relay_mapper) == 0)
-            g_warning ("Relay mapper '%s' is not readable.", relay_mapper);
-          else if (gvm_file_is_executable (relay_mapper) == 0)
-            g_warning ("Relay mapper '%s' is not executable.", relay_mapper);
-          else
-            {
-              g_debug ("Using relay mapper '%s'.", relay_mapper);
-              set_relay_mapper_path (relay_mapper);
-            }
-        }
+      if (gvm_file_exists (relay_mapper) == 0)
+        g_warning ("Relay mapper '%s' not found.", relay_mapper);
+      else if (gvm_file_is_readable (relay_mapper) == 0)
+        g_warning ("Relay mapper '%s' is not readable.", relay_mapper);
+      else if (gvm_file_is_executable (relay_mapper) == 0)
+        g_warning ("Relay mapper '%s' is not executable.", relay_mapper);
       else
-        g_debug ("Relay mapper disabled.");
+        {
+          g_debug ("Using relay mapper '%s'.", relay_mapper);
+          set_relay_mapper_path (relay_mapper);
+        }
     }
   else
-    {
-      gchar *default_mapper = g_find_program_in_path ("gvm-relay-mapper");
-      if (default_mapper)
-        {
-          g_debug ("Using default relay mapper '%s'.", default_mapper);
-          set_relay_mapper_path (default_mapper);
-        }
-      else
-        g_debug ("No default relay mapper found.");
-    }
+    g_debug ("Relay mapper disabled.");
 
   /*
    * Parameters for new credential encryption keys

--- a/src/manage.c
+++ b/src/manage.c
@@ -853,6 +853,22 @@ scanner_type_valid (scanner_type_t scanner_type)
   return 0;
 }
 
+/**
+ * @brief Check if a scanner type supports UNIX sockets.
+ *
+ * @param[in]  scanner_type  Scanner type.
+ *
+ * @return 1 if unix sockets are supported, else 0.
+ */
+int
+scanner_type_supports_unix_sockets (scanner_type_t scanner_type)
+{
+  if (scanner_type == SCANNER_TYPE_OPENVAS
+      || scanner_type == SCANNER_TYPE_OSP_SENSOR)
+    return 1;
+  return 0;
+}
+
 
 /* Severity related functions. */
 

--- a/src/manage.h
+++ b/src/manage.h
@@ -341,6 +341,9 @@ typedef enum scanner_type
 int
 scanner_type_valid (scanner_type_t);
 
+int
+scanner_type_supports_unix_sockets (scanner_type_t);
+
 typedef resource_t credential_t;
 typedef resource_t alert_t;
 typedef resource_t filter_t;
@@ -2800,12 +2803,14 @@ manage_system_report (const char *, const char *, const char *, const char *,
 int
 manage_create_scanner (GSList *, const db_conn_info_t *, const char *,
                        const char *, const char *, const char *, const char *,
-                       const char *, const char *, const char *);
+                       const char *, const char *, const char *,
+                       const char *, const char *);
 
 int
 manage_modify_scanner (GSList *, const db_conn_info_t *, const char *,
                        const char *, const char *, const char *, const char *,
-                       const char *, const char *, const char *, const char *);
+                       const char *, const char *, const char *, const char *,
+                       const char *, const char *);
 
 int
 manage_delete_scanner (GSList *, const db_conn_info_t *, const gchar *);
@@ -2816,16 +2821,53 @@ manage_verify_scanner (GSList *, const db_conn_info_t *, const gchar *);
 int
 manage_get_scanners (GSList *, const db_conn_info_t *);
 
-int
+
+typedef enum {
+  CREATE_SCANNER_INTERNAL_ERROR = -1,     ///< Internal error
+  CREATE_SCANNER_SUCCESS = 0,             ///< Success
+  CREATE_SCANNER_ALREADY_EXISTS,          ///< Scanner already exists
+  CREATE_SCANNER_MISSING_TYPE,            ///< Missing type
+  CREATE_SCANNER_MISSING_HOST,            ///< Missing host
+  CREATE_SCANNER_CREDENTIAL_NOT_FOUND,    ///< Credential not found
+  CREATE_SCANNER_CREDENTIAL_NOT_CC,       ///< Credential must have type "cc"
+  CREATE_SCANNER_INVALID_TYPE,            ///< Invalid type
+  CREATE_SCANNER_INVALID_PORT,            ///< Invalid port
+  CREATE_SCANNER_INVALID_HOST,            ///< Invalid host
+  CREATE_SCANNER_INVALID_RELAY_PORT,      ///< Invalid relay port
+  CREATE_SCANNER_INVALID_RELAY_HOST,      ///< Invalid relay host
+  CREATE_SCANNER_UNIX_SOCKET_UNSUPPORTED, ///< Type doesn't support UNIX sockets
+  CREATE_SCANNER_PERMISSION_DENIED = 99   ///< Permission denied
+} create_scanner_return_t;
+
+create_scanner_return_t
 create_scanner (const char*, const char *, const char *, const char *,
-                const char *, scanner_t *, const char *, const char *);
+                const char *, scanner_t *, const char *, const char *,
+                const char *, const char *);
 
 int
 copy_scanner (const char*, const char*, const char *, scanner_t *);
 
-int
+typedef enum {
+  MODIFY_SCANNER_INTERNAL_ERROR = -1,     ///< Internal error
+  MODIFY_SCANNER_SUCCESS = 0,             ///< Success
+  MODIFY_SCANNER_ALREADY_EXISTS,          ///< Scanner already exists
+  MODIFY_SCANNER_MISSING_ID,              ///< Missing scanner id
+  MODIFY_SCANNER_NOT_FOUND,               ///< Scanner not found
+  MODIFY_SCANNER_CREDENTIAL_NOT_FOUND,    ///< Credential not found
+  MODIFY_SCANNER_CREDENTIAL_NOT_CC,       ///< Credential must have type "cc"
+  MODIFY_SCANNER_INVALID_TYPE,            ///< Invalid type
+  MODIFY_SCANNER_INVALID_PORT,            ///< Invalid port
+  MODIFY_SCANNER_INVALID_HOST,            ///< Invalid host
+  MODIFY_SCANNER_INVALID_RELAY_PORT,      ///< Invalid relay port
+  MODIFY_SCANNER_INVALID_RELAY_HOST,      ///< Invalid relay host
+  MODIFY_SCANNER_UNIX_SOCKET_UNSUPPORTED, ///< Type doesn't support UNIX sockets
+  MODIFY_SCANNER_PERMISSION_DENIED = 99   ///< Permission denied
+} modify_scanner_return_t;
+
+modify_scanner_return_t
 modify_scanner (const char*, const char*, const char*, const char *,
-                const char *, const char *, const char *, const char *);
+                const char *, const char *, const char *, const char *,
+                const char *, const char *);
 
 int
 delete_scanner (const char *, int);
@@ -2910,6 +2952,12 @@ scanner_iterator_key_pub (iterator_t *);
 
 const char*
 scanner_iterator_credential_type (iterator_t *);
+
+const char*
+scanner_iterator_relay_host (iterator_t *);
+
+int
+scanner_iterator_relay_port (iterator_t *);
 
 int
 scanner_config_iterator_readable (iterator_t *);

--- a/src/manage.h
+++ b/src/manage.h
@@ -2893,11 +2893,14 @@ scanner_writable (scanner_t);
 const char *
 scanner_uuid_default ();
 
+gboolean
+scanner_has_relay (scanner_t);
+
 char *
-scanner_host (scanner_t);
+scanner_host (scanner_t, gboolean);
 
 int
-scanner_port (scanner_t);
+scanner_port (scanner_t, gboolean);
 
 int
 scanner_type (scanner_t);
@@ -2998,7 +3001,8 @@ osp_connect_with_data (const char *,
                        int,
                        const char *,
                        const char *,
-                       const char *);
+                       const char *,
+                       gboolean);
 
 osp_connection_t *
 osp_scanner_connect (scanner_t);

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -3256,7 +3256,7 @@ migrate_256_to_257 ()
 }
 
 /**
- * @brief Migrate the database from version 256 to version 257.
+ * @brief Migrate the database from version 257 to version 258.
  *
  * @return 0 success, -1 error.
  */
@@ -3299,6 +3299,48 @@ migrate_257_to_258 ()
   /* Set the database version to 258. */
 
   set_db_version (258);
+
+  sql_commit ();
+
+  return 0;
+}
+
+/**
+ * @brief Migrate the database from version 258 to version 259.
+ *
+ * @return 0 success, -1 error.
+ */
+int
+migrate_258_to_259 ()
+{
+  sql_begin_immediate ();
+
+  /* Ensure that the database is currently version 258. */
+
+  if (manage_db_version () != 258)
+    {
+      sql_rollback ();
+      return -1;
+    }
+
+  /* Update the database. */
+
+  // Add relay_host and relay_port fields to scanners
+
+  sql ("ALTER TABLE scanners ADD COLUMN relay_host text;"); 
+  sql ("ALTER TABLE scanners ADD COLUMN relay_port integer;"); 
+
+  sql ("ALTER TABLE scanners_trash ADD COLUMN relay_host text;"); 
+  sql ("ALTER TABLE scanners_trash ADD COLUMN relay_port integer;");
+ 
+  // Set base values for new relay fields
+
+  sql ("UPDATE scanners SET relay_host = '', relay_port = 0;");
+  sql ("UPDATE scanners_trash SET relay_host = '', relay_port = 0;");
+
+  /* Set the database version to 259. */
+
+  set_db_version (259);
 
   sql_commit ();
 
@@ -3369,6 +3411,7 @@ static migrator_t database_migrators[] = {
   {256, migrate_255_to_256},
   {257, migrate_256_to_257},
   {258, migrate_257_to_258},
+  {259, migrate_258_to_259},
   /* End marker. */
   {-1, NULL}};
 

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -2692,7 +2692,9 @@ create_tables ()
        "  ca_pub text,"
        "  credential integer REFERENCES credentials (id) ON DELETE RESTRICT,"
        "  creation_time integer,"
-       "  modification_time integer);");
+       "  modification_time integer,"
+       "  relay_host text,"
+       "  relay_port integer);");
 
   sql ("CREATE TABLE IF NOT EXISTS configs"
        " (id SERIAL PRIMARY KEY,"
@@ -2796,7 +2798,9 @@ create_tables ()
        "  credential integer,"
        "  credential_location integer,"
        "  creation_time integer,"
-       "  modification_time integer);");
+       "  modification_time integer,"
+       "  relay_host text,"
+       "  relay_port integer);");
 
   sql ("CREATE TABLE IF NOT EXISTS tasks"
        " (id SERIAL PRIMARY KEY,"

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -60046,7 +60046,7 @@ manage_optimize (GSList *log_config, const db_conn_info_t *database,
         {
           fprintf (stderr,
                    "No relay mapper found."
-                   " Please check your $PATH or the --relay-mapper option.\n");
+                   " Please check your --relay-mapper option.\n");
           success_text = NULL;
           ret = -1;
         }

--- a/src/manage_sql_nvts_openvasd.c
+++ b/src/manage_sql_nvts_openvasd.c
@@ -547,8 +547,10 @@ nvts_feed_info_internal_from_openvasd (const gchar *scanner_uuid,
   resp = openvasd_get_health_ready (connector);
   if (resp->code == -1)
     {
+      gboolean has_relay = scanner_has_relay (scan);
       g_warning ("%s: failed to connect to %s:%d", __func__,
-                 scanner_host (scan), scanner_port (scan));
+                 scanner_host (scan, has_relay),
+                 scanner_port (scan, has_relay));
       ret = 1;
     }
   else if (resp->code  == 503)

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -5594,6 +5594,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <e>type</e>
       <e>ca_pub</e>
       <e>credential</e>
+      <o><e>relay_host</e></o>
+      <o><e>relay_port</e></o>
     </pattern>
     <ele>
       <name>name</name>
@@ -5644,6 +5646,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <required>1</required>
         </attrib>
       </pattern>
+    </ele>
+    <ele>
+      <name>relay_host</name>
+      <summary>Optional relay host of the scanner</summary>
+      <pattern>text</pattern>
+    </ele>
+    <ele>
+      <name>relay_port</name>
+      <summary>Optional relay port of the scanner</summary>
+      <pattern>text</pattern>
     </ele>
     <response>
       <pattern>
@@ -20268,7 +20280,7 @@ END:VCALENDAR
             <type>integer</type>
             <summary>Port of the scanner</summary>
           </column>
-         <column>
+          <column>
             <name>type</name>
             <type>
               <alts>
@@ -20277,6 +20289,16 @@ END:VCALENDAR
               </alts>
             </type>
             <summary>Scanner type: '1' for OSP, '2' for OpenVAS (classic)</summary>
+          </column>
+          <column>
+            <name>relay_host</name>
+            <type>text</type>
+            <summary>Relay host of the scanner</summary>
+          </column>
+          <column>
+            <name>relay_port</name>
+            <type>integer</type>
+            <summary>Relay port of the scanner</summary>
           </column>
         </filter_keywords>
       </attrib>
@@ -20339,6 +20361,8 @@ END:VCALENDAR
           <e>type</e>
           <e>ca_pub</e>
           <e>credential</e>
+          <e>relay_host</e>
+          <e>relay_port</e>
           <o><e>configs</e></o>
           <o><e>tasks</e></o>
         </pattern>
@@ -20522,6 +20546,16 @@ END:VCALENDAR
               <t>boolean</t>
             </pattern>
           </ele>
+        </ele>
+        <ele>
+          <name>relay_host</name>
+          <summary>Optional relay host of the scanner</summary>
+          <pattern>text</pattern>
+        </ele>
+        <ele>
+          <name>relay_port</name>
+          <summary>Optional relay port of the scanner</summary>
+          <pattern>text</pattern>
         </ele>
         <ele>
           <name>configs</name>
@@ -28269,6 +28303,8 @@ END:VCALENDAR
       <e>type</e>
       <o><e>ca_pub</e></o>
       <o><e>credential</e></o>
+      <o><e>relay_host</e></o>
+      <o><e>relay_port</e></o>
     </pattern>
     <ele>
       <name>comment</name>
@@ -28311,6 +28347,16 @@ END:VCALENDAR
           <required>1</required>
         </attrib>
       </pattern>
+    </ele>
+    <ele>
+      <name>relay_host</name>
+      <summary>Optional relay host of the scanner</summary>
+      <pattern>text</pattern>
+    </ele>
+    <ele>
+      <name>relay_port</name>
+      <summary>Optional relay port of the scanner</summary>
+      <pattern>text</pattern>
     </ele>
     <response>
       <pattern>


### PR DESCRIPTION
## What
Scanners now have the fields relay_host and relay_port which will
later override the host and port if they are set.

When trying to connect to an ospd-openvas or openvasd scanner, the
host and port from the new relay fields are used if they are set.
For ospd-openvas scanners the relay mapper is also not used if they
have their relay defined in the database.

The script for automatically mapping scanner hosts to relays
is now no longer detected automatically and has to be set with
the --relay-mapper, which is now also deprecated in favor of
the new scanner fields relay_host and relay_port.

## Why
Removing the automatic relay mapper eventually will simplify sensor connections
by no longer requiring an external script and managing the relays externally.

## References
GEA-987

