### PR TITLE
Add: Add create, modify, get, and delete support for agent groups

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -155,6 +155,8 @@ set(
   ALL_MANAGE_SRC
   manage.c
   manage_acl.c
+  manage_agent_common.c
+  manage_agent_groups.c
   manage_agents.c
   manage_agent_installers.c
   manage_alerts.c
@@ -185,6 +187,7 @@ set(
   ALL_MANAGE_SQL_SRC
   manage_sql.c
   manage_sql_copy.c
+  manage_sql_agent_groups.c
   manage_sql_agents.c
   manage_sql_agent_installers.c
   manage_sql_alerts.c
@@ -206,6 +209,7 @@ set(
 set(
   ALL_GMP_SRC
   gmp.c
+  gmp_agent_groups.c
   gmp_agents.c
   gmp_agent_installers.c
   gmp_base.c

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -4364,8 +4364,8 @@ typedef enum
   CLIENT_CREATE_USER_SOURCES_SOURCE,
 #if ENABLE_AGENTS
   CLIENT_DELETE_AGENT_GROUP,
-  CLIENT_DELETE_AGENTS,
   CLIENT_DELETE_AGENT_INSTALLER,
+  CLIENT_DELETE_AGENTS,
 #endif /* ENABLE_AGENTS */
   CLIENT_DELETE_ALERT,
   CLIENT_DELETE_ASSET,
@@ -4394,9 +4394,9 @@ typedef enum
   CLIENT_EMPTY_TRASHCAN,
 #if ENABLE_AGENTS
   CLIENT_GET_AGENT_GROUPS,
-  CLIENT_GET_AGENTS,
-  CLIENT_GET_AGENT_INSTALLERS,
   CLIENT_GET_AGENT_INSTALLER_FILE,
+  CLIENT_GET_AGENT_INSTALLERS,
+  CLIENT_GET_AGENTS,
 #endif /* ENABLE_AGENTS */
   CLIENT_GET_AGGREGATES,
   CLIENT_GET_AGGREGATES_DATA_COLUMN,
@@ -4932,22 +4932,22 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
             create_user_data->hosts_allow = 0;
           }
 #if ENABLE_AGENTS
-        else if (strcasecmp ("DELETE_AGENTS", element_name) == 0)
-          {
-            delete_agents_start (gmp_parser, attribute_names, attribute_values);
-            set_client_state (CLIENT_DELETE_AGENTS);
-          }
-        else if (strcasecmp ("DELETE_AGENT_INSTALLER", element_name) == 0)
-          {
-            delete_start ("agent_installer", "Agent Installer",
-                          attribute_names, attribute_values);
-            set_client_state (CLIENT_DELETE_REPORT_CONFIG);
-          }
         else if (strcasecmp ("DELETE_AGENT_GROUP", element_name) == 0)
           {
             delete_start ("agent_group", "Agent Group",
                           attribute_names, attribute_values);
             set_client_state (CLIENT_DELETE_AGENT_GROUP);
+          }
+        else if (strcasecmp ("DELETE_AGENT_INSTALLER", element_name) == 0)
+          {
+            delete_start ("agent_installer", "Agent Installer",
+                          attribute_names, attribute_values);
+            set_client_state (CLIENT_DELETE_AGENT_INSTALLER);
+          }
+        else if (strcasecmp ("DELETE_AGENTS", element_name) == 0)
+          {
+            delete_agents_start (gmp_parser, attribute_names, attribute_values);
+            set_client_state (CLIENT_DELETE_AGENTS);
           }
 #endif /* ENABLE_AGENTS */
         else if (strcasecmp ("DELETE_ALERT", element_name) == 0)
@@ -5207,11 +5207,11 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
 #if ENABLE_AGENTS
         ELSE_GET_START (agent_groups, AGENT_GROUPS)
 
-        ELSE_GET_START (agents, AGENTS)
+        ELSE_GET_START (agent_installer_file, AGENT_INSTALLER_FILE)
 
         ELSE_GET_START (agent_installers, AGENT_INSTALLERS)
 
-        ELSE_GET_START (agent_installer_file, AGENT_INSTALLER_FILE)
+        ELSE_GET_START (agents, AGENTS)
 #endif /* ENABLE_AGENTS */
 
         else if (strcasecmp ("GET_AGGREGATES", element_name) == 0)

--- a/src/gmp_agent_groups.c
+++ b/src/gmp_agent_groups.c
@@ -96,8 +96,7 @@ get_agent_groups_run (gmp_parser_t *gmp_parser, GError **error)
 
   while (1)
     {
-      scanner_t scanner;
-      char *agent_scanner_name, *agent_scanner_uuid;
+      const char *agent_scanner_name, *agent_scanner_uuid;
 
       ret = get_next (&agent_groups, &get_agent_groups_data.get, &first, &count,
                       init_agent_group_iterator);
@@ -110,9 +109,8 @@ get_agent_groups_run (gmp_parser_t *gmp_parser, GError **error)
           return;
         }
 
-      scanner = agent_group_iterator_scanner (&agent_groups);
-      agent_scanner_uuid = scanner_uuid (scanner);
-      agent_scanner_name = scanner_name (scanner);
+      agent_scanner_uuid = agent_group_iterator_scanner_id (&agent_groups);
+      agent_scanner_name = agent_group_iterator_scanner_name (&agent_groups);
 
       // Start <agent_group>
       SEND_GET_COMMON (agent_group,
@@ -125,29 +123,25 @@ get_agent_groups_run (gmp_parser_t *gmp_parser, GError **error)
                                agent_scanner_uuid ? agent_scanner_uuid : "",
                                agent_scanner_name ? agent_scanner_name : "");
 
-  iterator_t agent_iter;
-  if (init_agent_group_agents_iterator (&agent_iter, get_iterator_resource (&agent_groups)) == 0)
-  {
+      iterator_t agent_iter;
+      init_agent_group_agents_iterator (&agent_iter, get_iterator_resource (&agent_groups));
       SEND_TO_CLIENT_OR_FAIL ("<agents>");
       while (next (&agent_iter))
-      {
-        const char *uuid = agent_group_agent_iterator_uuid (&agent_iter);
-        const char *name = agent_group_agent_iterator_name (&agent_iter);
+        {
+          const char *uuid = agent_group_agent_iterator_uuid (&agent_iter);
+          const char *name = agent_group_agent_iterator_name (&agent_iter);
 
-        SENDF_TO_CLIENT_OR_FAIL (
-          "<agent id=\"%s\"><name>%s</name></agent>",
-          uuid ? uuid : "",
-          name ? name : "");
-      }
-        SEND_TO_CLIENT_OR_FAIL ("</agents>");
-        cleanup_iterator (&agent_iter);
-    }
+          SENDF_TO_CLIENT_OR_FAIL (
+            "<agent id=\"%s\"><name>%s</name></agent>",
+            uuid ? uuid : "",
+            name ? name : "");
+        }
+
+      SEND_TO_CLIENT_OR_FAIL ("</agents>");
+      cleanup_iterator (&agent_iter);
 
       SEND_TO_CLIENT_OR_FAIL ("</agent_group>");
       count++;
-
-      g_free(agent_scanner_name);
-      g_free(agent_scanner_uuid);
     }
 
   cleanup_iterator (&agent_groups);

--- a/src/gmp_agent_groups.c
+++ b/src/gmp_agent_groups.c
@@ -1,0 +1,713 @@
+/* Copyright (C) 2009-2022 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file gmp_agent_groups.c
+ * @brief GVM GMP layer: Agent groups.
+ *
+ * GMP Handlers for reading, creating, modifying and deleting agent groups.
+ */
+
+#include "gmp_agent_groups.h"
+#include "manage.h"
+
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md gmp"
+
+/* GET_AGENT_GROUPS */
+
+/**
+ * @struct get_agent_groups_t
+ * @brief data for <get_agent_groups> command
+ *
+ */
+typedef struct
+{
+    get_data_t get;
+} get_agent_groups_t;
+
+/**
+ * @brief Parser <get_agent_groups> callback data.
+ */
+static get_agent_groups_t get_agent_groups_data;
+
+static void
+get_agent_groups_reset ()
+{
+    get_data_reset (&get_agent_groups_data.get);
+    memset (&get_agent_groups_data, 0, sizeof (get_agent_groups_data));
+}
+
+/**
+ * @brief start getting agent groups
+ *
+ * @param[in] attribute_names  the names of the attributes
+ * @param[in] attribute_values the values of the attributes
+ */
+void
+get_agent_groups_start (const gchar **attribute_names,
+                        const gchar **attribute_values)
+{
+    get_data_parse_attributes (&get_agent_groups_data.get,
+                               "agent_groups",
+                               attribute_names,
+                               attribute_values);
+}
+
+/**
+ * @brief complete get agent groups command
+ *
+ * @param[in] gmp_parser GMP Parser handling the current session
+ * @param[in] error      The errors, if any.
+ */
+void
+get_agent_groups_run (gmp_parser_t *gmp_parser, GError **error)
+{
+#if ENABLE_AGENTS
+  iterator_t agent_groups;
+  int count = 0, filtered, ret, first;
+
+  ret = init_get ("get_agent_groups",
+                  &get_agent_groups_data.get,
+                  "Agent Groups",
+                  &first);
+
+  if (ret)
+    {
+      SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX ("get_agent_groups", "Permission denied"));
+      get_agent_groups_reset ();
+      return;
+    }
+
+  ret = init_agent_group_iterator (&agent_groups, &get_agent_groups_data.get);
+  if (ret)
+    {
+      SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX ("get_agent_groups", "Permission denied"));
+      get_agent_groups_reset ();
+      return;
+    }
+
+  SEND_GET_START ("agent_group");
+
+  while (1)
+    {
+      ret = get_next (&agent_groups, &get_agent_groups_data.get, &first, &count,
+                      init_agent_group_iterator);
+      if (ret == 1)
+        break;
+      if (ret == -1)
+        {
+          internal_error_send_to_client (error);
+          get_agent_groups_reset ();
+          return;
+        }
+
+      // Start <agent_group>
+      SEND_GET_COMMON (agent_group,
+                       &get_agent_groups_data.get,
+                       &agent_groups);
+
+      SENDF_TO_CLIENT_OR_FAIL ("<scanner id=\"%s\">"
+                               "<name>%s</name>"
+                               "</scanner>",
+                               scanner_uuid (agent_group_iterator_scanner (&agent_groups)),
+                               scanner_name (agent_group_iterator_scanner (&agent_groups)));
+
+      gchar *agents = agent_group_agents_string (get_iterator_resource (&agent_groups));
+      SENDF_TO_CLIENT_OR_FAIL ("<agents>%s</agents>", agents ? agents : "");
+      g_free (agents);
+
+      SEND_TO_CLIENT_OR_FAIL ("</agent_group>");
+      count++;
+    }
+
+  cleanup_iterator (&agent_groups);
+
+  filtered = get_agent_groups_data.get.id
+               ? 1
+               : agent_group_count (&get_agent_groups_data.get);
+
+  SEND_GET_END ("agent_group", &get_agent_groups_data.get, count, filtered);
+
+#else
+  SEND_TO_CLIENT_OR_FAIL (XML_ERROR_UNAVAILABLE ("get_agent_groups",
+                                                 "Command unavailable"));
+#endif
+
+  get_agent_groups_reset ();
+}
+
+
+/* CREATE_AGENT_GROUP */
+
+/**
+ * @brief The create_agent_group command
+ */
+typedef struct
+{
+  context_data_t *context;
+} create_agent_group_t;
+
+/**
+ * @brief Data used by parser to handle create_agent_group command
+ */
+static create_agent_group_t create_agent_group_data;
+
+/**
+ * @brief Resets create_agent_group command data.
+ */
+static void
+create_agent_group_reset ()
+{
+  if (create_agent_group_data.context->first)
+    {
+      free_entity (create_agent_group_data.context->first->data);
+      g_slist_free_1 (create_agent_group_data.context->first);
+    }
+    g_free (create_agent_group_data.context);
+    memset (&create_agent_group_data, 0, sizeof (create_agent_group_t));
+}
+
+/**
+ * @brief Start the create_agent_group command
+ *
+ * @param[in] gmp_parser       current instance of GMP parser.
+ * @param[in] attribute_names  All attribute names.
+ * @param[in] attribute_values All attribute values.
+ */
+void
+create_agent_group_start (gmp_parser_t *gmp_parser,
+                          const gchar **attribute_names,
+                          const gchar **attribute_values)
+{
+  memset (&create_agent_group_data, 0, sizeof (create_agent_group_t));
+  create_agent_group_data.context = g_malloc0 (sizeof (context_data_t));
+  create_agent_group_element_start (gmp_parser, "create_agent_group",
+                                    attribute_names, attribute_values);
+}
+
+/**
+ * @brief Start an element of the create_agent_group command
+ *
+ * @param[in]  gmp_parser        current instance of GMP parser.
+ * @param[in]  name              name of element being started.
+ * @param[in]  attribute_names   All attribute names.
+ * @param[in]  attribute_values  All attribute values.
+ */
+void
+create_agent_group_element_start (gmp_parser_t *gmp_parser, const gchar *name,
+                                  const gchar **attribute_names,
+                                  const gchar **attribute_values)
+{
+  xml_handle_start_element (create_agent_group_data.context, name,
+                            attribute_names, attribute_values);
+}
+
+/**
+ * @brief End element in create_agent_group command
+ *
+ * @param[in] gmp_parser  The current GMP parser instance
+ * @param[in] error       the errors, if any
+ * @param[in] name        name of element
+ *
+ * @return 1 if the command ran successfully, 0 otherwise
+ */
+int
+create_agent_group_element_end (gmp_parser_t *gmp_parser, GError **error,
+                                const gchar *name)
+{
+  xml_handle_end_element (create_agent_group_data.context, name);
+  if (create_agent_group_data.context->done)
+  {
+    create_agent_group_run (gmp_parser, error);
+    return 1;
+  }
+  return 0;
+}
+
+/**
+ * @brief Add text to element in create_agent_group command
+ *
+ * @param[in] text      the text to add.
+ * @param[in] text_len  the length of the text being added
+ */
+void
+create_agent_group_element_text (const gchar *text, gsize text_len)
+{
+  xml_handle_text (create_agent_group_data.context, text, text_len);
+}
+
+/**
+ * @brief Execute the create_agent_group command
+ *
+ * @param[in] gmp_parser  current instance of GMP parser.
+ * @param[in] error       the errors, if any.
+ */
+void
+create_agent_group_run (gmp_parser_t *gmp_parser, GError **error)
+{
+#if ENABLE_AGENTS
+  entity_t root, copy, name, comment, agents_elem;
+  const char *name_text;
+  agent_group_data_t group_data;
+  agent_uuid_list_t agent_uuids = NULL;
+  agent_group_t new_agent_group;
+
+  root = (entity_t) create_agent_group_data.context->first->data;
+
+  // Handle copy logic if provided
+  copy = entity_child (root, "copy");
+  if (copy)
+  {
+    // Parse <name> and <comment> elements
+    name = entity_child (root, "name");
+    comment = entity_child (root, "comment");
+
+    name_text = (name && entity_text (name)) ? entity_text (name) : NULL;
+    const char *comment_text = (comment && entity_text (comment)) ? entity_text (comment) : "";
+
+    // Call the updated copy_agent_group with name
+    switch (copy_agent_group (name_text,
+                              comment_text,
+                              entity_text (copy),
+                              &new_agent_group))
+    {
+      case 0:
+      {
+        char *uuid = agent_group_uuid (new_agent_group);
+        SENDF_TO_CLIENT_OR_FAIL (XML_OK_CREATED_ID ("create_agent_group"), uuid);
+        log_event ("agent_group", "Agent Group", uuid, "copied");
+        free (uuid);
+        break;
+      }
+      case 2:
+        if (send_find_error_to_client ("create_agent_group", "agent_group",
+                                       entity_text (copy), gmp_parser))
+        {
+          error_send_to_client (error);
+          return;
+        }
+      log_event_fail ("agent_group", "Agent Group", NULL, "copied");
+      break;
+      case 99:
+        SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX ("create_agent_group", "Permission denied"));
+      break;
+      case -1:
+        default:
+          SEND_TO_CLIENT_OR_FAIL (XML_INTERNAL_ERROR ("create_agent_group"));
+      log_event_fail ("agent_group", "Agent Group", NULL, "copied");
+      break;
+    }
+
+    create_agent_group_reset ();
+    return;
+  }
+
+  // Parse required fields
+  name = entity_child (root, "name");
+  if (!name || !(name_text = entity_text (name)) || strlen (name_text) == 0)
+    {
+      SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX ("create_agent_group", "Missing or empty <name>"));
+      create_agent_group_reset ();
+      return;
+    }
+
+  comment = entity_child (root, "comment");
+
+  // Allocate and populate group data
+  group_data = agent_group_data_new();
+  group_data->name = g_strdup (name_text);
+  group_data->comment = comment ? g_strdup (entity_text (comment)) : g_strdup ("");
+  group_data->creation_time = group_data->modification_time = time (NULL);
+
+  // Parse <agents> if provided
+  agents_elem = entity_child (root, "agents");
+  if (agents_elem)
+    {
+      GSList *agent_entities = agents_elem->entities;
+      int uuid_count = g_slist_length (agent_entities);
+      agent_uuids = agent_uuid_list_new (uuid_count);
+
+      int index = 0;
+      for (; agent_entities; agent_entities = g_slist_next (agent_entities))
+        {
+          entity_t agent_elem = agent_entities->data;
+          if (strcmp (entity_name (agent_elem), "agent") != 0)
+            continue;
+
+          const gchar *uuid = entity_attribute (agent_elem, "id");
+          if (uuid && is_uuid (uuid))
+            agent_uuids->agent_uuids[index++] = g_strdup (uuid);
+          else
+            {
+              agent_uuid_list_free (agent_uuids);
+              agent_group_data_free(group_data);
+              SENDF_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX ("create_agent_group",
+                                                         "Invalid agent UUID: %s"),
+                                       uuid);
+              create_agent_group_reset ();
+              return;
+            }
+        }
+      agent_uuids->count = index;
+    }
+
+  // Execute creation
+  agent_group_resp_t response = create_agent_group (group_data, agent_uuids);
+
+  switch (response)
+  {
+    case AGENT_GROUP_RESP_SUCCESS:
+    {
+      char *uuid = agent_group_uuid (sql_last_insert_id ());
+      SENDF_TO_CLIENT_OR_FAIL (XML_OK_CREATED_ID ("create_agent_group"), uuid);
+      log_event ("agent_group", "Agent Group", uuid, "created");
+      g_free (uuid);
+      break;
+    }
+
+    case AGENT_GROUP_RESP_NO_AGENTS_PROVIDED:
+      SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX ("create_agent_group", "No agents provided"));
+      log_event_fail ("agent_group", "Agent Group", NULL, "created");
+      break;
+
+    case AGENT_GROUP_RESP_SCANNER_NOT_FOUND:
+      if (send_find_error_to_client ("create_agent_group",
+                                     "scanner",
+                                     NULL,
+                                     gmp_parser))
+      {
+        error_send_to_client (error);
+        create_agent_group_reset ();
+        return;
+      }
+
+      log_event_fail ("create_agent_group", "Agent Group", NULL, "created");
+      break;
+
+    case AGENT_GROUP_RESP_SCANNER_PERMISSION:
+      SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX ("create_agent_group",
+                                                "Permission denied"));
+
+      log_event_fail ("create_agent_group", "Agent Group", NULL, "created");
+      break;
+    case AGENT_GROUP_RESP_AGENT_SCANNER_MISMATCH:
+      SEND_TO_CLIENT_OR_FAIL (
+        XML_ERROR_SYNTAX ("create_agent_group", "Agents belong to different scanners"));
+      log_event_fail ("agent_group", "Agent Group", NULL, "created");
+      break;
+
+    case AGENT_GROUP_RESP_INVALID_ARGUMENT:
+      SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX ("create_agent_group", "Invalid input"));
+      log_event_fail ("agent_group", "Agent Group", NULL, "created");
+    break;
+
+    case AGENT_GROUP_RESP_AGENT_NOT_FOUND:
+      if (send_find_error_to_client ("create_agent_group",
+                                     "agent",
+                                     NULL,
+                                     gmp_parser))
+      {
+        error_send_to_client (error);
+        create_agent_group_reset ();
+        return;
+      }
+
+      log_event_fail ("create_agent_group", "Agent Group", NULL, "created");
+      break;
+
+    case AGENT_GROUP_RESP_INTERNAL_ERROR:
+      default:
+        SEND_TO_CLIENT_OR_FAIL (XML_INTERNAL_ERROR ("create_agent_group"));
+        log_event_fail ("agent_group", "Agent Group", NULL, "created");
+        break;
+  }
+
+  // Cleanup
+  agent_uuid_list_free (agent_uuids);
+  agent_group_data_free(group_data);
+
+#else
+  SEND_TO_CLIENT_OR_FAIL (XML_ERROR_UNAVAILABLE ("create_agent_group",
+                                                 "Command unavailable"));
+#endif
+
+  create_agent_group_reset ();
+}
+
+/* MODIFY_AGENT_GROUP */
+
+/**
+ * @struct modify_agent_group_data_t
+ * @brief data for <modify_agent_group> command
+ */
+typedef struct
+{
+    context_data_t *context;
+} modify_agent_group_data_t;
+
+/**
+ * @brief Parser <modify_agent_group> callback data.
+ */
+static modify_agent_group_data_t modify_agent_group_data;
+
+static void
+modify_agent_group_reset ()
+{
+  if (modify_agent_group_data.context && modify_agent_group_data.context->first)
+    {
+      free_entity (modify_agent_group_data.context->first->data);
+      g_slist_free_1 (modify_agent_group_data.context->first);
+    }
+
+  g_free (modify_agent_group_data.context);
+  memset (&modify_agent_group_data, 0, sizeof (modify_agent_group_data_t));
+}
+
+/**
+ * @brief Start the element in the <modify_agent_group> command.
+ *
+ * @param[in] gmp_parser       Active GMP parser instance.
+ * @param[in] name             Name of the XML element being parsed.
+ * @param[in] attribute_names  Null-terminated array of attribute names.
+ * @param[in] attribute_values Null-terminated array of attribute values.
+ */
+void
+modify_agent_group_element_start (gmp_parser_t *gmp_parser,
+                                  const gchar *name,
+                                  const gchar **attribute_names,
+                                  const gchar **attribute_values)
+{
+  xml_handle_start_element (modify_agent_group_data.context,
+                            name,
+                            attribute_names,
+                            attribute_values);
+}
+
+/**
+ * @brief Initialize the <modify_agent_group> GMP command.
+ *
+ * @param[in] gmp_parser        Active GMP parser instance.
+ * @param[in] attribute_names   Null-terminated array of attribute names.
+ * @param[in] attribute_values  Null-terminated array of attribute names.
+ */
+void
+modify_agent_group_start (gmp_parser_t *gmp_parser,
+                          const gchar **attribute_names,
+                          const gchar **attribute_values)
+{
+  memset (&modify_agent_group_data, 0, sizeof (modify_agent_group_data_t));
+  modify_agent_group_data.context = g_malloc0 (sizeof (context_data_t));
+
+  modify_agent_group_element_start (gmp_parser, "modify_agent_group",
+                                    attribute_names, attribute_values);
+}
+
+/**
+ * @brief Add text to element for modify_agent_group.
+ *
+ * @param[in]  text         Text.
+ * @param[in]  text_len     Text length.
+ */
+void
+modify_agent_group_element_text (const gchar *text, gsize text_len)
+{
+  xml_handle_text (modify_agent_group_data.context, text, text_len);
+}
+
+/**
+ * @brief End the XML element within the <modify_agent_group> command.
+ *
+ * @param[in] gmp_parser  Active GMP parser instance
+ * @param[in] error       The errors, if any
+ * @param[in] name        Name of the XML element that ended.
+ *
+ * @return 1 if the command ran successfully, 0 otherwise
+ */
+int
+modify_agent_group_element_end (gmp_parser_t *gmp_parser, GError **error,
+                                const gchar *name)
+{
+  xml_handle_end_element (modify_agent_group_data.context, name);
+  if (modify_agent_group_data.context->done)
+  {
+    modify_agent_group_run (gmp_parser, error);
+    return 1;
+  }
+  return 0;
+}
+
+/**
+ * @brief Execute the <modify_agent_group> GMP command.
+ *
+ * @param[in] gmp_parser  Active GMP parser instance.
+ * @param[in] error       the errors, if any.
+ */
+void
+modify_agent_group_run (gmp_parser_t *gmp_parser, GError **error)
+{
+#if ENABLE_AGENTS
+  entity_t root, name, comment, agents_elem;
+  const char *agent_group_uuid, *name_text;
+
+  root = (entity_t) modify_agent_group_data.context->first->data;
+
+  agent_group_uuid = entity_attribute (root, "agent_group_id");
+
+  if (!agent_group_uuid || !is_uuid (agent_group_uuid))
+    {
+      SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX ("modify_agent_group",
+                                                "Missing or invalid agent_group_id"));
+      modify_agent_group_reset ();
+      return;
+    }
+
+  agent_group_t agent_group = agent_group_id_by_uuid (agent_group_uuid);
+  if (!agent_group)
+    {
+      if (send_find_error_to_client ("modify_agent_group",
+                                     "agent_group",
+                                     agent_group_uuid,
+                                     gmp_parser))
+      {
+        error_send_to_client (error);
+        modify_agent_group_reset ();
+        return;
+      }
+    }
+
+  name = entity_child (root, "name");
+  if (!name || !(name_text = entity_text (name)) || strlen (name_text) == 0)
+    {
+      SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX ("modify_agent_group",
+                                                "modify_agent_group requires a name"));
+      modify_agent_group_reset ();
+      return;
+    }
+
+  comment = entity_child (root, "comment");
+
+  // Parse agent UUIDs
+  agents_elem = entity_child (root, "agents");
+  agent_uuid_list_t agent_uuids = NULL;
+
+  if (agents_elem)
+    {
+      GSList *agent_entities = agents_elem->entities;
+      int count = g_slist_length (agent_entities);
+      agent_uuids = agent_uuid_list_new (count);
+
+      int index = 0;
+      for (; agent_entities; agent_entities = g_slist_next (agent_entities))
+        {
+          entity_t agent_elem = agent_entities->data;
+
+          if (strcmp (entity_name (agent_elem), "agent") != 0)
+            continue;
+
+          const gchar *uuid = entity_attribute (agent_elem, "id");
+
+          if (uuid && is_uuid (uuid))
+            agent_uuids->agent_uuids[index++] = g_strdup (uuid);
+          else
+            {
+              agent_uuid_list_free (agent_uuids);
+              SENDF_TO_CLIENT_OR_FAIL (
+                XML_ERROR_SYNTAX ("modify_agent_group", "Agent UUID '%s' is invalid"), uuid);
+              modify_agent_group_reset ();
+              return;
+            }
+        }
+    }
+
+  // Prepare agent group data
+  agent_group_data_t group_data = agent_group_data_new();
+  group_data->name = g_strdup (name_text);
+  group_data->comment = g_strdup (comment ? entity_text (comment) : "");
+  group_data->modification_time = time(NULL);
+
+  agent_group_resp_t response = modify_agent_group (agent_group, group_data, agent_uuids);
+
+  switch (response)
+    {
+      case AGENT_GROUP_RESP_SUCCESS:
+        {
+          char *uuid = g_strdup (agent_group_uuid);
+          SENDF_TO_CLIENT_OR_FAIL (XML_OK ("modify_agent_group"));
+          log_event ("agent_group", "Agent Group", uuid, "modified");
+          g_free (uuid);
+          break;
+        }
+
+      case AGENT_GROUP_RESP_NO_AGENTS_PROVIDED:
+        SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX ("modify_agent_group", "No agents provided"));
+        log_event_fail ("agent_group", "Agent Group", NULL, "modified");
+        break;
+
+      case AGENT_GROUP_RESP_SCANNER_NOT_FOUND:
+        if (send_find_error_to_client ("modify_agent_group",
+                                       "scanner",
+                                       NULL,
+                                       gmp_parser))
+          {
+            error_send_to_client (error);
+            modify_agent_group_reset ();
+            return;
+          }
+
+        log_event_fail ("agent_group", "Agent Group", NULL, "modified");
+        break;
+
+      case AGENT_GROUP_RESP_SCANNER_PERMISSION:
+        SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX ("modify_agent_group", "Permission denied"));
+        log_event_fail ("agent_group", "Agent Group", NULL, "modified");
+        break;
+
+      case AGENT_GROUP_RESP_AGENT_SCANNER_MISMATCH:
+        SEND_TO_CLIENT_OR_FAIL (
+          XML_ERROR_SYNTAX ("modify_agent_group", "Agents belong to different scanners"));
+        log_event_fail ("agent_group", "Agent Group", NULL, "modified");
+        break;
+
+      case AGENT_GROUP_RESP_INVALID_ARGUMENT:
+        SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX ("modify_agent_group", "Invalid input"));
+        log_event_fail ("agent_group", "Agent Group", NULL, "modified");
+        break;
+
+      case AGENT_GROUP_RESP_AGENT_NOT_FOUND:
+        if (send_find_error_to_client ("modify_agent_group",
+                                       "agent",
+                                       NULL,
+                                       gmp_parser))
+          {
+            error_send_to_client (error);
+            modify_agent_group_reset ();
+            return;
+          }
+
+        log_event_fail ("agent_group", "Agent Group", NULL, "modified");
+        break;
+
+      case AGENT_GROUP_RESP_INTERNAL_ERROR:
+      default:
+        SEND_TO_CLIENT_OR_FAIL (XML_INTERNAL_ERROR ("modify_agent_group"));
+        log_event_fail ("agent_group", "Agent Group", NULL, "modified");
+        break;
+    }
+
+  // Cleanup
+  agent_group_data_free (group_data);
+  agent_uuid_list_free (agent_uuids);
+
+#else
+  SEND_TO_CLIENT_OR_FAIL (XML_ERROR_UNAVAILABLE ("modify_agent_group",
+                                                 "Command unavailable"));
+#endif
+
+  modify_agent_group_reset ();
+}

