### PR TITLE
Change: Replace global ignore_max_rows_per_page

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -11332,7 +11332,8 @@ handle_get_aggregates (gmp_parser_t *gmp_parser, GError **error)
   if (filter || get->filter)
     {
       gchar *new_filter;
-      new_filter = manage_clean_filter (filter ? filter : get->filter);
+      new_filter = manage_clean_filter (filter ? filter : get->filter,
+                                        get->ignore_max_rows_per_page);
       g_free (filter);
       if ((strcmp (type, "task") == 0)
           && (filter_term_value (new_filter, "apply_overrides")
@@ -11347,7 +11348,7 @@ handle_get_aggregates (gmp_parser_t *gmp_parser, GError **error)
       filter = new_filter;
     }
   else
-    filter = manage_clean_filter ("");
+    filter = manage_clean_filter ("", get->ignore_max_rows_per_page);
 
   type_many = g_string_new (type);
 
@@ -18572,7 +18573,8 @@ handle_get_tasks (gmp_parser_t *gmp_parser, GError **error)
   else
     filter = NULL;
 
-  clean_filter = manage_clean_filter (filter ? filter : get->filter);
+  clean_filter = manage_clean_filter (filter ? filter : get->filter,
+                                      get->ignore_max_rows_per_page);
   apply_overrides = filter_term_apply_overrides (clean_filter);
   min_qod = filter_term_min_qod (clean_filter);
   g_free (clean_filter);

--- a/src/gmp_get.c
+++ b/src/gmp_get.c
@@ -172,7 +172,8 @@ init_get (gchar *command, get_data_t * get, const gchar *setting_name,
         {
           gchar *new_filter, *clean;
 
-          clean = manage_clean_filter_remove (term, get->filter_replace);
+          clean = manage_clean_filter_remove (term, get->filter_replace,
+                                              get->ignore_max_rows_per_page);
           new_filter = g_strdup_printf
                         ("%s=%s %s",
                          get->filter_replace,
@@ -598,12 +599,13 @@ send_get_end_internal (const char *type, get_data_t *get, int get_counts,
       max = -1;
     }
 
-  max = manage_max_rows (max);
+  max = manage_max_rows (max, get->ignore_max_rows_per_page);
 
   if (filter || get->filter)
     {
       gchar *new_filter;
-      new_filter = manage_clean_filter (filter ? filter : get->filter);
+      new_filter = manage_clean_filter (filter ? filter : get->filter,
+                                        get->ignore_max_rows_per_page);
       g_free (filter);
       if ((strcmp (type, "task") == 0)
           || (strcmp (type, "report") == 0)
@@ -649,12 +651,14 @@ send_get_end_internal (const char *type, get_data_t *get, int get_counts,
         filter = manage_clean_filter("apply_overrides="
                                      G_STRINGIFY (APPLY_OVERRIDES_DEFAULT)
                                      " min_qod="
-                                     G_STRINGIFY (MIN_QOD_DEFAULT));
+                                     G_STRINGIFY (MIN_QOD_DEFAULT),
+                                     get->ignore_max_rows_per_page);
       else if (strcmp (type, "vuln") == 0)
         filter = manage_clean_filter(" min_qod="
-                                     G_STRINGIFY (MIN_QOD_DEFAULT));
+                                     G_STRINGIFY (MIN_QOD_DEFAULT),
+                                     get->ignore_max_rows_per_page);
       else
-        filter = manage_clean_filter ("");
+        filter = manage_clean_filter ("", get->ignore_max_rows_per_page);
     }
 
   type_many = g_string_new (type);

--- a/src/manage.h
+++ b/src/manage.h
@@ -1577,10 +1577,10 @@ manage_report_filter_controls (const gchar *, int *, int *, gchar **, int *,
                                gchar **, int *, int *, int *, int *, gchar **);
 
 gchar *
-manage_clean_filter (const gchar *);
+manage_clean_filter (const gchar *, int);
 
 gchar *
-manage_clean_filter_remove (const gchar *, const gchar *);
+manage_clean_filter_remove (const gchar *, const gchar *, int);
 
 int
 manage_count_hosts (const char *, const char *);
@@ -3337,7 +3337,7 @@ secinfo_count_after (const get_data_t *, const char *, time_t, gboolean);
 /* Settings. */
 
 int
-manage_max_rows (int);
+manage_max_rows (int, int);
 
 int
 setting_count (const char *);

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -320,7 +320,8 @@ filter_term_sql (const char *);
 
 gchar *
 filter_clause (const char*, const char*, const char **, column_t *,
-               column_t *, int, gchar **, int *, int *, array_t **, gchar **);
+               column_t *, int, int, gchar **, int *, int *, array_t **,
+               gchar **);
 
 void
 check_alerts ();


### PR DESCRIPTION
## What
The global ignore_max_rows_per_page option is replaced by the get data field and parameters of the functions where it is relevant.

## Why
This removes dependencies on this variable and the need to reset it to ensure the option is disabled where it is no longer needed.

## References
GEA-1075

## Checklist


