### PR TITLE
Fix: leak of openvasd_resp_t

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -8090,10 +8090,13 @@ stop_openvasd_task (task_t task)
   if (response->code < 0)
     {
       ret = -1;
+      openvasd_response_cleanup (response);
       g_free (scan_id);
       goto end_stop_openvasd;
     }
+  openvasd_response_cleanup (response);
   response = openvasd_delete_scan (connector);
+  openvasd_response_cleanup (response);
   g_free (scan_id);
 end_stop_openvasd:
   openvasd_connector_free (connector);
@@ -8173,6 +8176,7 @@ prepare_openvasd_scan_for_resume (task_t task, const char *scan_id,
           openvasd_response_cleanup (response);
           return -1;
         }
+      openvasd_response_cleanup (response);
       response = openvasd_delete_scan (connection);
       if (response->code != 204)
         {
@@ -8182,6 +8186,7 @@ prepare_openvasd_scan_for_resume (task_t task, const char *scan_id,
           openvasd_connector_free (connection);
           return -1;
         }
+      openvasd_response_cleanup (response);
       openvasd_connector_free (connection);
       trim_partial_report (global_current_report);
       return 1;
@@ -8202,6 +8207,7 @@ prepare_openvasd_scan_for_resume (task_t task, const char *scan_id,
           openvasd_connector_free (connection);
           return -1;
         }
+      openvasd_response_cleanup (response);
       openvasd_connector_free (connection);
       trim_partial_report (global_current_report);
       return 1;
@@ -8222,6 +8228,7 @@ prepare_openvasd_scan_for_resume (task_t task, const char *scan_id,
           openvasd_connector_free (connection);
           return -1;
         }
+      openvasd_response_cleanup (response);
       openvasd_connector_free (connection);
       trim_partial_report (global_current_report);
       return 1;

--- a/src/manage_sql_nvts_openvasd.c
+++ b/src/manage_sql_nvts_openvasd.c
@@ -275,6 +275,7 @@ update_nvts_from_openvasd_vts (openvasd_connector_t connector,
   resp = openvasd_get_vt_stream_init (connector);
   if (resp->code < 0)
     {
+      openvasd_response_cleanup (resp);
       g_warning ("%s: failed to get VTs", __func__);
       return -1;
     }
@@ -435,6 +436,7 @@ update_nvt_cache_openvasd (gchar *db_feed_version,
   resp = openvasd_get_vts (connector);
   if (resp->code != 200)
     {
+      openvasd_response_cleanup (resp);
       g_warning ("%s: failed to get scanner preferences", __func__);
       return -1;
     }
@@ -518,6 +520,8 @@ update_nvt_cache_openvasd (gchar *db_feed_version,
   check_preference_names (1, old_nvts_last_modified);
 
   check_whole_only_in_configs ();
+
+  openvasd_response_cleanup (resp);
 
   return 0;
 }


### PR DESCRIPTION
## What

Always free `openvasd_resp_t`.

## Why

Cleaner.

Note this only affects gvmd built with `-D OPENVASD=1`.

## References

Compile with `OPENVASD=1` requires /pull/2441.
