### PR TITLE
Change: use functions instead of direct SQL in alert trigger

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -8999,10 +8999,7 @@ trigger_to_vfire (alert_t alert, task_t task, report_t report, event_t event,
 
   // Get report
   if (report == 0)
-    switch (sql_int64 (&report,
-                       "SELECT max (id) FROM reports"
-                       " WHERE task = %llu",
-                       task))
+    switch (task_last_report_any_status (task, &report))
       {
         case 0:
           if (report)
@@ -9948,10 +9945,7 @@ trigger (alert_t alert, task_t task, report_t report, event_t event,
             }
 
           if (report == 0)
-            switch (sql_int64 (&report,
-                                "SELECT max (id) FROM reports"
-                                " WHERE task = %llu",
-                                task))
+            switch (task_last_report_any_status (task, &report))
               {
                 case 0:
                   if (report)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -10464,14 +10464,9 @@ trigger (alert_t alert, task_t task, report_t report, event_t event,
               return -1;
             }
 
-          owner_id = sql_string ("SELECT uuid FROM users"
-                                 " WHERE id = (SELECT owner FROM alerts"
-                                 "              WHERE id = %llu)",
-                                 alert);
-          owner_name = sql_string ("SELECT name FROM users"
-                                   " WHERE id = (SELECT owner FROM alerts"
-                                   "              WHERE id = %llu)",
-                                   alert);
+
+          owner_id = alert_owner_uuid (alert);
+          owner_name = alert_owner_name (alert);
 
           if (owner_id == NULL)
             {

--- a/src/manage_sql_alerts.c
+++ b/src/manage_sql_alerts.c
@@ -1610,6 +1610,20 @@ alert_owner_uuid (alert_t alert)
 }
 
 /**
+ * @brief Return the name of the owner of an alert.
+ *
+ * @param[in]  alert  Alert.
+ *
+ * @return Newly allocated user name.
+ */
+char*
+alert_owner_name (alert_t alert)
+{
+  return sql_string ("SELECT name FROM users WHERE id ="
+                     " (SELECT owner FROM alerts WHERE id = %llu);",
+                     alert);
+}
+/**
  * @brief Return the name of an alert.
  *
  * @param[in]  alert  Alert.

--- a/src/manage_sql_alerts.h
+++ b/src/manage_sql_alerts.h
@@ -64,6 +64,9 @@ alert_owner (alert_t);
 char *
 alert_owner_uuid (alert_t);
 
+char*
+alert_owner_name (alert_t);
+
 char *
 alert_name (alert_t);
 


### PR DESCRIPTION
## What

Use functions instead of SQL in the alert triggering code.

## Why

I'm removing the little bits of SQL from the `Events and Alerts` section of `manage_sql.c` so that the code can be moved to `manage_alerts.c`.

## References

Similar to /pull/2454. 

## Tests

I modified the alert code to keep the tmp dirs used during trigger. Then I ran SMB, vfire and Start Task. The tmp reports looked correct.
