### PR TITLE
Move alert conditions and methods

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -97,6 +97,7 @@
 #include "gmp_tls_certificates.h"
 #include "manage.h"
 #include "manage_acl.h"
+#include "manage_alerts.h"
 #include "manage_port_lists.h"
 #include "manage_report_configs.h"
 #include "manage_report_formats.h"

--- a/src/manage.c
+++ b/src/manage.c
@@ -1399,33 +1399,6 @@ report_t global_current_report = (report_t) 0;
 /* Alerts. */
 
 /**
- * @brief Get the name of an alert condition.
- *
- * @param[in]  condition  Condition.
- *
- * @return The name of the condition (for example, "Always").
- */
-const char*
-alert_condition_name (alert_condition_t condition)
-{
-  switch (condition)
-    {
-      case ALERT_CONDITION_ALWAYS:
-        return "Always";
-      case ALERT_CONDITION_FILTER_COUNT_AT_LEAST:
-        return "Filter count at least";
-      case ALERT_CONDITION_FILTER_COUNT_CHANGED:
-        return "Filter count changed";
-      case ALERT_CONDITION_SEVERITY_AT_LEAST:
-        return "Severity at least";
-      case ALERT_CONDITION_SEVERITY_CHANGED:
-        return "Severity changed";
-      default:
-        return "Internal Error";
-    }
-}
-
-/**
  * @brief Get the name of an alert event.
  *
  * @param[in]  event  Event.
@@ -1444,56 +1417,6 @@ event_name (event_t event)
       case EVENT_ASSIGNED_TICKET_CHANGED: return "Assigned ticket changed";
       case EVENT_OWNED_TICKET_CHANGED:    return "Owned ticket changed";
       default:                            return "Internal Error";
-    }
-}
-
-/**
- * @brief Get a description of an alert condition.
- *
- * @param[in]  condition  Condition.
- * @param[in]  alert  Alert.
- *
- * @return Freshly allocated description of condition.
- */
-gchar*
-alert_condition_description (alert_condition_t condition,
-                             alert_t alert)
-{
-  switch (condition)
-    {
-      case ALERT_CONDITION_ALWAYS:
-        return g_strdup ("Always");
-      case ALERT_CONDITION_FILTER_COUNT_AT_LEAST:
-        {
-          char *count;
-          gchar *ret;
-
-          count = alert_data (alert, "condition", "count");
-          ret = g_strdup_printf ("Filter count at least %s",
-                                 count ? count : "0");
-          free (count);
-          return ret;
-        }
-      case ALERT_CONDITION_FILTER_COUNT_CHANGED:
-        return g_strdup ("Filter count changed");
-      case ALERT_CONDITION_SEVERITY_AT_LEAST:
-        {
-          char *level = alert_data (alert, "condition", "severity");
-          gchar *ret = g_strdup_printf ("Task severity is at least '%s'",
-                                        level);
-          free (level);
-          return ret;
-        }
-      case ALERT_CONDITION_SEVERITY_CHANGED:
-        {
-          char *direction;
-          direction = alert_data (alert, "condition", "direction");
-          gchar *ret = g_strdup_printf ("Task severity %s", direction);
-          free (direction);
-          return ret;
-        }
-      default:
-        return g_strdup ("Internal Error");
     }
 }
 
@@ -1566,29 +1489,6 @@ alert_method_name (alert_method_t method)
       case ALERT_METHOD_VFIRE:       return "Alemba vFire";
       default:                       return "Internal Error";
     }
