### PR TITLE
Add scan queue handling for OSP scans

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -176,6 +176,8 @@ set(
   manage_utils.c
   manage_migrators.c
   manage_pg.c
+  manage_scan_handler.c
+  manage_scan_queue.c
 )
 
 set(
@@ -196,6 +198,7 @@ set(
   manage_sql_nvts_osp.c
   manage_sql_nvts_openvasd.c
   manage_sql_nvts_common.c
+  manage_sql_scan_queue.c
 )
 
 set(

--- a/src/gvmd_log_conf.cmake_in
+++ b/src/gvmd_log_conf.cmake_in
@@ -24,6 +24,13 @@ prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
 file=${GVMD_LOG_FILE}
 level=127
 
+[md   scan]
+prepend=%t %s %p
+separator=:
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=${GVMD_LOG_FILE}
+level=127
+
 [md  crypt]
 prepend=%t %s %p
 separator=:

--- a/src/manage.c
+++ b/src/manage.c
@@ -56,6 +56,7 @@
 #include "manage_port_lists.h"
 #include "manage_report_configs.h"
 #include "manage_report_formats.h"
+#include "manage_scan_queue.h"
 #include "manage_sql.h"
 #include "manage_sql_secinfo.h"
 #include "manage_sql_nvts.h"
@@ -4151,6 +4152,21 @@ manage_sync (sigset_t *sigmask_current,
 }
 
 /**
+ * @brief Handle queued task actions like the scan queue or report processing.
+ */
+void
+manage_queued_task_actions ()
+{
+  reinit_manage_process ();
+  manage_session_init (current_credentials.uuid);
+  
+  setproctitle ("Manage process report imports");
+  manage_process_report_imports ();
+  setproctitle ("Manage scan queue");
+  manage_handle_scan_queue ();
+}
+
+/**
  * @brief Perform any processing of imported reports that is due.
  *
  * In gvmd, periodically called from the main daemon loop.
@@ -4163,10 +4179,7 @@ manage_process_report_imports ()
   report_t report;
   int pid, ret;
 
-  reinit_manage_process ();
-  manage_session_init (current_credentials.uuid);
-
- init_report_awaiting_processing_iterator (&reports, MAX_REPORTS_PER_TICK);
+  init_report_awaiting_processing_iterator (&reports, MAX_REPORTS_PER_TICK);
 
   while (next (&reports))
     {
@@ -4190,7 +4203,7 @@ manage_process_report_imports ()
                       __func__,
                       report);
           cleanup_iterator (&reports);
-          exit (EXIT_FAILURE);
+          return;
         }
 
       pid = fork ();
@@ -4257,7 +4270,7 @@ manage_process_report_imports ()
                          strerror (errno));
             g_free (lockfile_path);
             cleanup_iterator (&reports);
-            exit (EXIT_FAILURE);
+            return;
     
           default:
             /* Parent. */
@@ -4266,7 +4279,6 @@ manage_process_report_imports ()
           }
     }
   cleanup_iterator (&reports);
-  exit (EXIT_SUCCESS);
 }
 
 /**

--- a/src/manage.h
+++ b/src/manage.h
@@ -855,6 +855,9 @@ severity_data_level_counts (const severity_data_t*,
 const char*
 run_status_name (task_status_t);
 
+void
+set_task_interrupted (task_t, const gchar *);
+
 int
 start_task (const char *, char**);
 

--- a/src/manage.h
+++ b/src/manage.h
@@ -1001,6 +1001,9 @@ report_t
 make_report (task_t, const char *, task_status_t);
 
 void
+manage_queued_task_actions ();
+
+void
 manage_process_report_imports ();
 
 int
@@ -2802,6 +2805,11 @@ slave_relay_connection (gvm_connection_t *, gvm_connection_t *);
  * @brief Seconds between calls to manage_schedule.
  */
 #define SCHEDULE_PERIOD 10
