### PR TITLE
Change: move alert max vars out of `manage_sql.c`

### DIFF
--- a/src/manage_alerts.c
+++ b/src/manage_alerts.c
@@ -39,6 +39,40 @@
 /* Variables. */
 
 /**
+ * @brief Default max number of bytes of reports attached to email alerts.
+ */
+#define MAX_EMAIL_ATTACHMENT_SIZE 1048576
+
+/**
+ * @brief Maximum number of bytes of reports attached to email alerts.
+ *
+ * A value less or equal to 0 allows any size.
+ */
+static int max_email_attachment_size = MAX_EMAIL_ATTACHMENT_SIZE;
+
+/**
+ * @brief Get the max number of bytes of reports attached to email alerts.
+ *
+ * @return The size in bytes.
+ */
+int
+get_max_email_attachment_size ()
+{
+  return max_email_attachment_size;
+}
+
+/**
+ * @brief Set the max email attachment size.
+ *
+ * @param size The new size in bytes.
+ */
+void
+set_max_email_attachment_size (int size)
+{
+  max_email_attachment_size = size;
+}
+
+/**
  * @brief Default max number of bytes of reports included in email alerts.
  */
 #define MAX_EMAIL_INCLUDE_SIZE 20000

--- a/src/manage_alerts.c
+++ b/src/manage_alerts.c
@@ -39,6 +39,40 @@
 /* Variables. */
 
 /**
+ * @brief Default max number of bytes of reports included in email alerts.
+ */
+#define MAX_EMAIL_INCLUDE_SIZE 20000
+
+/**
+ * @brief Maximum number of bytes of reports included in email alerts.
+ *
+ * A value less or equal to 0 allows any size.
+ */
+static int max_email_include_size = MAX_EMAIL_INCLUDE_SIZE;
+
+/**
+ * @brief Get the max number of bytes of reports included in email alerts.
+ *
+ * @return The size in bytes.
+ */
+int
+get_max_email_include_size ()
+{
+  return max_email_include_size;
+}
+
+/**
+ * @brief Set the max email include size.
+ *
+ * @param size The new size in bytes.
+ */
+void
+set_max_email_include_size (int size)
+{
+  max_email_include_size = size;
+}
+
+/**
  * @brief Default max number of bytes of user-defined message in email alerts.
  */
 #define MAX_EMAIL_MESSAGE_SIZE 2000
@@ -53,7 +87,7 @@ static int max_email_message_size = MAX_EMAIL_MESSAGE_SIZE;
 /**
  * @brief Get the max email message size.
  *
- * @return The current timeout in minutes.
+ * @return The size in bytes.
  */
 int
 get_max_email_message_size ()
@@ -62,9 +96,9 @@ get_max_email_message_size ()
 }
 
 /**
- * @brief Set the authentication cache timeout.
+ * @brief Set the max email message size.
  *
- * @param new_timeout The new timeout in minutes.
+ * @param size The new size in bytes.
  */
 void
 set_max_email_message_size (int size)

--- a/src/manage_alerts.c
+++ b/src/manage_alerts.c
@@ -36,6 +36,43 @@
 #define G_LOG_DOMAIN "md manage"
 
 
+/* Variables. */
+
+/**
+ * @brief Default max number of bytes of user-defined message in email alerts.
+ */
+#define MAX_EMAIL_MESSAGE_SIZE 2000
+
+/**
+ * @brief Maximum number of bytes of user-defined message text in email alerts.
+ *
+ * A value less or equal to 0 allows any size.
+ */
+static int max_email_message_size = MAX_EMAIL_MESSAGE_SIZE;
+
+/**
+ * @brief Get the max email message size.
+ *
+ * @return The current timeout in minutes.
+ */
+int
+get_max_email_message_size ()
+{
+  return max_email_message_size;
+}
+
+/**
+ * @brief Set the authentication cache timeout.
+ *
+ * @param new_timeout The new timeout in minutes.
+ */
+void
+set_max_email_message_size (int size)
+{
+  max_email_message_size = size;
+}
+
+
 /* Alert report data. */
 
 /**

--- a/src/manage_alerts.h
+++ b/src/manage_alerts.h
@@ -28,6 +28,12 @@
 
 typedef resource_t alert_t;
 
+int
+get_max_email_message_size ();
+
+void
+set_max_email_message_size (int);
+
 /**
  * @brief Types of alert conditions.
  */

--- a/src/manage_alerts.h
+++ b/src/manage_alerts.h
@@ -29,6 +29,12 @@
 typedef resource_t alert_t;
 
 int
+get_max_email_attachment_size ();
+
+void
+set_max_email_attachment_size (int);
+
+int
 get_max_email_include_size ();
 
 void

--- a/src/manage_alerts.h
+++ b/src/manage_alerts.h
@@ -29,6 +29,12 @@
 typedef resource_t alert_t;
 
 int
+get_max_email_include_size ();
+
+void
+set_max_email_include_size (int);
+
+int
 get_max_email_message_size ();
 
 void

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -382,18 +382,6 @@ static manage_connection_forker_t manage_fork_connection;
 static int max_hosts = MANAGE_MAX_HOSTS;
 
 /**
- * @brief Default max number of bytes of reports attached to email alerts.
- */
-#define MAX_ATTACH_LENGTH 1048576
-
-/**
- * @brief Maximum number of bytes of reports attached to email alerts.
- *
- * A value less or equal to 0 allows any size.
- */
-static int max_attach_length = MAX_ATTACH_LENGTH;
-
-/**
  * @brief Memory cache of NVT information from the database.
  */
 static nvtis_t* nvti_cache = NULL;
