### PR TITLE
Fix: Ensure semaphore set is accessible after a fork

### DIFF
--- a/src/ipc.c
+++ b/src/ipc.c
@@ -181,6 +181,38 @@ init_semaphore_set ()
 }
 
 /**
+ * @brief Reinitializes the semaphore set.
+ *
+ * @return 0 success, -1 error
+ */
+int
+reinit_semaphore_set ()
+{
+  gchar *key_file_name = g_build_filename (GVM_STATE_DIR, "gvmd.sem", NULL);
+
+  semaphore_set_key = ftok (key_file_name, 0);
+
+  if (semaphore_set_key < 0)
+    {
+      g_warning ("%s: error creating semaphore key for file %s: %s",
+                 __func__, key_file_name, strerror (errno));
+      g_free (key_file_name);
+      return -1;
+    }
+  g_free (key_file_name);
+
+  semaphore_set = semget (semaphore_set_key, 0, 0);
+
+  if (semaphore_set < 0)
+    {
+      g_warning ("%s: error getting semaphore set: %s",
+                 __func__, strerror (errno));
+      return -1;
+    }
+  return 0;
+}
+
+/**
  * @brief Performs a semaphore operation (signal or wait).
  *
  * A negative op_value will try to decrease the semaphore value

--- a/src/ipc.h
+++ b/src/ipc.h
@@ -39,4 +39,7 @@ init_semaphore_set ();
 int
 semaphore_op (semaphore_index_t, short int, time_t);
 
+int
+reinit_semaphore_set ();
+
 #endif /* not _GVMD_IPC_H */

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -6304,6 +6304,8 @@ init_manage_create_functions ()
 void
 init_manage_process (const db_conn_info_t *database)
 {
+  if (reinit_semaphore_set())
+    abort ();
   if (init_manage_open_db (database))
     return;
   init_manage_create_functions ();


### PR DESCRIPTION
## What
Ensure semaphore set is accessible after a fork.

## Why
Semaphores are used for opening database connections, concurrent scans and processing of imported reports.

## References
GEA-1109


