### PR TITLE
Change: Update parsing of VTs metdata timestamp and fix JSON path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,12 +239,6 @@ if(NOT GVM_SCAP_DATA_DIR)
   set(GVM_SCAP_DATA_DIR "${GVM_STATE_DIR}/scap-data")
 endif(NOT GVM_SCAP_DATA_DIR)
 
-if(FEED_VT_METADATA)
-  if(NOT GVM_NVT_DATA_DIR)
-    set(GVM_NVT_DATA_DIR "${LOCALSTATEDIR}/lib/openvas/vt-metadata")
-  endif(NOT GVM_NVT_DATA_DIR)
-endif(FEED_VT_METADATA)
-
 # System username to use when dropping privileges
 if(NOT GVM_DEFAULT_DROP_USER)
   set(GVM_DEFAULT_DROP_USER "")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -558,9 +558,6 @@ add_definitions(
 
 add_definitions(-DGVM_CERT_RES_DIR="${GVM_CERT_RES_DIR}")
 add_definitions(-DGVM_CERT_DATA_DIR="${GVM_CERT_DATA_DIR}")
-if(FEED_VT_METADATA)
-  add_definitions(-DGVM_NVT_DATA_DIR="${GVM_NVT_DATA_DIR}")
-endif(FEED_VT_METADATA)
 
 if(GVM_SCANNER_CERTIFICATE)
   add_definitions(-DSCANNERCERT="${GVM_SCANNER_CERTIFICATE}")


### PR DESCRIPTION


## What
- Update parsing of VTs metdata timestamp to use `plugin_feed_info.inc`.
- Fix the path for VT metadata JSON feed file to `GVM_NVT_DIR`.
- Fail when the timestamp is missing.

## Why
- Required to correctly parse the feed file and the timestamp
- To keep same behavior as reading from the scanner when the feed version was missing.

## References
GEA-936


