### PR TITLE
Fix header for secinfo_feed_version_status

### DIFF
--- a/src/manage_sql_secinfo.h
+++ b/src/manage_sql_secinfo.h
@@ -181,7 +181,7 @@
 #define SECINFO_COMMIT_SIZE_DEFAULT 0
 
 int
-secinfo_feed_version_status ();
+secinfo_feed_version_status (const char *);
 
 pid_t
 manage_sync_scap (sigset_t *);


### PR DESCRIPTION
## What
A missing param is added to the header file declaration of secinfo_feed_version_status.

## Why
This fixes an error with some compiler versions.

## References
Fixes #2443
## Checklist
