### PR TITLE
Fix: Recreation of view "result_vt_epss" after rebuilding NVTs.

### DIFF
--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -6663,6 +6663,8 @@ update_vt_scap_extra_data ()
        " FROM epss_candidates"
        " WHERE epss_candidates.vt_oid = nvts.oid"
        "   AND epss_candidates.rank = 1;");
+
+  create_view_result_vt_epss ();
 }
 
 /**


### PR DESCRIPTION

## What
Now the view "result_vt_epss" is recreated after NVTs were rebuild.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This is a bug-fix. The EPSS score was sometimes not displayed in reports.
<!-- Describe why are these changes necessary? -->

## References
GEA-930
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist
Tested manually on my local development system.
<!-- Remove this section if not applicable to your changes -->