--- a/src/gmp_agent_groups.h
+++ b/src/gmp_agent_groups.h
@@ -1,0 +1,67 @@
+/* Copyright (C) 2009-2022 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file gmp_agent_groups.h
+ * @brief GVM GMP layer: Agent Group headers.
+ *
+ * Header for GMP Agent Group handlers
+ */
+
+#ifndef _GVMD_GMP_AGENT_GROUPS_H
+#define _GVMD_GMP_AGENT_GROUPS_H
+
+#include "gmp_base.h"
+#include "gmp_get.h"
+
+void
+get_agent_groups_start (const gchar **,
+                        const gchar **);
+
+void
+get_agent_groups_run (gmp_parser_t *, GError **);
+
+void
+create_agent_group_start (gmp_parser_t *gmp_parser,
+                          const gchar **attribute_names,
+                          const gchar **attribute_values);
+
+void
+create_agent_group_element_start (gmp_parser_t *, const gchar *,
+                                  const gchar **,
+                                  const gchar **);
+
+void
+create_agent_group_run (gmp_parser_t *, GError **);
+
+int
+create_agent_group_element_end (gmp_parser_t *, GError **,
+                                const gchar *);
+
+void
+create_agent_group_element_text (const gchar *, gsize);
+
+void
+modify_agent_group_element_start (gmp_parser_t *,
+                                  const gchar *,
+                                  const gchar **,
+                                  const gchar **);
+
+void
+modify_agent_group_start (gmp_parser_t *,
+                          const gchar **,
+                          const gchar **);
+
+void
+modify_agent_group_element_text (const gchar *text, gsize text_len);
+
+void
+modify_agent_group_run (gmp_parser_t *, GError **);
+
+int
+modify_agent_group_element_end (gmp_parser_t *, GError **,
+                                const gchar *);
+
+#endif // _GVMD_GMP_AGENT_GROUPS_H

--- a/src/gmp_agents.c
+++ b/src/gmp_agents.c
@@ -120,6 +120,9 @@ get_agents_run (gmp_parser_t *gmp_parser, GError **error)
     {
       ret = get_next (&agents, &get_agents_data.get, &first, &count,
                       init_agent_iterator);
+      scanner_t scanner;
+      char *agent_scanner_name, *agent_scanner_uuid;
+
       if (ret == 1)
         break;
       if (ret == -1)
@@ -129,6 +132,9 @@ get_agents_run (gmp_parser_t *gmp_parser, GError **error)
           return;
         }
 
+      scanner = agent_iterator_scanner (&agents);
+      agent_scanner_uuid = scanner_uuid (scanner);
+      agent_scanner_name = scanner_name (scanner);
       SEND_GET_COMMON_NO_TRASH (agent,
                                 &get_agents_data.get,
                                 &agents);
@@ -153,9 +159,8 @@ get_agents_run (gmp_parser_t *gmp_parser, GError **error)
                                agent_iterator_connection_status (&agents),
                                iso_if_time (agent_iterator_last_update (&agents)),
                                agent_iterator_schedule (&agents),
-                               scanner_uuid (agent_iterator_scanner (&agents)),
-                               scanner_name (agent_iterator_scanner (&agents))
-                               );
+                               agent_scanner_uuid ? agent_scanner_uuid : "",
+                               agent_scanner_name ? agent_scanner_name : "");
 
       // IPs
       agent_ip_data_list_t ip_list = load_agent_ip_addresses (agent_iterator_agent_id (&agents));
@@ -171,6 +176,9 @@ get_agents_run (gmp_parser_t *gmp_parser, GError **error)
       // Close agent
       SEND_TO_CLIENT_OR_FAIL ("</agent>");
       count++;
+
+      g_free(agent_scanner_name);
+      g_free(agent_scanner_uuid);
     }
 
   cleanup_iterator (&agents);

--- a/src/manage.c
+++ b/src/manage.c
@@ -7027,6 +7027,10 @@ delete_resource (const char *type, const char *resource_id, int ultimate)
     return delete_report_config (resource_id, ultimate);
   if (strcasecmp (type, "ticket") == 0)
     return delete_ticket (resource_id, ultimate);
+#if ENABLE_AGENTS
+  if (strcasecmp (type, "agent_group") == 0)
+    return delete_agent_group (resource_id, ultimate);
+#endif
   if (strcasecmp (type, "tls_certificate") == 0)
     return delete_tls_certificate (resource_id, ultimate);
   assert (0);

--- a/src/manage.h
+++ b/src/manage.h
@@ -56,6 +56,7 @@
 
 #if ENABLE_AGENTS
 #include <gvm/agent_controller/agent_controller.h>
+#include "manage_agent_groups.h"
 #include "manage_agents.h"
 #endif
 

