### PR TITLE
Change: remove redundant check of roles_str

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -42930,20 +42930,16 @@ clean_feed_role_permissions (const char *type,
 
   sql_roles = g_string_new ("(");
 
-  if (roles_str)
+  roles = g_strsplit (roles_str, ",", 0);
+  role = roles;
+  while (*role)
     {
-      roles = g_strsplit (roles_str, ",", 0);
-      role = roles;
-      while (*role)
-        {
-          gchar *quoted_role = sql_insert (*role);
-          g_string_append (sql_roles, quoted_role);
+      gchar *quoted_role = sql_insert (*role);
+      g_string_append (sql_roles, quoted_role);
 
-          role ++;
-          if (*role)
-            g_string_append (sql_roles, ", ");
-        }
-
+      role ++;
+      if (*role)
+        g_string_append (sql_roles, ", ");
     }
 
   g_string_append (sql_roles, ")");


### PR DESCRIPTION
## What

Remove redundant check in `clean_feed_role_permissions`.

## Why

The function will return directly above if `roles` is NULL, so this check was always true.

Trying to address this warning in the CI:
```
#10 9.450 /source/src/manage_sql.c: In function 'clean_feed_role_permissions':
#10 9.459 /source/src/manage_sql.c:43001:3: warning: 'roles' may be used uninitialized [-Wmaybe-uninitialized]
#10 9.459 43001 |   g_strfreev (roles);
#10 9.459       |   ^~~~~~~~~~~~~~~~~~
```

## Test

Ran `gvmd --optimize cleanup-feed-permissions` and looked for the `Keeping permissions for roles` messages.