### PR TITLE
Change: move alert check functions out of `manage_sql.c`

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -524,9 +524,6 @@ set_resource_id_deprecated (const char *, const char *, gboolean);
  "was created or assigned erroneously.\n"
 
 int
-manage_check_alerts (GSList *, const db_conn_info_t *);
-
-int
 create_alert (const char*, const char*, const char*, const char*, event_t,
               GPtrArray*, alert_condition_t, GPtrArray*, alert_method_t,
               GPtrArray*, alert_t*);

--- a/src/manage_alerts.c
+++ b/src/manage_alerts.c
@@ -372,3 +372,37 @@ manage_test_alert (const char *alert_id, gchar **script_message)
   free (report_id);
   return ret;
 }
+
+/**
+ * @brief Check if any SecInfo alerts are due.
+ *
+ * @param[in]  log_config  Log configuration.
+ * @param[in]  database    Location of manage database.
+ *
+ * @return 0 success, -1 error,
+ *         -2 database is too old, -3 database needs to be initialised
+ *         from server, -5 database is too new.
+ */
+int
+manage_check_alerts (GSList *log_config, const db_conn_info_t *database)
+{
+  int ret;
+
+  g_info ("   Checking alerts.");
+
+  ret = manage_option_setup (log_config, database,
+                             0 /* avoid_db_check_inserts */);
+  if (ret)
+    return ret;
+
+  /* Setup a dummy user, so that create_user will work. */
+  current_credentials.uuid = "";
+
+  check_alerts ();
+
+  current_credentials.uuid = NULL;
+
+  manage_option_cleanup ();
+
+  return ret;
+}

--- a/src/manage_alerts.h
+++ b/src/manage_alerts.h
@@ -22,6 +22,7 @@
 #include "iterator.h"
 #include "manage_get.h"
 #include "manage_tasks.h"
+#include "sql.h"
 
 #include <glib.h>
 
@@ -171,5 +172,8 @@ alert_task_iterator_uuid (iterator_t*);
 
 int
 alert_task_iterator_readable (iterator_t*);
