### PR TITLE
Change: set default vector to empty string

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -13813,7 +13813,9 @@ handle_get_info (gmp_parser_t *gmp_parser, GError **error)
                              cve_info_iterator_severity (&info)
                               ? cve_info_iterator_severity (&info)
                               : "",
-                             cve_info_iterator_vector (&info),
+                              cve_info_iterator_vector (&info)
+                              ? cve_info_iterator_vector (&info)
+                              : "",
                              cve_info_iterator_description (&info),
                              cve_info_iterator_products (&info));
 

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -13813,7 +13813,7 @@ handle_get_info (gmp_parser_t *gmp_parser, GError **error)
                              cve_info_iterator_severity (&info)
                               ? cve_info_iterator_severity (&info)
                               : "",
-                              cve_info_iterator_vector (&info)
+                             cve_info_iterator_vector (&info)
                               ? cve_info_iterator_vector (&info)
                               : "",
                              cve_info_iterator_description (&info),


### PR DESCRIPTION
## What
Set default value of vector to empty string

## Why
Prevent issues with what is shown when the cvss vector is empty or not included.

## References
https://jira.greenbone.net/browse/GEA-888