### PR TITLE
Fix: Revert incorrect port formatting from int to gchar*

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -57175,7 +57175,7 @@ add_openvasd_result_to_report (openvasd_result_t res, gpointer *results_aux)
   test_id = res->oid;
   host = res->ip_address;
   hostname = res->hostname;
-  port = g_strdup (res->port);
+  port = res->port;
 
   /* Add report host if it doesn't exist. */
   manage_report_host_add (rep_aux->report, host, 0, 0);
@@ -57201,7 +57201,6 @@ add_openvasd_result_to_report (openvasd_result_t res, gpointer *results_aux)
         }
       desc = res->message;
       g_free (hash_value);
-      g_free (port);
       g_free (type);
       return;
     }
@@ -57258,7 +57257,6 @@ add_openvasd_result_to_report (openvasd_result_t res, gpointer *results_aux)
       g_free (hash_value);
     }
 
-  g_free (port);
   g_free (nvt_id);
   g_free (type);
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -57038,7 +57038,7 @@ check_openvasd_result_exists (report_t report, task_t task,
   else if (res->port > 0)
     {
       char buf[6];
-      snprintf (buf, sizeof(buf) , "%d", res->port);
+      snprintf (buf, sizeof(buf) , "%s", res->port);
       port_str = g_strdup (buf);
     }
   else
@@ -57186,7 +57186,7 @@ add_openvasd_result_to_report (openvasd_result_t res, gpointer *results_aux)
   test_id = res->oid;
   host = res->ip_address;
   hostname = res->hostname;
-  port = g_strdup_printf ("%d", res->port);
+  port = g_strdup (res->port);
 
   /* Add report host if it doesn't exist. */
   manage_report_host_add (rep_aux->report, host, 0, 0);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -57032,25 +57032,13 @@ check_openvasd_result_exists (report_t report, task_t task,
 {
   GString *result_string;
   int return_value = 0;
-  char *port_str = NULL;
-  if (res->port == 0 && res->detail_value && *res->detail_value)
-    port_str = g_strdup ("general/Host_Details");
-  else if (res->port > 0)
-    {
-      char buf[6];
-      snprintf (buf, sizeof(buf) , "%s", res->port);
-      port_str = g_strdup (buf);
-    }
-  else
-    port_str = "";
-
   result_string = g_string_new ("");
   g_string_append_printf (result_string, "host:%s\n"
                           "hostname:%s\n"
                           "type:%s\n"
                           "description:%s\n"
                           "port:%s",res->ip_address, res->hostname,
-                          res->type, res->message, port_str);
+                          res->type, res->message, res->port);
 
  *entity_hash_value = get_md5_hash_from_string (result_string->str);
   if (g_hash_table_contains (hashed_openvasd_results, *entity_hash_value))
@@ -57086,6 +57074,7 @@ check_openvasd_result_exists (report_t report, task_t task,
               else
                 {
                   g_debug ("%s: Result without severity", __func__);
+                  g_string_free (result_string, TRUE);
                   return 0;
                 }
             }


### PR DESCRIPTION
## What

Revert incorrect port formatting from int to gchar*

## Why

The original changes incorrectly treated res->port, a gchar *, as an int, which led to heap corruption at runtime during scan execution. This caused instability and failure in openvasd processes. The fix restores the correct type handling.

## References

https://github.com/greenbone/gvmd/pull/2437



