### PR TITLE
Change: move more alert functions out of `manage_sql.c`

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -537,9 +537,6 @@ modify_alert (const char*, const char*, const char*, const char*,
               alert_method_t, GPtrArray*);
 
 int
-manage_test_alert (const char *, gchar **);
-
-int
 alert_in_use (alert_t);
 
 int

--- a/src/manage_alerts.c
+++ b/src/manage_alerts.c
@@ -25,6 +25,9 @@
 
 #include "manage_alerts.h"
 #include "manage_sql.h"
+#include "manage_acl.h"
+
+#include <gvm/util/uuidutils.h>
 
 #undef G_LOG_DOMAIN
 /**
@@ -238,4 +241,134 @@ alert_method_from_name (const char* name)
   if (strcasecmp (name, "Alemba vFire") == 0)
     return ALERT_METHOD_VFIRE;
   return ALERT_METHOD_ERROR;
+}
+
+/**
+ * @brief Test an alert.
+ *
+ * @param[in]  alert_id    Alert UUID.
+ * @param[out] script_message  Custom message from the alert script.
+ *
+ * @return 0 success, 1 failed to find alert, 2 failed to find task,
+ *         99 permission denied, -1 error, -2 failed to find report format
+ *         for alert, -3 failed to find filter for alert, -4 failed to find
+ *         credential for alert, -5 alert script failed.
+ */
+int
+manage_test_alert (const char *alert_id, gchar **script_message)
+{
+  int ret;
+  alert_t alert;
+  task_t task;
+  report_t report;
+  result_t result;
+  char *task_id, *report_id;
+  time_t now;
+  char now_string[26];
+  gchar *clean;
+
+  if (acl_user_may ("test_alert") == 0)
+    return 99;
+
+  if (find_alert_with_permission (alert_id, &alert, "test_alert"))
+    return -1;
+  if (alert == 0)
+    return 1;
+
+  if (alert_event (alert) == EVENT_NEW_SECINFO
+      || alert_event (alert) == EVENT_UPDATED_SECINFO)
+    {
+      char *alert_event_data;
+      gchar *type;
+
+      alert_event_data = alert_data (alert, "event", "secinfo_type");
+      type = g_strdup_printf ("%s_example", alert_event_data ?: "NVT");
+      free (alert_event_data);
+
+      if (alert_event (alert) == EVENT_NEW_SECINFO)
+        ret = manage_alert (alert_id, "0", EVENT_NEW_SECINFO, (void*) type,
+                            script_message);
+      else
+        ret = manage_alert (alert_id, "0", EVENT_UPDATED_SECINFO, (void*) type,
+                            script_message);
+
+      g_free (type);
+
+      return ret;
+    }
+
+  task = make_task (g_strdup ("Temporary Task for Alert"),
+                    g_strdup (""),
+                    0,  /* Exclude from assets. */
+                    0); /* Skip event and log. */
+
+  report_id = gvm_uuid_make ();
+  if (report_id == NULL)
+    return -1;
+  task_uuid (task, &task_id);
+  report = make_report (task, report_id, TASK_STATUS_DONE);
+
+  result = make_result (task, "127.0.0.1", "localhost", "23/tcp",
+                        "1.3.6.1.4.1.25623.1.0.10330", "Alarm",
+                        "A telnet server seems to be running on this port.",
+                        NULL);
+  if (result)
+    report_add_result (report, result);
+
+
+  result = make_result (
+              task, "127.0.0.1", "localhost", "general/tcp",
+              "1.3.6.1.4.1.25623.1.0.103823", "Alarm",
+              "IP,Host,Port,SSL/TLS-Version,Ciphers,Application-CPE\n"
+              "127.0.0.1,localhost,443,TLSv1.1;TLSv1.2",
+              NULL);
+  if (result)
+    report_add_result (report, result);
+
+  now = time (NULL);
+  if (strlen (ctime_r (&now, now_string)) == 0)
+    {
+      ret = -1;
+      goto exit;
+    }
+  clean = g_strdup (now_string);
+  if (clean[strlen (clean) - 1] == '\n')
+    clean[strlen (clean) - 1] = '\0';
+  set_task_start_time_ctime (task, g_strdup (clean));
+  set_scan_start_time_ctime (report, g_strdup (clean));
+  set_scan_host_start_time_ctime (report, "127.0.0.1", clean);
+
+  insert_report_host_detail (report,
+                             "127.0.0.1",
+                             "nvt",
+                             "1.3.6.1.4.1.25623.1.0.108577",
+                             "",
+                             "App",
+                             "cpe:/a:openbsd:openssh:8.9p1",
+                             "0123456789ABCDEF0123456789ABCDEF");
+
+  insert_report_host_detail (report,
+                             "127.0.0.1",
+                             "nvt",
+                             "1.3.6.1.4.1.25623.1.0.10330",
+                             "Host Details",
+                             "best_os_cpe",
+                             "cpe:/o:canonical:ubuntu_linux:22.04",
+                             "123456789ABCDEF0123456789ABCDEF0");
+
+  set_scan_host_end_time_ctime (report, "127.0.0.1", clean);
+  set_scan_end_time_ctime (report, clean);
+  g_free (clean);
+  ret = manage_alert (alert_id,
+                      task_id,
+                      EVENT_TASK_RUN_STATUS_CHANGED,
+                      (void*) TASK_STATUS_DONE,
+                      script_message);
+ exit:
+  /* No one should be running this task, so we don't worry about the lock.  We
+   * could guarantee that no one runs the task, but this is a very rare case. */
+  delete_task (task, 1);
+  free (task_id);
+  free (report_id);
+  return ret;
 }

