### PR TITLE
Change: use functions to access report times

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -9561,17 +9561,9 @@ trigger (alert_t alert, task_t task, report_t report, event_t event,
 
               report_id = report_uuid (report);
 
-              creation_time
-                = sql_string ("SELECT iso_time (start_time)"
-                              " FROM reports"
-                              " WHERE id = %llu",
-                              report);
+              creation_time = report_start_time (report);
 
-              modification_time
-                = sql_string ("SELECT iso_time (end_time)"
-                              " FROM reports"
-                              " WHERE id = %llu",
-                              report);
+              modification_time = report_end_time (report);
 
               file_name
                 = gvm_export_file_name (fname_format,
@@ -21708,6 +21700,37 @@ report_modification_time (report_t report)
                      report);
 }
 
+/**
+ * @brief Get the start time of a report.
+ *
+ * @param[in]  report  Report.
+ *
+ * @return Time in ISO format.
+ */
+gchar *
+report_start_time (report_t report)
+{
+  return sql_string ("SELECT iso_time (start_time)"
+                     " FROM reports"
+                     " WHERE id = %llu",
+                     report);
+}
+
+/**
+ * @brief Get the end time of a report.
+ *
+ * @param[in]  report  Report.
+ *
+ * @return Time in ISO format.
+ */
+gchar *
+report_end_time (report_t report)
+{
+  return sql_string ("SELECT iso_time (end_time)"
+                     " FROM reports"
+                     " WHERE id = %llu",
+                     report);
+}
 
 /**
  * @brief Return the run status of the scan associated with a report.

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -196,6 +196,10 @@ gchar *report_host_best_os_cpe (report_host_t);
 
 gchar *report_host_best_os_txt (report_host_t);
 
+gchar *report_start_time (report_t);
+
+gchar *report_end_time (report_t);
+
 void trim_report (report_t);
 
 int delete_report_internal (report_t);


### PR DESCRIPTION
## What

Use functions instead of direct SQL to access report times in alert function `trigger`.

## Why

I'm removing the direct SQL from the `Events and Alerts` section of `manage_sql.c`, so that the section can go into `manage_alerts.c`. 

## References

Follows /pull/2455.

## Testing

I ran a scan with an email alert. The times used for the email attachment looked right.


