### PR TITLE
Update credentials gmp commands for oci targets

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -2217,6 +2217,20 @@ credential_target_iterator_name (iterator_t*);
 int
 credential_target_iterator_readable (iterator_t*);
 
+#if ENABLE_CONTAINER_SCANNING
+void
+init_credential_oci_image_target_iterator (iterator_t*, credential_t, int);
+
+const char*
+credential_oci_target_iterator_uuid (iterator_t*);
+
+const char*
+credential_oci_target_iterator_name (iterator_t*);
+
+int
+credential_oci_target_iterator_readable (iterator_t*);
+#endif /* ENABLE_CONTAINER_SCANNING */
+
 void
 init_credential_scanner_iterator (iterator_t*, credential_t, int);
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -45736,6 +45736,21 @@ delete_user (const char *user_id_arg, const char *name_arg,
   sql ("DELETE FROM targets WHERE owner = %llu;", user);
   sql ("DELETE FROM targets_trash WHERE owner = %llu;", user);
 
+#if ENABLE_CONTAINER_SCANNING
+  /* OCI Image Targets. */
+  if (user_resources_in_use (user,
+                             "oci_image_targets",
+                             oci_image_target_in_use,
+                             "oci_image_targets_trash",
+                             trash_oci_image_target_in_use))
+    {
+      sql_rollback ();
+      return 9;
+    }
+  sql ("DELETE FROM oci_image_targets WHERE owner = %llu;", user);
+  sql ("DELETE FROM oci_image_targets_trash WHERE owner = %llu;", user);
+#endif /* ENABLE_CONTAINER_SCANNING */
+
   /* Delete resources used indirectly by tasks */
 
   /* Filters (used by alerts and settings). */

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -12824,6 +12824,13 @@ END:VCALENDAR
         <summary>Whether to include a list of targets using the credentials</summary>
         <type>boolean</type>
       </attrib>
+@IF_ENABLE_CONTAINER_SCANNNING@
+      <attrib>
+        <name>oci_image_targets</name>
+        <summary>Whether to include a list of OCI image targets using the credentials</summary>
+        <type>boolean</type>
+      </attrib>
+@ENDIF_ENABLE_CONTAINER_SCANNNING@
       <attrib>
         <name>format</name>
         <type>
@@ -12882,6 +12889,9 @@ END:VCALENDAR
           <o><e>certificate_info</e></o>
           <o><e>scanners</e></o>
           <o><e>targets</e></o>
+@IF_ENABLE_CONTAINER_SCANNNING@
+          <o><e>oci_image_targets</e></o>
+@ENDIF_ENABLE_CONTAINER_SCANNNING@
           <o>
             <or>
               <e>public_key</e>
@@ -13157,6 +13167,37 @@ END:VCALENDAR
             </ele>
           </ele>
         </ele>
+@IF_ENABLE_CONTAINER_SCANNNING@
+        <ele>
+          <name>oci_image_targets</name>
+          <summary>All OCI image targets using this credential</summary>
+          <pattern>
+            <any><e>oci_image_target</e></any>
+          </pattern>
+          <ele>
+            <name>oci_image_target</name>
+            <pattern>
+              <attrib>
+                <name>id</name>
+                <type>uuid</type>
+                <required>1</required>
+              </attrib>
+              <e>name</e>
+              <o><e>permissions</e></o>
+            </pattern>
+            <ele>
+              <name>name</name>
+              <summary>The name of the OCI image target</summary>
+              <pattern><t>name</t></pattern>
+            </ele>
+            <ele>
+              <name>permissions</name>
+              <summary>Permissions the user has on the OCI image target</summary>
+              <pattern></pattern>
+            </ele>
+          </ele>
+        </ele>
+@ENDIF_ENABLE_CONTAINER_SCANNNING@
         <ele>
           <name>public_key</name>
           <pattern>text</pattern>


### PR DESCRIPTION
## What
1) Getting and deleting credentials should account for OCI image targets.

- Added a boolean attribute `oci_image_targets` to `get_credentials` to to include a list of OCI image targets using the credentials.
- Added a check if credentials are in use by any OCI image target before deletion.

2) Remove OCI image targets on user deletion.

Changes are behind a toggle `ENABLE_CONTAINER_SCANNING`

## Why
The credentials details page in GSA displays the targets using the credential. To keep the same behavior for OCI image targets.

## References
GEA-1180