--- a/src/manage_alerts.h
+++ b/src/manage_alerts.h
@@ -110,6 +110,9 @@ alert_method_t
 alert_method (alert_t alert);
 
 int
+manage_test_alert (const char *, gchar **);
+
+int
 init_alert_iterator (iterator_t*, get_data_t*);
 
 int

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -13459,54 +13459,6 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
   return -1;
 }
 
-/**
- * @brief Header for "New NVTs" alert message.
- */
-#define NEW_NVTS_HEADER                                                       \
-/* Open-Xchange (OX) AppSuite XHTML File HTML Injection Vuln...  NoneAvailable       0.0 100% */ \
-  "Name                                                          Solution Type  Severity  QOD\n" \
-  "------------------------------------------------------------------------------------------\n"
-
-/**
- * @brief Header for "New NVTs" alert message, when there's an OID.
- */
-#define NEW_NVTS_HEADER_OID                                                   \
-/* Open-Xchange (OX) AppSuite XHTML File HTML Injection Vuln...  NoneAvailable       0.0 100%  1.3... */ \
-  "Name                                                          Solution Type  Severity  QOD  OID\n" \
-  "------------------------------------------------------------------------------------------------\n"
-
-/**
- * @brief Header for "New CVEs" alert message.
- */
-#define NEW_CVES_HEADER                                                         \
-/* CVE-2014-100001       6.8  Cross-site request forgery (CSRF) vulnerability in... */ \
-  "Name             Severity  Description\n"                                    \
-  "--------------------------------------------------------------------------------\n"
-
-/**
- * @brief Header for "New CPEs" alert message.
- */
-#define NEW_CPES_HEADER                                                        \
-/* cpe:/a:.joomclan:com_joomclip                                 1024cms... */ \
-  "Name                                                          Title\n"      \
-  "------------------------------------------------------------------------------------------\n"
-
-/**
- * @brief Header for "New CERT-Bund Advisories" alert message.
- */
-#define NEW_CERT_BUNDS_HEADER                                                       \
-/* CB-K13/0849  Novell SUSE Linux Enterprise Server: Mehrere Schwachstellen... */   \
-  "Name         Title\n"                                                            \
-  "------------------------------------------------------------------------------------------\n"
-
-/**
- * @brief Header for "New DFN-CERT Advisories" alert message.
- */
-#define NEW_DFN_CERTS_HEADER                                                   \
-/* DFN-CERT-2008-1100  Denial of Service Schwachstelle in der... */            \
-  "Name                Title\n"                                                \
-  "------------------------------------------------------------------------------------------\n"
-
 
 /* Task functions. */
 
