### PR TITLE
Throw an error when providing an invalid LDAP certificate.

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -24815,9 +24815,12 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                       setting = g_slist_next (setting);
                     }
 
-                  manage_set_ldap_info (ldap_enabled, ldap_host, ldap_authdn,
-                                        ldap_plaintext, ldap_cacert,
-                                        ldap_ldaps_only);
+                  if (manage_set_ldap_info (ldap_enabled, ldap_host, ldap_authdn,
+                                            ldap_plaintext, ldap_cacert,
+                                            ldap_ldaps_only))
+                    SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX
+                                             ("modify_auth",
+                                              "Invalid certificate"));
                 }
               if (strcmp (group, "method:radius_connect") == 0)
                 {

--- a/src/manage.h
+++ b/src/manage.h
@@ -3677,7 +3677,7 @@ vuln_count (const get_data_t*);
 void
 manage_get_ldap_info (int *, gchar **, gchar **, int *, gchar **, int *);
 
-void
+int
 manage_set_ldap_info (int, gchar *, gchar *, int, gchar *, int);
 
 char *


### PR DESCRIPTION
## What
Now an error is thrown, when an invalid certificate is provided in the Administration/LDAP dialog.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This fixes a bug.
<!-- Describe why are these changes necessary? -->

## References
GEA-1072
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist
Tested manually on my local development system.
<!-- Remove this section if not applicable to your changes -->