+
+/**
+ * @brief Seconds between calls to manage_queued_task_actions.
+ */
+#define QUEUE_PERIOD 5
 
 /**
  * @brief Minimum schedule timeout seconds.

--- a/src/manage_osp.c
+++ b/src/manage_osp.c
@@ -10,6 +10,7 @@
 
 #include "ipc.h"
 #include "manage_osp.h"
+#include "manage_scan_queue.h"
 #include "manage_sql.h"
 
 #undef G_LOG_DOMAIN
@@ -886,6 +887,8 @@ run_osp_scan_get_report (task_t task, int from, char **report_id)
  * @param[in]  report     Row id of the scan report
  * @param[in]  scan_id    UUID of the scan report
  * @param[in]  conn_data   Data used to connect to the scanner.
+ * @param[in,out]  queued_status_updated  Whether the "queued" status was set.
+ * @param[in,out]  started                Whether the scan was started.
  * 
  * @return 0 if scan finished, 1 if caller should retry if appropriate,
  *         2 if scan is running or queued by the scanner,
@@ -895,7 +898,7 @@ run_osp_scan_get_report (task_t task, int from, char **report_id)
 static int
 update_osp_scan (task_t task, report_t report, const char *scan_id,
                  osp_connect_data_t *conn_data, int *retry_ptr,
-                 int *queued_status_updated_ptr, int *started_ptr)
+                 int *queued_status_updated, int *started)
 {
   int progress;
   osp_scan_status_t osp_scan_status;
@@ -979,12 +982,12 @@ update_osp_scan (task_t task, report_t report, const char *scan_id,
 
           if (osp_scan_status == OSP_SCAN_STATUS_QUEUED)
             {
-              if (*queued_status_updated_ptr == FALSE)
+              if (*queued_status_updated == FALSE)
                 {
                   set_task_run_status (task, TASK_STATUS_QUEUED);
                   set_report_scan_run_status (global_current_report,
                                               TASK_STATUS_QUEUED);
-                  *queued_status_updated_ptr = TRUE;
+                  *queued_status_updated = TRUE;
                   return 2;
                 }
             }
@@ -1032,15 +1035,21 @@ update_osp_scan (task_t task, report_t report, const char *scan_id,
             {
               delete_osp_scan (scan_id, conn_data);
               osp_scan_semaphore_update_end (FALSE, task, report);
+              if (*started == FALSE)
+                {
+                  set_task_run_status (task, TASK_STATUS_RUNNING);
+                  set_report_scan_run_status (global_current_report,
+                                              TASK_STATUS_RUNNING);
+                }
               return 0;
             }
           else if (osp_scan_status == OSP_SCAN_STATUS_RUNNING
-                    && *started_ptr == FALSE)
+                    && *started == FALSE)
             {
               set_task_run_status (task, TASK_STATUS_RUNNING);
               set_report_scan_run_status (global_current_report,
                                           TASK_STATUS_RUNNING);
-              *started_ptr = TRUE;
+              *started = TRUE;
               return 2;
             }
         }
@@ -1053,24 +1062,27 @@ update_osp_scan (task_t task, report_t report, const char *scan_id,
  * 
  * @param[in]  task       The task of the OSP scan
  * @param[in]  target     The target of the scan task
- * @param[in]  report_id  UUID of the scan report
- * @param[in]  from       0 start from beginning, 1 continue from stopped,
+ * @param[in]  scan_id    UUID of the scan / report
+ * @param[in]  start_from 0 start from beginning, 1 continue from stopped,
  *                        2 continue if stopped else start from beginning.
+ * @param[in]  wait_until_active  Whether to wait until scan is queued or
+ *                                running
  *
  * @return 0 success, -1 if error.
  */
 int
