### PR TITLE
Fix: Use report format #defines correctly

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -15407,7 +15407,7 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
               /* Skip task name for Anonymous XML report format. */
               if (get_reports_data->format_id == NULL
                   || strcmp (get_reports_data->format_id,
-                             "REPORT_FORMAT_UUID_ANON_XML"))
+                             REPORT_FORMAT_UUID_ANON_XML))
                 {
                   gchar *report_task_name;
                   report_task_name = task_name (task);
@@ -15480,7 +15480,7 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
                                      REPORT_FORMAT_UUID_XML)
                                 && strcmp
                                     (get_reports_data->format_id,
-                                      "REPORT_FORMAT_UUID_ANON_XML"),
+                                     REPORT_FORMAT_UUID_ANON_XML),
                                 send_to_client,
                                 gmp_parser->client_writer,
                                 gmp_parser->client_writer_data,

--- a/src/manage_alerts.c
+++ b/src/manage_alerts.c
@@ -4914,7 +4914,7 @@ trigger (alert_t alert, task_t task, report_t report, event_t event,
                    "scp_report_format",
                    NULL,
                    /* XML fallback. */
-                   "REPORT_FORMAT_UUID_XML",
+                   REPORT_FORMAT_UUID_XML,
                    notes_details, overrides_details,
                    &report_content, &content_length, NULL,
                    NULL, NULL, NULL, NULL,
@@ -5018,7 +5018,7 @@ trigger (alert_t alert, task_t task, report_t report, event_t event,
                    "send_report_format",
                    NULL,
                    /* XML fallback. */
-                   "REPORT_FORMAT_UUID_XML",
+                   REPORT_FORMAT_UUID_XML,
                    notes_details, overrides_details,
                    &report_content, &content_length, NULL,
                    NULL, NULL, NULL, NULL,
@@ -5109,7 +5109,7 @@ trigger (alert_t alert, task_t task, report_t report, event_t event,
                   (alert, report, task, get,
                    "smb_report_format",
                    NULL,
-                   "REPORT_FORMAT_UUID_XML", /* XML fallback */
+                   REPORT_FORMAT_UUID_XML, /* XML fallback */
                    notes_details, overrides_details,
                    &report_content, &content_length, &extension,
                    NULL, NULL, NULL, NULL, &report_format, NULL);
@@ -5432,7 +5432,7 @@ trigger (alert_t alert, task_t task, report_t report, event_t event,
                   (alert, report, task, get,
                    NULL, /* Report format not configurable */
                    NULL,
-                   "REPORT_FORMAT_UUID_XML", /* XML fallback */
+                   REPORT_FORMAT_UUID_XML, /* XML fallback */
                    notes_details, overrides_details,
                    &report_content, &content_length, &extension,
                    NULL, NULL, NULL, NULL, &report_format, NULL);


### PR DESCRIPTION
## What
In some places "REPORT_FORMAT_UUID_XML" and
"REPORT_FORMAT_UUID_ANON_XML" were used literally as string contents,
not as preprocessor constants inserting the actual UUIDs.

This is fixed in this PR.

## Why
This was a mistake breaking the behavior using these UUIDs.

## References
#2463

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