@@ -34098,6 +34050,54 @@ target_task_iterator_readable (iterator_t* iterator)
 
 
 /* SecInfo Alerts. */
+
+/**
+ * @brief Header for "New NVTs" alert message.
+ */
+#define NEW_NVTS_HEADER                                                       \
+/* Open-Xchange (OX) AppSuite XHTML File HTML Injection Vuln...  NoneAvailable       0.0 100% */ \
+  "Name                                                          Solution Type  Severity  QOD\n" \
+  "------------------------------------------------------------------------------------------\n"
+
+/**
+ * @brief Header for "New NVTs" alert message, when there's an OID.
+ */
+#define NEW_NVTS_HEADER_OID                                                   \
+/* Open-Xchange (OX) AppSuite XHTML File HTML Injection Vuln...  NoneAvailable       0.0 100%  1.3... */ \
+  "Name                                                          Solution Type  Severity  QOD  OID\n" \
+  "------------------------------------------------------------------------------------------------\n"
+
+/**
+ * @brief Header for "New CVEs" alert message.
+ */
+#define NEW_CVES_HEADER                                                         \
+/* CVE-2014-100001       6.8  Cross-site request forgery (CSRF) vulnerability in... */ \
+  "Name             Severity  Description\n"                                    \
+  "--------------------------------------------------------------------------------\n"
+
+/**
+ * @brief Header for "New CPEs" alert message.
+ */
+#define NEW_CPES_HEADER                                                        \
+/* cpe:/a:.joomclan:com_joomclip                                 1024cms... */ \
+  "Name                                                          Title\n"      \
+  "------------------------------------------------------------------------------------------\n"
+
+/**
+ * @brief Header for "New CERT-Bund Advisories" alert message.
+ */
+#define NEW_CERT_BUNDS_HEADER                                                       \
+/* CB-K13/0849  Novell SUSE Linux Enterprise Server: Mehrere Schwachstellen... */   \
+  "Name         Title\n"                                                            \
+  "------------------------------------------------------------------------------------------\n"
+
+/**
+ * @brief Header for "New DFN-CERT Advisories" alert message.
+ */
+#define NEW_DFN_CERTS_HEADER                                                   \
+/* DFN-CERT-2008-1100  Denial of Service Schwachstelle in der... */            \
+  "Name                Title\n"                                                \
+  "------------------------------------------------------------------------------------------\n"
 
 /**
  * @brief Check for new SCAP SecInfo after an update.

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -8071,21 +8071,6 @@ alert_name (alert_t alert)
 }
 
 /**
- * @brief Return the UUID of the owner of an alert.
- *
- * @param[in]  alert  Alert.
- *
- * @return UUID of owner.
- */
-static char *
-alert_owner_uuid (alert_t alert)
-{
-  return sql_string ("SELECT uuid FROM users"
-                     " WHERE id = (SELECT owner FROM alerts WHERE id = %llu);",
-                     alert);
-}
-
-/**
  * @brief Return the UUID of the filter of an alert.
  *
  * @param[in]  alert  Alert.

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -900,7 +900,7 @@ nvts_check_time ()
  *
  * @return Last time SCAP was checked.
  */