--- a/src/manage_agent_common.c
+++ b/src/manage_agent_common.c
@@ -1,0 +1,59 @@
+/* Copyright (C) 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file manage_agent_common.c
+ * @brief Implementation of shared agent utilities for GVMD.
+ */
+
+#if ENABLE_AGENTS
+#include "manage_agent_common.h"
+
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md manage"
+
+/**
+ * @brief Allocate and initialize a new agent_uuid_list_t structure.
+ *
+ * @param[in] count Number of UUID entries to allocate.
+ *
+ * @return A newly allocated agent_uuid_list_t, or NULL on allocation failure.
+ */
+agent_uuid_list_t
+agent_uuid_list_new (int count)
+{
+    if (count <= 0)
+        return NULL;
+
+    agent_uuid_list_t list = g_malloc0 (sizeof (struct agent_uuid_list));
+
+    list->count = count;
+    list->agent_uuids = g_malloc0 (sizeof (gchar *) * (count + 1));
+
+    return list;
+}
+
+/**
+ * @brief Free an agent_uuid_list_t and its contents.
+ *
+ * @param[in] uuid_list List of agent UUIDs to free.
+ */
+void
+agent_uuid_list_free (agent_uuid_list_t uuid_list)
+{
+    if (!uuid_list)
+        return;
+
+    for (int i = 0; i < uuid_list->count; ++i)
+        g_free (uuid_list->agent_uuids[i]);
+
+    g_free (uuid_list->agent_uuids);
+    g_free (uuid_list);
+}
+
+#endif // ENABLE_AGENTS

--- a/src/manage_agent_common.h
+++ b/src/manage_agent_common.h
@@ -1,0 +1,38 @@
+/* Copyright (C) 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file manage_agent_common.h
+ * @brief Common utilities for agent management in GVMD.
+ *
+ * This header provides shared data structures and utility functions
+ * used by both the agent and agent group management.
+ */
+
+#if ENABLE_AGENTS
+#ifndef _GVMD_MANAGE_AGENT_COMMON_H
+#define _GVMD_MANAGE_AGENT_COMMON_H
+
+#include <glib.h>
+
+/**
+ * @struct agent_uuid_list
+ * @brief A structure to store a list of agent UUIDs.
+ */
+struct agent_uuid_list
+{
+    int count;           ///< Number of UUIDs in the list
+    gchar **agent_uuids; ///< Array of UUID strings
+};
+typedef struct agent_uuid_list *agent_uuid_list_t;
+
+agent_uuid_list_t
+agent_uuid_list_new (int count);
+
+void
+agent_uuid_list_free (agent_uuid_list_t uuid_list);
+
+#endif // _GVMD_MANAGE_AGENT_COMMON_H
+#endif // ENABLE_AGENTS

--- a/src/manage_agent_groups.c
+++ b/src/manage_agent_groups.c
@@ -1,0 +1,100 @@
+/* Copyright (C) 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file manage_agent_groups.c
+ * @brief Agent group data utilities and access control checks for GVMD.
+ */
+
+#if ENABLE_AGENTS
+#include "manage_agent_groups.h"
+
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md manage"
+
+/**
+ * @brief Allocate and initialize a new agent_group_data_t structure.
+ *
+ * @return A newly allocated agent_group_data_t pointer, or NULL on failure.
+ */
+
+agent_group_data_t
+agent_group_data_new ()
+{
+  return (agent_group_data_t) g_malloc0 (sizeof (struct agent_group_data));
+}
+
+/**
+ * @brief Free an agent_group_data_t structure and its contents.
+ *
+ * @param[in] data Pointer to the agent_group_data structure to free.
+ */
+void
+agent_group_data_free (agent_group_data_t data)
+{
+  if (!data)
+    return;
+
+  g_free (data->uuid);
+  g_free (data->name);
+  g_free (data->comment);
+  g_free (data);
+}
+
+/**
+ * @brief Return whether a agent_group is in use.
+ *
+ * @param[in]  agent_group  Agent Group row id.
+ *
+ * @return 1 if in use, else 0.
+ */
+int
+agent_group_in_use (agent_group_t agent_group)
+{
+  return 0;
+}
+
+/**
+ * @brief Return whether a trashcan agent_group is in use.
+ *
+ * @param[in]  agent_group  Agent Group row id.
+ *
+ * @return 1 if in use, else 0.
+ */
+int
+trash_agent_group_in_use (agent_group_t agent_group)
+{
+  return 0;
+}
+
+/**
+ * @brief Return whether a agent_group is writable.
+ *
+ * @param[in]  agent_group  Agent Group row id.
+ *
+ * @return 1 if writable, else 0.
+ */
+int
+agent_group_writable (agent_group_t agent_group)
+{
+  return 1;
+}
+
+/**
+ * @brief Return whether a trashcan agent_group is writable.
+ *
+ * @param[in]  agent_group  Agent Group row id.
+ *
+ * @return 1 if writable, else 0.
+ */
+int
+trash_agent_group_writable (agent_group_t agent_group)
+{
+  return trash_agent_group_in_use (agent_group) == 0;
+}
+#endif //ENABLE_AGENTS

--- a/src/manage_agent_groups.h
+++ b/src/manage_agent_groups.h
@@ -75,9 +75,6 @@ agent_group_count (const get_data_t *get);
 int
 init_agent_group_iterator (iterator_t *iterator, get_data_t *get);
 
-gchar *
-agent_group_agents_string (agent_group_t group_id);
-
 scanner_t
 agent_group_iterator_scanner (iterator_t *iterator);
 
@@ -107,6 +104,16 @@ trash_agent_group_writable (agent_group_t);
 
 void
 delete_agent_groups_by_scanner (scanner_t scanner);
+
+int
+init_agent_group_agents_iterator (iterator_t *iterator,
+                                  agent_group_t group_id);
+
+const char*
+agent_group_agent_iterator_uuid (iterator_t *iterator);
+
+const char*
+agent_group_agent_iterator_name (iterator_t *iterator);
 
 #endif // _GVMD_MANAGE_AGENT_GROUPS_H
 #endif // ENABLE_AGENTS

--- a/src/manage_agent_groups.h
+++ b/src/manage_agent_groups.h
@@ -78,6 +78,12 @@ init_agent_group_iterator (iterator_t *iterator, get_data_t *get);
 scanner_t
 agent_group_iterator_scanner (iterator_t *iterator);
 
+const char*
+agent_group_iterator_scanner_name (iterator_t *iterator);
+
+const char*
+agent_group_iterator_scanner_id (iterator_t *iterator);
+
 int
 copy_agent_group (const char *name,
                   const char *comment,
@@ -105,7 +111,7 @@ trash_agent_group_writable (agent_group_t);
 void
 delete_agent_groups_by_scanner (scanner_t scanner);
 
-int
+void
 init_agent_group_agents_iterator (iterator_t *iterator,
                                   agent_group_t group_id);
 

--- a/src/manage_agent_groups.h
+++ b/src/manage_agent_groups.h
@@ -1,0 +1,112 @@
+/* Copyright (C) 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file manage_agent_groups.h
+ * @brief Agent group management interface for GVMD.
+ *
+ * This header defines core data structures and function prototypes
+ * for managing agent groups within GVMD, including creation, modification,
+ * deletion, and membership listing. It also provides iterator-based access
+ * for frontend filtering and listing.
+ */
+
+#if ENABLE_AGENTS
+#ifndef _GVMD_MANAGE_AGENT_GROUPS_H
+#define _GVMD_MANAGE_AGENT_GROUPS_H
+
+#include "iterator.h"
+#include "manage.h"
+#include "manage_agent_common.h"
+
+typedef resource_t agent_group_t;
+
+/**
+ * @struct agent_group_data
+ * @brief Represents an agent group and its metadata.
+ */
+struct agent_group_data
+{
+  agent_group_t row_id;
+  gchar *uuid;
+  gchar *name;
+  gchar *comment;
+  user_t owner;
+  scanner_t scanner;
+  time_t creation_time;
+  time_t modification_time;
+};
+typedef struct agent_group_data *agent_group_data_t;
+
+typedef enum {
+    AGENT_GROUP_RESP_SUCCESS = 0,                       ///< Success
+    AGENT_GROUP_RESP_NO_AGENTS_PROVIDED = -1,           ///< No agent UUIDs provided
+    AGENT_GROUP_RESP_SCANNER_NOT_FOUND = -2,            ///< Scanner not found
+    AGENT_GROUP_RESP_SCANNER_PERMISSION = -3,           ///< Permission issue for getting Scanner
+    AGENT_GROUP_RESP_AGENT_SCANNER_MISMATCH = -4,       ///< Agent list count mismatch (not same scanner)
+    AGENT_GROUP_RESP_INVALID_ARGUMENT = -5,             ///< Failed invalid argument
+    AGENT_GROUP_RESP_AGENT_NOT_FOUND = -6,              ///< Failed getting agent id
+    AGENT_GROUP_RESP_INTERNAL_ERROR = -7                ///< Internal error
+  } agent_group_resp_t;
+
+agent_group_data_t
+agent_group_data_new ();
+
+void
+agent_group_data_free (agent_group_data_t data);
+
+agent_group_resp_t
+create_agent_group (agent_group_data_t group_data,
+                    agent_uuid_list_t agent_uuids);
+
+agent_group_resp_t
+modify_agent_group (agent_group_t agent_group,
+                    agent_group_data_t group_data,
+                    agent_uuid_list_t agent_uuids);
+
+int
+delete_agent_group (const gchar *agent_group_uuid, int ultimate);
+
+int
+agent_group_count (const get_data_t *get);
+
+int
+init_agent_group_iterator (iterator_t *iterator, get_data_t *get);
+
+gchar *
+agent_group_agents_string (agent_group_t group_id);
+
+scanner_t
+agent_group_iterator_scanner (iterator_t *iterator);
+
+int
+copy_agent_group (const char *name,
+                  const char *comment,
+                  const char *group_uuid,
+                  agent_group_t *new_group_return);
+
+char *
+agent_group_uuid (agent_group_t group_id);
+
+agent_group_t
+agent_group_id_by_uuid (const gchar *agent_group_uuid);
+
+int
+agent_group_in_use (agent_group_t);
+
+int
+trash_agent_group_in_use (agent_group_t);
+
+int
+agent_group_writable (agent_group_t);
+
+int
+trash_agent_group_writable (agent_group_t);
+
+void
+delete_agent_groups_by_scanner (scanner_t scanner);
+
+#endif // _GVMD_MANAGE_AGENT_GROUPS_H
+#endif // ENABLE_AGENTS

--- a/src/manage_agents.c
+++ b/src/manage_agents.c
@@ -476,45 +476,6 @@ agent_data_list_free (agent_data_list_t agents)
 }
 
 /**
- * @brief Allocate and initialize a new agent_uuid_list_t structure.
- *
- * @param[in] count Number of UUID entries to allocate.
- *
- * @return A newly allocated agent_uuid_list_t, or NULL on allocation failure.
- */
-agent_uuid_list_t
-agent_uuid_list_new (int count)
-{
-  if (count <= 0)
-    return NULL;
-
-  agent_uuid_list_t list = g_malloc0 (sizeof (struct agent_uuid_list));
-
-  list->count = count;
-  list->agent_uuids = g_malloc0 (sizeof (gchar *) * (count + 1));
-
-  return list;
-}
-
-/**
- * @brief Free an agent_uuid_list_t and its contents.
- *
- * @param[in] uuid_list List of agent UUIDs to free.
- */
-void
-agent_uuid_list_free (agent_uuid_list_t uuid_list)
-{
-  if (!uuid_list)
-    return;
-
-  for (int i = 0; i < uuid_list->count; ++i)
-    g_free (uuid_list->agent_uuids[i]);
-
-  g_free (uuid_list->agent_uuids);
-  g_free (uuid_list);
-}
-
-/**
  * @brief Synchronize agents from the agent controller to GVMD.
  *
  * Gets all agent information from the agent controller

--- a/src/manage_agents.h
+++ b/src/manage_agents.h
@@ -20,6 +20,7 @@
 
 #include "iterator.h"
 #include "manage.h"
+#include "manage_agent_common.h"
 
 typedef resource_t agent_t;
 
@@ -93,13 +94,6 @@ struct agent_data_list
 };
 typedef struct agent_data_list *agent_data_list_t;
 
-struct agent_uuid_list
-{
-  int count;
-  gchar **agent_uuids;
-};
-typedef struct agent_uuid_list *agent_uuid_list_t;
-
 typedef enum {
   AGENT_RESPONSE_SUCCESS = 0,                       ///< Success
   AGENT_RESPONSE_NO_AGENTS_PROVIDED = -1,           ///< No agent UUIDs provided
@@ -135,12 +129,6 @@ agent_ip_data_free (agent_ip_data_t ip_data);
 
 void
 agent_data_list_free (agent_data_list_t agents);
-
-agent_uuid_list_t
-agent_uuid_list_new (int count);
-
-void
-agent_uuid_list_free (agent_uuid_list_t uuid_list);
 
 agent_response_t
 sync_agents_from_agent_controller (gvmd_agent_connector_t connector);

--- a/src/manage_commands.c
+++ b/src/manage_commands.c
@@ -21,6 +21,9 @@
  */
 command_t gmp_commands[]
  = {{"AUTHENTICATE", "Authenticate with the manager." },
+#if ENABLE_AGENTS
+    {"CREATE_AGENT_GROUP", "Create an agent group."},
+#endif
     {"CREATE_ALERT", "Create an alert."},
     {"CREATE_ASSET", "Create an asset."},
     {"CREATE_CONFIG", "Create a config."},
@@ -45,6 +48,7 @@ command_t gmp_commands[]
     {"CREATE_TLS_CERTIFICATE", "Create a TLS certificate."},
     {"CREATE_USER", "Create a new user."},
 #if ENABLE_AGENTS
+    {"DELETE_AGENT_GROUP", "Delete an agent group."},
     {"DELETE_AGENTS", "Delete one or more agents."},
     {"DELETE_AGENT_INSTALLER", "Delete an agent installer."},
 #endif /* ENABLE_AGENTS */
@@ -74,6 +78,7 @@ command_t gmp_commands[]
     {"DESCRIBE_AUTH", "Get details about the used authentication methods."},
     {"EMPTY_TRASHCAN", "Empty the trashcan."},
 #if ENABLE_AGENTS
+    {"GET_AGENT_GROUPS", "Get all agent groups."},
     {"GET_AGENTS", "Get all agents."},
     {"GET_AGENT_INSTALLERS", "Get all agent installers."},
     {"GET_AGENT_INSTALLER_FILE", "Get an agent installer file."},
@@ -114,6 +119,7 @@ command_t gmp_commands[]
     {"GET_VULNS", "Get all vulnerabilities."},
     {"HELP", "Get this help text."},
 #if ENABLE_AGENTS
+    {"MODIFY_AGENT_GROUP", "Modify an agent group."},
     {"MODIFY_AGENTS", "Modify one or more existing agents."},
 #endif /* ENABLE_AGENTS */
     {"MODIFY_ALERT", "Modify an existing alert."},

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -2301,6 +2301,36 @@ create_tables ()
        "  version_start_excl text,"
        "  version_end_incl text,"
        "  version_end_excl text);");
+
+  sql ("CREATE TABLE IF NOT EXISTS agent_groups"
+     " (id SERIAL PRIMARY KEY,"
+     "  uuid TEXT NOT NULL UNIQUE,"
+     "  name TEXT NOT NULL,"
+     "  scanner INTEGER NOT NULL REFERENCES scanners (id) ON DELETE RESTRICT,"
+     "  owner INTEGER REFERENCES users (id) ON DELETE RESTRICT,"
+     "  comment TEXT,"
+     "  creation_time INTEGER,"
+     "  modification_time INTEGER);");
+
+  sql ("CREATE TABLE IF NOT EXISTS agent_group_agents"
+       " (group_id INTEGER NOT NULL REFERENCES agent_groups (id) ON DELETE CASCADE,"
+       "  agent_id INTEGER NOT NULL REFERENCES agents (id) ON DELETE CASCADE,"
+       "  PRIMARY KEY (group_id, agent_id));");
+
+  sql ("CREATE TABLE IF NOT EXISTS agent_groups_trash"
+       " (id SERIAL PRIMARY KEY,"
+       "  uuid text UNIQUE NOT NULL,"
+       "  owner integer REFERENCES users (id) ON DELETE RESTRICT,"
+       "  scanner INTEGER NOT NULL REFERENCES scanners (id) ON DELETE RESTRICT,"
+       "  name text NOT NULL,"
+       "  comment text,"
+       "  creation_time integer,"
+       "  modification_time integer);");
+
+  sql ("CREATE TABLE IF NOT EXISTS agent_group_agents_trash"
+       " (id SERIAL PRIMARY KEY,"
+       "  agent_group integer REFERENCES agent_groups_trash (id) ON DELETE RESTRICT,"
+       "  agent integer REFERENCES agents (id) ON DELETE RESTRICT);");
 #endif /* ENABLE_AGENTS */
 
   sql ("CREATE TABLE IF NOT EXISTS alerts"

--- a/src/manage_resources.c
+++ b/src/manage_resources.c
@@ -29,8 +29,8 @@ valid_type (const char* type)
 
 #if ENABLE_AGENTS
   if (strcasecmp (type, "agent") == 0
-      || strcasecmp (type, "agent_installer") == 0
-      || strcasecmp (type, "agent_group") == 0)
+      || strcasecmp (type, "agent_group") == 0
+      || strcasecmp (type, "agent_installer") == 0)
     return 1;
 #endif
 
@@ -97,10 +97,10 @@ type_db_name (const char* type)
 #if ENABLE_AGENTS
   if (strcasecmp (type, "Agent") == 0)
     return "agent";
