### PR TITLE
Fix: Convert integer port to string using g_strdup_printf

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -57186,7 +57186,7 @@ add_openvasd_result_to_report (openvasd_result_t res, gpointer *results_aux)
   test_id = res->oid;
   host = res->ip_address;
   hostname = res->hostname;
-  port = g_strdup (res->port);
+  port = g_strdup_printf ("%d", res->port);
 
   /* Add report host if it doesn't exist. */
   manage_report_host_add (rep_aux->report, host, 0, 0);


### PR DESCRIPTION
## What

Replaced a call to g_strdup(res->port) with g_strdup_printf("%d", res->port) in add_openvasd_result_to_report() to fix a type mismatch.

## Why

Using g_strdup() caused a compiler error due to implicit int-to-pointer conversion.




