### PR TITLE
Fix: use parse_vt_json when OPENVASD=1

### DIFF
--- a/src/manage_sql_nvts_openvasd.c
+++ b/src/manage_sql_nvts_openvasd.c
@@ -37,6 +37,7 @@
 #include "sql.h"
 
 #include <gvm/util/jsonpull.h>
+#include <gvm/util/vtparser.h>
 
 #undef G_LOG_DOMAIN
 /**
@@ -325,8 +326,7 @@ update_nvts_from_openvasd_vts (openvasd_connector_t connector,
       // If the stream is not running anymore, parse the remaining VTs.
       while ((running && non_read_count > GVM_JSON_PULL_READ_BUFFER_SIZE * 8) || !running)
         {
-          nvti = openvasd_parse_vt (&parser, &event);
-          if (nvti == NULL)
+          if (parse_vt_json (&parser, &event, &nvti))
             {
               break_flag = 1;
               break;


### PR DESCRIPTION
## What

In `update_nvts_from_openvasd_vts` use `parse_vt_json`.

## Why

`openvasd_parse_vt` was renamed to `parse_vt_json`.

## References

Was renamed in https://github.com/greenbone/gvm-libs/pull/915.