### PR TITLE
Allow to run our CI pipeline from GitHub forks

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,7 @@ jobs:
   scan-build:
     name: scan-build (clang static analyzer)
     runs-on: ubuntu-latest
-    container: ${{ vars.SELF_HOSTED_REGISTRY }}/community/gvm-libs:stable
+    container: ${{ vars.SELF_HOSTED_REGISTRY || 'registry.community.greenbone.net' }}/community/gvm-libs:stable
     steps:
       - name: Check out gvmd
         uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
           - stable
           - oldstable
           - testing
-    container: ${{ vars.SELF_HOSTED_REGISTRY }}/community/gvm-libs:${{ matrix.container }}
+    container: ${{ vars.SELF_HOSTED_REGISTRY || 'registry.community.greenbone.net' }}/community/gvm-libs:${{ matrix.container }}
     steps:
       - uses: actions/checkout@v4
       - name: Install build dependencies
@@ -76,7 +76,7 @@ jobs:
         container:
           - stable
           - testing
-    container: ${{ vars.SELF_HOSTED_REGISTRY }}/community/gvm-libs:${{ matrix.container }}
+    container: ${{ vars.SELF_HOSTED_REGISTRY || 'registry.community.greenbone.net' }}/community/gvm-libs:${{ matrix.container }}
     steps:
       - uses: actions/checkout@v4
       - name: Install build dependencies
@@ -90,7 +90,7 @@ jobs:
   test-units:
     name: Unit Tests
     runs-on: ubuntu-latest
-    container: ${{ vars.SELF_HOSTED_REGISTRY }}/community/gvm-libs:stable
+    container: ${{ vars.SELF_HOSTED_REGISTRY || 'registry.community.greenbone.net' }}/community/gvm-libs:stable
     steps:
       - name: Check out gvmd
         uses: actions/checkout@v4
@@ -111,6 +111,7 @@ jobs:
       - name: Configure and run tests
         run: CTEST_OUTPUT_ON_FAILURE=1 cmake --build build -- tests test
       - name: Upload test coverage to Codecov
+        if: github.repository == 'greenbone/gvmd'
         uses: codecov/codecov-action@v5
         with:
           files: build/coverage/coverage.xml

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,8 +1,8 @@
-name: 'Build Documentation'
+name: "Build Documentation"
 
 on:
   push:
-    branches: [ main, stable, oldstable ]
+    branches: [main, stable, oldstable]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,7 +22,7 @@ jobs:
   build-gmp-doc:
     name: Build GMP documentation
     runs-on: ubuntu-latest
-    container: ${{ vars.IMAGE_REGISTRY }}/greenbone/gvmd-build:stable
+    container: ${{ vars.SELF_HOSTED_REGISTRY || 'registry.community.greenbone.net' }}/community/gvm-libs:stable
     steps:
       - name: Check out gvmd
         uses: actions/checkout@v4

--- a/.github/workflows/codeql-analysis-c.yml
+++ b/.github/workflows/codeql-analysis-c.yml
@@ -2,14 +2,14 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main, stable, oldstable ]
+    branches: [main, stable, oldstable]
   pull_request:
-    branches: [ main, stable, oldstable ]
+    branches: [main, stable, oldstable]
     paths-ignore:
-      - '**/*.md'
-      - '**/*.txt'
+      - "**/*.md"
+      - "**/*.txt"
   schedule:
-    - cron: '30 5 * * 0' # 5:30h on Sundays
+    - cron: "30 5 * * 0" # 5:30h on Sundays
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,28 +23,28 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    container: ${{ vars.SELF_HOSTED_REGISTRY }}/community/gvm-libs:stable
+    container: ${{ vars.SELF_HOSTED_REGISTRY || 'registry.community.greenbone.net' }}/community/gvm-libs:stable
 
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'c' ]
+        language: ["c"]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    - name: Install build dependencies
-      run: sh .github/install-dependencies.sh .github/build-dependencies.list
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-    # build between init and analyze ...
-    - name: Configure and compile gvmd
-      run: |
-        mkdir build
-        cd build/
-        cmake -DCMAKE_BUILD_TYPE=Debug ..
-        make install
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install build dependencies
+        run: sh .github/install-dependencies.sh .github/build-dependencies.list
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+      # build between init and analyze ...
+      - name: Configure and compile gvmd
+        run: |
+          mkdir build
+          cd build/
+          cmake -DCMAKE_BUILD_TYPE=Debug ..
+          make install
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -2,10 +2,10 @@ name: Build and Push Container Images
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     tags: ["v*"]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
     inputs:
       ref-name:
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository == 'greenbone/gvmd'
     name: Build and Push to Greenbone Registry
     uses: greenbone/workflows/.github/workflows/container-build-push-2nd-gen.yml@main
     with:


### PR DESCRIPTION


## What

Allow to run our CI pipeline from GitHub forks

## Why
For whatever reason the vars GitHub context is not available in forks. Therefore the containers couldn't be downloaded.

## References

https://github.com/greenbone/gvmd/pull/2489

