### PR TITLE
Require CMake >= 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.5)
 
 message ("-- Configuring Greenbone Vulnerability Manager...")
 


### PR DESCRIPTION

## What

Require CMake >= 3.5

## Why

CMake 4.0 drops support for CMake < 3.5. Therefore require CMake 3.5 as minimum version to allow using CMake 4.0. All our supported platforms already provide CMake >= 3.5

## References

https://github.com/greenbone/gvm-libs/issues/910