-  if (strcasecmp (type, "Agent Installer") == 0)
-    return "agent_installer";
   if (strcasecmp (type, "Agent Group") == 0)
     return "agent_group";
+  if (strcasecmp (type, "Agent Installer") == 0)
+    return "agent_installer";
 #endif
 
   if (strcasecmp (type, "Alert") == 0)

--- a/src/manage_resources.c
+++ b/src/manage_resources.c
@@ -29,7 +29,8 @@ valid_type (const char* type)
 
 #if ENABLE_AGENTS
   if (strcasecmp (type, "agent") == 0
-      || strcasecmp (type, "agent_installer") == 0) 
+      || strcasecmp (type, "agent_installer") == 0
+      || strcasecmp (type, "agent_group") == 0)
     return 1;
 #endif
 
@@ -98,6 +99,8 @@ type_db_name (const char* type)
     return "agent";
   if (strcasecmp (type, "Agent Installer") == 0)
     return "agent_installer";
+  if (strcasecmp (type, "Agent Group") == 0)
+    return "agent_group";
 #endif
 
   if (strcasecmp (type, "Alert") == 0)

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -95,6 +95,7 @@
 #include <gvm/util/ldaputils.h>
 #include <gvm/gmp/gmp.h>
 #include "manage_report_configs.h"
+#include "manage_sql_agent_groups.h"
 
 #undef G_LOG_DOMAIN
 /**
@@ -32501,6 +32502,9 @@ delete_scanner (const char *scanner_id, int ultimate)
     }
 
 #if ENABLE_AGENTS
+  // Delete agent groups related to the scanner.
+  delete_agent_groups_by_scanner (scanner);
+  // Delete agents related to the scanner.
   delete_agents_by_scanner_and_uuids (scanner, NULL);
 #endif // ENABLE_AGENTS
 
@@ -39265,6 +39269,13 @@ manage_restore (const char *id)
       return 99;
     }
 
+#if ENABLE_AGENTS
+  /* Agent Group. */
+  ret = restore_agent_group (id);
+  if (ret != 2)
+    return ret;
+#endif
+
   /* Port List. */
   ret = restore_port_list (id);
   if (ret != 2)
@@ -40286,6 +40297,9 @@ manage_empty_trashcan ()
       sql_rollback ();
       return 99;
     }
