### PR TITLE
Fix: Prevent signal when running Sourcefire alert.

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -6854,7 +6854,7 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
 
   pkcs12_file = g_strdup_printf ("%s/pkcs12", report_dir);
 
-  if (strlen (pkcs12_64))
+  if (pkcs12_64 && strlen (pkcs12_64))
     pkcs12 = (gchar*) g_base64_decode (pkcs12_64, &pkcs12_len);
   else
     {


### PR DESCRIPTION


## What
Now a signal is prevented when running a Sourcefire alert with no certificate provided.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This was a bug.
<!-- Describe why are these changes necessary? -->

## References
GEA-1087
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist
Tested manually on my local development system.
<!-- Remove this section if not applicable to your changes -->



