### PR TITLE
Change: move first function to new file manage_sql_alerts.c

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -123,7 +123,8 @@ add_executable (manage-utils-test
                 manage_report_configs.c
                 manage_report_formats.c
                 manage_authentication.c
-                manage_sql.c manage_sql_nvts.c manage_sql_secinfo.c
+                manage_sql.c manage_sql_alerts.c
+                manage_sql_nvts.c manage_sql_secinfo.c
                 manage_sql_port_lists.c manage_sql_configs.c
                 manage_sql_report_configs.c
                 manage_sql_report_formats.c
@@ -158,7 +159,8 @@ add_executable (manage-test
                 manage_report_configs.c
                 manage_report_formats.c
                 manage_authentication.c
-                manage_sql.c manage_sql_nvts.c manage_sql_secinfo.c
+                manage_sql.c manage_sql_alerts.c
+                manage_sql_nvts.c manage_sql_secinfo.c
                 manage_sql_port_lists.c manage_sql_configs.c
                 manage_sql_report_configs.c
                 manage_sql_report_formats.c
@@ -193,6 +195,7 @@ add_executable (manage-sql-test
                 manage_report_configs.c
                 manage_report_formats.c
                 manage_authentication.c
+                manage_sql_alerts.c
                 manage_sql_nvts.c manage_sql_secinfo.c
                 manage_sql_port_lists.c manage_sql_configs.c
                 manage_sql_report_configs.c
@@ -228,7 +231,8 @@ add_executable (gmp-tickets-test
                 manage_report_configs.c
                 manage_report_formats.c
                 manage_authentication.c
-                manage_sql.c manage_sql_nvts.c manage_sql_secinfo.c
+                manage_sql.c manage_sql_alerts.c
+                manage_sql_nvts.c manage_sql_secinfo.c
                 manage_sql_port_lists.c manage_sql_configs.c
                 manage_sql_report_configs.c
                 manage_sql_report_formats.c
@@ -263,7 +267,8 @@ add_executable (utils-test
                 manage_report_configs.c
                 manage_report_formats.c
                 manage_authentication.c
-                manage_sql.c manage_sql_nvts.c manage_sql_secinfo.c
+                manage_sql.c manage_sql_alerts.c
+                manage_sql_nvts.c manage_sql_secinfo.c
                 manage_sql_port_lists.c manage_sql_configs.c
                 manage_sql_report_configs.c
                 manage_sql_report_formats.c
@@ -315,7 +320,8 @@ add_executable (gvmd
                 manage_report_configs.c
                 manage_report_formats.c
                 manage_authentication.c
-                manage_sql.c manage_sql_nvts.c manage_sql_secinfo.c
+                manage_sql.c manage_sql_alerts.c
+                manage_sql_nvts.c manage_sql_secinfo.c
                 manage_sql_port_lists.c manage_sql_configs.c
                 manage_sql_report_configs.c
                 manage_sql_report_formats.c
@@ -537,6 +543,7 @@ set (C_FILES "${CMAKE_CURRENT_SOURCE_DIR}/gvmd.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_report_formats.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_authentication.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql.c"
+  "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql_alerts.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql_configs.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql_nvts.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql_port_lists.c"

--- a/src/manage.h
+++ b/src/manage.h
@@ -545,9 +545,6 @@ delete_alert (const char *, int);
 char *
 alert_uuid (alert_t);
 
-gboolean
-find_alert_with_permission (const char *, alert_t *, const char *);
-
 int
 manage_test_alert (const char *, gchar **);
 

--- a/src/manage_alerts.h
+++ b/src/manage_alerts.h
@@ -89,4 +89,7 @@ alert_method_name (alert_method_t);
 alert_method_t
 alert_method_from_name (const char*);
 
+gboolean
+find_alert_with_permission (const char *, alert_t *, const char *);
+
 #endif /* not _GVMD_MANAGE_ALERTS_H */

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -6762,22 +6762,6 @@ manage_check_alerts (GSList *log_config, const db_conn_info_t *database)
 }
 
 /**
- * @brief Find a alert for a specific permission, given a UUID.
- *
- * @param[in]   uuid        UUID of alert.
- * @param[out]  alert       Alert return, 0 if successfully failed to find alert.
- * @param[in]   permission  Permission.
- *
- * @return FALSE on success (including if failed to find alert), TRUE on error.
- */
-gboolean
-find_alert_with_permission (const char* uuid, alert_t* alert,
-                            const char *permission)
-{
-  return find_resource_with_permission ("alert", uuid, alert, permission, 0);
-}
-
-/**
  * @brief Validate an email address.
  *
  * @param[in]  address  Email address.

--- a/src/manage_sql_alerts.c
+++ b/src/manage_sql_alerts.c
@@ -1,0 +1,43 @@
+/* Copyright (C) 2019-2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "manage_alerts.h"
+#include "manage_sql.h"
+
+/**
+ * @file manage_sql_alerts.c
+ * @brief GVM management layer: Alert SQL
+ *
+ * The Alert SQL for the GVM management layer.
+ */
+
+/**
+ * @brief Find a alert for a specific permission, given a UUID.
+ *
+ * @param[in]   uuid        UUID of alert.
+ * @param[out]  alert       Alert return, 0 if successfully failed to find alert.
+ * @param[in]   permission  Permission.
+ *
+ * @return FALSE on success (including if failed to find alert), TRUE on error.
+ */
+gboolean
+find_alert_with_permission (const char* uuid, alert_t* alert,
+                            const char *permission)
+{
+  return find_resource_with_permission ("alert", uuid, alert, permission, 0);
+}


### PR DESCRIPTION
## What

Move `find_alert_with_permission` to new file `manage_sql_alerts.c`.

This is the start of moving the SQL parts of the alert code from `manage_sql.c` to a dedicated file.

## Why

More organised. Reduces the size of `manage_sql.c`.

Note that header goes in `manage_alerts.h`, as is done for the same header for configs, port_lists, etc.

## References

Follow /pull/2408