-}
-
-/**
- * @brief Get an alert condition from a name.
- *
- * @param[in]  name  Condition name.
- *
- * @return The condition.
- */
-alert_condition_t
-alert_condition_from_name (const char* name)
-{
-  if (strcasecmp (name, "Always") == 0)
-    return ALERT_CONDITION_ALWAYS;
-  if (strcasecmp (name, "Filter count at least") == 0)
-    return ALERT_CONDITION_FILTER_COUNT_AT_LEAST;
-  if (strcasecmp (name, "Filter count changed") == 0)
-    return ALERT_CONDITION_FILTER_COUNT_CHANGED;
-  if (strcasecmp (name, "Severity at least") == 0)
-    return ALERT_CONDITION_SEVERITY_AT_LEAST;
-  if (strcasecmp (name, "Severity changed") == 0)
-    return ALERT_CONDITION_SEVERITY_CHANGED;
-  return ALERT_CONDITION_ERROR;
 }
 
 /**

--- a/src/manage.c
+++ b/src/manage.c
@@ -1396,7 +1396,7 @@ task_t current_scanner_task = (task_t) 0;
 report_t global_current_report = (report_t) 0;
 
 
-/* Alerts. */
+/* Events. */
 
 /**
  * @brief Get the name of an alert event.
@@ -1464,34 +1464,6 @@ event_description (event_t event, const void *event_data, const char *task_name)
 }
 
 /**
- * @brief Get the name of an alert method.
- *
- * @param[in]  method  Method.
- *
- * @return The name of the method (for example, "Email" or "SNMP").
- */
-const char*
-alert_method_name (alert_method_t method)
-{
-  switch (method)
-    {
-      case ALERT_METHOD_EMAIL:       return "Email";
-      case ALERT_METHOD_HTTP_GET:    return "HTTP Get";
-      case ALERT_METHOD_SCP:         return "SCP";
-      case ALERT_METHOD_SEND:        return "Send";
-      case ALERT_METHOD_SMB:         return "SMB";
-      case ALERT_METHOD_SNMP:        return "SNMP";
-      case ALERT_METHOD_SOURCEFIRE:  return "Sourcefire Connector";
-      case ALERT_METHOD_START_TASK:  return "Start Task";
-      case ALERT_METHOD_SYSLOG:      return "Syslog";
-      case ALERT_METHOD_TIPPINGPOINT:return "TippingPoint SMS";
-      case ALERT_METHOD_VERINICE:    return "verinice Connector";
-      case ALERT_METHOD_VFIRE:       return "Alemba vFire";
-      default:                       return "Internal Error";
-    }
-}
-
-/**
  * @brief Get an event from a name.
  *
  * @param[in]  name  Event name.
@@ -1514,43 +1486,6 @@ event_from_name (const char* name)
   if (strcasecmp (name, "Owned ticket changed") == 0)
     return EVENT_OWNED_TICKET_CHANGED;
   return EVENT_ERROR;
-}
-
-/**
- * @brief Get an alert method from a name.
- *
- * @param[in]  name  Method name.
- *
- * @return The method.
- */
-alert_method_t
-alert_method_from_name (const char* name)
-{
-  if (strcasecmp (name, "Email") == 0)
-    return ALERT_METHOD_EMAIL;
-  if (strcasecmp (name, "HTTP Get") == 0)
-    return ALERT_METHOD_HTTP_GET;
-  if (strcasecmp (name, "SCP") == 0)
-    return ALERT_METHOD_SCP;
-  if (strcasecmp (name, "Send") == 0)
-    return ALERT_METHOD_SEND;
-  if (strcasecmp (name, "SMB") == 0)
-    return ALERT_METHOD_SMB;
-  if (strcasecmp (name, "SNMP") == 0)
-    return ALERT_METHOD_SNMP;
-  if (strcasecmp (name, "Sourcefire Connector") == 0)
-    return ALERT_METHOD_SOURCEFIRE;
-  if (strcasecmp (name, "Start Task") == 0)
-    return ALERT_METHOD_START_TASK;
-  if (strcasecmp (name, "Syslog") == 0)
-    return ALERT_METHOD_SYSLOG;
-  if (strcasecmp (name, "TippingPoint SMS") == 0)
-    return ALERT_METHOD_TIPPINGPOINT;
-  if (strcasecmp (name, "verinice Connector") == 0)
-    return ALERT_METHOD_VERINICE;
-  if (strcasecmp (name, "Alemba vFire") == 0)
-    return ALERT_METHOD_VFIRE;
-  return ALERT_METHOD_ERROR;
 }
 
 

--- a/src/manage.h
+++ b/src/manage.h
@@ -533,26 +533,6 @@ typedef enum
   EVENT_OWNED_TICKET_CHANGED
 } event_t;
 
