### PR TITLE
Add cancellation of running CI jobs on new commit

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, stable, oldstable]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-format:
     name: Check formatting

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ main, stable, oldstable ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   generate-doc-and-upload-coverage:
     name: Build XML documentation and upload coverage

--- a/.github/workflows/codeql-analysis-c.yml
+++ b/.github/workflows/codeql-analysis-c.yml
@@ -11,6 +11,10 @@ on:
   schedule:
     - cron: '30 5 * * 0' # 5:30h on Sundays
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -13,6 +13,10 @@ on:
         description: "The ref to build a container image from. For example a tag v23.0.0."
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build and Push to Greenbone Registry

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -3,6 +3,10 @@ name: Conventional Commits
 on:
   pull_request_target:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: write
   contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,5 +1,10 @@
 name: 'Dependency Review'
+
 on: [pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ on:
         type: string
         description: Set an explicit version, that will overwrite release-type. Fails if version is not compliant.
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-release:
     name: Create a new release

--- a/.github/workflows/sbom-upload.yml
+++ b/.github/workflows/sbom-upload.yml
@@ -3,6 +3,11 @@ on:
   workflow_dispatch:
   push:
     branches: ["main"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   SBOM-upload:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Add cancellation of running CI jobs on new commit in same ref
to all workflows.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why

We usually don't need to continue running old jobs when a new commit comes in that starts the same jobs again.

This saves us some running time and resources.

<!-- Describe why are these changes necessary? -->

## References
see DEVOPS-1538

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [NA] Tests