### PR TITLE
Use CMake object libraries and variables for source lists

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -137,11 +137,9 @@ include_directories(
   ${PostgreSQL_SERVER_INCLUDE_DIRS}
 )
 
-## Object libraries
-
-add_library(
-  all-manage-obj
-  OBJECT
+# Source lists
+set(
+  ALL_MANAGE_SRC
   manage.c
   manage_acl.c
   manage_alerts.c
@@ -160,9 +158,8 @@ add_library(
   manage_pg.c
 )
 
-add_library(
-  all-manage-sql-obj
-  OBJECT
+set(
+  ALL_MANAGE_SQL_SRC
   manage_sql.c
   manage_sql_alerts.c
   manage_sql_events.c
@@ -179,9 +176,8 @@ add_library(
   manage_sql_nvts_common.c
 )
 
-add_library(
-  all-gmp-obj
-  OBJECT
+set(
+  ALL_GMP_SRC
   gmp.c
   gmp_base.c
   gmp_configs.c
@@ -196,11 +192,10 @@ add_library(
   gmp_tls_certificates.c
 )
 
-add_library(all-sql-obj OBJECT sql.c sql_pg.c)
+set(ALL_SQL_SRC sql.c sql_pg.c)
 
-add_library(
-  all-misc-obj
-  OBJECT
+set(
+  ALL_MISC_SRC
   debug_utils.c
   gvmd.c
   gmpd.c
@@ -210,8 +205,22 @@ add_library(
   utils.c
 )
 
+## Object libraries
+
+add_library(all-manage-obj OBJECT ${ALL_MANAGE_SRC})
+
+add_library(all-manage-sql-obj OBJECT ${ALL_MANAGE_SQL_SRC})
+
+add_library(all-gmp-obj OBJECT ${ALL_GMP_SRC})
+
+add_library(all-sql-obj OBJECT ${ALL_SQL_SRC})
+
+add_library(all-misc-obj OBJECT ${ALL_MISC_SRC})
+
 ## Program
 
+set(TEST_TARGET_EXTRA_SRC ${ALL_MANAGE_SRC})
+list(REMOVE_ITEM TEST_TARGET_EXTRA_SRC manage_utils.c)
 add_executable(
   manage-utils-test
   EXCLUDE_FROM_ALL
@@ -220,25 +229,13 @@ add_executable(
   $<TARGET_OBJECTS:all-manage-sql-obj>
   $<TARGET_OBJECTS:all-misc-obj>
   $<TARGET_OBJECTS:all-sql-obj>
-  manage.c
-  manage_acl.c
-  manage_alerts.c
-  manage_configs.c
-  manage_events.c
-  manage_get.c
-  manage_license.c
-  manage_port_lists.c
-  manage_preferences.c
-  manage_report_configs.c
-  manage_report_formats.c
-  manage_authentication.c
-  manage_tls_certificates.c
-  manage_migrators.c
-  manage_pg.c
+  ${TEST_TARGET_EXTRA_SRC}
 )
 
 add_test(manage-utils-test manage-utils-test)
 
+set(TEST_TARGET_EXTRA_SRC ${ALL_MANAGE_SRC})
+list(REMOVE_ITEM TEST_TARGET_EXTRA_SRC manage.c)
 add_executable(
   manage-test
   EXCLUDE_FROM_ALL
@@ -247,25 +244,13 @@ add_executable(
   $<TARGET_OBJECTS:all-manage-sql-obj>
   $<TARGET_OBJECTS:all-misc-obj>
   $<TARGET_OBJECTS:all-sql-obj>
-  manage_utils.c
-  manage_acl.c
-  manage_alerts.c
-  manage_configs.c
-  manage_events.c
-  manage_get.c
-  manage_license.c
-  manage_port_lists.c
-  manage_preferences.c
-  manage_report_configs.c
-  manage_report_formats.c
-  manage_authentication.c
-  manage_tls_certificates.c
-  manage_migrators.c
-  manage_pg.c
+  ${TEST_TARGET_EXTRA_SRC}
 )
 
 add_test(manage-test manage-test)
 
+set(TEST_TARGET_EXTRA_SRC ${ALL_MANAGE_SQL_SRC})
+list(REMOVE_ITEM TEST_TARGET_EXTRA_SRC manage_sql.c)
 add_executable(
   manage-sql-test
   EXCLUDE_FROM_ALL
@@ -274,23 +259,13 @@ add_executable(
   $<TARGET_OBJECTS:all-misc-obj>
   $<TARGET_OBJECTS:all-manage-obj>
   $<TARGET_OBJECTS:all-sql-obj>
-  manage_sql_alerts.c
-  manage_sql_nvts.c
-  manage_sql_events.c
-  manage_sql_secinfo.c
-  manage_sql_port_lists.c
-  manage_sql_configs.c
-  manage_sql_report_configs.c
-  manage_sql_report_formats.c
-  manage_sql_tickets.c
-  manage_sql_tls_certificates.c
-  manage_sql_nvts_osp.c
-  manage_sql_nvts_openvasd.c
-  manage_sql_nvts_common.c
+  ${TEST_TARGET_EXTRA_SRC}
 )
 
 add_test(manage-sql-test manage-sql-test)
 
+set(TEST_TARGET_EXTRA_SRC ${ALL_GMP_SRC})
+list(REMOVE_ITEM TEST_TARGET_EXTRA_SRC gmp_tickets.c)
 add_executable(
   gmp-tickets-test
   EXCLUDE_FROM_ALL
@@ -299,21 +274,13 @@ add_executable(
   $<TARGET_OBJECTS:all-manage-sql-obj>
   $<TARGET_OBJECTS:all-misc-obj>
   $<TARGET_OBJECTS:all-sql-obj>
-  gmp.c
-  gmp_base.c
-  gmp_configs.c
-  gmp_delete.c
-  gmp_get.c
-  gmp_license.c
-  gmp_logout.c
-  gmp_port_lists.c
-  gmp_report_configs.c
-  gmp_report_formats.c
-  gmp_tls_certificates.c
+  ${TEST_TARGET_EXTRA_SRC}
 )
 
 add_test(gmp-tickets-test gmp-tickets-test)
 
+set(TEST_TARGET_EXTRA_SRC ${ALL_MISC_SRC})
+list(REMOVE_ITEM TEST_TARGET_EXTRA_SRC utils.c)
 add_executable(
   utils-test
   EXCLUDE_FROM_ALL
@@ -322,12 +289,7 @@ add_executable(
   $<TARGET_OBJECTS:all-manage-obj>
   $<TARGET_OBJECTS:all-manage-sql-obj>
   $<TARGET_OBJECTS:all-sql-obj>
-  debug_utils.c
-  gvmd.c
-  gmpd.c
-  ipc.c
-  lsc_user.c
-  lsc_crypt.c
+  ${TEST_TARGET_EXTRA_SRC}
 )
 
 add_test(utils-test utils-test)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -137,18 +137,12 @@ include_directories(
   ${PostgreSQL_SERVER_INCLUDE_DIRS}
 )
 
-## Program
+## Object libraries
 
-add_executable(
-  manage-utils-test
-  EXCLUDE_FROM_ALL
-  manage_utils_tests.c
-  debug_utils.c
-  gvmd.c
-  gmpd.c
-  ipc.c
+add_library(
+  all-manage-obj
+  OBJECT
   manage.c
-  sql.c
   manage_acl.c
   manage_alerts.c
   manage_configs.c
@@ -160,6 +154,15 @@ add_executable(
   manage_report_configs.c
   manage_report_formats.c
   manage_authentication.c
+  manage_tls_certificates.c
+  manage_utils.c
+  manage_migrators.c
+  manage_pg.c
+)
+
+add_library(
+  all-manage-sql-obj
+  OBJECT
   manage_sql.c
   manage_sql_alerts.c
   manage_sql_events.c
@@ -171,13 +174,14 @@ add_executable(
   manage_sql_report_formats.c
   manage_sql_tickets.c
   manage_sql_tls_certificates.c
-  manage_tls_certificates.c
-  manage_migrators.c
-  sql_pg.c
-  manage_pg.c
-  lsc_user.c
-  lsc_crypt.c
-  utils.c
+  manage_sql_nvts_osp.c
+  manage_sql_nvts_openvasd.c
+  manage_sql_nvts_common.c
+)
+
+add_library(
+  all-gmp-obj
+  OBJECT
   gmp.c
   gmp_base.c
   gmp_configs.c
@@ -190,9 +194,47 @@ add_executable(
   gmp_report_formats.c
   gmp_tickets.c
   gmp_tls_certificates.c
-  manage_sql_nvts_osp.c
-  manage_sql_nvts_openvasd.c
-  manage_sql_nvts_common.c
+)
+
+add_library(all-sql-obj OBJECT sql.c sql_pg.c)
+
+add_library(
+  all-misc-obj
+  OBJECT
+  debug_utils.c
+  gvmd.c
+  gmpd.c
+  ipc.c
+  lsc_user.c
+  lsc_crypt.c
+  utils.c
+)
+
+## Program
+
+add_executable(
+  manage-utils-test
+  EXCLUDE_FROM_ALL
+  manage_utils_tests.c
+  $<TARGET_OBJECTS:all-gmp-obj>
+  $<TARGET_OBJECTS:all-manage-sql-obj>
+  $<TARGET_OBJECTS:all-misc-obj>
+  $<TARGET_OBJECTS:all-sql-obj>
+  manage.c
+  manage_acl.c
+  manage_alerts.c
+  manage_configs.c
+  manage_events.c
+  manage_get.c
+  manage_license.c
+  manage_port_lists.c
+  manage_preferences.c
+  manage_report_configs.c
+  manage_report_formats.c
+  manage_authentication.c
+  manage_tls_certificates.c
+  manage_migrators.c
+  manage_pg.c
 )
 
 add_test(manage-utils-test manage-utils-test)
@@ -201,12 +243,11 @@ add_executable(
   manage-test
   EXCLUDE_FROM_ALL
   manage_tests.c
-  debug_utils.c
-  gvmd.c
-  gmpd.c
-  ipc.c
+  $<TARGET_OBJECTS:all-gmp-obj>
+  $<TARGET_OBJECTS:all-manage-sql-obj>
+  $<TARGET_OBJECTS:all-misc-obj>
+  $<TARGET_OBJECTS:all-sql-obj>
   manage_utils.c
-  sql.c
   manage_acl.c
   manage_alerts.c
   manage_configs.c
@@ -218,39 +259,9 @@ add_executable(
   manage_report_configs.c
   manage_report_formats.c
   manage_authentication.c
-  manage_sql.c
-  manage_sql_alerts.c
-  manage_sql_events.c
-  manage_sql_nvts.c
-  manage_sql_secinfo.c
-  manage_sql_port_lists.c
-  manage_sql_configs.c
-  manage_sql_report_configs.c
-  manage_sql_report_formats.c
-  manage_sql_tickets.c
-  manage_sql_tls_certificates.c
   manage_tls_certificates.c
   manage_migrators.c
-  sql_pg.c
   manage_pg.c
-  lsc_user.c
-  lsc_crypt.c
-  utils.c
-  gmp.c
-  gmp_base.c
-  gmp_configs.c
-  gmp_delete.c
-  gmp_get.c
-  gmp_license.c
-  gmp_logout.c
-  gmp_port_lists.c
-  gmp_report_configs.c
-  gmp_report_formats.c
-  gmp_tickets.c
-  gmp_tls_certificates.c
-  manage_sql_nvts_osp.c
-  manage_sql_nvts_openvasd.c
-  manage_sql_nvts_common.c
 )
 
 add_test(manage-test manage-test)
@@ -259,24 +270,10 @@ add_executable(
   manage-sql-test
   EXCLUDE_FROM_ALL
   manage_sql_tests.c
-  debug_utils.c
-  gvmd.c
-  gmpd.c
-  ipc.c
-  manage_utils.c
-  manage.c
-  sql.c
-  manage_acl.c
-  manage_alerts.c
-  manage_configs.c
-  manage_events.c
-  manage_get.c
-  manage_license.c
-  manage_port_lists.c
-  manage_preferences.c
-  manage_report_configs.c
-  manage_report_formats.c
-  manage_authentication.c
+  $<TARGET_OBJECTS:all-gmp-obj>
+  $<TARGET_OBJECTS:all-misc-obj>
+  $<TARGET_OBJECTS:all-manage-obj>
+  $<TARGET_OBJECTS:all-sql-obj>
   manage_sql_alerts.c
   manage_sql_nvts.c
   manage_sql_events.c
@@ -287,25 +284,6 @@ add_executable(
   manage_sql_report_formats.c
   manage_sql_tickets.c
   manage_sql_tls_certificates.c
-  manage_tls_certificates.c
-  manage_migrators.c
-  sql_pg.c
-  manage_pg.c
-  lsc_user.c
-  lsc_crypt.c
-  utils.c
-  gmp.c
-  gmp_base.c
-  gmp_configs.c
-  gmp_delete.c
-  gmp_get.c
-  gmp_license.c
-  gmp_logout.c
-  gmp_port_lists.c
-  gmp_report_configs.c
-  gmp_report_formats.c
-  gmp_tickets.c
-  gmp_tls_certificates.c
   manage_sql_nvts_osp.c
   manage_sql_nvts_openvasd.c
   manage_sql_nvts_common.c
@@ -317,42 +295,10 @@ add_executable(
   gmp-tickets-test
   EXCLUDE_FROM_ALL
   gmp_tickets_tests.c
-  debug_utils.c
-  gvmd.c
-  gmpd.c
-  ipc.c
-  manage_utils.c
-  manage.c
-  sql.c
-  manage_acl.c
-  manage_alerts.c
-  manage_configs.c
-  manage_events.c
-  manage_get.c
-  manage_license.c
-  manage_port_lists.c
-  manage_preferences.c
-  manage_report_configs.c
-  manage_report_formats.c
-  manage_authentication.c
-  manage_sql.c
-  manage_sql_alerts.c
-  manage_sql_events.c
-  manage_sql_nvts.c
-  manage_sql_secinfo.c
-  manage_sql_port_lists.c
-  manage_sql_configs.c
-  manage_sql_report_configs.c
-  manage_sql_report_formats.c
-  manage_sql_tickets.c
-  manage_sql_tls_certificates.c
-  manage_tls_certificates.c
-  manage_migrators.c
-  sql_pg.c
-  manage_pg.c
-  lsc_user.c
-  lsc_crypt.c
-  utils.c
+  $<TARGET_OBJECTS:all-manage-obj>
+  $<TARGET_OBJECTS:all-manage-sql-obj>
+  $<TARGET_OBJECTS:all-misc-obj>
+  $<TARGET_OBJECTS:all-sql-obj>
   gmp.c
   gmp_base.c
   gmp_configs.c
@@ -364,9 +310,6 @@ add_executable(
   gmp_report_configs.c
   gmp_report_formats.c
   gmp_tls_certificates.c
-  manage_sql_nvts_osp.c
-  manage_sql_nvts_openvasd.c
-  manage_sql_nvts_common.c
 )
 
 add_test(gmp-tickets-test gmp-tickets-test)
@@ -375,56 +318,16 @@ add_executable(
   utils-test
   EXCLUDE_FROM_ALL
   utils_tests.c
+  $<TARGET_OBJECTS:all-gmp-obj>
+  $<TARGET_OBJECTS:all-manage-obj>
+  $<TARGET_OBJECTS:all-manage-sql-obj>
+  $<TARGET_OBJECTS:all-sql-obj>
   debug_utils.c
   gvmd.c
   gmpd.c
   ipc.c
-  manage_utils.c
-  manage.c
-  sql.c
-  manage_acl.c
-  manage_alerts.c
-  manage_configs.c
-  manage_events.c
-  manage_get.c
-  manage_license.c
-  manage_port_lists.c
-  manage_preferences.c
-  manage_report_configs.c
-  manage_report_formats.c
-  manage_authentication.c
-  manage_sql.c
-  manage_sql_alerts.c
-  manage_sql_events.c
-  manage_sql_nvts.c
-  manage_sql_secinfo.c
-  manage_sql_port_lists.c
-  manage_sql_configs.c
-  manage_sql_report_configs.c
-  manage_sql_report_formats.c
-  manage_sql_tickets.c
-  manage_sql_tls_certificates.c
-  manage_tls_certificates.c
-  manage_migrators.c
-  sql_pg.c
-  manage_pg.c
   lsc_user.c
   lsc_crypt.c
-  gmp.c
-  gmp_base.c
-  gmp_configs.c
-  gmp_delete.c
-  gmp_get.c
-  gmp_license.c
-  gmp_logout.c
-  gmp_port_lists.c
-  gmp_report_configs.c
-  gmp_report_formats.c
-  gmp_tickets.c
-  gmp_tls_certificates.c
-  manage_sql_nvts_osp.c
-  manage_sql_nvts_openvasd.c
-  manage_sql_nvts_common.c
 )
 
 add_test(utils-test utils-test)
@@ -464,57 +367,11 @@ add_custom_target(
 add_executable(
   gvmd
   main.c
-  gvmd.c
-  debug_utils.c
-  gmpd.c
-  ipc.c
-  manage_utils.c
-  manage.c
-  sql.c
-  manage_acl.c
-  manage_alerts.c
-  manage_configs.c
-  manage_events.c
-  manage_get.c
-  manage_license.c
-  manage_port_lists.c
-  manage_preferences.c
-  manage_report_configs.c
-  manage_report_formats.c
-  manage_authentication.c
-  manage_sql.c
-  manage_sql_alerts.c
-  manage_sql_events.c
-  manage_sql_nvts.c
-  manage_sql_secinfo.c
-  manage_sql_port_lists.c
-  manage_sql_configs.c
-  manage_sql_report_configs.c
-  manage_sql_report_formats.c
-  manage_sql_tickets.c
-  manage_sql_tls_certificates.c
-  manage_tls_certificates.c
-  manage_migrators.c
-  sql_pg.c
-  manage_pg.c
-  lsc_user.c
-  lsc_crypt.c
-  utils.c
-  gmp.c
-  gmp_base.c
-  gmp_configs.c
-  gmp_delete.c
-  gmp_get.c
-  gmp_license.c
-  gmp_logout.c
-  gmp_port_lists.c
-  gmp_report_configs.c
-  gmp_report_formats.c
-  gmp_tickets.c
-  gmp_tls_certificates.c
-  manage_sql_nvts_osp.c
-  manage_sql_nvts_openvasd.c
-  manage_sql_nvts_common.c
+  $<TARGET_OBJECTS:all-gmp-obj>
+  $<TARGET_OBJECTS:all-manage-obj>
+  $<TARGET_OBJECTS:all-manage-sql-obj>
+  $<TARGET_OBJECTS:all-misc-obj>
+  $<TARGET_OBJECTS:all-sql-obj>
 )
 
 target_link_libraries(


### PR DESCRIPTION
## What
Source files for executables are now grouped into a object libraries in CMakeLists.txt.
The source files are now stored in variables.
In test executable targets the source files not part of an object library are specified by copies of those lists with conflicting
files removed.

## Why
With this source files do not have to be added exlicitly to every executable, avoiding some repetition for the test executables when adding source files or tests.
Object libraries also allow CMake to reuse already compiled object files, reducing the compilation time for building all tests.
The use of variables and the list funtion further reduces the amount of repetition.

## References
GEA-1070

## Checklist

This change only affects the build, so no tests are needed