+
+int
+manage_check_alerts (GSList *, const db_conn_info_t *);
 
 #endif /* not _GVMD_MANAGE_ALERTS_H */

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -6639,40 +6639,6 @@ DEF_ACCESS (task_role_iterator_uuid, 4);
 /* Events and Alerts. */
 
 /**
- * @brief Check if any SecInfo alerts are due.
- *
- * @param[in]  log_config  Log configuration.
- * @param[in]  database    Location of manage database.
- *
- * @return 0 success, -1 error,
- *         -2 database is too old, -3 database needs to be initialised
- *         from server, -5 database is too new.
- */
-int
-manage_check_alerts (GSList *log_config, const db_conn_info_t *database)
-{
-  int ret;
-
-  g_info ("   Checking alerts.");
-
-  ret = manage_option_setup (log_config, database,
-                             0 /* avoid_db_check_inserts */);
-  if (ret)
-    return ret;
-
-  /* Setup a dummy user, so that create_user will work. */
-  current_credentials.uuid = "";
-
-  check_alerts ();
-
-  current_credentials.uuid = NULL;
-
-  manage_option_cleanup ();
-
-  return ret;
-}
-
-/**
  * @brief Validate an email address.
  *
  * @param[in]  address  Email address.

--- a/src/manage_sql_alerts.c
+++ b/src/manage_sql_alerts.c
@@ -754,3 +754,219 @@ alert_task_iterator_readable (iterator_t* iterator)
   if (iterator->done) return 0;
   return iterator_int (iterator, 2);
 }
+
+/**
+ * @brief Check for new SCAP SecInfo after an update.
+ */
+static void
+check_for_new_scap ()
+{
+  if (manage_scap_loaded ())
+    {
+      if (sql_int ("SELECT EXISTS"
+                   " (SELECT * FROM scap.cves"
+                   "  WHERE creation_time"
+                   "        > coalesce (CAST ((SELECT value FROM meta"
+                   "                           WHERE name"
+                   "                                 = 'scap_check_time')"
+                   "                          AS INTEGER),"
+                   "                    0));"))
+        event (EVENT_NEW_SECINFO, "cve", 0, 0);
+
+      if (sql_int ("SELECT EXISTS"
+                   " (SELECT * FROM scap.cpes"
+                   "  WHERE creation_time"
+                   "        > coalesce (CAST ((SELECT value FROM meta"
+                   "                           WHERE name"
+                   "                                 = 'scap_check_time')"
+                   "                          AS INTEGER),"
+                   "                    0));"))
+        event (EVENT_NEW_SECINFO, "cpe", 0, 0);
+    }
+}
+
+/**
+ * @brief Check for new CERT SecInfo after an update.
+ */
+static void
+check_for_new_cert ()
+{
+  if (manage_cert_loaded ())
+    {
+      if (sql_int ("SELECT EXISTS"
+                   " (SELECT * FROM cert.cert_bund_advs"
+                   "  WHERE creation_time"
+                   "        > coalesce (CAST ((SELECT value FROM meta"
+                   "                           WHERE name"
+                   "                                 = 'cert_check_time')"
+                   "                          AS INTEGER),"
+                   "                    0));"))
+        event (EVENT_NEW_SECINFO, "cert_bund_adv", 0, 0);
+
+      if (sql_int ("SELECT EXISTS"
+                   " (SELECT * FROM cert.dfn_cert_advs"
+                   "  WHERE creation_time"
+                   "        > coalesce (CAST ((SELECT value FROM meta"
+                   "                           WHERE name"
+                   "                                 = 'cert_check_time')"
+                   "                          AS INTEGER),"
+                   "                    0));"))
+        event (EVENT_NEW_SECINFO, "dfn_cert_adv", 0, 0);
+    }
+}
+
+/**
+ * @brief Check for updated SCAP SecInfo after an update.
+ */
+static void
+check_for_updated_scap ()
+{
+  if (manage_scap_loaded ())
+    {
+      if (sql_int ("SELECT EXISTS"
+                   " (SELECT * FROM scap.cves"
+                   "  WHERE modification_time"
+                   "        > coalesce (CAST ((SELECT value FROM meta"
+                   "                           WHERE name"
+                   "                                 = 'scap_check_time')"
+                   "                          AS INTEGER),"
+                   "                    0)"
+                   "  AND creation_time"
+                   "      <= coalesce (CAST ((SELECT value FROM meta"
+                   "                          WHERE name"
+                   "                                = 'scap_check_time')"
+                   "                         AS INTEGER),"
+                   "                   0));"))
+        event (EVENT_UPDATED_SECINFO, "cve", 0, 0);
+
+      if (sql_int ("SELECT EXISTS"
+                   " (SELECT * FROM scap.cpes"
+                   "  WHERE modification_time"
+                   "        > coalesce (CAST ((SELECT value FROM meta"
+                   "                           WHERE name"
+                   "                                 = 'scap_check_time')"
+                   "                          AS INTEGER),"
+                   "                    0)"
+                   "  AND creation_time"
+                   "      <= coalesce (CAST ((SELECT value FROM meta"
+                   "                          WHERE name"
+                   "                                = 'scap_check_time')"
+                   "                         AS INTEGER),"
+                   "                   0));"))
+        event (EVENT_UPDATED_SECINFO, "cpe", 0, 0);
+    }
+}
+
+/**
+ * @brief Check for updated CERT SecInfo after an update.
+ */
+static void
+check_for_updated_cert ()
+{
+  if (manage_cert_loaded ())
+    {
+      if (sql_int ("SELECT EXISTS"
+                   " (SELECT * FROM cert.cert_bund_advs"
+                   "  WHERE modification_time"
+                   "        > coalesce (CAST ((SELECT value FROM meta"
+                   "                           WHERE name"
+                   "                                 = 'cert_check_time')"
+                   "                          AS INTEGER),"
+                   "                    0)"
+                   "  AND creation_time"
+                   "      <= coalesce (CAST ((SELECT value FROM meta"
+                   "                          WHERE name"
+                   "                                = 'cert_check_time')"
+                   "                         AS INTEGER),"
+                   "                   0));"))
+        event (EVENT_UPDATED_SECINFO, "cert_bund_adv", 0, 0);
+
+      if (sql_int ("SELECT EXISTS"
+                   " (SELECT * FROM cert.dfn_cert_advs"
+                   "  WHERE modification_time"
+                   "        > coalesce (CAST ((SELECT value FROM meta"
+                   "                           WHERE name"
+                   "                                 = 'cert_check_time')"
+                   "                          AS INTEGER),"
+                   "                    0)"
+                   "  AND creation_time"
+                   "      <= coalesce (CAST ((SELECT value FROM meta"
+                   "                          WHERE name"
+                   "                                = 'cert_check_time')"
+                   "                         AS INTEGER),"
+                   "                   0));"))
+        event (EVENT_UPDATED_SECINFO, "dfn_cert_adv", 0, 0);
+    }
+}
+
+/**
+ * @brief Check if any SecInfo alerts are due.
+ */
+void
+check_alerts ()
+{
+  if (manage_scap_loaded ())
+    {
+      int max_time;
+
+      max_time
+       = sql_int ("SELECT %s"
+                  "        ((SELECT max (modification_time) FROM scap.cves),"
+                  "         (SELECT max (modification_time) FROM scap.cpes),"
+                  "         (SELECT max (creation_time) FROM scap.cves),"
+                  "         (SELECT max (creation_time) FROM scap.cpes));",
+                  sql_greatest ());
+
+      if (sql_int ("SELECT NOT EXISTS (SELECT * FROM meta"
+                   "                   WHERE name = 'scap_check_time')"))
+        sql ("INSERT INTO meta (name, value)"
+             " VALUES ('scap_check_time', %i);",
+             max_time);
+      else if (sql_int ("SELECT value = '0' FROM meta"
+                        " WHERE name = 'scap_check_time';"))
+        sql ("UPDATE meta SET value = %i"
+             " WHERE name = 'scap_check_time';",
+             max_time);
+      else
+        {
+          check_for_new_scap ();
+          check_for_updated_scap ();
+          sql ("UPDATE meta SET value = %i"
+               " WHERE name = 'scap_check_time';",
+               max_time);
+        }
+    }
+
+  if (manage_cert_loaded ())
+    {
+      int max_time;
+
+      max_time
+       = sql_int ("SELECT"
+                  " %s"
+                  "  ((SELECT max (modification_time) FROM cert.cert_bund_advs),"
+                  "   (SELECT max (modification_time) FROM cert.dfn_cert_advs),"
+                  "   (SELECT max (creation_time) FROM cert.cert_bund_advs),"
+                  "   (SELECT max (creation_time) FROM cert.dfn_cert_advs));",
+                  sql_greatest ());
+
+      if (sql_int ("SELECT NOT EXISTS (SELECT * FROM meta"
+                   "                   WHERE name = 'cert_check_time')"))
+        sql ("INSERT INTO meta (name, value)"
+             " VALUES ('cert_check_time', %i);",
+             max_time);
+      else if (sql_int ("SELECT value = '0' FROM meta"
+                        " WHERE name = 'cert_check_time';"))
+        sql ("UPDATE meta SET value = %i"
+             " WHERE name = 'cert_check_time';",
+             max_time);
+      else
+        {
+          check_for_new_cert ();
+          check_for_updated_cert ();
+          sql ("UPDATE meta SET value = %i"
+               " WHERE name = 'cert_check_time';",
+               max_time);
+        }
+    }
+}


### PR DESCRIPTION
## What

Move `check_alerts` and `manage_check_alerts`.

## Why

Better organisation. Smaller `manage_sql.c`.

## References

Follows /pull/2423.


