### PR TITLE
Change: use function instead of SQL for vfire_call_ iterator

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -8979,7 +8979,6 @@ trigger_to_vfire (alert_t alert, task_t task, report_t report, event_t event,
   iterator_t data_iterator;
   GTree *call_input;
   char *description_template;
-  int name_offset;
 
   if ((event == EVENT_TICKET_RECEIVED)
       || (event == EVENT_ASSIGNED_TICKET_CHANGED)
@@ -9159,21 +9158,14 @@ trigger_to_vfire (alert_t alert, task_t task, report_t report, event_t event,
   // Call input data
   call_input = g_tree_new_full ((GCompareDataFunc) g_strcmp0,
                                 NULL, g_free, g_free);
-  name_offset = strlen ("vfire_call_");
-  init_iterator (&data_iterator,
-                 "SELECT name, data"
-                 " FROM alert_method_data"
-                 " WHERE alert = %llu"
-                 " AND name %s 'vfire_call_%%';",
-                 alert, sql_ilike_op ());
+  init_alert_vfire_call_iterator (&data_iterator, alert);
 
   while (next (&data_iterator))
     {
       gchar *name, *value;
-      name = g_strdup (iterator_string (&data_iterator, 0)
-                        + name_offset);
-      value = g_strdup (iterator_string (&data_iterator, 1));
 
+      name = g_strdup (alert_vfire_call_iterator_name (&data_iterator));
+      value = g_strdup (alert_vfire_call_iterator_value (&data_iterator));
       g_tree_replace (call_input, name, value);
     }
   cleanup_iterator (&data_iterator);

--- a/src/manage_sql_alerts.c
+++ b/src/manage_sql_alerts.c
@@ -2206,6 +2206,55 @@ alert_task_iterator_readable (iterator_t* iterator)
 }
 
 /**
+ * @brief Initialise a vFire alert iterator for method call data.
+ *
+ * @param[in]  iterator   Iterator.
+ * @param[in]  alert  Alert.
+ */
+void
+init_alert_vfire_call_iterator (iterator_t *iterator, alert_t alert)
+{
+  init_iterator (iterator,
+                 "SELECT SUBSTR(name, %i), data"
+                 " FROM alert_method_data"
+                 " WHERE alert = %llu"
+                 " AND name %s 'vfire_call_%%';",
+                 strlen ("vfire_call_") + 1, alert, sql_ilike_op ());
+}
+
+/**
+ * @brief Return the name from an alert vFire call iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return Name, or NULL if iteration is complete.
+ */
+const char*
+alert_vfire_call_iterator_name (iterator_t *iterator)
+{
+  const char *ret;
+  if (iterator->done) return NULL;
+  ret = iterator_string (iterator, 0);
+  return ret;
+}
+
+/**
+ * @brief Return the value from an alert vFire call iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return Value, or NULL if iteration is complete.
+ */
+const char*
+alert_vfire_call_iterator_value (iterator_t *iterator)
+{
+  const char *ret;
+  if (iterator->done) return NULL;
+  ret = iterator_string (iterator, 1);
+  return ret;
+}
+
+/**
  * @brief Check for new SCAP SecInfo after an update.
  */
 static void

--- a/src/manage_sql_alerts.h
+++ b/src/manage_sql_alerts.h
@@ -79,4 +79,13 @@ alert_data (alert_t, const char *, const char *);
 int
 alert_applies_to_task (alert_t, task_t);
 
+void
+init_alert_vfire_call_iterator (iterator_t *, alert_t);
+
+const char*
+alert_vfire_call_iterator_name (iterator_t *);
+
+const char*
+alert_vfire_call_iterator_value (iterator_t *);
+
 #endif /* not _GVMD_MANAGE_SQL_ALERTS_H */


### PR DESCRIPTION
## What

Use iterator functions to access the vFire alert "vfire_call_*" method data.

## Why

This removes the last of the direct SQL from the alert trigger code, so it can now be moved to `manage_alerts.c`.

The overall goal is to move the alert code out of `manage_sql.c` to reduce the size of `manage_sql.c`.

## References

Follows /pull/2461.

## Testing

I ran the vFire alert and checked the XML config passed to the `greenbone_vfire_connector` script. The XML has the "vire_call_" method data, in the same way as it does when I run the alert on the main branch.