### PR TITLE
Fix: check return args of find_resource_no_acl

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -7332,7 +7332,7 @@ nvts_feed_info (gchar **vts_version, gchar **feed_name, gchar **feed_vendor,
 {
 #if OPENVASD == 1
   return nvts_feed_info_internal_from_openvasd (SCANNER_UUID_OPENVASD_DEFAULT,
-                                  vts_version);
+                                                vts_version);
 #else
   return nvts_feed_info_internal (get_osp_vt_update_socket (),
                                   vts_version,
@@ -7407,7 +7407,7 @@ nvts_check_feed (int *lockfile_in_use,
   char *vts_version = NULL;
 
   ret = nvts_feed_info_internal_from_openvasd (SCANNER_UUID_OPENVASD_DEFAULT,
-                                  &vts_version);
+                                               &vts_version);
   self_test_exit_error = 0;
   *self_test_error_msg = NULL;
   if (ret == 0 && vts_version)

--- a/src/manage.c
+++ b/src/manage.c
@@ -4311,8 +4311,6 @@ get_osp_performance_string (scanner_t scanner, int start, int end,
                             const char *titles, gchar **performance_str,
                             gchar **error)
 {
-  int return_value;
-
 #if OPENVASD
   openvasd_connector_t connector;
   int err;
@@ -4341,7 +4339,7 @@ get_osp_performance_string (scanner_t scanner, int start, int end,
 #else
   gboolean has_relay;
   char *host, *ca_pub, *key_pub, *key_priv;
-  int port;
+  int return_value, port;
   osp_connection_t *connection = NULL;
   int connection_retry;
   osp_get_performance_opts_t opts;

--- a/src/manage_sql_nvts_openvasd.c
+++ b/src/manage_sql_nvts_openvasd.c
@@ -410,6 +410,8 @@ update_nvt_cache_openvasd (gchar *db_feed_version,
   /* Update NVTs. */
   if (find_resource_no_acl ("scanner", SCANNER_UUID_OPENVASD_DEFAULT, &scan))
     return -1;
+  if (scan == 0)
+    return -1;
 
   connector = openvasd_scanner_connect (scan, NULL);
   if (!connector)
@@ -537,7 +539,11 @@ nvts_feed_info_internal_from_openvasd (const gchar *scanner_uuid,
   openvasd_connector_t connector = NULL;
   openvasd_resp_t resp = NULL;
   int ret;
+
   if (find_resource_no_acl ("scanner", scanner_uuid, &scan))
+    return -1;
+
+  if (scan == 0)
     return -1;
 
   connector = openvasd_scanner_connect (scan, NULL);


### PR DESCRIPTION
## What

Add missing checks of the `scan` argument "returned" from `find_resource_no_acl`.

Also move a variable that was causing compile failure. 

## Why

These find functions always need the arg checked as well as the regular return. This was causing aborts when the openvasd scanner is missing from the db.
