### PR TITLE
Fix: Use shared lock in get_feed_lock_status

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -12632,7 +12632,7 @@ get_feed_lock_status (const char *lockfile_name, gchar **timestamp)
   else
     {
       umask (old_umask);
-      if (flock (lockfile, LOCK_EX | LOCK_NB))  /* Exclusive, Non blocking. */
+      if (flock (lockfile, LOCK_SH | LOCK_NB))  /* Shared, Non blocking. */
         {
           if (errno == EWOULDBLOCK)
             {


### PR DESCRIPTION
## What
The get_feed_lock_status now uses a shared file lock instead of an exclusive one.

## Why
Exclusive locks should only be used for actual feed syncs, so that checking the feed status does not get reported as a sync in progress.

## References
GEA-1010

