### PR TITLE
Add: add support to check if agents are in use

### DIFF
--- a/src/gmp_agents.c
+++ b/src/gmp_agents.c
@@ -445,7 +445,7 @@ modify_agents_run (gmp_parser_t *gmp_parser, GError **error)
         SEND_TO_CLIENT_OR_FAIL (XML_INTERNAL_ERROR ("modify_agents"));
         log_event_fail ("agents", "Agents", NULL, "modified");
         break;
-
+      case AGENT_RESPONSE_IN_USE_ERROR:
       default:
         SEND_TO_CLIENT_OR_FAIL (XML_INTERNAL_ERROR ("modify_agents"));
         log_event_fail ("agents", "Agents", NULL, "modified");
@@ -705,6 +705,11 @@ delete_agents_run (gmp_parser_t *gmp_parser, GError **error)
       case AGENT_RESPONSE_INTERNAL_ERROR:
         SEND_TO_CLIENT_OR_FAIL (XML_INTERNAL_ERROR ("delete_agents"));
         log_event_fail ("agents", "Agents", NULL, "deleted");
+        break;
+
+      case AGENT_RESPONSE_IN_USE_ERROR:
+        SENDF_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX ("delete_agents", "Resource is in use"));
+        log_event_fail ("agent", "Agents", NULL, "deleted");
         break;
 
       default:

--- a/src/manage_agent_groups.h
+++ b/src/manage_agent_groups.h
@@ -18,8 +18,9 @@
 #define _GVMD_MANAGE_AGENT_GROUPS_H
 
 #include "iterator.h"
-#include "manage.h"
 #include "manage_agent_common.h"
+#include "manage_get.h"
+#include "manage_resources.h"
 
 typedef resource_t agent_group_t;
 

--- a/src/manage_agents.c
+++ b/src/manage_agents.c
@@ -728,6 +728,13 @@ delete_and_resync_agents (agent_uuid_list_t agent_uuids)
       return get_result;
     }
 
+  if (agents_in_use (agent_uuids))
+    {
+      agent_controller_agent_list_free (agent_control_list);
+      manage_option_cleanup ();
+      return AGENT_RESPONSE_IN_USE_ERROR;
+    }
+
   connector = gvmd_agent_connector_new_from_scanner (scanner);
   if (!connector)
     {

--- a/src/manage_agents.h
+++ b/src/manage_agents.h
@@ -19,8 +19,11 @@
 #define _GVMD_MANAGE_AGENTS_H
 
 #include "iterator.h"
-#include "manage.h"
 #include "manage_agent_common.h"
+#include "manage_get.h"
+#include "manage_resources.h"
+
+#include <agent_controller/agent_controller.h>
 
 typedef resource_t agent_t;
 
@@ -106,7 +109,8 @@ typedef enum {
   AGENT_RESPONSE_INVALID_ARGUMENT = -8,             ///< Failed invalid argument
   AGENT_RESPONSE_INVALID_AGENT_OWNER = -9,          ///< Failed getting owner UUID
   AGENT_RESPONSE_AGENT_NOT_FOUND = -10,             ///< Failed getting owner UUID
-  AGENT_RESPONSE_INTERNAL_ERROR = -11               ///< Internal error
+  AGENT_RESPONSE_INTERNAL_ERROR = -11,              ///< Internal error
+  AGENT_RESPONSE_IN_USE_ERROR = -12                 ///< Agent is in used by an Agent Group
 } agent_response_t;
 
 gvmd_agent_connector_t
@@ -194,6 +198,9 @@ agent_in_use (agent_t agent);
 
 void
 delete_agents_by_scanner_and_uuids (scanner_t scanner, agent_uuid_list_t agent_uuids);
+
+gboolean
+agents_in_use (agent_uuid_list_t agent_uuids);
 
 #endif // _GVMD_MANAGE_AGENTS_H
 #endif // ENABLE_AGENTS


### PR DESCRIPTION
## What

Adds support for checking whether agents are currently in use by any agent group, including those in the trash table.

## Why

This change is necessary to prevent accidental deletion or modification of agents that are still referenced in agent groups. 

## References

GEA-968
