### PR TITLE
Fix: Typo in scanner trash columns

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -42564,7 +42564,7 @@ delete_scanner (const char *scanner_id, int ultimate)
      " WHEN credential_location = " G_STRINGIFY (LOCATION_TABLE)        \
      " THEN (SELECT type FROM credentials WHERE id = credential)"       \
      " ELSE (SELECT type FROM credentials_trash WHERE id = credential)" \
-     " END",                                                            \
+     " END)",                                                            \
      "credential_type",                                                 \
      KEYWORD_TYPE_STRING                                                \
    },                                                                   \


### PR DESCRIPTION
## What
The credential_type column in SCANNER_ITERATOR_TRASH_COLUMNS was missing a closing parenthesis.

## Why
This caused SQL errors when getting scanners in the trashcan.

## References
GEA-987