### PR TITLE
Change: use function to get alert SMB file path format

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -9958,19 +9958,7 @@ trigger (alert_t alert, task_t task, report_t report, event_t event,
           share_path = alert_data (alert, "method", "smb_share_path");
           max_protocol = alert_data (alert, "method", "smb_max_protocol");
 
-          file_path_format
-            = sql_string ("SELECT value FROM tags"
-                          " WHERE name = 'smb-alert:file_path'"
-                          "   AND EXISTS"
-                          "         (SELECT * FROM tag_resources"
-                          "           WHERE resource_type = 'task'"
-                          "             AND resource = %llu"
-                          "             AND tag = tags.id)"
-                          " ORDER BY modification_time LIMIT 1;",
-                          task);
-
-          if (file_path_format == NULL)
-            file_path_format = alert_data (alert, "method", "smb_file_path");
+          file_path_format = alert_smb_file_path (alert, task);
 
           file_path_is_dir = (g_str_has_suffix (file_path_format, "\\")
                               || g_str_has_suffix (file_path_format, "/"));

--- a/src/manage_sql_alerts.c
+++ b/src/manage_sql_alerts.c
@@ -2420,3 +2420,32 @@ check_alerts ()
         }
     }
 }
+
+/**
+ * @brief Get the SMB file path format to use for an alert.
+ *
+ * @param[in]  alert  Alert.
+ * @param[in]  task   Task.
+ *
+ * @return Freshly allocated path if there's a tag, else NULL.
+ */
+gchar *
+alert_smb_file_path (alert_t alert, task_t task)
+{
+  gchar *file_path_format;
+
+  file_path_format = sql_string ("SELECT value FROM tags"
+                                 " WHERE name = 'smb-alert:file_path'"
+                                 "   AND EXISTS"
+                                 "         (SELECT * FROM tag_resources"
+                                 "           WHERE resource_type = 'task'"
+                                 "             AND resource = %llu"
+                                 "             AND tag = tags.id)"
+                                 " ORDER BY modification_time LIMIT 1;",
+                                 task);
+
+  if (file_path_format)
+    return file_path_format;
+
+  return alert_data (alert, "method", "smb_file_path");
+}

--- a/src/manage_sql_alerts.h
+++ b/src/manage_sql_alerts.h
@@ -79,4 +79,7 @@ alert_data (alert_t, const char *, const char *);
 int
 alert_applies_to_task (alert_t, task_t);
 
+gchar *
+alert_smb_file_path (alert_t, task_t);
+
 #endif /* not _GVMD_MANAGE_SQL_ALERTS_H */


### PR DESCRIPTION
## What

Use an new interface function to get the SMB file path format for an alert.

## Why

I'm moving the last bits of SQL out of the alert trigger code so that it can go into `manage_alerts.c`.

Part of moving the alert code out of `manage_sql.c`.

## References

Follows /pull/2460.

## Test

I modified the path format value of an SMB alert, ran the alert, then checked in the log that the path was used.
Then I tagged the task with `smb-alert:file_path`, ran the task, and checked in the log that the alert used the path from the tag.

Side note: There might be an existing error in the tag SQL statement. I suspect it should be checking `tags.active`. For example, if I disable the tag the alert still uses the path from the tag. Probably the SQL should be part of the tag API instead of being here in the alert code.