### PR TITLE
Install ca-certificates in container images

### DIFF
--- a/.github/runtime-dependencies.list
+++ b/.github/runtime-dependencies.list
@@ -49,6 +49,10 @@
 # Required for set up certificates for GVM
 # gnutls-bin
 
+# SSL/TLS verification
+# ca-certificates
+
+ca-certificates
 dpkg
 fakeroot
 nsis


### PR DESCRIPTION



## What

Install ca-certificates in container images
## Why
Add the ca-certificates to the container images to allow SSL/TLS verification for example when using curl with http or TLS for the MTA setup.

## References

Replaces #2390
Closes https://github.com/greenbone/gvmd/issues/2316 https://github.com/greenbone/docs/issues/483


