### PR TITLE
Change: move alert_filter_id to alerts file

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -5361,28 +5361,6 @@ DEF_ACCESS (task_role_iterator_uuid, 4);
 /* Events and Alerts. */
 
 /**
- * @brief Return the UUID of the filter of an alert.
- *
- * @param[in]  alert  Alert.
- *
- * @return UUID if there's a filter, else NULL.
- */
-static char *
-alert_filter_id (alert_t alert)
-{
-  return sql_string ("SELECT"
-                     " (CASE WHEN (SELECT filter IS NULL OR filter = 0"
-                     "             FROM alerts WHERE id = %llu)"
-                     "  THEN NULL"
-                     "  ELSE (SELECT uuid FROM filters"
-                     "        WHERE id = (SELECT filter FROM alerts"
-                     "                    WHERE id = %llu))"
-                     "  END);",
-                     alert,
-                     alert);
-}
-
-/**
  * @brief Write the content of a plain text email to a stream.
  *
  * @param[in]  content_file  Stream to write the email content to.

--- a/src/manage_sql_alerts.c
+++ b/src/manage_sql_alerts.c
@@ -1637,6 +1637,28 @@ alert_name (alert_t alert)
 }
 
 /**
+ * @brief Return the UUID of the filter of an alert.
+ *
+ * @param[in]  alert  Alert.
+ *
+ * @return UUID if there's a filter, else NULL.
+ */
+char *
+alert_filter_id (alert_t alert)
+{
+  return sql_string ("SELECT"
+                     " (CASE WHEN (SELECT filter IS NULL OR filter = 0"
+                     "             FROM alerts WHERE id = %llu)"
+                     "  THEN NULL"
+                     "  ELSE (SELECT uuid FROM filters"
+                     "        WHERE id = (SELECT filter FROM alerts"
+                     "                    WHERE id = %llu))"
+                     "  END);",
+                     alert,
+                     alert);
+}
+
+/**
  * @brief Return whether a alert is in use by a task.
  *
  * @param[in]  alert  Alert.

--- a/src/manage_sql_alerts.h
+++ b/src/manage_sql_alerts.h
@@ -70,6 +70,9 @@ alert_owner_name (alert_t);
 char *
 alert_name (alert_t);
 
+char *
+alert_filter_id (alert_t);
+
 event_t
 alert_event (alert_t);
 


### PR DESCRIPTION
## What

Move `alert_filter_id` to `manage_sql_alerts.c`.

## Why

Better organisation. Smaller `manage_sql.c`.

`alert_filter_id` was static as it is only used by `trigger`, but `trigger` will be moved to `manage_alerts.c`.

## References

Follows /pull/2462.


