### PR TITLE
Fix: CMake warning in GetGit.cmake

### DIFF
--- a/cmake/GetGit.cmake
+++ b/cmake/GetGit.cmake
@@ -36,7 +36,7 @@ macro(git_get_revision dir variable)
   )
   string(REPLACE "/" "_" GIT_BRANCH ${GIT_BRANCH})
   set(${variable} "${GIT_COMMIT_HASH}-${GIT_BRANCH}")
-endmacro(Git_GET_REVISION)
+endmacro()
 
 if(EXISTS "${SOURCE_DIR}/.git/")
   if(GIT_EXECUTABLE)


### PR DESCRIPTION
Clone of /pull/2430 by @cfi-gb to work around CI.

## What
When building `gvmd` the following warning can be seen:

```
-- Found Git: /usr/bin/git (found version "2.47.2")
CMake Warning (dev) in cmake/GetGit.cmake:
  A logical block opening on the line

    /path/to/gvmd/cmake/GetGit.cmake:24 (macro)

  closes on the line

    /path/to/gvmd/cmake/GetGit.cmake:39 (endmacro)

  with mis-matching arguments.
Call Stack (most recent call first):
  CMakeLists.txt:40 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

It seems this got introduced in #2417 where `macro (Git_GET_REVISION` got changed to `macro(git_get_revision` but the `endmacro(Git_GET_REVISION)` got kept (See https://github.com/greenbone/gvmd/commit/0da39a209e8021e2adfcd1abc1b256596af6ce31#diff-bb9de5852c4d55994d868cdf8d57319c915d67ec7d0bf51e4a55cb0ee612b805)

I have now applied the same from greenbone/gsad#203 (See https://github.com/greenbone/gsad/commit/6515b9e0746c28e707338312052001ae518ee39b#diff-bb9de5852c4d55994d868cdf8d57319c915d67ec7d0bf51e4a55cb0ee612b805) to prevent this warning.

## Why
No warning when compiling from sources.

## References
None