-handle_osp_scan_start (task_t task, target_t target, const char *report_id,
-                       int from)
+handle_osp_scan_start (task_t task, target_t target, const char *scan_id,
+                       int start_from, gboolean wait_until_active)
 {
   char *error = NULL;
-  int rc = launch_osp_openvas_task (task, target, report_id, from, &error);
+  int rc;
 
+  rc = launch_osp_openvas_task (task, target, scan_id, start_from, &error);
   if (rc)
     {
       result_t result;
 
-      g_warning ("OSP start_scan %s: %s", report_id, error);
+      g_warning ("OSP start_scan %s: %s", scan_id, error);
       result = make_osp_result (task, "", "", "",
                                 threat_message_type ("Error"),
                                 error, "", "", QOD_DEFAULT, NULL, NULL);
@@ -1084,7 +1096,74 @@ handle_osp_scan_start (task_t task, target_t target, const char *report_id,
 
       return (-1);
     }
-  return 0;
+
+  if (wait_until_active)
+    {
+      gboolean started, queued_status_updated;
+      scanner_t scanner;
+      osp_connect_data_t *conn_data;
+      int connection_retry, retry;
+      report_t report;
+
+      started = FALSE;
+      queued_status_updated = FALSE;
+      report = global_current_report;
+      scanner = task_scanner (task);
+      conn_data = osp_connect_data_from_scanner (scanner);
+
+      connection_retry = get_scanner_connection_retry ();
+      retry = connection_retry;
+      rc = -1;
+      while (retry >= 0)
+        {
+          int sem_op_ret, run_status;
+
+          run_status = task_run_status (task);
+          if (run_status == TASK_STATUS_STOPPED
+              || run_status == TASK_STATUS_STOP_REQUESTED)
+            {
+              rc = -4;
+              break;
+            }
+
+          sem_op_ret = osp_scan_semaphore_update_start (TRUE, task, report);
+          if (sem_op_ret == 1)
+            continue;
+          else if (sem_op_ret)
+            {
+              delete_osp_scan (scan_id, conn_data);
+              rc = -3;
+              break;
+            }
+
+          rc = update_osp_scan (task, report, scan_id, conn_data,
+                                &retry, &queued_status_updated, &started);
+
+          // Exit loop on error or if scan finished
+          if (rc <= 0)
+            break;
+
+          if (osp_scan_semaphore_update_end (TRUE, task, report))
+            {
+              delete_osp_scan (scan_id, conn_data);
+              rc = -3;
+              break;
+            }
+          
+          // Exit loop if scan is queued or started
+          if (rc == 2)
+            break;
+
+          retry = connection_retry;
+          gvm_sleep (5);
+        }
+
+      osp_connect_data_free (conn_data);
+    }
+  else
+    rc = 0;
+
+  return rc < 0 ? -1 : 0;
 }
 
 /**
@@ -1093,24 +1172,36 @@ handle_osp_scan_start (task_t task, target_t target, const char *report_id,
  * @param[in]   task      The task.
  * @param[in]   report    The report.
  * @param[in]   scan_id   The UUID of the scan on the scanner.
+ * @param[in]   yield_time  Time after which to yield if there are more
+ * .                        queued scans than the maximum active count or
+ *                          0 for non-queued scans running until the end.
  *
  * @return 0 if success, -1 if error, -2 if scan was stopped,
  *         -3 if the scan was interrupted, -4 already stopped.
  */
 int
-handle_osp_scan (task_t task, report_t report, const char *scan_id)
+handle_osp_scan (task_t task, report_t report, const char *scan_id,
+                 time_t yield_time)
 {
+  int max_active_scans;
+  task_status_t task_status;
   int rc;
   scanner_t scanner;
   osp_connect_data_t *conn_data;
   gboolean started, queued_status_updated;
   int retry, connection_retry;
 
+  if (yield_time)
+    {
+      max_active_scans = get_max_active_scan_handlers ();
+    }
+
   scanner = task_scanner (task);
   conn_data = osp_connect_data_from_scanner (scanner);
 
-  started = FALSE;
-  queued_status_updated = FALSE;
+  task_status = task_run_status (task);
+  started = (task_status == TASK_STATUS_RUNNING);
+  queued_status_updated = started || (task_status == TASK_STATUS_QUEUED);
   connection_retry = get_scanner_connection_retry ();
 
   retry = connection_retry;
@@ -1150,6 +1241,11 @@ handle_osp_scan (task_t task, report_t report, const char *scan_id)
           rc = -3;
           break;
         }
+
+      if (yield_time 
+          && time (NULL) >= yield_time
+          && scan_queue_length () > max_active_scans)
+        break;
 
       retry = connection_retry;
       gvm_sleep (5);

--- a/src/manage_osp.h
+++ b/src/manage_osp.h
@@ -46,10 +46,10 @@ int
 run_osp_scan_get_report (task_t, int, char **);
 
 int
-handle_osp_scan_start (task_t, target_t, const char *, int);
+handle_osp_scan_start (task_t, target_t, const char *, int, gboolean);
 
 int
-handle_osp_scan (task_t, report_t, const char *);
+handle_osp_scan (task_t, report_t, const char *, time_t);
 
 int
 handle_osp_scan_end (task_t, int);

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -2709,7 +2709,8 @@ create_tables ()
        " (report integer unique,"
        "  queued_time_secs integer,"
        "  queued_time_nano integer,"
-       "  handler_pid integer);");
+       "  handler_pid integer,"
+       "  start_from integer);");
   
   sql ("CREATE TABLE IF NOT EXISTS scanners"
        " (id SERIAL PRIMARY KEY,"

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -2705,6 +2705,12 @@ create_tables ()
        "  timestamp bigint,"
        "  tls_versions text);");
 