-/**
- * @brief Types of alerts.
- */
-typedef enum
-{
-  ALERT_METHOD_ERROR,
-  ALERT_METHOD_EMAIL,
-  ALERT_METHOD_HTTP_GET,
-  ALERT_METHOD_SOURCEFIRE,
-  ALERT_METHOD_START_TASK,
-  ALERT_METHOD_SYSLOG,
-  ALERT_METHOD_VERINICE,
-  ALERT_METHOD_SEND,
-  ALERT_METHOD_SCP,
-  ALERT_METHOD_SNMP,
-  ALERT_METHOD_SMB,
-  ALERT_METHOD_TIPPINGPOINT,
-  ALERT_METHOD_VFIRE,
-} alert_method_t;
-
 int
 manage_check_alerts (GSList *, const db_conn_info_t *);
 
@@ -635,14 +615,8 @@ event_description (event_t, const void *, const char *);
 alert_method_t
 alert_method (alert_t alert);
 
-const char*
-alert_method_name (alert_method_t);
-
 event_t
 event_from_name (const char*);
-
-alert_method_t
-alert_method_from_name (const char*);
 
 void
 init_alert_data_iterator (iterator_t *, alert_t, int, const char *);

--- a/src/manage.h
+++ b/src/manage.h
@@ -25,6 +25,7 @@
 #define _GVMD_MANAGE_H
 
 #include "iterator.h"
+#include "manage_alerts.h"
 #include "manage_configs.h"
 #include "manage_get.h"
 #include "sql.h"
@@ -333,7 +334,6 @@ int
 scanner_type_valid (scanner_type_t);
 
 typedef resource_t credential_t;
-typedef resource_t alert_t;
 typedef resource_t filter_t;
 typedef resource_t group_t;
 typedef resource_t host_t;
@@ -553,19 +553,6 @@ typedef enum
   ALERT_METHOD_VFIRE,
 } alert_method_t;
 
-/**
- * @brief Types of alert conditions.
- */
-typedef enum
-{
-  ALERT_CONDITION_ERROR,
-  ALERT_CONDITION_ALWAYS,
-  ALERT_CONDITION_SEVERITY_AT_LEAST,
-  ALERT_CONDITION_SEVERITY_CHANGED,
-  ALERT_CONDITION_FILTER_COUNT_AT_LEAST,
-  ALERT_CONDITION_FILTER_COUNT_CHANGED
-} alert_condition_t;
-
 int
 manage_check_alerts (GSList *, const db_conn_info_t *);
 
@@ -640,12 +627,6 @@ int
 alert_iterator_active (iterator_t*);
 
 const char*
-alert_condition_name (alert_condition_t);
-
-gchar*
-alert_condition_description (alert_condition_t, alert_t);
-
-const char*
 event_name (event_t);
 
 gchar*
@@ -656,9 +637,6 @@ alert_method (alert_t alert);
 
 const char*
 alert_method_name (alert_method_t);
-
-alert_condition_t
-alert_condition_from_name (const char*);
 
 event_t
 event_from_name (const char*);

--- a/src/manage_alerts.c
+++ b/src/manage_alerts.c
@@ -171,3 +171,71 @@ alert_condition_from_name (const char* name)
     return ALERT_CONDITION_SEVERITY_CHANGED;
   return ALERT_CONDITION_ERROR;
 }