-static int
+int
 scap_check_time ()
 {
   return sql_int ("SELECT"
@@ -918,7 +918,7 @@ scap_check_time ()
  *
  * @return Last time CERT was checked.
  */
-static int
+int
 cert_check_time ()
 {
   return sql_int ("SELECT"
@@ -13506,75 +13506,6 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
 /* DFN-CERT-2008-1100  Denial of Service Schwachstelle in der... */            \
   "Name                Title\n"                                                \
   "------------------------------------------------------------------------------------------\n"
-
-/**
- * @brief Return the SecInfo count.
- *
- * @param[in]  alert      Alert.
- * @param[in]  filter_id  Condition filter id.
- *
- * @return 1 if met, else 0.
- */
-time_t
-alert_secinfo_count (alert_t alert, char *filter_id)
-{
-  get_data_t get;
-  int db_count, uuid_was_null;
-  event_t event;
-  gboolean get_modified;
-  time_t feed_version_epoch;
-  char *secinfo_type;
-
-  event = alert_event (alert);
-  get_modified = (event == EVENT_UPDATED_SECINFO);
-
-  if (current_credentials.uuid == NULL)
-    {
-      current_credentials.uuid = alert_owner_uuid (alert);
-      uuid_was_null = 1;
-    }
-  else
-    uuid_was_null = 0;
-
-  memset (&get, '\0', sizeof (get));
-  if (filter_id && strlen (filter_id) && strcmp (filter_id, "0"))
-    get.filt_id = filter_id;
-
-  secinfo_type = alert_data (alert, "event", "secinfo_type");
-
-  if (strcmp (secinfo_type, "nvt") == 0)
-    {
-      feed_version_epoch = nvts_feed_version_epoch ();
-      db_count = nvt_info_count_after (&get,
-                                       feed_version_epoch,
-                                       get_modified);
-    }
-  else if (strcmp (secinfo_type, "cert_bund_adv") == 0
-           || strcmp (secinfo_type, "dfn_cert_adv") == 0)
-    {
-      feed_version_epoch = cert_check_time ();
-      db_count = secinfo_count_after (&get,
-                                      secinfo_type,
-                                      feed_version_epoch,
-                                      get_modified);
-    }
-  else // assume SCAP data
-    {
-      feed_version_epoch = scap_check_time ();
-      db_count = secinfo_count_after (&get,
-                                      secinfo_type,
-                                      feed_version_epoch,
-                                      get_modified);
-    }
-
-  if (uuid_was_null)
-    {
-      free (current_credentials.uuid);
-      current_credentials.uuid = NULL;
-    }
-
-  return db_count;
-}
 
 
 /* Task functions. */

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -483,6 +483,12 @@ int manage_cert_db_exists ();
 int manage_scap_db_exists ();
 
 int
+cert_check_time ();
+
+int
+scap_check_time ();
+
+int
 count (const char *, const get_data_t *, column_t *, column_t *, const char **,
        int, const char *, const char *, int);
 
@@ -530,9 +536,6 @@ event_alert_iterator_active (iterator_t *);
 
 int
 alert_applies_to_task (alert_t, task_t);
-
-time_t
-alert_secinfo_count (alert_t, char *);
 
 int
 task_second_last_report (task_t, report_t *);

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -410,6 +410,8 @@ int create_current_report (task_t, char **, task_status_t);
 
 char *alert_data (alert_t, const char *, const char *);
 
+event_t alert_event (alert_t);
+
 int init_task_schedule_iterator (iterator_t *);
 
 void cleanup_task_schedule_iterator (iterator_t *);

--- a/src/manage_sql_alerts.c
+++ b/src/manage_sql_alerts.c
@@ -289,6 +289,21 @@ alert_owner (alert_t alert)
 }
 
 /**
+ * @brief Return the UUID of the owner of an alert.
+ *
+ * @param[in]  alert  Alert.
+ *
+ * @return UUID of owner.
+ */
+char *
+alert_owner_uuid (alert_t alert)
+{
+  return sql_string ("SELECT uuid FROM users"
+                     " WHERE id = (SELECT owner FROM alerts WHERE id = %llu);",
+                     alert);
+}
+
+/**
  * @brief Return the condition associated with an alert.
  *
  * @param[in]  alert  Alert.

--- a/src/manage_sql_alerts.h
+++ b/src/manage_sql_alerts.h
@@ -61,4 +61,7 @@
 user_t
 alert_owner (alert_t);
 
+char *
+alert_owner_uuid (alert_t);
+
 #endif /* not _GVMD_MANAGE_SQL_ALERTS_H */


### PR DESCRIPTION
## What

Move a few functions out of `manage_sql.c`.

Also move some `#define`s down in the file.

## Why

Reduce size of `manage_sql.c`.

## References

Follows /pull/2422.