### PR TITLE
Change: improve the names of the internal trigger functions

### DIFF
--- a/src/manage_events.c
+++ b/src/manage_events.c
@@ -459,8 +459,8 @@ trigger_with_presets (alert_t alert, task_t task, report_t report,
                                     method == ALERT_METHOD_EMAIL ? 1000 : -1);
     }
 
-  ret = trigger_2 (alert, task, report, event, event_data, method, condition,
-                   &get, 1, 1, script_message);
+  ret = trigger (alert, task, report, event, event_data, method, condition,
+                 &get, 1, 1, script_message);
   free (results_filter);
   g_free (get.filter);
   return ret;

--- a/src/manage_events.c
+++ b/src/manage_events.c
@@ -433,9 +433,10 @@ condition_met (task_t task, report_t report, alert_t alert,
  *         -5 alert script failed.
  */
 static int
-trigger_1 (alert_t alert, task_t task, report_t report, event_t event,
-           const void* event_data, alert_method_t method,
-           alert_condition_t condition, gchar **script_message)
+trigger_with_presets (alert_t alert, task_t task, report_t report,
+                      event_t event, const void* event_data,
+                      alert_method_t method, alert_condition_t condition,
+                      gchar **script_message)
 {
   int ret;
   get_data_t get;
@@ -664,14 +665,14 @@ event (event_t event, void* event_data, resource_t resource_1,
 
       alert = g_array_index (alerts_triggered, alert_t, index);
       condition = alert_condition (alert);
-      trigger_1 (alert,
-                 resource_1,
-                 resource_2,
-                 event,
-                 event_data,
-                 alert_method (alert),
-                 condition,
-                 NULL);
+      trigger_with_presets (alert,
+                            resource_1,
+                            resource_2,
+                            event,
+                            event_data,
+                            alert_method (alert),
+                            condition,
+                            NULL);
     }
 
   g_array_free (alerts_triggered, TRUE);
@@ -720,6 +721,6 @@ manage_alert (const char *alert_id, const char *task_id, event_t event,
 
   condition = alert_condition (alert);
   method = alert_method (alert);
-  return trigger_1 (alert, task, 0, event, event_data, method, condition,
-                    script_message);
+  return trigger_with_presets (alert, task, 0, event, event_data, method,
+                               condition, script_message);
 }

--- a/src/manage_events.c
+++ b/src/manage_events.c
@@ -417,7 +417,7 @@ condition_met (task_t task, report_t report, alert_t alert,
 }
 
 /**
- * @brief Escalate an event with preset report filtering.
+ * @brief Trigger an event with preset report filtering.
  *
  * @param[in]  alert       Alert.
  * @param[in]  task        Task.
@@ -433,9 +433,9 @@ condition_met (task_t task, report_t report, alert_t alert,
  *         -5 alert script failed.
  */
 static int
-escalate_1 (alert_t alert, task_t task, report_t report, event_t event,
-            const void* event_data, alert_method_t method,
-            alert_condition_t condition, gchar **script_message)
+trigger_1 (alert_t alert, task_t task, report_t report, event_t event,
+           const void* event_data, alert_method_t method,
+           alert_condition_t condition, gchar **script_message)
 {
   int ret;
   get_data_t get;
@@ -458,8 +458,8 @@ escalate_1 (alert_t alert, task_t task, report_t report, event_t event,
                                     method == ALERT_METHOD_EMAIL ? 1000 : -1);
     }
 
-  ret = escalate_2 (alert, task, report, event, event_data, method, condition,
-                    &get, 1, 1, script_message);
+  ret = trigger_2 (alert, task, report, event, event_data, method, condition,
+                   &get, 1, 1, script_message);
   free (results_filter);
   g_free (get.filter);
   return ret;
@@ -664,21 +664,21 @@ event (event_t event, void* event_data, resource_t resource_1,
 
       alert = g_array_index (alerts_triggered, alert_t, index);
       condition = alert_condition (alert);
-      escalate_1 (alert,
-                  resource_1,
-                  resource_2,
-                  event,
-                  event_data,
-                  alert_method (alert),
-                  condition,
-                  NULL);
+      trigger_1 (alert,
+                 resource_1,
+                 resource_2,
+                 event,
+                 event_data,
+                 alert_method (alert),
+                 condition,
+                 NULL);
     }
 
   g_array_free (alerts_triggered, TRUE);
 }
 
 /**
- * @brief Escalate an alert with task and event data.
+ * @brief Trigger an alert with task and event data.
  *
  * @param[in]  alert_id    Alert UUID.
  * @param[in]  task_id     Task UUID.
@@ -720,6 +720,6 @@ manage_alert (const char *alert_id, const char *task_id, event_t event,
 
   condition = alert_condition (alert);
   method = alert_method (alert);
-  return escalate_1 (alert, task, 0, event, event_data, method, condition,
-                     script_message);
+  return trigger_1 (alert, task, 0, event, event_data, method, condition,
+                    script_message);
 }

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -10528,11 +10528,11 @@ trigger_to_vfire (alert_t alert, task_t task, report_t report, event_t event,
  *         find filter, -4 failed to find credential, -5 alert script failed.
  */
 int
-trigger_2 (alert_t alert, task_t task, report_t report, event_t event,
-           const void* event_data, alert_method_t method,
-           alert_condition_t condition,
-           const get_data_t *get, int notes_details, int overrides_details,
-           gchar **script_message)
+trigger (alert_t alert, task_t task, report_t report, event_t event,
+         const void* event_data, alert_method_t method,
+         alert_condition_t condition,
+          const get_data_t *get, int notes_details, int overrides_details,
+          gchar **script_message)
 {
   if (script_message)
     *script_message = NULL;
@@ -27761,9 +27761,9 @@ manage_send_report (report_t report, report_t delta_report,
       condition = alert_condition (alert);
       method = alert_method (alert);
 
-      ret = trigger_2 (alert, task, report, EVENT_TASK_RUN_STATUS_CHANGED,
-                       (void*) TASK_STATUS_DONE, method, condition,
-                       get, notes_details, overrides_details, NULL);
+      ret = trigger (alert, task, report, EVENT_TASK_RUN_STATUS_CHANGED,
+                     (void*) TASK_STATUS_DONE, method, condition,
+                     get, notes_details, overrides_details, NULL);
       if (ret == -3)
         return -4;
       if (ret == -1)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -8064,7 +8064,7 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
   gchar *script, *script_dir;
   gchar *report_file, *pkcs12_file, *pkcs12, *clean_password;
   gchar *clean_ip, *clean_port;
-  char report_dir[] = "/tmp/gvmd_escalate_XXXXXX";
+  char report_dir[] = "/tmp/gvmd_event_XXXXXX";
   GError *error;
   gsize pkcs12_len;
 
@@ -10211,7 +10211,7 @@ generate_report_filename (report_t report, report_format_t report_format,
 }
 
 /**
- * @brief Escalate an event.
+ * @brief Trigger an event.
  *
  * @param[in]  alert       Alert.
  * @param[in]  task        Task.
@@ -10229,11 +10229,11 @@ generate_report_filename (report_t report, report_format_t report_format,
  *         find filter, -4 failed to find credential, -5 alert script failed.
  */
 static int
-escalate_to_vfire (alert_t alert, task_t task, report_t report, event_t event,
-                   const void* event_data, alert_method_t method,
-                   alert_condition_t condition, const get_data_t *get,
-                   int notes_details, int overrides_details,
-                   gchar **script_message)
+trigger_to_vfire (alert_t alert, task_t task, report_t report, event_t event,
+                  const void* event_data, alert_method_t method,
+                  alert_condition_t condition, const get_data_t *get,
+                  int notes_details, int overrides_details,
+                  gchar **script_message)
 {
   int ret;
   char *credential_id;
@@ -10510,7 +10510,7 @@ escalate_to_vfire (alert_t alert, task_t task, report_t report, event_t event,
 }
 
 /**
- * @brief Escalate an event.
+ * @brief Trigger an event.
  *
  * @param[in]  alert   Alert.
  * @param[in]  task        Task.
@@ -10528,11 +10528,11 @@ escalate_to_vfire (alert_t alert, task_t task, report_t report, event_t event,
  *         find filter, -4 failed to find credential, -5 alert script failed.
  */
 int
-escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
-            const void* event_data, alert_method_t method,
-            alert_condition_t condition,
-            const get_data_t *get, int notes_details, int overrides_details,
-            gchar **script_message)
+trigger_2 (alert_t alert, task_t task, report_t report, event_t event,
+           const void* event_data, alert_method_t method,
+           alert_condition_t condition,
+           const get_data_t *get, int notes_details, int overrides_details,
+           gchar **script_message)
 {
   if (script_message)
     *script_message = NULL;
@@ -11704,10 +11704,10 @@ escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
       case ALERT_METHOD_VFIRE:
         {
           int ret;
-          ret = escalate_to_vfire (alert, task, report, event,
-                                   event_data, method, condition,
-                                   get, notes_details, overrides_details,
-                                   script_message);
+          ret = trigger_to_vfire (alert, task, report, event,
+                                  event_data, method, condition,
+                                  get, notes_details, overrides_details,
+                                  script_message);
           return ret;
         }
       case ALERT_METHOD_START_TASK:
@@ -27707,10 +27707,10 @@ manage_report (report_t report, report_t delta_report, const get_data_t *get,
  * @param[in]  send               Function to write to client.
  * @param[in]  send_data_1        Second argument to \p send.
  * @param[in]  send_data_2        Third argument to \p send.
- * @param[in]  alert_id       ID of alert to escalate report with,
+ * @param[in]  alert_id           ID of alert to trigger with the report,
  *                                instead of getting report.  NULL to get
  *                                report.
- * @param[in]  prefix              Text to send to client before the report.
+ * @param[in]  prefix             Text to send to client before the report.
  *
  * @return 0 success, -1 error, -2 failed to find alert report format, -3 error
  *         during alert, -4 failed to find alert filter, 1 failed to find alert,
@@ -27744,7 +27744,7 @@ manage_send_report (report_t report, report_t delta_report,
   if (report_task (report, &task))
     return -1;
 
-  /* Escalate instead, if requested. */
+  /* Trigger alert instead, if requested. */
 
   if (alert_id)
     {
@@ -27761,9 +27761,9 @@ manage_send_report (report_t report, report_t delta_report,
       condition = alert_condition (alert);
       method = alert_method (alert);
 
-      ret = escalate_2 (alert, task, report, EVENT_TASK_RUN_STATUS_CHANGED,
-                        (void*) TASK_STATUS_DONE, method, condition,
-                        get, notes_details, overrides_details, NULL);
+      ret = trigger_2 (alert, task, report, EVENT_TASK_RUN_STATUS_CHANGED,
+                       (void*) TASK_STATUS_DONE, method, condition,
+                       get, notes_details, overrides_details, NULL);
       if (ret == -3)
         return -4;
       if (ret == -1)

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -515,11 +515,11 @@ void
 update_all_config_caches ();
 
 int
-trigger_2 (alert_t alert, task_t task, report_t report, event_t event,
-           const void* event_data, alert_method_t method,
-           alert_condition_t condition,
-           const get_data_t *get, int notes_details, int overrides_details,
-           gchar **script_message);
+trigger (alert_t alert, task_t task, report_t report, event_t event,
+         const void* event_data, alert_method_t method,
+         alert_condition_t condition,
+         const get_data_t *get, int notes_details, int overrides_details,
+         gchar **script_message);
 
 int
 task_second_last_report (task_t, report_t *);

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -515,11 +515,11 @@ void
 update_all_config_caches ();
 
 int
-escalate_2 (alert_t alert, task_t task, report_t report, event_t event,
-            const void* event_data, alert_method_t method,
-            alert_condition_t condition,
-            const get_data_t *get, int notes_details, int overrides_details,
-            gchar **script_message);
+trigger_2 (alert_t alert, task_t task, report_t report, event_t event,
+           const void* event_data, alert_method_t method,
+           alert_condition_t condition,
+           const get_data_t *get, int notes_details, int overrides_details,
+           gchar **script_message);
 
 int
 task_second_last_report (task_t, report_t *);


### PR DESCRIPTION
## What

Rename the "escalate" functions.

## Why

"Trigger" is more usual for this situation. "Escalate" could mean the severity of the situation has increased.

Preparing to move the functions to a dedicated file.

## References

Follows /pull/2427