@@ -11189,8 +11177,8 @@ email_secinfo (alert_t alert, task_t task, event_t event,
   if (list && notice && strcmp (notice, "2") == 0)
     {
       /* Add list as text attachment. */
-      if (max_attach_length <= 0
-          || strlen (list) <= max_attach_length)
+      if (get_max_email_attachment_size () <= 0
+          || strlen (list) <= get_max_email_attachment_size ())
         base64 = g_base64_encode ((guchar*) list,
                                   strlen (list));
     }
@@ -11987,7 +11975,7 @@ escalate_to_vfire (alert_t alert, task_t task, report_t report, event_t event,
                                      0,
                                      0,
                                      0,
-                                     max_attach_length);
+                                     get_max_email_attachment_size ());
 
   g_tree_replace (call_input,
                   g_strdup ("description"),
@@ -12267,8 +12255,8 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
                                                      alert, task, 0);
                     }
                   g_free (alert_subject);
-                  if (max_attach_length <= 0
-                      || content_length <= max_attach_length)
+                  if (get_max_email_attachment_size () <= 0
+                      || content_length <= get_max_email_attachment_size ())
                     base64 = g_base64_encode ((guchar*) report_content,
                                               content_length);
                   g_free (report_content);
@@ -12285,7 +12273,7 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
                                               host_summary, NULL, 0,
                                               base64 == NULL,
                                               0,
-                                              max_attach_length);
+                                              get_max_email_attachment_size ());
                   g_free (message);
                   g_free (condition_desc);
                   g_free (term);
@@ -15549,7 +15537,7 @@ init_manage_internal (GSList *log_config,
 
   max_hosts = max_ips_per_target;
   if (max_email_attachment_size)
-    max_attach_length = max_email_attachment_size;
+    set_max_email_attachment_size (max_email_attachment_size);
   if (max_email_include_size)
     set_max_email_include_size (max_email_include_size);
   if (max_email_message_size)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -406,18 +406,6 @@ static int max_content_length = MAX_CONTENT_LENGTH;
 static int max_attach_length = MAX_ATTACH_LENGTH;
 
 /**
- * @brief Default max number of bytes of user-defined message in email alerts.
- */
-#define MAX_EMAIL_MESSAGE_LENGTH 2000
-
-/**
- * @brief Maximum number of bytes of user-defined message text in email alerts.
- *
- * A value less or equal to 0 allows any size.
- */
-static int max_email_message_length = MAX_EMAIL_MESSAGE_LENGTH;
-
-/**
  * @brief Memory cache of NVT information from the database.
  */
 static nvtis_t* nvti_cache = NULL;
@@ -6893,7 +6881,7 @@ validate_email_data (alert_method_t method, const gchar *name, gchar **data,
 
   if (method == ALERT_METHOD_EMAIL
       && strcmp (name, "message") == 0
-      && strlen (*data) > max_email_message_length)
+      && strlen (*data) > get_max_email_message_size ())
     return for_modify ? 10 : 8;
 
   if (method == ALERT_METHOD_EMAIL
@@ -15575,7 +15563,7 @@ init_manage_internal (GSList *log_config,
   if (max_email_include_size)
     max_content_length = max_email_include_size;
   if (max_email_message_size)
-    max_email_message_length = max_email_message_size;
+    set_max_email_message_size (max_email_message_size);
 
   g_log_set_handler (G_LOG_DOMAIN,
                      ALL_LOG_LEVELS,

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -382,18 +382,6 @@ static manage_connection_forker_t manage_fork_connection;
 static int max_hosts = MANAGE_MAX_HOSTS;
 
 /**
- * @brief Default max number of bytes of reports included in email alerts.
- */
-#define MAX_CONTENT_LENGTH 20000
-
-/**
- * @brief Maximum number of bytes of reports included in email alerts.
- *
- * A value less or equal to 0 allows any size.
- */
-static int max_content_length = MAX_CONTENT_LENGTH;
-
-/**
  * @brief Default max number of bytes of reports attached to email alerts.
  */
 #define MAX_ATTACH_LENGTH 1048576
@@ -10838,17 +10826,19 @@ alert_message_print (const gchar *message, event_t event,
               {
                 if (content)
                   {
+                    int max;
+
+                    max = get_max_email_include_size ();
                     g_string_append_printf (new_message,
                                             "%.*s",
                                             /* Cast for 64 bit. */
-                                            (int) MIN (content_length,
-                                                       max_content_length),
+                                            (int) MIN (content_length, max),
                                             content);
-                    if (content_length > max_content_length)
+                    if (content_length > max)
                       g_string_append_printf (new_message,
                                               "\n... (report truncated after"
                                               " %i characters)\n",
-                                              max_content_length);
+                                              max);
                   }
 
                 break;
@@ -12211,9 +12201,9 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
                                               host_summary, report_content,
                                               content_length,
                                               content_length
-                                              > max_content_length,
+                                              > get_max_email_include_size (),
                                               0,
-                                              max_content_length);
+                                              get_max_email_include_size ());
                   g_free (message);
                   g_free (report_content);
                   g_free (condition_desc);
@@ -15561,7 +15551,7 @@ init_manage_internal (GSList *log_config,
   if (max_email_attachment_size)
     max_attach_length = max_email_attachment_size;
   if (max_email_include_size)
-    max_content_length = max_email_include_size;
+    set_max_email_include_size (max_email_include_size);
   if (max_email_message_size)
     set_max_email_message_size (max_email_message_size);
 


### PR DESCRIPTION
## What

Move the max size variables out of `manage_sql.c`.

Also use functions to access them.

## Why

Smaller `manage_sql.c`.

Using functions makes the internal names more consistent (eg `max_email_message_length` was being used for `--max-email-message-size`).

## References

Follows /pull/2424.