+
+
+/* Alert methods. */
+
+/**
+ * @brief Get the name of an alert method.
+ *
+ * @param[in]  method  Method.
+ *
+ * @return The name of the method (for example, "Email" or "SNMP").
+ */
+const char*
+alert_method_name (alert_method_t method)
+{
+  switch (method)
+    {
+      case ALERT_METHOD_EMAIL:       return "Email";
+      case ALERT_METHOD_HTTP_GET:    return "HTTP Get";
+      case ALERT_METHOD_SCP:         return "SCP";
+      case ALERT_METHOD_SEND:        return "Send";
+      case ALERT_METHOD_SMB:         return "SMB";
+      case ALERT_METHOD_SNMP:        return "SNMP";
+      case ALERT_METHOD_SOURCEFIRE:  return "Sourcefire Connector";
+      case ALERT_METHOD_START_TASK:  return "Start Task";
+      case ALERT_METHOD_SYSLOG:      return "Syslog";
+      case ALERT_METHOD_TIPPINGPOINT:return "TippingPoint SMS";
+      case ALERT_METHOD_VERINICE:    return "verinice Connector";
+      case ALERT_METHOD_VFIRE:       return "Alemba vFire";
+      default:                       return "Internal Error";
+    }
+}
+
+/**
+ * @brief Get an alert method from a name.
+ *
+ * @param[in]  name  Method name.
+ *
+ * @return The method.
+ */
+alert_method_t
+alert_method_from_name (const char* name)
+{
+  if (strcasecmp (name, "Email") == 0)
+    return ALERT_METHOD_EMAIL;
+  if (strcasecmp (name, "HTTP Get") == 0)
+    return ALERT_METHOD_HTTP_GET;
+  if (strcasecmp (name, "SCP") == 0)
+    return ALERT_METHOD_SCP;
+  if (strcasecmp (name, "Send") == 0)
+    return ALERT_METHOD_SEND;
+  if (strcasecmp (name, "SMB") == 0)
+    return ALERT_METHOD_SMB;
+  if (strcasecmp (name, "SNMP") == 0)
+    return ALERT_METHOD_SNMP;
+  if (strcasecmp (name, "Sourcefire Connector") == 0)
+    return ALERT_METHOD_SOURCEFIRE;
+  if (strcasecmp (name, "Start Task") == 0)
+    return ALERT_METHOD_START_TASK;
+  if (strcasecmp (name, "Syslog") == 0)
+    return ALERT_METHOD_SYSLOG;
+  if (strcasecmp (name, "TippingPoint SMS") == 0)
+    return ALERT_METHOD_TIPPINGPOINT;
+  if (strcasecmp (name, "verinice Connector") == 0)
+    return ALERT_METHOD_VERINICE;
+  if (strcasecmp (name, "Alemba vFire") == 0)
+    return ALERT_METHOD_VFIRE;
+  return ALERT_METHOD_ERROR;
+}

--- a/src/manage_alerts.c
+++ b/src/manage_alerts.c
@@ -24,12 +24,16 @@
  */
 
 #include "manage_alerts.h"
+#include "manage_sql.h"
 
 #undef G_LOG_DOMAIN
 /**
  * @brief GLib log domain.
  */
 #define G_LOG_DOMAIN "md manage"
+
+
+/* Alert report data. */
 
 /**
  * @brief Frees a alert_report_data_t struct, including contained data.
@@ -63,4 +67,107 @@ alert_report_data_reset (alert_report_data_t *data)
   g_free (data->report_format_name);
 
   memset (data, 0, sizeof (alert_report_data_t));
+}
+
+
+/* Alert conditions. */
+
+/**
+ * @brief Get the name of an alert condition.
+ *
+ * @param[in]  condition  Condition.
+ *
+ * @return The name of the condition (for example, "Always").
+ */
+const char*
+alert_condition_name (alert_condition_t condition)
+{
+  switch (condition)
+    {
+      case ALERT_CONDITION_ALWAYS:
+        return "Always";
+      case ALERT_CONDITION_FILTER_COUNT_AT_LEAST:
+        return "Filter count at least";
+      case ALERT_CONDITION_FILTER_COUNT_CHANGED:
+        return "Filter count changed";
+      case ALERT_CONDITION_SEVERITY_AT_LEAST:
+        return "Severity at least";
+      case ALERT_CONDITION_SEVERITY_CHANGED:
+        return "Severity changed";
+      default:
+        return "Internal Error";
+    }
+}
+
+/**
+ * @brief Get a description of an alert condition.
+ *
+ * @param[in]  condition  Condition.
+ * @param[in]  alert  Alert.
+ *
+ * @return Freshly allocated description of condition.
+ */
+gchar*
+alert_condition_description (alert_condition_t condition,
+                             alert_t alert)
+{
+  switch (condition)
+    {
+      case ALERT_CONDITION_ALWAYS:
+        return g_strdup ("Always");
+      case ALERT_CONDITION_FILTER_COUNT_AT_LEAST:
+        {
+          char *count;
+          gchar *ret;
+
+          count = alert_data (alert, "condition", "count");
+          ret = g_strdup_printf ("Filter count at least %s",
+                                 count ? count : "0");
+          free (count);
+          return ret;
+        }
+      case ALERT_CONDITION_FILTER_COUNT_CHANGED:
+        return g_strdup ("Filter count changed");
+      case ALERT_CONDITION_SEVERITY_AT_LEAST:
+        {
+          char *level = alert_data (alert, "condition", "severity");
+          gchar *ret = g_strdup_printf ("Task severity is at least '%s'",
+                                        level);
+          free (level);
+          return ret;
+        }
+      case ALERT_CONDITION_SEVERITY_CHANGED:
+        {
+          char *direction;
+          direction = alert_data (alert, "condition", "direction");
+          gchar *ret = g_strdup_printf ("Task severity %s", direction);
+          free (direction);
+          return ret;
+        }
+      default:
+        return g_strdup ("Internal Error");
+    }
+}
+
+/**
+ * @brief Get an alert condition from a name.
+ *
+ * @param[in]  name  Condition name.
+ *
+ * @return The condition.
+ */
+alert_condition_t
+alert_condition_from_name (const char* name)
+{
+  if (strcasecmp (name, "Always") == 0)
+    return ALERT_CONDITION_ALWAYS;
+  if (strcasecmp (name, "Filter count at least") == 0)
+    return ALERT_CONDITION_FILTER_COUNT_AT_LEAST;
+  if (strcasecmp (name, "Filter count changed") == 0)
+    return ALERT_CONDITION_FILTER_COUNT_CHANGED;
+  if (strcasecmp (name, "Severity at least") == 0)
+    return ALERT_CONDITION_SEVERITY_AT_LEAST;
+  if (strcasecmp (name, "Severity changed") == 0)
+    return ALERT_CONDITION_SEVERITY_CHANGED;
+  return ALERT_CONDITION_ERROR;
 }