+#if ENABLE_AGENTS
+  empty_trashcan_agent_groups ();
+#endif
 
   sql ("DELETE FROM nvt_selectors"
        " WHERE name != '" MANAGE_NVT_SELECTOR_UUID_ALL "'"
@@ -43615,7 +43629,9 @@ modify_setting (const gchar *uuid, const gchar *name,
   if (uuid)
     {
       /* Filters */
-      if (strcmp (uuid, "c544a310-dc13-49c6-858e-f3160d75e221") == 0)
+      if (strcmp (uuid, "391fc4f4-9f6c-4f0e-a689-37dd7d70d144") == 0)
+        setting_name = g_strdup ("Agent Groups Filter");
+      else if (strcmp (uuid, "c544a310-dc13-49c6-858e-f3160d75e221") == 0)
         setting_name = g_strdup ("Agents Filter");
       else if (strcmp (uuid, "a39a719a-e6bc-4d9f-a1e6-a53e5b014b05") == 0)
         setting_name = g_strdup ("Agent Installers Filter");

--- a/src/manage_sql_agent_groups.c
+++ b/src/manage_sql_agent_groups.c
@@ -1,0 +1,639 @@
+/* Copyright (C) 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file manage_sql_agent_groups.c
+ * @brief SQL backend implementation for agent group management in GVMD.
+ *
+ * This file provides the implementation of SQL interactions related to
+ * agent group data, including creation, update, deletion, and assignment of agents
+ * to groups. It supports both regular SQL operations and trash handling.
+ */
+
+#if ENABLE_AGENTS
+
+#include "manage_acl.h"
+#include "manage_sql_agent_groups.h"
+#include "manage_sql_agents.h"
+#include "manage_sql_copy.h"
+
+#include <util/uuidutils.h>
+
+#undef G_LOG_DOMAIN
+#define G_LOG_DOMAIN "md manage"
+
+/**
+ * @brief Retrieve the scanner ID for a given agent group.
+ *
+ * @param[in]  agent_group_id  Row ID of the agent group.
+ * @param[out] scanner         Pointer to store the resulting scanner ID.
+ *
+ * @return 0 on success, -1 on failure.
+ */
+static int
+get_scanner_by_agent_group_id (agent_group_t agent_group_id, scanner_t *scanner)
+{
+  g_return_val_if_fail (scanner, -1);
+
+  if (sql_int64 (scanner,
+                 "SELECT scanner FROM agent_groups WHERE id = %llu;",
+                 agent_group_id) != 0)
+    return -1;
+
+  return 0;
+}
+
+/**
+ * @brief Maps result of get_scanner_from_agent_uuid to agent_group_resp_t.
+ *
+ * @param[in] result The integer result returned by get_scanner_from_agent_uuid.
+ *
+ * @return The corresponding agent_group_resp_t value.
+ */
+static agent_group_resp_t
+map_get_scanner_result_to_agent_group_resp (int result)
+{
+  switch (result)
+  {
+    case 0:
+      return AGENT_GROUP_RESP_SUCCESS;
+
+    case -1:
+    case -4:
+      return AGENT_GROUP_RESP_INVALID_ARGUMENT;
+
+    case -2:
+      return AGENT_GROUP_RESP_INTERNAL_ERROR;
+
+    case -3:
+      return AGENT_GROUP_RESP_AGENT_NOT_FOUND;
+
+    default:
+      return AGENT_GROUP_RESP_INTERNAL_ERROR;
+  }
+}
+
+
+/**
+ * @brief Count the number of agent groups based on filter criteria.
+ *
+ * @param[in] get  Pointer to the get_data_t structure containing filters and options.
+ *
+ * @return The number of matching agent groups.
+ */
+int
+agent_group_count (const get_data_t *get)
+{
+  static const char *extra_columns[] = AGENT_GROUP_ITERATOR_FILTER_COLUMNS;
+  static column_t columns[] = AGENT_GROUP_ITERATOR_COLUMNS;
+  static column_t trash_columns[] = AGENT_GROUP_ITERATOR_TRASH_COLUMNS;
+
+  return count ("agent_group", get, columns, trash_columns, extra_columns, 0, 0, 0, TRUE);
+}
+
+/**
+ * @brief Initialize an iterator for retrieving agent groups.
+ *
+ * @param[in,out] iterator  Pointer to the iterator to initialize.
+ * @param[in]     get       Pointer to the get_data_t structure containing filters and options.
+ *
+ * @return 0 on success, non-zero on failure.
+ */
+int
+init_agent_group_iterator (iterator_t *iterator, get_data_t *get)
+{
+  static const char *filter_columns[] = AGENT_GROUP_ITERATOR_FILTER_COLUMNS;
+  static column_t columns[] = AGENT_GROUP_ITERATOR_COLUMNS;
+  static column_t trash_columns[] = AGENT_GROUP_ITERATOR_TRASH_COLUMNS;
+
+  return init_get_iterator (iterator, "agent_group", get, columns, trash_columns, filter_columns, 0, NULL, NULL, TRUE);
+}
+
+/**
+ * @brief Create a new agent group with associated agents.
+ *
+ * Generates a UUID for the group, validates the scanner UUID, inserts the group into the DB,
+ * and associates the specified agents with the group (validating scanner ownership).
+ *
+ * @param[in,out] group_data     Pointer to the agent group data. `uuid` will be set if not provided.
+ * @param[in]     agent_uuids    List of agent UUIDs to assign to the group.
+ *
+ * @return Response code indicating result:
+ *         - AGENT_GROUP_RESP_SUCCESS on success
+ *         - Error code (e.g., AGENT_GROUP_RESP_SCANNER_NOT_FOUND) on failure
+ */
+agent_group_resp_t
+create_agent_group (agent_group_data_t group_data,
+                    agent_uuid_list_t agent_uuids)
+{
+  assert (current_credentials.uuid);
+
+  if (!agent_uuids || agent_uuids->count == 0)
+    return AGENT_GROUP_RESP_NO_AGENTS_PROVIDED;
+
+  // GET scanner ID from the first agent
+  scanner_t scanner = 0;
+  int ret = get_scanner_from_agent_uuid (agent_uuids->agent_uuids[0], &scanner);
+  agent_group_resp_t map_response = map_get_scanner_result_to_agent_group_resp (ret);
+  if (map_response != AGENT_GROUP_RESP_SUCCESS)
+    return map_response;
+
+  //Set scanner to agent_group
+  group_data->scanner = scanner;
+
+  // Ensure UUID is generated
+  if (!group_data->uuid)
+    {
+      group_data->uuid = gvm_uuid_make ();
+      if (!group_data->uuid)
+        return AGENT_GROUP_RESP_INTERNAL_ERROR;
+    }
+
+  gchar *quoted_uuid = sql_quote (group_data->uuid);
+  gchar *quoted_name = sql_quote (group_data->name);
+  gchar *quoted_comment = sql_quote (group_data->comment);
+  gchar *quoted_user_uuid = sql_quote (current_credentials.uuid);
+
+  sql_begin_immediate ();
+
+  // Insert into agent_groups (scanner added)
+  sql ("INSERT INTO agent_groups (uuid, name, comment, scanner, owner, creation_time, modification_time) "
+       "VALUES ('%s', '%s', '%s', %llu, "
+       "  (SELECT id FROM users WHERE uuid = '%s'),"
+       "  %ld, %ld);",
+       quoted_uuid,
+       quoted_name,
+       quoted_comment,
+       group_data->scanner,
+       quoted_user_uuid,
+       group_data->creation_time,
+       group_data->modification_time);
+
+  g_free (quoted_uuid);
+  g_free (quoted_name);
+  g_free (quoted_comment);
+  g_free (quoted_user_uuid);
+
+  agent_group_t new_agent_group = sql_last_insert_id ();
+  if (new_agent_group == 0)
+    {
+      sql_rollback ();
+      return AGENT_GROUP_RESP_INTERNAL_ERROR;
+    }
+
+  // Prepare COPY buffer
+  db_copy_buffer_t buffer;
+  db_copy_buffer_init (&buffer, 16 * 1024,
+                       "COPY agent_group_agents (group_id, agent_id) FROM STDIN;");
+
+  for (int i = 0; i < agent_uuids->count; ++i)
+    {
+      const gchar *uuid = agent_uuids->agent_uuids[i];
+      agent_t agent_id = agent_id_by_uuid_and_scanner (uuid, group_data->scanner);
+
+      if (agent_id == 0)
+        {
+          db_copy_buffer_cleanup (&buffer);
+          sql_rollback ();
+          return AGENT_GROUP_RESP_AGENT_SCANNER_MISMATCH;
+        }
+
+      db_copy_buffer_append_printf (&buffer, "%llu\t%llu\n", new_agent_group, agent_id);
+    }
+
+  db_copy_buffer_commit (&buffer, TRUE);
+  db_copy_buffer_cleanup (&buffer);
+
+  sql_commit ();
+
+  return AGENT_GROUP_RESP_SUCCESS;
+}
+
+/**
+ * @brief Modify an existing agent group (metadata and associated agents).
+ *
+ * @param agent_group ID of the group to modify.
+ * @param group_data New metadata for the group.
+ * @param agent_uuids New list of agent UUIDs to associate.
+ *
+ * @return Response code indicating result:
+ *         - AGENT_GROUP_RESP_SUCCESS on success
+ *         - Error code (e.g., AGENT_GROUP_RESP_AGENT_NOT_FOUND) on failure
+ */
+agent_group_resp_t
+modify_agent_group (agent_group_t agent_group,
+                    agent_group_data_t group_data,
+                    agent_uuid_list_t agent_uuids)
+{
+  gchar *quoted_name = sql_quote (group_data->name);
+  gchar *quoted_comment = sql_quote (group_data->comment);
+
+  sql_begin_immediate ();
+
+  sql ("UPDATE agent_groups SET name = '%s', comment = '%s', "
+       "modification_time = %ld WHERE id = %llu;",
+       quoted_name,
+       quoted_comment,
+       group_data->modification_time,
+       agent_group);
+
+  g_free (quoted_name);
+  g_free (quoted_comment);
+
+  if (!agent_uuids || agent_uuids->count == 0)
+    {
+      sql_commit ();
+      return AGENT_GROUP_RESP_SUCCESS;
+    }
+
+  // Clean up old agents from db
+  sql ("DELETE FROM agent_group_agents WHERE group_id = %llu;", agent_group);
+
+  db_copy_buffer_t buffer;
+  db_copy_buffer_init (&buffer, 16 * 1024,
+                       "COPY agent_group_agents (group_id, agent_id) FROM STDIN;");
+
+  scanner_t scanner = 0;
+  int ret = get_scanner_by_agent_group_id (agent_group, &scanner);
+  if (ret == -1)
+    {
+      db_copy_buffer_cleanup (&buffer);
+      sql_rollback ();
+      return AGENT_GROUP_RESP_SCANNER_NOT_FOUND;
+    }
+  group_data->scanner = scanner;
+
+  for (int i = 0; i < agent_uuids->count; ++i)
+    {
+    const gchar *uuid = agent_uuids->agent_uuids[i];
+    agent_t agent_id = agent_id_by_uuid_and_scanner (uuid, group_data->scanner);
+    if (agent_id == 0)
+    {
+      db_copy_buffer_cleanup (&buffer);
+      sql_rollback ();
+      return AGENT_GROUP_RESP_AGENT_SCANNER_MISMATCH;
+    }
+
+     db_copy_buffer_append_printf (&buffer, "%llu\t%llu\n", agent_group, agent_id);
+    }
+
+  db_copy_buffer_commit (&buffer, TRUE);
+  db_copy_buffer_cleanup (&buffer);
+
+  sql_commit ();
+
+  return AGENT_GROUP_RESP_SUCCESS;
+}
+
+/**
+ * @brief Delete an agent group, either softly (move to trash) or permanently.
+ *
+ * @param[in] agent_group_uuid  UUID of the agent group to delete.
+ * @param[in] ultimate          If 0, perform a soft delete (move to trash);
+ *                              if non-zero, perform a hard delete.
+ *
+ * @return 0 on success, 1 if already exists, 2 if not found, 99 permission denied, -1 on error.
+ */
+int
+delete_agent_group (const char *agent_group_uuid, int ultimate)
+{
+  agent_group_t agent_group = 0;
+
+  sql_begin_immediate ();
+
+  if (acl_user_may ("delete_agent_group") == 0)
+    {
+      sql_rollback ();
+      return 99;
+    }
+
+  // Try to find in active agent_groups
+  if (find_resource_with_permission ("agent_group", agent_group_uuid,
+                                     &agent_group, "delete_agent_group", 0))
+    {
+      sql_rollback ();
+      return -1;
+    }
+
+  if (agent_group == 0)
+    {
+      // Try to find in trash
+      if (find_trash ("agent_group", agent_group_uuid, &agent_group))
+        {
+          sql_rollback ();
+          return -1;
+        }
+
+      if (agent_group == 0)
+        {
+          sql_rollback ();
+          return 2;
+        }
+
+      if (ultimate == 0)
+        {
+          sql_commit ();
+          return 0;  // Already in trash
+        }
+
+      // Hard delete from trash
+      sql ("DELETE FROM permissions"
+           " WHERE resource_type = 'agent_group'"
+           " AND resource_location = %i"
+           " AND resource = %llu;",
+           LOCATION_TRASH,
+           agent_group);
+
+      tags_remove_resource ("agent_group", agent_group, LOCATION_TRASH);
+
+      sql ("DELETE FROM agent_group_agents_trash WHERE agent_group = %llu;", agent_group);
+      sql ("DELETE FROM agent_groups_trash WHERE id = %llu;", agent_group);
+
+      sql_commit ();
+      return 0;
+    }
+
+  if (ultimate == 0)
+    {
+      agent_group_t trash_id;
+
+      // Move to trash
+      sql ("INSERT INTO agent_groups_trash"
+           " (uuid, name, comment, owner, scanner, creation_time, modification_time)"
+           " SELECT uuid, name, comment, owner, scanner, creation_time, modification_time"
+           " FROM agent_groups WHERE id = %llu;",
+           agent_group);
+
+      trash_id = sql_last_insert_id ();
+
+      sql ("INSERT INTO agent_group_agents_trash"
+           " (agent_group, agent)"
+           " SELECT %llu, agent_id FROM agent_group_agents WHERE group_id = %llu;",
+           trash_id, agent_group);
+
+      permissions_set_locations ("agent_group", agent_group, trash_id, LOCATION_TRASH);
+      tags_set_locations ("agent_group", agent_group, trash_id, LOCATION_TRASH);
+    }
+  else
+    {
+      // Hard delete
+      sql ("DELETE FROM permissions"
+           " WHERE resource_type = 'agent_group'"
+           " AND resource_location = %i"
+           " AND resource = %llu;",
+           LOCATION_TABLE,
+           agent_group);
+
+      tags_remove_resource ("agent_group", agent_group, LOCATION_TABLE);
+    }
+
+  // Clean up active entries
+  sql ("DELETE FROM agent_group_agents WHERE group_id = %llu;", agent_group);
+  sql ("DELETE FROM agent_groups WHERE id = %llu;", agent_group);
+
+  sql_commit ();
+  return 0;
+}
+
+/**
+ * @brief Restore an agent group from trash.
+ *
+ * If successful, commits the transaction before returning.
+ *
+ * @param[in]  agent_group_uuid  UUID of the trashed agent group.
+ *
+ * @return 0 success, 2 not found, -1 error.
+ */
+int
+restore_agent_group (const char *agent_group_uuid)
+{
+  agent_group_t trash_id, restored_id;
+
+  sql_begin_immediate ();
+
+  if (find_trash ("agent_group", agent_group_uuid, &trash_id))
+  {
+    sql_rollback ();
+    return -1;
+  }
+
+  if (trash_id == 0)
+  {
+    sql_rollback ();
+    return 2;
+  }
+
+  // Restore agent group metadata
+  sql ("INSERT INTO agent_groups"
+       " (uuid, name, comment, owner, scanner, creation_time, modification_time)"
+       " SELECT uuid, name, comment, owner, scanner, creation_time, modification_time"
+       " FROM agent_groups_trash WHERE id = %llu;",
+       trash_id);
+
+  restored_id = sql_last_insert_id ();
+
+  // Restore agents associated with the group
+  sql ("INSERT INTO agent_group_agents"
+       " (group_id, agent_id)"
+       " SELECT %llu, agent"
+       " FROM agent_group_agents_trash"
+       " WHERE agent_group = %llu;",
+       restored_id, trash_id);
+
+  // Restore permissions and tags
+  permissions_set_locations ("agent_group", trash_id, restored_id, LOCATION_TABLE);
+  tags_set_locations ("agent_group", trash_id, restored_id, LOCATION_TABLE);
+
+  // Clean up trash entries
+  sql ("DELETE FROM agent_group_agents_trash WHERE agent_group = %llu;", trash_id);
+  sql ("DELETE FROM agent_groups_trash WHERE id = %llu;", trash_id);
+
+  sql_commit ();
+  return 0;
+}
+
+/**
+ * @brief Empty agent group trashcans for current user.
+ */
+void
+empty_trashcan_agent_groups ()
+{
+  sql ("DELETE FROM permissions"
+       " WHERE resource_type = 'agent_group'"
+       " AND resource_location = %i"
+       " AND resource IN (SELECT id FROM agent_groups_trash"
+       "                  WHERE owner = (SELECT id FROM users"
+       "                                 WHERE uuid = '%s'));",
+       LOCATION_TRASH,
+       current_credentials.uuid);
+
+  sql ("DELETE FROM agent_group_agents_trash"
+       " WHERE agent_group IN (SELECT id FROM agent_groups_trash"
+       "                       WHERE owner = (SELECT id FROM users"
+       "                                      WHERE uuid = '%s'));",
+       current_credentials.uuid);
+
+  sql ("DELETE FROM agent_groups_trash"
+       " WHERE owner = (SELECT id FROM users WHERE uuid = '%s');",
+       current_credentials.uuid);
+}
+
+/**
+ * @brief Gets agent names of a group as a comma-separated string.
+ *
+ * @param[in] group_id The agent group ID.
+ *
+ * @return Comma-separated agent names (e.g., "name1, name2, name3"),
+ *         or NULL if none found.
+ */
+gchar *
+agent_group_agents_string (agent_group_t group_id)
+{
+  return sql_string (
+    "SELECT group_concat(name, ', ') "
+    "FROM (SELECT agents.name "
+    "      FROM agents, agent_group_agents "
+    "      WHERE agent_group_agents.group_id = %llu "
+    "      AND agent_group_agents.agent_id = agents.id "
+    "      GROUP BY agents.name) AS sub;",
+    group_id);
+}
+
+/**
+ * @brief Retrieve scanner ID of current agent group.
+ *
+ * @param[in] iterator  Iterator pointing to the current agent group entry.
+ *
+ * @return The scanner ID associated with the current agent group.
+ */
+scanner_t
+agent_group_iterator_scanner (iterator_t *iterator)
+{
+  return iterator_int (iterator, GET_ITERATOR_COLUMN_COUNT);
+}
+
+
+/**
+ * @brief Copy an agent group including its agent assignments.
+ *
+ * @param[in]  comment         Optional new comment.
+ * @param[in]  group_uuid      UUID of the agent group to copy.
+ * @param[out] new_group_return    Output: ID of the newly created agent group.
+ *
+ * @return 0 on success, 1 if already exists, 2 if not found, 99 permission denied, -1 on error.
+ */
+int
+copy_agent_group (const char *name,
+                  const char *comment,
+                  const char *group_uuid,
+                  agent_group_t *new_group_return)
+{
+  int ret;
+  agent_group_t new_group, old_group;
+
+  g_return_val_if_fail (group_uuid, -1);
+
+  sql_begin_immediate ();
+
+  // Copy core resource fields into new row
+  ret = copy_resource_lock ("agent_group", name, comment, group_uuid, "scanner", 1, &new_group,
+                            &old_group);
+  if (ret)
+  {
+    sql_rollback ();
+    return ret;  // 1=already exists, 2=not found, 99=perm denied, -1=error
+  }
+
+  // Copy agent mappings
+  sql ("INSERT INTO agent_group_agents (group_id, agent_id) "
+             "SELECT %llu, agent_id FROM agent_group_agents "
+             "WHERE group_id = %llu;",
+             new_group, old_group);
+
+  sql_commit ();
+
+  if (new_group_return)
+    *new_group_return = new_group;
+
+  return 0;
+}
+
+/**
+ * @brief Return the UUID of an agent group.
+ *
+ * @param[in]  group_id  Agent group ID.
+ *
+ * @return Newly allocated UUID string if found, else NULL.
+ */
+char *
+agent_group_uuid (agent_group_t group_id)
+{
+  g_return_val_if_fail (group_id, NULL);
+  return sql_string ("SELECT uuid FROM agent_groups WHERE id = %llu;", group_id);
+}
+
+/**
+ * @brief Return the row_id of an agent group.
+ *
+ * @param[in]  group_uuid  Agent group UUID.
+ *
+ * @return Allocated row_id if found, else 0.
+ */
+agent_group_t
+agent_group_id_by_uuid (const gchar *group_uuid)
+{
+  g_return_val_if_fail (group_uuid != NULL, 0);
+  return sql_int64_0 ("SELECT id FROM agent_groups WHERE uuid = '%s';", group_uuid);
+}
+
+/**
+ * @brief Delete agent groups by scanner ID.
+ *
+ * Deletes all agent groups, their agent mappings, and corresponding
+ * trash entries that are associated with the given scanner.
+ * It is called before scanner(Agent Controller) deletion.
+ *
+ * @param[in] scanner  Scanner row_id
+ */
+void
+delete_agent_groups_by_scanner (scanner_t scanner)
+{
+  if (!scanner)
+    return;
+
+  // Build common WHERE clause
+  GString *where_clause = g_string_new (NULL);
+  g_string_append_printf (where_clause, "WHERE scanner = %llu", scanner);
+
+  sql_begin_immediate ();
+
+  // Delete agent_group_agents entries for groups associated with the scanner
+  sql (
+    "DELETE FROM agent_group_agents "
+    "WHERE group_id IN (SELECT id FROM agent_groups %s);",
+    where_clause->str);
+
+  // Delete agent_groups entries
+  sql (
+    "DELETE FROM agent_groups %s;",
+    where_clause->str);
+
+  // Delete agent_group_agents_trash entries for trashed groups with the scanner
+  sql (
+    "DELETE FROM agent_group_agents_trash "
+    "WHERE agent_group IN (SELECT id FROM agent_groups_trash %s);",
+    where_clause->str);
+
+  // Delete agent_groups_trash entries
+  sql (
+    "DELETE FROM agent_groups_trash %s;",
+    where_clause->str);
+
+  sql_commit ();
+
+  g_string_free (where_clause, TRUE);
+}
+
+#endif // ENABLE_AGENTS

--- a/src/manage_sql_agent_groups.h
+++ b/src/manage_sql_agent_groups.h
@@ -1,0 +1,50 @@
+/* Copyright (C) 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file manage_sql_agent_groups.h
+ * @brief SQL management functions and iterator definitions for agent groups.
+ *
+ * This header provides iterator macros and function declarations used
+ * for managing agent groups in the SQL layer of GVMD, including support
+ * for trashcan handling and restoration.
+ */
+
+#if ENABLE_AGENTS
+#ifndef _GVMD_MANAGE_SQL_AGENT_GROUPS_H
+#define _GVMD_MANAGE_SQL_AGENT_GROUPS_H
+
+
+#include "manage_agent_groups.h"
+#include "manage_sql.h"
+
+#define AGENT_GROUP_ITERATOR_FILTER_COLUMNS \
+{                                           \
+  GET_ITERATOR_FILTER_COLUMNS,              \
+  "scanner",                                \
+  NULL                                      \
+}
+
+#define AGENT_GROUP_ITERATOR_COLUMNS                  \
+{                                                     \
+  GET_ITERATOR_COLUMNS (agent_groups),                \
+  { "scanner", NULL, KEYWORD_TYPE_INTEGER },          \
+  { NULL,      NULL, KEYWORD_TYPE_UNKNOWN }           \
+}
+
+#define AGENT_GROUP_ITERATOR_TRASH_COLUMNS             \
+{                                                      \
+  GET_ITERATOR_COLUMNS (agent_groups_trash),           \
+  { NULL,      NULL, KEYWORD_TYPE_UNKNOWN }            \
+}
+
+int
+restore_agent_group (const char *agent_group_uuid);
+
+void
+empty_trashcan_agent_groups (void);
+
+#endif // _GVMD_MANAGE_SQL_AGENT_GROUPS_H
+#endif // ENABLE_AGENTS

--- a/src/manage_sql_agent_groups.h
+++ b/src/manage_sql_agent_groups.h
@@ -40,6 +40,18 @@
   { NULL,      NULL, KEYWORD_TYPE_UNKNOWN }            \
 }
 
+#define AGENT_GROUP_AGENT_ITERATOR_COLUMNS                \
+{                                                         \
+  { "agents.uuid", NULL, KEYWORD_TYPE_STRING },           \
+  { "agents.name", NULL, KEYWORD_TYPE_STRING },           \
+  { NULL,          NULL, KEYWORD_TYPE_UNKNOWN }           \
+}
+
+#define AGENT_GROUP_AGENT_ITERATOR_FILTER_COLUMNS \
+{                                                 \
+  NULL                                            \
+}
+
 int
 restore_agent_group (const char *agent_group_uuid);
 

--- a/src/manage_sql_agent_groups.h
+++ b/src/manage_sql_agent_groups.h
@@ -23,33 +23,27 @@
 #define AGENT_GROUP_ITERATOR_FILTER_COLUMNS \
 {                                           \
   GET_ITERATOR_FILTER_COLUMNS,              \
-  "scanner",                                \
+  "scanner_name",                           \
+  "scanner_id",                             \
   NULL                                      \
 }
 
-#define AGENT_GROUP_ITERATOR_COLUMNS                  \
-{                                                     \
-  GET_ITERATOR_COLUMNS (agent_groups),                \
-  { "scanner", NULL, KEYWORD_TYPE_INTEGER },          \
-  { NULL,      NULL, KEYWORD_TYPE_UNKNOWN }           \
+#define AGENT_GROUP_ITERATOR_COLUMNS                          \
+{                                                             \
+  GET_ITERATOR_COLUMNS (agent_groups),                        \
+  { "scanner", NULL, KEYWORD_TYPE_INTEGER },                  \
+  { "scanner_name", "scanner_name", KEYWORD_TYPE_STRING },   \
+  { "scanner_uuid", "scanner_id", KEYWORD_TYPE_STRING },     \
+  { NULL,      NULL, KEYWORD_TYPE_UNKNOWN }                   \
 }
 
-#define AGENT_GROUP_ITERATOR_TRASH_COLUMNS             \
-{                                                      \
-  GET_ITERATOR_COLUMNS (agent_groups_trash),           \
-  { NULL,      NULL, KEYWORD_TYPE_UNKNOWN }            \
-}
-
-#define AGENT_GROUP_AGENT_ITERATOR_COLUMNS                \
-{                                                         \
-  { "agents.uuid", NULL, KEYWORD_TYPE_STRING },           \
-  { "agents.name", NULL, KEYWORD_TYPE_STRING },           \
-  { NULL,          NULL, KEYWORD_TYPE_UNKNOWN }           \
-}
-
-#define AGENT_GROUP_AGENT_ITERATOR_FILTER_COLUMNS \
-{                                                 \
-  NULL                                            \
+#define AGENT_GROUP_ITERATOR_TRASH_COLUMNS                    \
+{                                                             \
+  GET_ITERATOR_COLUMNS (agent_groups_trash),                  \
+  { "scanner", NULL, KEYWORD_TYPE_INTEGER },                  \
+  { "scanner_name", "scanner_name", KEYWORD_TYPE_STRING },   \
+  { "scanner_uuid", "scanner_id", KEYWORD_TYPE_STRING },     \
+  { NULL,      NULL, KEYWORD_TYPE_UNKNOWN }                   \
 }
 
 int

--- a/src/manage_sql_agents.c
+++ b/src/manage_sql_agents.c
@@ -667,4 +667,23 @@ update_agents_comment (agent_uuid_list_t agent_uuids, const gchar *new_comment)
   g_string_free (uuid_list, TRUE);
 }
 
+/**
+ * @brief Retrieve the internal row ID of an agent by its UUID and scanner ID.
+ *
+ * @param[in]  agent_uuid   The UUID of the agent.
+ * @param[in]  scanner_id   The scanner row ID.
+ *
+ * @return The row ID of the agent if found and associated with the scanner,
+ *         otherwise returns 0.
+ */
+agent_t
+agent_id_by_uuid_and_scanner (const gchar *agent_uuid, scanner_t scanner_id)
+{
+  g_return_val_if_fail (agent_uuid != NULL, 0);
+
+  return sql_int64_0 (
+    "SELECT id FROM agents WHERE uuid = '%s' AND scanner = %llu;",
+    agent_uuid, scanner_id);
+}
+
 #endif // ENABLE_AGENTS

--- a/src/manage_sql_agents.c
+++ b/src/manage_sql_agents.c
@@ -671,19 +671,41 @@ update_agents_comment (agent_uuid_list_t agent_uuids, const gchar *new_comment)
  * @brief Retrieve the internal row ID of an agent by its UUID and scanner ID.
  *
  * @param[in]  agent_uuid   The UUID of the agent.
- * @param[in]  scanner_id   The scanner row ID.
+ * @param[in]  scanner_id   The expected scanner row ID.
+ * @param[out] agent_id_out Pointer to store the resolved agent ID.
  *
- * @return The row ID of the agent if found and associated with the scanner,
- *         otherwise returns 0.
+ * @return 0 if success,
+ *         1 if agent not found,
+ *         2 if scanner mismatch.
  */
-agent_t
-agent_id_by_uuid_and_scanner (const gchar *agent_uuid, scanner_t scanner_id)
+int
+agent_id_by_uuid_and_scanner (const gchar *agent_uuid,
+                              scanner_t scanner_id,
+                              agent_t *agent_id_out)
 {
-  g_return_val_if_fail (agent_uuid != NULL, 0);
+  g_return_val_if_fail (agent_uuid != NULL, 1);
+  g_return_val_if_fail (agent_id_out != NULL, 1);
 
-  return sql_int64_0 (
+  // Get the agent ID with matching scanner
+  agent_t agent_id = sql_int64_0 (
     "SELECT id FROM agents WHERE uuid = '%s' AND scanner = %llu;",
     agent_uuid, scanner_id);
+
+  if (agent_id != 0)
+  {
+    *agent_id_out = agent_id;
+    return 0;  // success
+  }
+
+  // Check if agent exists but scanner doesn't match
+  agent_id = sql_int64_0 (
+    "SELECT id FROM agents WHERE uuid = '%s';",
+    agent_uuid);
+
+  if (agent_id != 0)
+    return 2;  // scanner mismatch
+
+  return 1;  // agent not found
 }
 
 #endif // ENABLE_AGENTS

--- a/src/manage_sql_agents.h
+++ b/src/manage_sql_agents.h
@@ -71,5 +71,8 @@ update_agents_comment (agent_uuid_list_t agent_uuids, const gchar *new_comment);
 int
 get_scanner_from_agent_uuid(const gchar *agent_uuid, scanner_t *scanner);
 
+agent_t
+agent_id_by_uuid_and_scanner (const gchar *agent_uuid, scanner_t scanner_id);
+
 #endif //_GVMD_MANAGE_SQL_AGENTS_H
 #endif // ENABLE_AGENTS

--- a/src/manage_sql_agents.h
+++ b/src/manage_sql_agents.h
@@ -71,8 +71,8 @@ update_agents_comment (agent_uuid_list_t agent_uuids, const gchar *new_comment);
 int
 get_scanner_from_agent_uuid(const gchar *agent_uuid, scanner_t *scanner);
 
-agent_t
-agent_id_by_uuid_and_scanner (const gchar *agent_uuid, scanner_t scanner_id);
+int
+agent_id_by_uuid_and_scanner (const gchar *agent_uuid, scanner_t scanner_id, agent_t *agent_id);
 
 #endif //_GVMD_MANAGE_SQL_AGENTS_H
 #endif // ENABLE_AGENTS

--- a/src/manage_utils.c
+++ b/src/manage_utils.c
@@ -306,6 +306,10 @@ valid_db_resource_type (const char* type)
 {
   if (type == NULL)
     return 0;
+#if ENABLE_AGENTS
+  if(strcasecmp (type, "agent_group") == 0)
+    return 1;
+#endif
 
 #ifdef ENABLE_AGENTS
   if ((strcasecmp (type, "agent") == 0)

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -6964,6 +6964,59 @@ END:VCALENDAR
     </example>
   </command>
   <command>
+    <name>delete_agent_installer</name>
+    <summary>Delete an agent installer</summary>
+    <description>
+      <p>
+        The client uses the delete_agent_installer command to delete an existing
+        agent installer.
+      </p>
+      <p>
+        Since this is a destructive command, the client is advised to ask
+        for confirmation from the user before sending this command to the
+        Manager.
+      </p>
+    </description>
+    <pattern>
+      <attrib>
+        <name>agent_installer_id</name>
+        <type>uuid</type>
+        <required>1</required>
+      </attrib>
+      <attrib>
+        <name>ultimate</name>
+        <summary>Whether to remove entirely, or to the trashcan</summary>
+        <type>boolean</type>
+        <required>1</required>
+      </attrib>
+    </pattern>
+    <response>
+      <pattern>
+        <attrib>
+          <name>status</name>
+          <type>status</type>
+          <required>1</required>
+        </attrib>
+        <attrib>
+          <name>status_text</name>
+          <type>text</type>
+          <required>1</required>
+        </attrib>
+      </pattern>
+    </response>
+    <example>
+      <summary>Delete an agent installer</summary>
+      <request>
+        <delete_agent_installer
+          agent_installer_id="267a3405-e84a-47da-97b2-5fa0d2e8995e">
+        </delete_agent_installer>
+      </request>
+      <response>
+        <delete_agent_installer_response status="200" status_text="OK"/>
+      </response>
+    </example>
+  </command>
+  <command>
     <name>delete_agents</name>
     <summary>Delete agents</summary>
     <description>
@@ -7027,59 +7080,6 @@ END:VCALENDAR
       </request>
       <response>
         <delete_agents_response status="200" status_text="OK"/>
-      </response>
-    </example>
-  </command>
-  <command>
-    <name>delete_agent_installer</name>
-    <summary>Delete an agent installer</summary>
-    <description>
-      <p>
-        The client uses the delete_agent_installer command to delete an existing
-        agent installer.
-      </p>
-      <p>
-        Since this is a destructive command, the client is advised to ask
-        for confirmation from the user before sending this command to the
-        Manager.
-      </p>
-    </description>
-    <pattern>
-      <attrib>
-        <name>agent_installer_id</name>
-        <type>uuid</type>
-        <required>1</required>
-      </attrib>
-      <attrib>
-        <name>ultimate</name>
-        <summary>Whether to remove entirely, or to the trashcan</summary>
-        <type>boolean</type>
-        <required>1</required>
-      </attrib>
-    </pattern>
-    <response>
-      <pattern>
-        <attrib>
-          <name>status</name>
-          <type>status</type>
-          <required>1</required>
-        </attrib>
-        <attrib>
-          <name>status_text</name>
-          <type>text</type>
-          <required>1</required>
-        </attrib>
-      </pattern>
-    </response>
-    <example>
-      <summary>Delete an agent installer</summary>
-      <request>
-        <delete_agent_installer
-          agent_installer_id="267a3405-e84a-47da-97b2-5fa0d2e8995e">
-        </delete_agent_installer>
-      </request>
-      <response>
-        <delete_agent_installer_response status="200" status_text="OK"/>
       </response>
     </example>
   </command>
@@ -8355,6 +8355,177 @@ END:VCALENDAR
   </command>
   @IF_ENABLE_AGENTS@
   <command>
+    <name>get_agent_groups</name>
+    <summary>Get agent groups</summary>
+    <description>
+      <p>
+        The client uses the <code>get_agent_groups</code> command to retrieve a list of agent groups.
+      </p>
+    </description>
+    <pattern>
+      <o><e>agent_group_id</e></o>
+      <o><e>filter</e></o>
+      <o><e>filt_id</e></o>
+    </pattern>
+    <ele>
+      <name>agent_group_id</name>
+      <summary>UUID of a specific agent group</summary>
+      <pattern><type>uuid</type></pattern>
+      <required>0</required>
+    </ele>
+    <ele>
+      <name>filter</name>
+      <summary>Filter term</summary>
+      <pattern><type>text</type></pattern>
+      <required>0</required>
+    </ele>
+    <ele>
+      <name>filt_id</name>
+      <summary>Filter UUID</summary>
+      <pattern><type>uuid</type></pattern>
+      <required>0</required>
+    </ele>
+    <response>
+      <pattern>
+        <attrib>
+          <name>status</name>
+          <type>status</type>
+          <required>1</required>
+        </attrib>
+        <attrib>
+          <name>status_text</name>
+          <type>text</type>
+          <required>1</required>
+        </attrib>
+        <any><e>agent_group</e></any>
+        <o><e>filters</e></o>
+        <o><e>sort</e></o>
+        <o><e>agent_groups</e></o>
+        <o><e>agent_group_count</e></o>
+      </pattern>
+      <ele>
+        <name>agent_group</name>
+        <pattern>
+          <attrib>
+            <name>id</name>
+            <type>uuid</type>
+            <required>1</required>
+          </attrib>
+          <e>owner</e>
+          <e>name</e>
+          <e>comment</e>
+          <e>creation_time</e>
+          <e>modification_time</e>
+          <e>writable</e>
+          <e>in_use</e>
+          <e>permissions</e>
+          <e>scanner</e>
+          <e>agents</e>
+        </pattern>
+        <ele>
+          <name>agents</name>
+          <summary>Agents assigned to the group</summary>
+          <pattern>
+            <any><e>agent</e></any>
+          </pattern>
+          <ele>
+            <name>agent</name>
+            <pattern>
+              <attrib>
+                <name>id</name>
+                <type>uuid</type>
+                <required>1</required>
+              </attrib>
+              <e>name</e>
+            </pattern>
+            <ele>
+              <name>name</name>
+              <summary>Name of the agent</summary>
+              <pattern><t>name</t></pattern>
+            </ele>
+          </ele>
+        </ele>
+      </ele>
+      <ele>
+        <name>filters</name>
+        <pattern>
+          <attrib>
+            <name>id</name>
+            <type>uuid</type>
+            <required>1</required>
+          </attrib>
+          <e>term</e>
+          <e>keywords</e>
+        </pattern>
+      </ele>
+      <ele>
+        <name>sort</name>
+        <pattern>
+          <e>field</e>
+        </pattern>
+      </ele>
+      <ele>
+        <name>agent_groups</name>
+        <pattern>
+          <attrib>
+            <name>start</name>
+            <type>integer</type>
+            <required>1</required>
+          </attrib>
+          <attrib>
+            <name>max</name>
+            <type>integer</type>
+            <required>1</required>
+          </attrib>
+        </pattern>
+      </ele>
+      <ele>
+        <name>agent_group_count</name>
+        <pattern>
+          <e>filtered</e>
+          <e>page</e>
+        </pattern>
+      </ele>
+    </response>
+    <example>
+      <summary>Get all agent groups</summary>
+      <request>
+        <get_agent_groups/>
+      </request>
+      <response>
+        <get_agent_groups_response status="200" status_text="OK">
+          <agent_group id="cadc0390-f392-4cc5-9fbf-62af5e78a930">
+            <owner>
+              <name>username</name>
+            </owner>
+            <name>Test Agent Group</name>
+            <comment>Created via gvm-cli for testing</comment>
+            <creation_time>2025-07-15T14:15:31Z</creation_time>
+            <modification_time>2025-07-15T14:15:31Z</modification_time>
+            <writable>1</writable>
+            <in_use>0</in_use>
+            <permissions>
+              <permission>
+                <name>Everything</name>
+              </permission>
+            </permissions>
+            <scanner id="3b4be213-281f-49ee-b457-5a5f34f71510">
+              <name>Agent Controller</name>
+            </scanner>
+            <agents>
+              <agent id="6b9ac61f-aaaa-bbbb-cccc-ddeeff001122">
+                <name>GAT-29</name>
+              </agent>
+              <agent id="6b9ac61f-bbbb-cccc-dddd-eeff00112233">
+                <name>GAT-29-p0MPX0FT</name>
+              </agent>
+            </agents>
+          </agent_group>
+        </get_agent_groups_response>
+      </response>
+    </example>
+  </command>
+  <command>
     <name>get_agent_installers</name>
     <summary>Get one or many agent installers</summary>
     <description>
@@ -8964,6 +9135,459 @@ END:VCALENDAR
       <response>
         <get_agent_installer_file_response>
         </get_agent_installer_file_response>
+      </response>
+    </example>
+  </command>
+  <command>
+    <name>get_agents</name>
+    <summary>Get agents</summary>
+    <description>
+      <p>
+        The client uses the <code>get_agents</code> command to retrieve a list of registered agents.
+      </p>
+      <p>
+        The response includes detailed information about each agent, including metadata,
+        status, schedule, scanner association, and IP addresses.
+      </p>
+    </description>
+    <pattern>
+      <attrib>
+        <name>agent_id</name>
+        <summary>ID of a specific agent</summary>
+        <type>uuid</type>
+      </attrib>
+      <attrib>
+        <name>filter</name>
+        <summary>Filter term</summary>
+        <type>text</type>
+        <filter_keywords>
+          <option>
+            <name>first</name>
+            <type>integer</type>
+            <summary>Index of the first item returned, starting at 1 (e.g. first=5 starts at the 5th item)</summary>
+          </option>
+          <option>
+            <name>rows</name>
+            <type>integer</type>
+            <summary>Number of items to return</summary>
+          </option>
+          <option>
+            <name>sort</name>
+            <type>text</type>
+            <summary>Column to sort by in ascending order</summary>
+          </option>
+          <option>
+            <name>sort-reverse</name>
+            <type>text</type>
+            <summary>Column to sort by in descending order</summary>
+          </option>
+          <column>
+            <name>uuid</name>
+            <type>uuid</type>
+            <summary>Agent unique identifier</summary>
+          </column>
+          <column>
+            <name>agent_id</name>
+            <type>text</type>
+            <summary>Agent ID</summary>
+          </column>
+          <column>
+            <name>name</name>
+            <type>name</type>
+            <summary>Name of the agent</summary>
+          </column>
+          <column>
+            <name>hostname</name>
+            <type>text</type>
+            <summary>Hostname of the agent machine</summary>
+          </column>
+          <column>
+            <name>scanner</name>
+            <type>text</type>
+            <summary>UUID of the scanner the agent belongs to</summary>
+          </column>
+          <column>
+            <name>authorized</name>
+            <type>integer</type>
+            <summary>Whether the agent is authorized (1) or not (0)</summary>
+          </column>
+          <column>
+            <name>min_interval</name>
+            <type>integer</type>
+            <summary>Minimum interval between scans (in seconds)</summary>
+          </column>
+          <column>
+            <name>heartbeat_interval</name>
+            <type>integer</type>
+            <summary>Interval for agent heartbeat (in seconds)</summary>
+          </column>
+          <column>
+            <name>connection_status</name>
+            <type>text</type>
+            <summary>Status of agent connection</summary>
+          </column>
+          <column>
+            <name>last_update</name>
+            <type>iso_time</type>
+            <summary>Last time the agent was updated</summary>
+          </column>
+          <column>
+            <name>schedule</name>
+            <type>text</type>
+            <summary>Scheduled update interval</summary>
+          </column>
+          <column>
+            <name>comment</name>
+            <type>text</type>
+            <summary>Agent comment field</summary>
+          </column>
+          <column>
+            <name>created</name>
+            <type>iso_time</type>
+            <summary>Creation time</summary>
+          </column>
+          <column>
+            <name>modified</name>
+            <type>iso_time</type>
+            <summary>Modification time</summary>
+          </column>
+          <column>
+            <name>owner</name>
+            <type>name</type>
+            <summary>Name of the owner</summary>
+          </column>
+          <column>
+            <name>id</name>
+            <type>uuid</type>
+            <summary>ID alias for agent UUID</summary>
+          </column>
+        </filter_keywords>
+      </attrib>
+      <attrib>
+        <name>filt_id</name>
+        <summary>Filter UUID</summary>
+        <type>uuid</type>
+      </attrib>
+    </pattern>
+    <response>
+      <pattern>
+        <attrib>
+          <name>status</name>
+          <type>status</type>
+          <required>1</required>
+        </attrib>
+        <attrib>
+          <name>status_text</name>
+          <type>text</type>
+          <required>1</required>
+        </attrib>
+        <any><e>agent</e></any>
+        <e>filters</e>
+        <e>sort</e>
+        <e>agents</e>
+        <e>agent_count</e>
+      </pattern>
+      <ele>
+        <name>agent</name>
+        <pattern>
+          <attrib>
+            <name>id</name>
+            <type>uuid</type>
+            <required>1</required>
+          </attrib>
+          <e>owner</e>
+          <e>name</e>
+          <e>comment</e>
+          <e>creation_time</e>
+          <e>modification_time</e>
+          <e>writable</e>
+          <e>in_use</e>
+          <e>permissions</e>
+          <e>hostname</e>
+          <e>agent_id</e>
+          <e>authorized</e>
+          <e>min_interval</e>
+          <e>heartbeat_interval</e>
+          <e>connection_status</e>
+          <e>last_update</e>
+          <e>schedule</e>
+          <e>scanner</e>
+          <any><e>ip</e></any>
+        </pattern>
+        <ele>
+          <name>owner</name>
+          <summary>Owner of the agent</summary>
+          <pattern><e>name</e></pattern>
+          <ele>
+            <name>name</name>
+            <summary>Name of the owner</summary>
+            <pattern><type>name</type></pattern>
+          </ele>
+        </ele>
+        <ele>
+          <name>name</name>
+          <summary>Name of the agent</summary>
+          <pattern><type>name</type></pattern>
+        </ele>
+        <ele>
+          <name>comment</name>
+          <summary>Comment on the agent</summary>
+          <pattern><type>text</type></pattern>
+        </ele>
+        <ele>
+          <name>creation_time</name>
+          <summary>Creation timestamp</summary>
+          <pattern><type>iso_time</type></pattern>
+        </ele>
+        <ele>
+          <name>modification_time</name>
+          <summary>Modification timestamp</summary>
+          <pattern><type>iso_time</type></pattern>
+        </ele>
+        <ele>
+          <name>writable</name>
+          <summary>Whether agent is writable</summary>
+          <pattern><type>boolean</type></pattern>
+        </ele>
+        <ele>
+          <name>in_use</name>
+          <summary>Whether agent is currently in use</summary>
+          <pattern><type>boolean</type></pattern>
+        </ele>
+        <ele>
+          <name>permissions</name>
+          <summary>Permissions current user has on the agent</summary>
+          <pattern><any><e>permission</e></any></pattern>
+          <ele>
+            <name>permission</name>
+            <pattern><e>name</e></pattern>
+            <ele>
+              <name>name</name>
+              <summary>Permission name</summary>
+              <pattern><type>name</type></pattern>
+            </ele>
+          </ele>
+        </ele>
+        <ele>
+          <name>hostname</name>
+          <summary>Hostname of the agent</summary>
+          <pattern><type>text</type></pattern>
+        </ele>
+        <ele>
+          <name>agent_id</name>
+          <summary>Agent identifier string</summary>
+          <pattern><type>text</type></pattern>
+        </ele>
+        <ele>
+          <name>authorized</name>
+          <summary>Authorization flag</summary>
+          <pattern><type>integer</type></pattern>
+        </ele>
+        <ele>
+          <name>min_interval</name>
+          <summary>Minimum interval in seconds</summary>
+          <pattern><type>integer</type></pattern>
+        </ele>
+        <ele>
+          <name>heartbeat_interval</name>
+          <summary>Heartbeat interval in seconds</summary>
+          <pattern><type>integer</type></pattern>
+        </ele>
+        <ele>
+          <name>connection_status</name>
+          <summary>Connection status of the agent</summary>
+          <pattern><type>text</type></pattern>
+        </ele>
+        <ele>
+          <name>last_update</name>
+          <summary>Timestamp of last update</summary>
+          <pattern><type>iso_time</type></pattern>
+        </ele>
+        <ele>
+          <name>schedule</name>
+          <summary>Agent schedule</summary>
+          <pattern><type>text</type></pattern>
+        </ele>
+        <ele>
+          <name>scanner</name>
+          <summary>Associated scanner</summary>
+          <pattern>
+            <attrib>
+              <name>id</name>
+              <type>uuid</type>
+            </attrib>
+            <e>name</e>
+          </pattern>
+          <ele>
+            <name>name</name>
+            <summary>Name of the scanner</summary>
+            <pattern><type>name</type></pattern>
+          </ele>
+        </ele>
+        <ele>
+          <name>ip</name>
+          <summary>IP addresses of the agent</summary>
+          <pattern><type>text</type></pattern>
+        </ele>
+      </ele>
+      <ele>
+        <name>filters</name>
+        <pattern>
+          <attrib>
+            <name>id</name>
+            <type>uuid</type>
+            <required>1</required>
+          </attrib>
+          <e>term</e>
+          <e>keywords</e>
+        </pattern>
+        <ele>
+          <name>term</name>
+          <summary>Filter term</summary>
+          <pattern><type>text</type></pattern>
+        </ele>
+        <ele>
+          <name>keywords</name>
+          <summary>Parsed filter keywords</summary>
+          <pattern><any><e>keyword</e></any></pattern>
+          <ele>
+            <name>keyword</name>
+            <pattern>
+              <e>column</e>
+              <e>relation</e>
+              <e>value</e>
+            </pattern>
+            <ele>
+              <name>column</name>
+              <summary>Filter column</summary>
+              <pattern><type>text</type></pattern>
+            </ele>
+            <ele>
+              <name>relation</name>
+              <summary>Operator</summary>
+              <pattern><alts><alt>=</alt><alt>:</alt><alt>~</alt><alt>&gt;</alt><alt>&lt;</alt></alts></pattern>
+            </ele>
+            <ele>
+              <name>value</name>
+              <summary>Filter value</summary>
+              <pattern><type>text</type></pattern>
+            </ele>
+          </ele>
+        </ele>
+      </ele>
+      <ele>
+        <name>sort</name>
+        <pattern><e>field</e></pattern>
+        <ele>
+          <name>field</name>
+          <pattern><e>order</e></pattern>
+          <ele>
+            <name>order</name>
+            <pattern><alts><alt>ascending</alt><alt>descending</alt></alts></pattern>
+          </ele>
+        </ele>
+      </ele>
+      <ele>
+        <name>agents</name>
+        <pattern>
+          <attrib>
+            <name>start</name>
+            <type>integer</type>
+            <required>1</required>
+          </attrib>
+          <attrib>
+            <name>max</name>
+            <type>integer</type>
+            <required>1</required>
+          </attrib>
+        </pattern>
+      </ele>
+      <ele>
+        <name>agent_count</name>
+        <pattern>
+          <e>filtered</e>
+          <e>page</e>
+        </pattern>
+        <ele>
+          <name>filtered</name>
+          <summary>Count after filtering</summary>
+          <pattern><type>integer</type></pattern>
+        </ele>
+        <ele>
+          <name>page</name>
+          <summary>Page count</summary>
+          <pattern><type>integer</type></pattern>
+        </ele>
+      </ele>
+    </response>
+    <example>
+      <summary>Retrieve a filtered agent result</summary>
+      <request>
+        <get_agents/>
+      </request>
+      <response>
+        <get_agents_response status="200" status_text="OK">
+          <agent id="62462fe0-5834-4630-afc2-0d040c63487c">
+            <owner>
+              <name>username</name>
+            </owner>
+            <name>GAT-29-p0MPX0FT</name>
+            <comment>Routine sync update</comment>
+            <creation_time>2025-05-30T06:24:51Z</creation_time>
+            <modification_time>2025-06-03T09:20:26Z</modification_time>
+            <writable>1</writable>
+            <in_use>0</in_use>
+            <permissions>
+              <permission>
+                <name>Everything</name>
+              </permission>
+            </permissions>
+            <hostname>GAT-29</hostname>
+            <agent_id>GAT-29-p0MPX0FT</agent_id>
+            <authorized>1</authorized>
+            <min_interval>2000</min_interval>
+            <heartbeat_interval>0</heartbeat_interval>
+            <connection_status>inactive</connection_status>
+            <last_update>2025-05-23T08:25:17Z</last_update>
+            <schedule>@every 8h</schedule>
+            <scanner id="3b4be213-281f-49ee-b457-5a5f34f71510">
+              <name>Agent Controller</name>
+            </scanner>
+            <ip>127.0.0.1</ip>
+            <ip>::1</ip>
+            <ip>192.168.79.157</ip>
+            <ip>fe80::fe3e:acb9:1b5b:27da</ip>
+            <ip>192.168.1.11</ip>
+          </agent>
+          <filters id="">
+            <term>first=1 rows=10 sort=name</term>
+            <keywords>
+              <keyword>
+                <column>first</column>
+                <relation>=</relation>
+                <value>1</value>
+              </keyword>
+              <keyword>
+                <column>rows</column>
+                <relation>=</relation>
+                <value>10</value>
+              </keyword>
+              <keyword>
+                <column>sort</column>
+                <relation>=</relation>
+                <value>name</value>
+              </keyword>
+            </keywords>
+          </filters>
+          <sort>
+            <field>name<order>ascending</order></field>
+          </sort>
+          <agents start="1" max="1000"/>
+          <agent_count>
+            <filtered>1</filtered>
+            <page>1</page>
+          </agent_count>
+        </get_agents_response>
       </response>
     </example>
   </command>
@@ -9623,632 +10247,6 @@ END:VCALENDAR
       </response>
     </example>
   </command>
-  @IF_ENABLE_AGENTS@
-  <command>
-    <name>get_agent_groups</name>
-    <summary>Get agent groups</summary>
-    <description>
-      <p>
-        The client uses the <code>get_agent_groups</code> command to retrieve a list of agent groups.
-      </p>
-    </description>
-    <pattern>
-      <o><e>agent_group_id</e></o>
-      <o><e>filter</e></o>
-      <o><e>filt_id</e></o>
-    </pattern>
-    <ele>
-      <name>agent_group_id</name>
-      <summary>UUID of a specific agent group</summary>
-      <pattern><type>uuid</type></pattern>
-      <required>0</required>
-    </ele>
-    <ele>
-      <name>filter</name>
-      <summary>Filter term</summary>
-      <pattern><type>text</type></pattern>
-      <required>0</required>
-    </ele>
-    <ele>
-      <name>filt_id</name>
-      <summary>Filter UUID</summary>
-      <pattern><type>uuid</type></pattern>
-      <required>0</required>
-    </ele>
-    <response>
-      <pattern>
-        <attrib>
-          <name>status</name>
-          <type>status</type>
-          <required>1</required>
-        </attrib>
-        <attrib>
-          <name>status_text</name>
-          <type>text</type>
-          <required>1</required>
-        </attrib>
-        <any><e>agent_group</e></any>
-        <o><e>filters</e></o>
-        <o><e>sort</e></o>
-        <o><e>agent_groups</e></o>
-        <o><e>agent_group_count</e></o>
-      </pattern>
-      <ele>
-        <name>agent_group</name>
-        <pattern>
-          <attrib>
-            <name>id</name>
-            <type>uuid</type>
-            <required>1</required>
-          </attrib>
-          <e>owner</e>
-          <e>name</e>
-          <e>comment</e>
-          <e>creation_time</e>
-          <e>modification_time</e>
-          <e>writable</e>
-          <e>in_use</e>
-          <e>permissions</e>
-          <e>scanner</e>
-          <e>agents</e>
-        </pattern>
-        <ele>
-          <name>agents</name>
-          <summary>Agents assigned to the group</summary>
-          <pattern>
-            <any><e>agent</e></any>
-          </pattern>
-          <ele>
-            <name>agent</name>
-            <pattern>
-              <attrib>
-                <name>id</name>
-                <type>uuid</type>
-                <required>1</required>
-              </attrib>
-              <e>name</e>
-            </pattern>
-            <ele>
-              <name>name</name>
-              <summary>Name of the agent</summary>
-              <pattern><t>name</t></pattern>
-            </ele>
-          </ele>
-        </ele>
-      </ele>
-      <ele>
-        <name>filters</name>
-        <pattern>
-          <attrib>
-            <name>id</name>
-            <type>uuid</type>
-            <required>1</required>
-          </attrib>
-          <e>term</e>
-          <e>keywords</e>
-        </pattern>
-      </ele>
-      <ele>
-        <name>sort</name>
-        <pattern>
-          <e>field</e>
-        </pattern>
-      </ele>
-      <ele>
-        <name>agent_groups</name>
-        <pattern>
-          <attrib>
-            <name>start</name>
-            <type>integer</type>
-            <required>1</required>
-          </attrib>
-          <attrib>
-            <name>max</name>
-            <type>integer</type>
-            <required>1</required>
-          </attrib>
-        </pattern>
-      </ele>
-      <ele>
-        <name>agent_group_count</name>
-        <pattern>
-          <e>filtered</e>
-          <e>page</e>
-        </pattern>
-      </ele>
-    </response>
-    <example>
-      <summary>Get all agent groups</summary>
-      <request>
-        <get_agent_groups/>
-      </request>
-      <response>
-        <get_agent_groups_response status="200" status_text="OK">
-          <agent_group id="cadc0390-f392-4cc5-9fbf-62af5e78a930">
-            <owner>
-              <name>username</name>
-            </owner>
-            <name>Test Agent Group</name>
-            <comment>Created via gvm-cli for testing</comment>
-            <creation_time>2025-07-15T14:15:31Z</creation_time>
-            <modification_time>2025-07-15T14:15:31Z</modification_time>
-            <writable>1</writable>
-            <in_use>0</in_use>
-            <permissions>
-              <permission>
-                <name>Everything</name>
-              </permission>
-            </permissions>
-            <scanner id="3b4be213-281f-49ee-b457-5a5f34f71510">
-              <name>Agent Controller</name>
-            </scanner>
-            <agents>
-              <agent id="6b9ac61f-aaaa-bbbb-cccc-ddeeff001122">
-                <name>GAT-29</name>
-              </agent>
-              <agent id="6b9ac61f-bbbb-cccc-dddd-eeff00112233">
-                <name>GAT-29-p0MPX0FT</name>
-              </agent>
-            </agents>
-          </agent_group>
-        </get_agent_groups_response>
-      </response>
-    </example>
-  </command>
-  <command>
-    <name>get_agents</name>
-    <summary>Get agents</summary>
-    <description>
-      <p>
-        The client uses the <code>get_agents</code> command to retrieve a list of registered agents.
-      </p>
-      <p>
-        The response includes detailed information about each agent, including metadata,
-        status, schedule, scanner association, and IP addresses.
-      </p>
-    </description>
-    <pattern>
-      <attrib>
-        <name>agent_id</name>
-        <summary>ID of a specific agent</summary>
-        <type>uuid</type>
-      </attrib>
-      <attrib>
-        <name>filter</name>
-        <summary>Filter term</summary>
-        <type>text</type>
-        <filter_keywords>
-          <option>
-            <name>first</name>
-            <type>integer</type>
-            <summary>Index of the first item returned, starting at 1 (e.g. first=5 starts at the 5th item)</summary>
-          </option>
-          <option>
-            <name>rows</name>
-            <type>integer</type>
-            <summary>Number of items to return</summary>
-          </option>
-          <option>
-            <name>sort</name>
-            <type>text</type>
-            <summary>Column to sort by in ascending order</summary>
-          </option>
-          <option>
-            <name>sort-reverse</name>
-            <type>text</type>
-            <summary>Column to sort by in descending order</summary>
-          </option>
-          <column>
-            <name>uuid</name>
-            <type>uuid</type>
-            <summary>Agent unique identifier</summary>
-          </column>
-          <column>
-            <name>agent_id</name>
-            <type>text</type>
-            <summary>Agent ID</summary>
-          </column>
-          <column>
-            <name>name</name>
-            <type>name</type>
-            <summary>Name of the agent</summary>
-          </column>
-          <column>
-            <name>hostname</name>
-            <type>text</type>
-            <summary>Hostname of the agent machine</summary>
-          </column>
-          <column>
-            <name>scanner</name>
-            <type>text</type>
-            <summary>UUID of the scanner the agent belongs to</summary>
-          </column>
-          <column>
-            <name>authorized</name>
-            <type>integer</type>
-            <summary>Whether the agent is authorized (1) or not (0)</summary>
-          </column>
-          <column>
-            <name>min_interval</name>
-            <type>integer</type>
-            <summary>Minimum interval between scans (in seconds)</summary>
-          </column>
-          <column>
-            <name>heartbeat_interval</name>
-            <type>integer</type>
-            <summary>Interval for agent heartbeat (in seconds)</summary>
-          </column>
-          <column>
-            <name>connection_status</name>
-            <type>text</type>
-            <summary>Status of agent connection</summary>
-          </column>
-          <column>
-            <name>last_update</name>
-            <type>iso_time</type>
-            <summary>Last time the agent was updated</summary>
-          </column>
-          <column>
-            <name>schedule</name>
-            <type>text</type>
-            <summary>Scheduled update interval</summary>
-          </column>
-          <column>
-            <name>comment</name>
-            <type>text</type>
-            <summary>Agent comment field</summary>
-          </column>
-          <column>
-            <name>created</name>
-            <type>iso_time</type>
-            <summary>Creation time</summary>
-          </column>
-          <column>
-            <name>modified</name>
-            <type>iso_time</type>
-            <summary>Modification time</summary>
-          </column>
-          <column>
-            <name>owner</name>
-            <type>name</type>
-            <summary>Name of the owner</summary>
-          </column>
-          <column>
-            <name>id</name>
-            <type>uuid</type>
-            <summary>ID alias for agent UUID</summary>
-          </column>
-        </filter_keywords>
-      </attrib>
-      <attrib>
-        <name>filt_id</name>
-        <summary>Filter UUID</summary>
-        <type>uuid</type>
-      </attrib>
-    </pattern>
-    <response>
-      <pattern>
-        <attrib>
-          <name>status</name>
-          <type>status</type>
-          <required>1</required>
-        </attrib>
-        <attrib>
-          <name>status_text</name>
-          <type>text</type>
-          <required>1</required>
-        </attrib>
-        <any><e>agent</e></any>
-        <e>filters</e>
-        <e>sort</e>
-        <e>agents</e>
-        <e>agent_count</e>
-      </pattern>
-      <ele>
-        <name>agent</name>
-        <pattern>
-          <attrib>
-            <name>id</name>
-            <type>uuid</type>
-            <required>1</required>
-          </attrib>
-          <e>owner</e>
-          <e>name</e>
-          <e>comment</e>
-          <e>creation_time</e>
-          <e>modification_time</e>
-          <e>writable</e>
-          <e>in_use</e>
-          <e>permissions</e>
-          <e>hostname</e>
-          <e>agent_id</e>
-          <e>authorized</e>
-          <e>min_interval</e>
-          <e>heartbeat_interval</e>
-          <e>connection_status</e>
-          <e>last_update</e>
-          <e>schedule</e>
-          <e>scanner</e>
-          <any><e>ip</e></any>
-        </pattern>
-        <ele>
-          <name>owner</name>
-          <summary>Owner of the agent</summary>
-          <pattern><e>name</e></pattern>
-          <ele>
-            <name>name</name>
-            <summary>Name of the owner</summary>
-            <pattern><type>name</type></pattern>
-          </ele>
-        </ele>
-        <ele>
-          <name>name</name>
-          <summary>Name of the agent</summary>
-          <pattern><type>name</type></pattern>
-        </ele>
-        <ele>
-          <name>comment</name>
-          <summary>Comment on the agent</summary>
-          <pattern><type>text</type></pattern>
-        </ele>
-        <ele>
-          <name>creation_time</name>
-          <summary>Creation timestamp</summary>
-          <pattern><type>iso_time</type></pattern>
-        </ele>
-        <ele>
-          <name>modification_time</name>
-          <summary>Modification timestamp</summary>
-          <pattern><type>iso_time</type></pattern>
-        </ele>
-        <ele>
-          <name>writable</name>
-          <summary>Whether agent is writable</summary>
-          <pattern><type>boolean</type></pattern>
-        </ele>
-        <ele>
-          <name>in_use</name>
-          <summary>Whether agent is currently in use</summary>
-          <pattern><type>boolean</type></pattern>
-        </ele>
-        <ele>
-          <name>permissions</name>
-          <summary>Permissions current user has on the agent</summary>
-          <pattern><any><e>permission</e></any></pattern>
-          <ele>
-            <name>permission</name>
-            <pattern><e>name</e></pattern>
-            <ele>
-              <name>name</name>
-              <summary>Permission name</summary>
-              <pattern><type>name</type></pattern>
-            </ele>
-          </ele>
-        </ele>
-        <ele>
-          <name>hostname</name>
-          <summary>Hostname of the agent</summary>
-          <pattern><type>text</type></pattern>
-        </ele>
-        <ele>
-          <name>agent_id</name>
-          <summary>Agent identifier string</summary>
-          <pattern><type>text</type></pattern>
-        </ele>
-        <ele>
-          <name>authorized</name>
-          <summary>Authorization flag</summary>
-          <pattern><type>integer</type></pattern>
-        </ele>
-        <ele>
-          <name>min_interval</name>
-          <summary>Minimum interval in seconds</summary>
-          <pattern><type>integer</type></pattern>
-        </ele>
-        <ele>
-          <name>heartbeat_interval</name>
-          <summary>Heartbeat interval in seconds</summary>
-          <pattern><type>integer</type></pattern>
-        </ele>
-        <ele>
-          <name>connection_status</name>
-          <summary>Connection status of the agent</summary>
-          <pattern><type>text</type></pattern>
-        </ele>
-        <ele>
-          <name>last_update</name>
-          <summary>Timestamp of last update</summary>
-          <pattern><type>iso_time</type></pattern>
-        </ele>
-        <ele>
-          <name>schedule</name>
-          <summary>Agent schedule</summary>
-          <pattern><type>text</type></pattern>
-        </ele>
-        <ele>
-          <name>scanner</name>
-          <summary>Associated scanner</summary>
-          <pattern>
-            <attrib>
-              <name>id</name>
-              <type>uuid</type>
-            </attrib>
-            <e>name</e>
-          </pattern>
-          <ele>
-            <name>name</name>
-            <summary>Name of the scanner</summary>
-            <pattern><type>name</type></pattern>
-          </ele>
-        </ele>
-        <ele>
-          <name>ip</name>
-          <summary>IP addresses of the agent</summary>
-          <pattern><type>text</type></pattern>
-        </ele>
-      </ele>
-      <ele>
-        <name>filters</name>
-        <pattern>
-          <attrib>
-            <name>id</name>
-            <type>uuid</type>
-            <required>1</required>
-          </attrib>
-          <e>term</e>
-          <e>keywords</e>
-        </pattern>
-        <ele>
-          <name>term</name>
-          <summary>Filter term</summary>
-          <pattern><type>text</type></pattern>
-        </ele>
-        <ele>
-          <name>keywords</name>
-          <summary>Parsed filter keywords</summary>
-          <pattern><any><e>keyword</e></any></pattern>
-          <ele>
-            <name>keyword</name>
-            <pattern>
-              <e>column</e>
-              <e>relation</e>
-              <e>value</e>
-            </pattern>
-            <ele>
-              <name>column</name>
-              <summary>Filter column</summary>
-              <pattern><type>text</type></pattern>
-            </ele>
-            <ele>
-              <name>relation</name>
-              <summary>Operator</summary>
-              <pattern><alts><alt>=</alt><alt>:</alt><alt>~</alt><alt>&gt;</alt><alt>&lt;</alt></alts></pattern>
-            </ele>
-            <ele>
-              <name>value</name>
-              <summary>Filter value</summary>
-              <pattern><type>text</type></pattern>
-            </ele>
-          </ele>
-        </ele>
-      </ele>
-      <ele>
-        <name>sort</name>
-        <pattern><e>field</e></pattern>
-        <ele>
-          <name>field</name>
-          <pattern><e>order</e></pattern>
-          <ele>
-            <name>order</name>
-            <pattern><alts><alt>ascending</alt><alt>descending</alt></alts></pattern>
-          </ele>
-        </ele>
-      </ele>
-      <ele>
-        <name>agents</name>
-        <pattern>
-          <attrib>
-            <name>start</name>
-            <type>integer</type>
-            <required>1</required>
-          </attrib>
-          <attrib>
-            <name>max</name>
-            <type>integer</type>
-            <required>1</required>
-          </attrib>
-        </pattern>
-      </ele>
-      <ele>
-        <name>agent_count</name>
-        <pattern>
-          <e>filtered</e>
-          <e>page</e>
-        </pattern>
-        <ele>
-          <name>filtered</name>
-          <summary>Count after filtering</summary>
-          <pattern><type>integer</type></pattern>
-        </ele>
-        <ele>
-          <name>page</name>
-          <summary>Page count</summary>
-          <pattern><type>integer</type></pattern>
-        </ele>
-      </ele>
-    </response>
-    <example>
-      <summary>Retrieve a filtered agent result</summary>
-      <request>
-        <get_agents/>
-      </request>
-      <response>
-        <get_agents_response status="200" status_text="OK">
-          <agent id="62462fe0-5834-4630-afc2-0d040c63487c">
-            <owner>
-              <name>username</name>
-            </owner>
-            <name>GAT-29-p0MPX0FT</name>
-            <comment>Routine sync update</comment>
-            <creation_time>2025-05-30T06:24:51Z</creation_time>
-            <modification_time>2025-06-03T09:20:26Z</modification_time>
-            <writable>1</writable>
-            <in_use>0</in_use>
-            <permissions>
-              <permission>
-                <name>Everything</name>
-              </permission>
-            </permissions>
-            <hostname>GAT-29</hostname>
-            <agent_id>GAT-29-p0MPX0FT</agent_id>
-            <authorized>1</authorized>
-            <min_interval>2000</min_interval>
-            <heartbeat_interval>0</heartbeat_interval>
-            <connection_status>inactive</connection_status>
-            <last_update>2025-05-23T08:25:17Z</last_update>
-            <schedule>@every 8h</schedule>
-            <scanner id="3b4be213-281f-49ee-b457-5a5f34f71510">
-              <name>Agent Controller</name>
-            </scanner>
-            <ip>127.0.0.1</ip>
-            <ip>::1</ip>
-            <ip>192.168.79.157</ip>
-            <ip>fe80::fe3e:acb9:1b5b:27da</ip>
-            <ip>192.168.1.11</ip>
-          </agent>
-          <filters id="">
-            <term>first=1 rows=10 sort=name</term>
-            <keywords>
-              <keyword>
-                <column>first</column>
-                <relation>=</relation>
-                <value>1</value>
-              </keyword>
-              <keyword>
-                <column>rows</column>
-                <relation>=</relation>
-                <value>10</value>
-              </keyword>
-              <keyword>
-                <column>sort</column>
-                <relation>=</relation>
-                <value>name</value>
-              </keyword>
-            </keywords>
-          </filters>
-          <sort>
-            <field>name<order>ascending</order></field>
-          </sort>
-          <agents start="1" max="1000"/>
-          <agent_count>
-            <filtered>1</filtered>
-            <page>1</page>
-          </agent_count>
-        </get_agents_response>
-      </response>
-    </example>
-  </command>
-  @ENDIF_ENABLE_AGENTS@
   <command>
     <name>get_alerts</name>
     <summary>Get one or many alerts</summary>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -3715,6 +3715,106 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </response>
     </example>
   </command>
+  @IF_ENABLE_AGENTS@
+  <command>
+    <name>create_agent_group</name>
+    <summary>Create an agent group</summary>
+    <description>
+      <p>
+        A name for the new agent group is required. Optionally, a comment and a list of agents
+        to include in the group should be provided.
+      </p>
+    </description>
+    <pattern>
+      <e>name</e>
+      <o><e>comment</e></o>
+      <o><e>agents</e></o>
+      <o><e>copy</e></o>
+    </pattern>
+    <ele>
+      <name>name</name>
+      <summary>Name of the new agent group</summary>
+      <pattern>text</pattern>
+      <required>1</required>
+    </ele>
+    <ele>
+      <name>comment</name>
+      <summary>Optional user-supplied comment</summary>
+      <pattern>text</pattern>
+      <required>0</required>
+    </ele>
+    <ele>
+      <name>agents</name>
+      <summary>List of agents to include in the group</summary>
+      <pattern>
+        <any><e>agent</e></any>
+      </pattern>
+      <ele>
+        <name>agent</name>
+        <pattern>
+          <attrib>
+            <name>id</name>
+            <type>uuid</type>
+            <required>1</required>
+          </attrib>
+        </pattern>
+      </ele>
+    </ele>
+    <ele>
+      <name>copy</name>
+      <summary>UUID of an existing group to copy from</summary>
+      <pattern>uuid</pattern>
+      <required>0</required>
+    </ele>
+    <response>
+      <pattern>
+        <attrib>
+          <name>status</name>
+          <type>status</type>
+          <required>1</required>
+        </attrib>
+        <attrib>
+          <name>status_text</name>
+          <type>text</type>
+          <required>1</required>
+        </attrib>
+        <attrib>
+          <name>id</name>
+          <type>uuid</type>
+          <required>1</required>
+        </attrib>
+      </pattern>
+    </response>
+    <example>
+      <summary>Create an agent group with agents</summary>
+      <request>
+        <create_agent_group>
+          <name>Test Agent Group</name>
+          <comment>Created via gvm-cli for testing</comment>
+          <agents>
+            <agent id="48c1b767-b699-45a4-a8bb-3325f2865913"/>
+            <agent id="c947ffac-a562-4ac9-9bb5-361b597c67be"/>
+          </agents>
+        </create_agent_group>
+      </request>
+      <response>
+        <create_agent_group_response status="201" status_text="Created" id="90f1cde5-a477-42f5-9e0a-b7a78f9bcd23"/>
+      </response>
+    </example>
+    <example>
+      <summary>Create an agent group by copying another</summary>
+      <request>
+        <create_agent_group>
+          <name>Copied Agent Group</name>
+          <copy>6c04e86e-ea40-46a1-80f4-cfce27f821b5</copy>
+        </create_agent_group>
+      </request>
+      <response>
+        <create_agent_group_response status="201" status_text="Created" id="abc123de-4f56-789a-bcde-1234567890ab"/>
+      </response>
+    </example>
+  </command>
+  @ENDIF_ENABLE_AGENTS@
   <command>
     <name>create_alert</name>
     <summary>Create an alert</summary>
@@ -6809,6 +6909,61 @@ END:VCALENDAR
   </command>
   @IF_ENABLE_AGENTS@
   <command>
+    <name>delete_agent_group</name>
+    <summary>Delete an agent group</summary>
+    <description>
+      <p>
+        The client uses the <code>delete_agent_group</code> command to delete an
+        existing agent group.
+      </p>
+      <p>
+        Since this is a destructive command, the client is advised to ask
+        for confirmation from the user before sending this command to the
+        Manager.
+      </p>
+      <p>
+        If <code>ultimate</code> is set to 1, the agent group is permanently deleted.
+        If set to 0, the group is moved to the trashcan and can be restored later.
+      </p>
+    </description>
+    <pattern>
+      <attrib>
+        <name>agent_group_id</name>
+        <type>uuid</type>
+        <required>1</required>
+      </attrib>
+      <attrib>
+        <name>ultimate</name>
+        <summary>Whether to remove entirely, or move to trashcan</summary>
+        <type>boolean</type>
+        <required>1</required>
+      </attrib>
+    </pattern>
+    <response>
+      <pattern>
+        <attrib>
+          <name>status</name>
+          <type>status</type>
+          <required>1</required>
+        </attrib>
+        <attrib>
+          <name>status_text</name>
+          <type>text</type>
+          <required>1</required>
+        </attrib>
+      </pattern>
+    </response>
+    <example>
+      <summary>Delete an agent group</summary>
+      <request>
+        <delete_agent_group agent_group_id="6fca29e3-8b96-4e6b-9ee1-8845680dbda5" ultimate="1"/>
+      </request>
+      <response>
+        <delete_agent_group_response status="200" status_text="OK"/>
+      </response>
+    </example>
+  </command>
+  <command>
     <name>delete_agents</name>
     <summary>Delete agents</summary>
     <description>
@@ -9469,6 +9624,147 @@ END:VCALENDAR
     </example>
   </command>
   @IF_ENABLE_AGENTS@
+  <command>
+    <name>get_agent_groups</name>
+    <summary>Get agent groups</summary>
+    <description>
+      <p>
+        The client uses the <code>get_agent_groups</code> command to retrieve a list of agent groups.
+      </p>
+    </description>
+    <pattern>
+      <o><e>agent_group_id</e></o>
+      <o><e>filter</e></o>
+      <o><e>filt_id</e></o>
+    </pattern>
+    <ele>
+      <name>agent_group_id</name>
+      <summary>UUID of a specific agent group</summary>
+      <pattern><type>uuid</type></pattern>
+      <required>0</required>
+    </ele>
+    <ele>
+      <name>filter</name>
+      <summary>Filter term</summary>
+      <pattern><type>text</type></pattern>
+      <required>0</required>
+    </ele>
+    <ele>
+      <name>filt_id</name>
+      <summary>Filter UUID</summary>
+      <pattern><type>uuid</type></pattern>
+      <required>0</required>
+    </ele>
+    <response>
+      <pattern>
+        <attrib>
+          <name>status</name>
+          <type>status</type>
+          <required>1</required>
+        </attrib>
+        <attrib>
+          <name>status_text</name>
+          <type>text</type>
+          <required>1</required>
+        </attrib>
+        <any><e>agent_group</e></any>
+        <o><e>filters</e></o>
+        <o><e>sort</e></o>
+        <o><e>agent_groups</e></o>
+        <o><e>agent_group_count</e></o>
+      </pattern>
+      <ele>
+        <name>agent_group</name>
+        <pattern>
+          <attrib>
+            <name>id</name>
+            <type>uuid</type>
+            <required>1</required>
+          </attrib>
+          <e>owner</e>
+          <e>name</e>
+          <e>comment</e>
+          <e>creation_time</e>
+          <e>modification_time</e>
+          <e>writable</e>
+          <e>in_use</e>
+          <e>permissions</e>
+          <e>scanner</e>
+          <e>agents</e>
+        </pattern>
+      </ele>
+      <ele>
+        <name>filters</name>
+        <pattern>
+          <attrib>
+            <name>id</name>
+            <type>uuid</type>
+            <required>1</required>
+          </attrib>
+          <e>term</e>
+          <e>keywords</e>
+        </pattern>
+      </ele>
+      <ele>
+        <name>sort</name>
+        <pattern>
+          <e>field</e>
+        </pattern>
+      </ele>
+      <ele>
+        <name>agent_groups</name>
+        <pattern>
+          <attrib>
+            <name>start</name>
+            <type>integer</type>
+            <required>1</required>
+          </attrib>
+          <attrib>
+            <name>max</name>
+            <type>integer</type>
+            <required>1</required>
+          </attrib>
+        </pattern>
+      </ele>
+      <ele>
+        <name>agent_group_count</name>
+        <pattern>
+          <e>filtered</e>
+          <e>page</e>
+        </pattern>
+      </ele>
+    </response>
+    <example>
+      <summary>Get all agent groups</summary>
+      <request>
+        <get_agent_groups/>
+      </request>
+      <response>
+        <get_agent_groups_response status="200" status_text="OK">
+          <agent_group id="cadc0390-f392-4cc5-9fbf-62af5e78a930">
+            <owner>
+              <name>username</name>
+            </owner>
+            <name>Test Agent Group</name>
+            <comment>Created via gvm-cli for testing</comment>
+            <creation_time>2025-07-15T14:15:31Z</creation_time>
+            <modification_time>2025-07-15T14:15:31Z</modification_time>
+            <writable>1</writable>
+            <in_use>0</in_use>
+            <permissions>
+              <permission>
+                <name>Everything</name>
+              </permission>
+            </permissions>
+            <scanner id="3b4be213-281f-49ee-b457-5a5f34f71510">
+              <name>Agent Controller</name>
+            </scanner>
+            <agents>GAT-29::6b9ac61f, GAT-29-p0MPX0FT</agents>
+          </agent_group>
+        </get_agent_groups_response>
+      </response>
+    </example>
+  </command>
   <command>
     <name>get_agents</name>
     <summary>Get agents</summary>
@@ -28028,6 +28324,84 @@ END:VCALENDAR
     </example>
   </command>
   @IF_ENABLE_AGENTS@
+  <command>
+    <name>modify_agent_group</name>
+    <summary>Modify an agent group</summary>
+    <description>
+      <p>
+        The <code>agent_group_id</code> attribute is required to identify which group
+        should be modified.
+      </p>
+    </description>
+    <pattern>
+      <attrib>
+        <name>agent_group_id</name>
+        <type>uuid</type>
+        <required>1</required>
+      </attrib>
+      <o><e>name</e></o>
+      <o><e>comment</e></o>
+      <o><e>agents</e></o>
+    </pattern>
+    <ele>
+      <name>name</name>
+      <summary>New name for the agent group</summary>
+      <pattern>text</pattern>
+      <required>0</required>
+    </ele>
+    <ele>
+      <name>comment</name>
+      <summary>Optional comment for the agent group</summary>
+      <pattern>text</pattern>
+      <required>0</required>
+    </ele>
+    <ele>
+      <name>agents</name>
+      <summary>List of agents to assign to the group</summary>
+      <pattern>
+        <any><e>agent</e></any>
+      </pattern>
+      <ele>
+        <name>agent</name>
+        <pattern>
+          <attrib>
+            <name>id</name>
+            <type>uuid</type>
+            <required>1</required>
+          </attrib>
+        </pattern>
+      </ele>
+    </ele>
+    <response>
+      <pattern>
+        <attrib>
+          <name>status</name>
+          <type>status</type>
+          <required>1</required>
+        </attrib>
+        <attrib>
+          <name>status_text</name>
+          <type>text</type>
+          <required>1</required>
+        </attrib>
+      </pattern>
+    </response>
+    <example>
+      <summary>Modify an agent group</summary>
+      <request>
+        <modify_agent_group agent_group_id="6fca29e3-8b96-4e6b-9ee1-8845680dbda5">
+          <name>Updated Group Name</name>
+          <comment>Modified via gvm-cli</comment>
+          <agents>
+            <agent id="48c1b767-b699-45a4-a8bb-3325f2865913"/>
+          </agents>
+        </modify_agent_group>
+      </request>
+      <response>
+        <modify_agent_group_response status="200" status_text="OK"/>
+      </response>
+    </example>
+  </command>
   <command>
     <name>modify_agents</name>
     <summary>Modify agents</summary>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -9692,6 +9692,29 @@ END:VCALENDAR
           <e>scanner</e>
           <e>agents</e>
         </pattern>
+        <ele>
+          <name>agents</name>
+          <summary>Agents assigned to the group</summary>
+          <pattern>
+            <any><e>agent</e></any>
+          </pattern>
+          <ele>
+            <name>agent</name>
+            <pattern>
+              <attrib>
+                <name>id</name>
+                <type>uuid</type>
+                <required>1</required>
+              </attrib>
+              <e>name</e>
+            </pattern>
+            <ele>
+              <name>name</name>
+              <summary>Name of the agent</summary>
+              <pattern><t>name</t></pattern>
+            </ele>
+          </ele>
+        </ele>
       </ele>
       <ele>
         <name>filters</name>
@@ -9759,7 +9782,14 @@ END:VCALENDAR
             <scanner id="3b4be213-281f-49ee-b457-5a5f34f71510">
               <name>Agent Controller</name>
             </scanner>
-            <agents>GAT-29::6b9ac61f, GAT-29-p0MPX0FT</agents>
+            <agents>
+              <agent id="6b9ac61f-aaaa-bbbb-cccc-ddeeff001122">
+                <name>GAT-29</name>
+              </agent>
+              <agent id="6b9ac61f-bbbb-cccc-dddd-eeff00112233">
+                <name>GAT-29-p0MPX0FT</name>
+              </agent>
+            </agents>
           </agent_group>
         </get_agent_groups_response>
       </response>


### PR DESCRIPTION
## What

This PR implements full GMP command support for agent group management. Specifically, it adds the following commands:

- create_agent_group
- modify_agent_group
- get_agent_groups
- delete_agent_group

## Why

These changes add the backend support needed to use agent groups in scans, making it easier to manage and reuse sets of agents.

## References

GEA-976