+  sql ("CREATE TABLE IF NOT EXISTS scan_queue"
+       " (report integer unique,"
+       "  queued_time_secs integer,"
+       "  queued_time_nano integer,"
+       "  handler_pid integer);");
+  
   sql ("CREATE TABLE IF NOT EXISTS scanners"
        " (id SERIAL PRIMARY KEY,"
        "  uuid text UNIQUE NOT NULL,"

--- a/src/manage_scan_handler.c
+++ b/src/manage_scan_handler.c
@@ -1,0 +1,197 @@
+/* Copyright (C) 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file scan_handler.c
+ * @brief Greenbone Vulnerability Manager scan handler.
+ */
+
+#include "utils.h"
+#include "manage_sql.h"
+#include "manage_sql_scan_queue.h"
+#include "manage_scan_handler.h"
+#include <unistd.h>
+#include <sys/wait.h>
+
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md   scan"
+
+/**
+ * @brief Handle a scan defined a by a queue entry.
+ * 
+ * @param[in]  report_id  UUID of the scan to handle.
+ * @param[in]  report     Row id of the scan to handle.
+ * @param[in]  task       Row id of the scan to handle.
+ * @param[in]  owner      Owner of the report.
+ *
+ * @return 0 success, -1 error.
+ */
+static int
+handle_scan_queue_entry (const char *report_id, report_t report, task_t task,
+                         user_t owner)
+{
+  time_t loop_end_time, last_loop_check;
+  gchar *owner_uuid = NULL, *owner_name = NULL;
+  int max_active_scan_handlers = get_max_active_scan_handlers ();
+  gboolean scan_active, may_continue_loop;
+  g_debug ("Handling scan in pid: %d | task: %llu | report: %llu",
+             getpid (), task, report);
+
+  owner_uuid = user_uuid (owner);
+  owner_name = owner_uuid ? user_name (owner_uuid) : NULL;
+  current_credentials.uuid = owner_uuid;
+  current_credentials.username = owner_name;
+  manage_session_init (current_credentials.uuid);
+  // TODO: Use these when real scan handling is introduced
+  // current_scanner_task = task;
+  // global_current_report = report;
+
+  loop_end_time = time (NULL) + get_scan_handler_active_time ();
+  last_loop_check = 0;
+
+  srand (getpid());
+
+  scan_active = may_continue_loop = TRUE;
+  while (scan_active && may_continue_loop)
+    {
+      // TODO: Replace with actual scan handling
+      g_debug ("Scan handler in pid %d running", getpid ());
+      gvm_sleep (1);
+      scan_active = rand () % 10;
+
+      last_loop_check = time (NULL);
+      if (last_loop_check >= loop_end_time
+          && scan_queue_length () > max_active_scan_handlers)
+        may_continue_loop = FALSE;
+    }
+
+  if (scan_active)
+    {
+      g_debug ("Scan handler in pid %d requeued", getpid ());
+      scan_queue_move_to_end (report);
+    }
+  else
+    {
+      g_debug ("Scan handler in pid %d finished", getpid ());
+      scan_queue_remove (report);
+    }
+
+  return 0;
+}
+
+/**
+ * @brief Fork a new handler process for a given scan queue entry.
+ * 
+ * @param[in]  report_id  UUID of the scan to handle.
+ * @param[in]  report     Row id of the scan to handle.
+ * @param[in]  task       Row id of the scan to handle.
+ * @param[in]  owner      Owner of the report.
+ *
+ * @return The PID of the new handler process or -1 on error.
+ */
+pid_t
+fork_scan_handler (const char *report_id, report_t report, task_t task,
+                   user_t owner)
+{
+  int pipe_fds[2];
+  int nbytes;
+  pid_t child_pid;
+  pid_t grandchild_pid;
+
+  pipe (pipe_fds);
+
+  child_pid = fork();
+  (void) handle_scan_queue_entry;
+
+  switch (child_pid)
+    {
+      case 0:
+        {
+          // Child
+          close (pipe_fds[0]); // Close input side of pipe
+          grandchild_pid = fork ();
+          switch (grandchild_pid)
+            {
+              case 0:
+                // Grandchild
+                close (pipe_fds[1]);
+                reinit_manage_process ();
+                handle_scan_queue_entry (report_id, report, task, owner);
+                exit (EXIT_SUCCESS);
+              case -1:
+                // Child on error
+                close(pipe_fds[1]);
+                g_warning ("%s: fork failed: %s", __func__, strerror (errno));
+                exit (EXIT_FAILURE);
+              default:
+                // Child on success
+                write (pipe_fds[1], &grandchild_pid, sizeof(grandchild_pid));
+                close(pipe_fds[1]); // Close output side of pipe
+                sql_close_fork ();
+                exit(EXIT_SUCCESS);
+            }
+        }
+      case -1:
+        {
+          // Parent on error
+          close (pipe_fds[0]);
+          close (pipe_fds[1]);
+          g_warning ("%s: fork failed: %s", __func__, strerror (errno));
+          return -1;
+        }
+      default:
+        {
+          // Parent on success
+          int status;
+
+          close(pipe_fds[1]); // Close output side of pipe
+
+          // Get PID of grandchild from pipe
+          grandchild_pid = 0;
+          nbytes = read(pipe_fds[0], &grandchild_pid, sizeof(grandchild_pid));
+          g_debug ("%s: Received pid: %d (%d bytes)",
+                   __func__, grandchild_pid, nbytes);
+
+          if (nbytes != sizeof (grandchild_pid))
+            {
+              if (nbytes == -1)
+                g_warning ("%s: Could not read handler PID from pipe: %s",
+                           __func__, strerror (errno));
+              else
+                g_warning ("%s: Could not read handler PID from pipe:"
+                           " received %d bytes, expected %zd",
+                           __func__, nbytes, sizeof(grandchild_pid));
+          
+              close(pipe_fds[0]); // Close input side of pipe
+              return -1;
+            }
+          
+          close(pipe_fds[0]); // Close input side of pipe
+          
+          /*  Wait to prevent zombie, then return. */
+          while (waitpid (child_pid, &status, 0) < 0)
+            {
+              if (errno == ECHILD)
+                {
+                  g_warning ("%s: Failed to get child exit status",
+                             __func__);
+                  return -1;
+                }
+              if (errno == EINTR)
+                continue;
+              g_warning ("%s: waitpid: %s",
+                         __func__,
+                         strerror (errno));
+              return -1;
+            }
+
+          return grandchild_pid;
+        }
+    }
+  return -1;
+}

--- a/src/manage_scan_handler.h
+++ b/src/manage_scan_handler.h
@@ -1,0 +1,20 @@
+/* Copyright (C) 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file scan_handler.h
+ * @brief Headers for Greenbone Vulnerability Manager scan handler.
+ */
+
+#ifndef _GVMD_SCAN_HANDLER_H
+#define _GVMD_SCAN_HANDLER_H
+
+#include "manage_scan_queue.h"
+#include <glib.h>
+
+int
+fork_scan_handler (const char *, report_t, task_t, user_t);
+
+#endif /* _GVMD_SCAN_HANDLER_H */

--- a/src/manage_scan_handler.h
+++ b/src/manage_scan_handler.h
@@ -15,6 +15,6 @@
 #include <glib.h>
 
 int
-fork_scan_handler (const char *, report_t, task_t, user_t);
+fork_scan_handler (const char *, report_t, task_t, user_t, int);
 
 #endif /* _GVMD_SCAN_HANDLER_H */

--- a/src/manage_scan_queue.c
+++ b/src/manage_scan_queue.c
@@ -1,0 +1,179 @@
+/* Copyright (C) 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file manage_scan_queue.c
+ * @brief Greenbone Vulnerability Manager scan queue.
+ */
+
+#include "utils.h"
+#include "manage_scan_queue.h"
+#include "manage_scan_handler.h"
+#include "manage_sql.h"
+#include "manage_sql_scan_queue.h"
+
+
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md   scan"
+
+/**
+ * @brief Option whether to use the scan queue for scanners that support it.
+ */
+static gboolean use_scan_queue = 0;
+
+/**
+ * @brief Minimum active time in seconds for queued scan handlers.
+ *
+ * Handlers will keep getting results of running scans for this time before
+ *  exiting, allowing the next queued scan handler to run.
+ * 
+ * Note that handlers can remain active for longer in some situations like
+ *  waiting for scanner responses, especially when starting a scan, or
+ *  post-processing that is not delegated to a dedicated process.
+ */
+static int scan_handler_active_time = 0;
+
+/**
+ * @brief Maximum number of scan handlers that can be active at the same time.
+ */
+static int max_active_scan_handlers = DEFAULT_MAX_ACTIVE_SCAN_HANDLERS;
+
+/**
+ * @brief Sets a new value for the option whether to use the scan queue.
+ * 
+ * @param[in]  new_use_scan_queue  The new value to set.
+ */
+void
+set_use_scan_queue (gboolean new_use_scan_queue)
+{
+  use_scan_queue = new_use_scan_queue ? 1 : 0;
+}
+
+/**
+ * @brief Gets whether to use the scan queue.
+ * 
+ * @return The current value of the option.
+ */
+gboolean
+get_use_scan_queue ()
+{
+  return use_scan_queue;
+}
+
+/**
+ * @brief Sets a new minimum active time for scan handlers.
+ * 
+ * @param[in]  new_active_time  The new value to set.
+ */
+void
+set_scan_handler_active_time (int new_active_time)
+{
+  scan_handler_active_time = new_active_time >= 0 ? new_active_time : 0;
+}
+
+/**
+ * @brief Gets the minimum active time for scan handlers.
+ * 
+ * @return The current value of the option.
+ */
+int
+get_scan_handler_active_time ()
+{
+  return scan_handler_active_time;
+}
+
+/**
+ * @brief Sets a new maxmimum number of concurrently active scan handlers
+ *         handled by the queue.
+ * 
+ * @param[in]  new_max  The new value to set.
+ */
+void
+set_max_active_scan_handlers (int new_max)
+{
+  max_active_scan_handlers = (new_max > 0) ? new_max : 0;
+}
+
+/**
+ * @brief Gets the maxmimum number of concurrently active scan handlers
+ *         handled by the queue.
+ * 
+ * @return The current value of the option.
+ */
+int
+get_max_active_scan_handlers ()
+{
+  return max_active_scan_handlers;
+}
+
+/**
+ * @brief Handle scans in the scan queue.
+ */
+void
+manage_handle_scan_queue ()
+{
+  iterator_t queue_iterator;
+  int active_count = 0;
+  
+  if (use_scan_queue == 0)
+    return;
+
+  init_scan_queue_iterator (&queue_iterator);
+  
+  while (next (&queue_iterator))
+    {
+      pid_t handler_pid;
+      report_t report;
+      
+      if (max_active_scan_handlers && active_count >= max_active_scan_handlers)
+        {
+          g_debug ("%s: one or more scans are waiting", __func__);
+          break;
+        }
+
+      handler_pid = scan_queue_iterator_handler_pid (&queue_iterator);
+      report = scan_queue_iterator_report (&queue_iterator);
+
+      if (handler_pid)
+        {
+          if (kill (handler_pid, 0))
+            {
+              g_debug ("%s: %d no longer running", __func__, handler_pid);
+              scan_queue_move_to_end (report);
+            }
+          else
+            {
+              active_count ++;
+              g_debug ("%s: %d still active", __func__, handler_pid);
+            }
+        }
+      else
+        {
+          pid_t new_handler_pid;
+          const char *report_id
+            = scan_queue_iterator_report_uuid (&queue_iterator);
+          task_t task
+            = scan_queue_iterator_task (&queue_iterator);
+          user_t owner
+            = scan_queue_iterator_owner (&queue_iterator);
+            
+          new_handler_pid = fork_scan_handler (report_id, report, task, owner);
+          if (new_handler_pid >= 0)
+            {
+              active_count ++;
+              scan_queue_set_handler_pid (report, new_handler_pid);
+            }
+          else
+            {
+              scan_queue_move_to_end (report);
+            }
+        }
+      
+    }
+  
+}

--- a/src/manage_scan_queue.c
+++ b/src/manage_scan_queue.c
@@ -161,8 +161,11 @@ manage_handle_scan_queue ()
             = scan_queue_iterator_task (&queue_iterator);
           user_t owner
             = scan_queue_iterator_owner (&queue_iterator);
+          int start_from
+            = scan_queue_iterator_start_from (&queue_iterator);
             
-          new_handler_pid = fork_scan_handler (report_id, report, task, owner);
+          new_handler_pid = fork_scan_handler (report_id, report, task, owner,
+                                               start_from);
           if (new_handler_pid >= 0)
             {
               active_count ++;

--- a/src/manage_scan_queue.h
+++ b/src/manage_scan_queue.h
@@ -42,6 +42,9 @@ manage_handle_scan_queue ();
 // Functions defined in manage_sql_scan_queue.c
 
 void
+scan_queue_clear ();
+
+void
 scan_queue_add (report_t);
 
 void

--- a/src/manage_scan_queue.h
+++ b/src/manage_scan_queue.h
@@ -1,0 +1,59 @@
+/* Copyright (C) 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file manage_scan_queue.h
+ * @brief Headers for Greenbone Vulnerability Manager scan queue.
+ */
+
+#ifndef _GVMD_MANAGE_SCAN_QUEUE_H
+#define _GVMD_MANAGE_SCAN_QUEUE_H
+
+#include <glib.h>
+#include "manage_resources.h"
+
+/**
+ * @brief Default maximum number of active scan handlers
+ */ 
+#define DEFAULT_MAX_ACTIVE_SCAN_HANDLERS 3
+
+void
+set_use_scan_queue (gboolean);
+
+gboolean
+get_use_scan_queue ();
+
+void
+set_scan_handler_active_time (int);
+
+int
+get_scan_handler_active_time ();
+
+void
+set_max_active_scan_handlers (int);
+
+int get_max_active_scan_handlers ();
+
+void
+manage_handle_scan_queue ();
+
+// Functions defined in manage_sql_scan_queue.c
+
+void
+scan_queue_add (report_t);
+
+void
+scan_queue_move_to_end (report_t);
+
+void
+scan_queue_set_handler_pid (report_t, pid_t);
+
+void
+scan_queue_remove (report_t);
+
+int
+scan_queue_length ();
+
+#endif /* _GVMD_SCAN_QUEUE_H */

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -43,6 +43,7 @@
 #include "manage_sql_secinfo.h"
 #include "manage_sql_nvts.h"
 #include "manage_tickets.h"
+#include "manage_scan_queue.h"
 #include "manage_sql_alerts.h"
 #include "manage_sql_configs.h"
 #include "manage_sql_port_lists.h"
@@ -7361,6 +7362,9 @@ stop_active_tasks ()
   iterator_t tasks;
   get_data_t get;
 
+  /* Clear the scan queue */
+  scan_queue_clear ();
+  
   /* Set requested and running tasks to stopped. */
 
   assert (current_credentials.uuid == NULL);
@@ -11978,6 +11982,25 @@ insert_report_host_detail (report_t report, const char *host,
 #define BUFFER_SIZE (20 * 1048576)  /* 20 MiB */
 
 /**
+ * @brief Set whether processing of a report is required
+ *        and whether to add it to assets.
+ * 
+ * @param[in]  report               The report to set the flags.
+ * @param[in]  processing_required  Whether processing is required.
+ * @param[in]  in_assets            Whether to add to assets.
+ */
+void
+report_set_processing_required (report_t report,
+                                int processing_required, int in_assets)
+{
+  sql ("UPDATE reports SET processing_required = %d, in_assets = %d"
+       " WHERE id = %llu;",
+       processing_required ? 1 : 0,
+       in_assets ? 1 : 0,
+       report);
+}
+
+/**
  * @brief Process imported report.
  * 
  * Adds TLS certificates to the database and creates assets from the report.
@@ -12517,10 +12540,7 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
 
   sql_commit ();
 
-  sql ("UPDATE reports SET processing_required = 1, in_assets = %d"
-       " WHERE id = %llu;",
-       in_assets_int ? 1 : 0,
-       report);
+  report_set_processing_required (report, 1, in_assets_int);
 
   gvm_close_sentry ();
   cleanup_manage_process (FALSE); //check this
@@ -40255,7 +40275,8 @@ manage_report_host_add (report_t report, const char *host, time_t start,
                         time_t end)
 {
   char *quoted_host = sql_quote (host);
-
+  resource_t report_host;
+  
   sql ("INSERT INTO report_hosts"
        " (report, host, start_time, end_time, current_port, max_port)"
        " SELECT %llu, '%s', %lld, %lld, 0, 0"
@@ -40263,8 +40284,11 @@ manage_report_host_add (report_t report, const char *host, time_t start,
        "                   AND host = '%s');",
        report, quoted_host, (long long) start, (long long) end, report,
        quoted_host);
+  report_host = sql_int64_0 ("SELECT id FROM report_hosts"
+                             " WHERE report = %llu AND host = '%s';",
+                             report, quoted_host);
   g_free (quoted_host);
-  return sql_last_insert_id ();
+  return report_host;
 }
 
 /**

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -455,6 +455,9 @@ create_indexes_cve ();
 void
 drop_indexes_cve ();
 
+void
+report_set_processing_required (report_t, int, int);
+
 int
 process_report_import (report_t);
 

--- a/src/manage_sql_scan_queue.c
+++ b/src/manage_sql_scan_queue.c
@@ -1,0 +1,163 @@
+/* Copyright (C) 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file manage_sql_scan_queue.c
+ * @brief Greenbone Vulnerability Manager scan queue SQL.
+ */
+
+#include "manage_get.h"
+#include "manage_sql_scan_queue.h"
+#include "sql.h"
+#include "time.h"
+
+/**
+ * @brief Add a scan to the queue.
+ * 
+ * @param[in]  report  The report of the scan to add.
+ */
+void
+scan_queue_add (report_t report)
+{
+  struct timespec ts;
+  
+  clock_gettime (CLOCK_REALTIME, &ts);
+  
+  sql ("INSERT INTO scan_queue"
+       " (report, queued_time_secs, queued_time_nano, handler_pid)"
+       " VALUES (%llu, %ld, %ld, 0)",
+       report, ts.tv_sec, ts.tv_nsec);
+}
+
+/**
+ * @brief Move a scan to end of the queue and reset the pid to 0.
+ * 
+ * @param[in]  report  The report of the scan to move.
+ */
+void
+scan_queue_move_to_end (report_t report)
+{
+  struct timespec ts;
+  clock_gettime (CLOCK_REALTIME, &ts);
+  sql ("UPDATE scan_queue"
+       " SET queued_time_secs = %d,"
+       "     queued_time_nano = %d,"
+       "     handler_pid = 0"
+       " WHERE report = %llu;",
+       ts.tv_sec, ts.tv_nsec, report);
+}
+
+/**
+ * @brief Set the pid of a scan.
+ * 
+ * @param[in]  report  The report of the scan to update.
+ * @param[in]  pid     The pid to set.
+ */
+void
+scan_queue_set_handler_pid (report_t report, pid_t pid)
+{
+  sql ("UPDATE scan_queue"
+       " SET handler_pid = %d"
+       " WHERE report = %llu;",
+       pid, report);
+}
+
+/**
+ * @brief Remove a scan from the queue.
+ * 
+ * @param[in]  report  The report of the scan to remove.
+ */
+void
+scan_queue_remove (report_t report)
+{
+  sql ("DELETE FROM scan_queue WHERE report = %llu", report);
+}
+
+/**
+ * @brief Remove a scan from the queue.
+ * 
+ * @param[in]  report  The report of the scan to remove.
+ */
+int
+scan_queue_length ()
+{
+  return sql_int ("SELECT count(*) FROM scan_queue");
+}
+
+/**
+ * Initialize a scan queue iterator, with the reports and task sorted so
+ *  the ones queued first are also returned first.
+ * 
+ * @param[in]  iterator The iterator to Initialize.
+ */
+void
+init_scan_queue_iterator (iterator_t *iterator)
+{
+  init_iterator (iterator,
+                 "SELECT report, handler_pid,"
+                 " reports.uuid, reports.task, reports.owner"
+                 " FROM scan_queue LEFT JOIN reports ON reports.id = report"
+                 " ORDER BY queued_time_secs ASC, queued_time_nano ASC;");
+}
+
+/**
+ * @brief Get the report row id from a scan queue iterator.
+ * 
+ * @return The report row id or 0 if iteration is finished.
+ */
+report_t
+scan_queue_iterator_report (iterator_t* iterator)
+{
+  if (iterator->done)
+    return 0;
+  return iterator_int64 (iterator, 0);
+}
+
+/**
+ * @brief Get the PID of the current handler from a scan queue iterator or
+ *        0 if there is no active handler.
+ * 
+ * @return The handler PID or 0 if iteration is finished.
+ */
+pid_t
+scan_queue_iterator_handler_pid (iterator_t *iterator)
+{
+  if (iterator->done)
+    return 0;
+  return iterator_int (iterator, 1);
+}
+
+/**
+ * @brief Get the report UUID from a scan queue iterator.
+ * 
+ * @return The report UUID or NULL if iteration is finished.
+ */
+DEF_ACCESS (scan_queue_iterator_report_uuid, 2);
+
+/**
+ * @brief Get the task row id from a scan queue iterator.
+ * 
+ * @return The task row id or 0 if iteration is finished.
+ */
+task_t
+scan_queue_iterator_task (iterator_t* iterator)
+{
+  if (iterator->done)
+    return 0;
+  return iterator_int64 (iterator, 3);
+}
+
+/**
+ * @brief Get the report's owner row id from a scan queue iterator.
+ * 
+ * @return The owner row id or 0 if iteration is finished.
+ */
+user_t
+scan_queue_iterator_owner (iterator_t* iterator)
+{
+  if (iterator->done)
+    return 0;
+  return iterator_int64 (iterator, 4);
+}

--- a/src/manage_sql_scan_queue.h
+++ b/src/manage_sql_scan_queue.h
@@ -25,6 +25,9 @@ scan_queue_iterator_report (iterator_t*);
 pid_t
 scan_queue_iterator_handler_pid (iterator_t *);
 
+int
+scan_queue_iterator_start_from (iterator_t*);
+
 const char *
 scan_queue_iterator_report_uuid (iterator_t *);
 

--- a/src/manage_sql_scan_queue.h
+++ b/src/manage_sql_scan_queue.h
@@ -1,0 +1,38 @@
+/* Copyright (C) 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file manage_sql_scan_queue.h
+ * @brief Headers for Greenbone Vulnerability Manager scan queue SQL.
+ */
+
+#ifndef _GVMD_MANAGE_SQL_SCAN_QUEUE_H
+#define _GVMD_MANAGE_SQL_SCAN_QUEUE_H
+
+#include "manage_scan_queue.h"
+#include "iterator.h"
+#include "manage_resources.h"
+#include "time.h"
+
+void
+init_scan_queue_iterator (iterator_t *);
+
+report_t
+scan_queue_iterator_report (iterator_t*);
+
+pid_t
+scan_queue_iterator_handler_pid (iterator_t *);
+
+const char *
+scan_queue_iterator_report_uuid (iterator_t *);
+
+task_t
+scan_queue_iterator_task (iterator_t*);
+
+user_t
+scan_queue_iterator_owner (iterator_t*);
+
+
+#endif /* _GVMD_MANAGE_SQL_SCAN_QUEUE_H */


### PR DESCRIPTION
## What
A new scan queue is added which can be enabled to limit the number of
scan handlers which are active at the same time by periodically
switching which tasks / reports are being updated.

## Why
This allows more tasks to be running at the same time without consuming
resources by having the scan handler run the whole time.

## References
GEA-1106

