### PR TITLE
Fix: Handle unused arguments in modify filter.

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -3093,12 +3093,6 @@ filter_name (filter_t);
 char*
 trash_filter_name (filter_t);
 
-char*
-filter_comment (filter_t);
-
-char*
-filter_type (filter_t);
-
 int
 create_filter (const char*, const char*, const char*, const char*, filter_t*);
 

--- a/src/manage.h
+++ b/src/manage.h
@@ -3093,6 +3093,12 @@ filter_name (filter_t);
 char*
 trash_filter_name (filter_t);
 
+char*
+filter_comment (filter_t);
+
+char*
+filter_type (filter_t);
+
 int
 create_filter (const char*, const char*, const char*, const char*, filter_t*);
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -43772,34 +43772,6 @@ trash_filter_name (filter_t filter)
 }
 
 /**
- * @brief Return the comment of a filter.
- *
- * @param[in]  filter  Filter.
- *
- * @return comment of filter.
- */
-char*
-filter_comment (filter_t filter)
-{
-  return sql_string ("SELECT comment FROM filters WHERE id = %llu;",
-                     filter);
-}
-
-/**
- * @brief Return the type of a filter.
- *
- * @param[in]  filter  Filter.
- *
- * @return type of filter.
- */
-char*
-filter_type (filter_t filter)
-{
-  return sql_string ("SELECT type FROM filters WHERE id = %llu;",
-                     filter);
-}
-
-/**
  * @brief Return the term of a filter.
  *
  * @param[in]  uuid  Filter UUID.

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -44504,9 +44504,8 @@ modify_filter (const char *filter_id, const char *name, const char *comment,
                   g_strdup ("");
 
   sql ("UPDATE filters SET"
-       " uuid = uuid"
-       "%s%s%s%s"
-       ", modification_time = m_now ()"
+       " modification_time = m_now ()"
+       " %s%s%s%s"
        " WHERE id = %llu;",
        t_name,
        t_comment,

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -44439,8 +44439,7 @@ int
 modify_filter (const char *filter_id, const char *name, const char *comment,
                const char *term, const char *type)
 {
-  gchar *quoted_name, *quoted_comment, *quoted_term, *quoted_type;
-  gchar *quoted_filter_id, *clean_term;
+  gchar *quoted_name, *quoted_comment, *quoted_term, *quoted_type, *clean_term;
   char *t_name, *t_comment, *t_term, *t_type;
   filter_t filter;
   const char *db_type;
@@ -44464,7 +44463,7 @@ modify_filter (const char *filter_id, const char *name, const char *comment,
     }
 
   db_type = type_db_name (type);
-  if (type && db_type && !((strcmp (db_type, "") == 0) || valid_type (db_type)))
+  if (db_type && !((strcmp (db_type, "") == 0) || valid_type (db_type)))
     {
       if (!valid_subtype (type))
         {
@@ -44473,13 +44472,9 @@ modify_filter (const char *filter_id, const char *name, const char *comment,
         }
     }
 
-  if (type && db_type)
+  if (type)
     {
       type = valid_subtype (type) ? type : db_type;
-    }
-  else
-    {
-      type = "";
     }
 
   assert (current_credentials.uuid);
@@ -44519,7 +44514,6 @@ modify_filter (const char *filter_id, const char *name, const char *comment,
         }
     }
 
-  quoted_filter_id = sql_quote(filter_id);
   quoted_name = sql_quote(name ?: "");
   clean_term = manage_clean_filter (term ? term : "",
                                     0 /* ignore_max_rows_per_page */);
@@ -44538,11 +44532,10 @@ modify_filter (const char *filter_id, const char *name, const char *comment,
                   g_strdup ("");
 
   sql ("UPDATE filters SET"
-       " uuid = '%s'"
+       " uuid = uuid"
        "%s%s%s%s"
        ", modification_time = m_now ()"
        " WHERE id = %llu;",
-       quoted_filter_id,
        t_name,
        t_comment,
        t_term,
@@ -44553,7 +44546,6 @@ modify_filter (const char *filter_id, const char *name, const char *comment,
   g_free (t_comment);
   g_free (t_term);
   g_free (t_type);
-  g_free (quoted_filter_id);
   g_free (quoted_comment);
   g_free (quoted_name);
   g_free (quoted_term);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -44462,10 +44462,10 @@ modify_filter (const char *filter_id, const char *name, const char *comment,
       return 1;
     }
 
-  f_name = name ? g_strdup (name) :  filter_name (filter);
-  f_comment = comment ? g_strdup (comment) :  filter_comment (filter);
-  f_type = type ? g_strdup (type) :  filter_type (filter);
-  f_term = term ? g_strdup (term) :  filter_term (filter_id);
+  f_name = name ? g_strdup (name) : filter_name (filter);
+  f_comment = comment ? g_strdup (comment) : filter_comment (filter);
+  f_type = type ? g_strdup (type) : filter_type (filter);
+  f_term = term ? g_strdup (term) : filter_term (filter_id);
 
   db_type = type_db_name (f_type);
   if (db_type && !((strcmp (db_type, "") == 0) || valid_type (db_type)))
@@ -44491,7 +44491,7 @@ modify_filter (const char *filter_id, const char *name, const char *comment,
   else
     {
       g_free (f_type);
-      f_type = g_strdup("");
+      f_type = g_strdup ("");
     }
 
   assert (current_credentials.uuid);


### PR DESCRIPTION
## What
Unused arguments for the python-gvm command "modify_filter" are now handled in gvmd.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This is a bug-fix.
<!-- Describe why are these changes necessary? -->

## References
GEA-1077
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist
Tested manually on my local development system.
<!-- Remove this section if not applicable to your changes -->


