### PR TITLE
Change: use defines for report format UUIDs

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -15442,7 +15442,7 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
                                 && get_reports_data->format_id
                                 && strcmp
                                     (get_reports_data->format_id,
-                                     "a994b278-1f62-11e1-96ac-406186ea4fc5")
+                                     REPORT_FORMAT_UUID_XML)
                                 && strcmp
                                     (get_reports_data->format_id,
                                       "5057e5cc-b825-11e4-9d0e-28d24461215b"),

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -15372,7 +15372,7 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
               /* Skip task name for Anonymous XML report format. */
               if (get_reports_data->format_id == NULL
                   || strcmp (get_reports_data->format_id,
-                             "5057e5cc-b825-11e4-9d0e-28d24461215b"))
+                             "REPORT_FORMAT_UUID_ANON_XML"))
                 {
                   gchar *report_task_name;
                   report_task_name = task_name (task);
@@ -15445,7 +15445,7 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
                                      REPORT_FORMAT_UUID_XML)
                                 && strcmp
                                     (get_reports_data->format_id,
-                                      "5057e5cc-b825-11e4-9d0e-28d24461215b"),
+                                      "REPORT_FORMAT_UUID_ANON_XML"),
                                 send_to_client,
                                 gmp_parser->client_writer,
                                 gmp_parser->client_writer_data,

--- a/src/manage_report_formats.h
+++ b/src/manage_report_formats.h
@@ -28,6 +28,11 @@
  */
 #define REPORT_FORMAT_UUID_XML "a994b278-1f62-11e1-96ac-406186ea4fc5"
 
+/**
+ * @brief Report format UUID.
+ */
+#define REPORT_FORMAT_UUID_ANON_XML "5057e5cc-b825-11e4-9d0e-28d24461215b"
+
 gboolean
 find_report_format_with_permission (const char*, report_format_t*,
                                     const char *);

--- a/src/manage_report_formats.h
+++ b/src/manage_report_formats.h
@@ -23,6 +23,11 @@
 
 #include <glib.h>
 
+/**
+ * @brief Report format UUID.
+ */
+#define REPORT_FORMAT_UUID_XML "a994b278-1f62-11e1-96ac-406186ea4fc5"
+
 gboolean
 find_report_format_with_permission (const char*, report_format_t*,
                                     const char *);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -9773,7 +9773,7 @@ trigger (alert_t alert, task_t task, report_t report, event_t event,
                    "scp_report_format",
                    NULL,
                    /* XML fallback. */
-                   "a994b278-1f62-11e1-96ac-406186ea4fc5",
+                   "REPORT_FORMAT_UUID_XML",
                    notes_details, overrides_details,
                    &report_content, &content_length, NULL,
                    NULL, NULL, NULL, NULL,
@@ -9877,7 +9877,7 @@ trigger (alert_t alert, task_t task, report_t report, event_t event,
                    "send_report_format",
                    NULL,
                    /* XML fallback. */
-                   "a994b278-1f62-11e1-96ac-406186ea4fc5",
+                   "REPORT_FORMAT_UUID_XML",
                    notes_details, overrides_details,
                    &report_content, &content_length, NULL,
                    NULL, NULL, NULL, NULL,
@@ -9980,7 +9980,7 @@ trigger (alert_t alert, task_t task, report_t report, event_t event,
                   (alert, report, task, get,
                    "smb_report_format",
                    NULL,
-                   "a994b278-1f62-11e1-96ac-406186ea4fc5", /* XML fallback */
+                   "REPORT_FORMAT_UUID_XML", /* XML fallback */
                    notes_details, overrides_details,
                    &report_content, &content_length, &extension,
                    NULL, NULL, NULL, NULL, &report_format, NULL);
@@ -10303,7 +10303,7 @@ trigger (alert_t alert, task_t task, report_t report, event_t event,
                   (alert, report, task, get,
                    NULL, /* Report format not configurable */
                    NULL,
-                   "a994b278-1f62-11e1-96ac-406186ea4fc5", /* XML fallback */
+                   "REPORT_FORMAT_UUID_XML", /* XML fallback */
                    notes_details, overrides_details,
                    &report_content, &content_length, &extension,
                    NULL, NULL, NULL, NULL, &report_format, NULL);


### PR DESCRIPTION
## What

Use `#defines` for UUIDs of the XML and Anonymous XML report formats.

## Why

Neater than spreading the UUIDs around.