--- a/src/manage_alerts.h
+++ b/src/manage_alerts.h
@@ -63,4 +63,30 @@ alert_report_data_free (alert_report_data_t *);
 void
 alert_report_data_reset (alert_report_data_t *);
 
+/**
+ * @brief Types of alerts.
+ */
+typedef enum
+{
+  ALERT_METHOD_ERROR,
+  ALERT_METHOD_EMAIL,
+  ALERT_METHOD_HTTP_GET,
+  ALERT_METHOD_SOURCEFIRE,
+  ALERT_METHOD_START_TASK,
+  ALERT_METHOD_SYSLOG,
+  ALERT_METHOD_VERINICE,
+  ALERT_METHOD_SEND,
+  ALERT_METHOD_SCP,
+  ALERT_METHOD_SNMP,
+  ALERT_METHOD_SMB,
+  ALERT_METHOD_TIPPINGPOINT,
+  ALERT_METHOD_VFIRE,
+} alert_method_t;
+
+const char*
+alert_method_name (alert_method_t);
+
+alert_method_t
+alert_method_from_name (const char*);
+
 #endif /* not _GVMD_MANAGE_ALERTS_H */

--- a/src/manage_alerts.h
+++ b/src/manage_alerts.h
@@ -19,7 +19,33 @@
 #ifndef _GVMD_MANAGE_ALERTS_H
 #define _GVMD_MANAGE_ALERTS_H
 
+#include "iterator.h"
+
 #include <glib.h>
+
+typedef resource_t alert_t;
+
+/**
+ * @brief Types of alert conditions.
+ */
+typedef enum
+{
+  ALERT_CONDITION_ERROR,
+  ALERT_CONDITION_ALWAYS,
+  ALERT_CONDITION_SEVERITY_AT_LEAST,
+  ALERT_CONDITION_SEVERITY_CHANGED,
+  ALERT_CONDITION_FILTER_COUNT_AT_LEAST,
+  ALERT_CONDITION_FILTER_COUNT_CHANGED
+} alert_condition_t;
+
+const char*
+alert_condition_name (alert_condition_t);
+
+gchar*
+alert_condition_description (alert_condition_t, alert_t);
+
+alert_condition_t
+alert_condition_from_name (const char*);
 
 /**
  * @brief Data about a report sent by an alert.


### PR DESCRIPTION
## What

Move the rest of the alert code from `manage.c` to `manage_alerts.c`.

## Why

Better organisation. Reduces the size of `manage.c`.

## References

Follows /pull/2398.

