### PR TITLE
Update copies of cmake files to current upstream versions from CMake 4.0.3

### DIFF
--- a/cmake/FindPackageHandleStandardArgs.cmake
+++ b/cmake/FindPackageHandleStandardArgs.cmake
@@ -1,20 +1,23 @@
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
-# file Copyright.txt or https://cmake.org/licensing for details.
+# file LICENSE.rst or https://cmake.org/licensing for details.
 
 #[=======================================================================[.rst:
 FindPackageHandleStandardArgs
 -----------------------------
 
-This module provides a function intended to be used in :ref:`Find Modules`
-implementing :command:`find_package(<PackageName>)` calls.  It handles the
-``REQUIRED``, ``QUIET`` and version-related arguments of ``find_package``.
-It also sets the ``<PackageName>_FOUND`` variable.  The package is
-considered found if all variables listed contain valid results, e.g.
-valid filepaths.
+This module provides functions intended to be used in :ref:`Find Modules`
+implementing :command:`find_package(<PackageName>)` calls.
 
 .. command:: find_package_handle_standard_args
 
-  There are two signatures::
+  This command handles the ``REQUIRED``, ``QUIET`` and version-related
+  arguments of :command:`find_package`.  It also sets the
+  ``<PackageName>_FOUND`` variable.  The package is considered found if all
+  variables listed contain valid results, e.g. valid filepaths.
+
+  There are two signatures:
+
+  .. code-block:: cmake
 
     find_package_handle_standard_args(<PackageName>
       (DEFAULT_MSG|<custom-failure-message>)
@@ -25,6 +28,7 @@ valid filepaths.
       [FOUND_VAR <result-var>]
       [REQUIRED_VARS <required-var>...]
       [VERSION_VAR <version-var>]
+      [HANDLE_VERSION_RANGE]
       [HANDLE_COMPONENTS]
       [CONFIG_MODE]
       [NAME_MISMATCHED]
@@ -47,18 +51,23 @@ valid filepaths.
     (recommended).  Not valid in the full signature.
 
   ``FOUND_VAR <result-var>``
-    Obsolete.  Specifies either ``<PackageName>_FOUND`` or
+    .. deprecated:: 3.3
+
+    Specifies either ``<PackageName>_FOUND`` or
     ``<PACKAGENAME>_FOUND`` as the result variable.  This exists only
     for compatibility with older versions of CMake and is now ignored.
-    Result variables of both names are always set for compatibility.
+    Result variables of both names are now always set for compatibility
+    also with or without this option.
 
   ``REQUIRED_VARS <required-var>...``
     Specify the variables which are required for this package.
     These may be named in the generated failure message asking the
     user to set the missing variable values.  Therefore these should
     typically be cache entries such as ``FOO_LIBRARY`` and not output
-    variables like ``FOO_LIBRARIES``. This option is mandatory if
-    ``HANDLE_COMPONENTS`` is not specified.
+    variables like ``FOO_LIBRARIES``.
+
+    .. versionchanged:: 3.18
+      If ``HANDLE_COMPONENTS`` is specified, this option can be omitted.
 
   ``VERSION_VAR <version-var>``
     Specify the name of a variable that holds the version of the package
@@ -68,6 +77,13 @@ valid filepaths.
     The default messages include information about the required
     version and the version which has been actually found, both
     if the version is ok or not.
+
+  ``HANDLE_VERSION_RANGE``
+    .. versionadded:: 3.19
+
+    Enable handling of a version range, if one is specified. Without this
+    option, a developer warning will be displayed if a version range is
+    specified.
 
   ``HANDLE_COMPONENTS``
     Enable handling of package components.  In this case, the command
@@ -85,6 +101,8 @@ valid filepaths.
     was found.
 
   ``REASON_FAILURE_MESSAGE <reason-failure-message>``
+    .. versionadded:: 3.16
+
     Specify a custom message of the reason for the failure which will be
     appended to the default generated message.
 
@@ -93,6 +111,8 @@ valid filepaths.
     generated message.  Not recommended.
 
   ``NAME_MISMATCHED``
+    .. versionadded:: 3.17
+
     Indicate that the ``<PackageName>`` does not match
     ``${CMAKE_FIND_PACKAGE_NAME}``. This is usually a mistake and raises a
     warning, but it may be intentional for usage of the command for components
@@ -151,19 +171,57 @@ In this case, a ``FindAutmoc4.cmake`` module wraps a call to
 directory for ``automoc4``.  Then the call to
 ``find_package_handle_standard_args`` produces a proper success/failure
 message.
+
+.. command:: find_package_check_version
+
+  .. versionadded:: 3.19
+
+  Helper function which can be used to check if a ``<version>`` is valid
+  against version-related arguments of :command:`find_package`.
+
+  .. code-block:: cmake
+
+    find_package_check_version(<version> <result-var>
+      [HANDLE_VERSION_RANGE]
+      [RESULT_MESSAGE_VARIABLE <message-var>]
+      )
+
+  The ``<result-var>`` will hold a boolean value giving the result of the check.
+
+  The options are:
+
+  ``HANDLE_VERSION_RANGE``
+    Enable handling of a version range, if one is specified. Without this
+    option, a developer warning will be displayed if a version range is
+    specified.
+
+  ``RESULT_MESSAGE_VARIABLE <message-var>``
+    Specify a variable to get back a message describing the result of the check.
+
+Example for the usage:
+
+.. code-block:: cmake
+
+  find_package_check_version(1.2.3 result HANDLE_VERSION_RANGE
+    RESULT_MESSAGE_VARIABLE reason)
+  if(result)
+    message(STATUS "${reason}")
+  else()
+    message(FATAL_ERROR "${reason}")
+  endif()
 #]=======================================================================]
 
 include(${CMAKE_CURRENT_LIST_DIR}/FindPackageMessage.cmake)
+
 
 # internal helper macro
 macro(_FPHSA_FAILURE_MESSAGE _msg)
   set(__msg "${_msg}")
   if(FPHSA_REASON_FAILURE_MESSAGE)
-    string(
-      APPEND
-      __msg
-      "\n    Reason given by package: ${FPHSA_REASON_FAILURE_MESSAGE}\n"
-    )
+    string(APPEND __msg "\n    Reason given by package: ${FPHSA_REASON_FAILURE_MESSAGE}\n")
+  elseif(NOT DEFINED PROJECT_NAME AND NOT CMAKE_SCRIPT_MODE_FILE)
+    string(APPEND __msg "\n"
+      "Hint: The project() command has not yet been called.  It sets up system-specific search paths.")
   endif()
   if(${_NAME}_FIND_REQUIRED)
     message(FATAL_ERROR "${__msg}")
@@ -174,58 +232,147 @@ macro(_FPHSA_FAILURE_MESSAGE _msg)
   endif()
 endmacro()
 
+
 # internal helper macro to generate the failure message when used in CONFIG_MODE:
 macro(_FPHSA_HANDLE_FAILURE_CONFIG_MODE)
   # <PackageName>_CONFIG is set, but FOUND is false, this means that some other of the REQUIRED_VARS was not found:
   if(${_NAME}_CONFIG)
-    _FPHSA_FAILURE_MESSAGE(
-      "${FPHSA_FAIL_MESSAGE}: missing:${MISSING_VARS} (found ${${_NAME}_CONFIG} ${VERSION_MSG})"
-    )
+    _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE}: missing:${MISSING_VARS} (found ${${_NAME}_CONFIG} ${VERSION_MSG})")
   else()
     # If _CONSIDERED_CONFIGS is set, the config-file has been found, but no suitable version.
     # List them all in the error message:
     if(${_NAME}_CONSIDERED_CONFIGS)
       set(configsText "")
-      list(LENGTH ${_NAME}_CONSIDERED_CONFIGS configsCount)
-      math(EXPR configsCount "${configsCount} - 1")
-      foreach(currentConfigIndex RANGE ${configsCount})
-        list(GET ${_NAME}_CONSIDERED_CONFIGS ${currentConfigIndex} filename)
-        list(GET ${_NAME}_CONSIDERED_VERSIONS ${currentConfigIndex} version)
+      foreach(filename version IN ZIP_LISTS ${_NAME}_CONSIDERED_CONFIGS ${_NAME}_CONSIDERED_VERSIONS)
         string(APPEND configsText "\n    ${filename} (version ${version})")
       endforeach()
       if(${_NAME}_NOT_FOUND_MESSAGE)
         if(FPHSA_REASON_FAILURE_MESSAGE)
-          string(
-            PREPEND
-            FPHSA_REASON_FAILURE_MESSAGE
-            "${${_NAME}_NOT_FOUND_MESSAGE}\n    "
-          )
+          string(PREPEND FPHSA_REASON_FAILURE_MESSAGE "${${_NAME}_NOT_FOUND_MESSAGE}\n    ")
         else()
           set(FPHSA_REASON_FAILURE_MESSAGE "${${_NAME}_NOT_FOUND_MESSAGE}")
         endif()
       else()
         string(APPEND configsText "\n")
       endif()
-      _FPHSA_FAILURE_MESSAGE(
-        "${FPHSA_FAIL_MESSAGE} ${VERSION_MSG}, checked the following files:${configsText}"
-      )
+      _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE} ${VERSION_MSG}, checked the following files:${configsText}")
+
     else()
       # Simple case: No Config-file was found at all:
-      _FPHSA_FAILURE_MESSAGE(
-        "${FPHSA_FAIL_MESSAGE}: found neither ${_NAME}Config.cmake nor ${_NAME_LOWER}-config.cmake ${VERSION_MSG}"
-      )
+      _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE}: found neither ${_NAME}Config.cmake nor ${_NAME_LOWER}-config.cmake ${VERSION_MSG}")
     endif()
   endif()
 endmacro()
 
+
+function(FIND_PACKAGE_CHECK_VERSION version result)
+  cmake_parse_arguments(PARSE_ARGV 2 FPCV "HANDLE_VERSION_RANGE;NO_AUTHOR_WARNING_VERSION_RANGE" "RESULT_MESSAGE_VARIABLE" "")
+
+  if(FPCV_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "find_package_check_version(): ${FPCV_UNPARSED_ARGUMENTS}: unexpected arguments")
+  endif()
+  if("RESULT_MESSAGE_VARIABLE" IN_LIST FPCV_KEYWORDS_MISSING_VALUES)
+    message(FATAL_ERROR "find_package_check_version(): RESULT_MESSAGE_VARIABLE expects an argument")
+  endif()
+
+  set(${result} FALSE PARENT_SCOPE)
+  if(FPCV_RESULT_MESSAGE_VARIABLE)
+    unset (${FPCV_RESULT_MESSAGE_VARIABLE} PARENT_SCOPE)
+  endif()
+
+  if(_CMAKE_FPHSA_PACKAGE_NAME)
+    set(package "${_CMAKE_FPHSA_PACKAGE_NAME}")
+  elseif(CMAKE_FIND_PACKAGE_NAME)
+    set(package "${CMAKE_FIND_PACKAGE_NAME}")
+  else()
+    message(FATAL_ERROR "find_package_check_version(): Cannot be used outside a 'Find Module'")
+  endif()
+
+  if(NOT FPCV_NO_AUTHOR_WARNING_VERSION_RANGE
+      AND ${package}_FIND_VERSION_RANGE AND NOT FPCV_HANDLE_VERSION_RANGE)
+    message(AUTHOR_WARNING
+      "find_package() specify a version range but the option "
+      "HANDLE_VERSION_RANGE` is not passed to find_package_check_version(). "
+      "Only the lower endpoint of the range will be used.")
+  endif()
+
+  set(version_ok FALSE)
+  unset (version_msg)
+
+  if(FPCV_HANDLE_VERSION_RANGE AND ${package}_FIND_VERSION_RANGE)
+    if((${package}_FIND_VERSION_RANGE_MIN STREQUAL "INCLUDE"
+          AND version VERSION_GREATER_EQUAL ${package}_FIND_VERSION_MIN)
+        AND ((${package}_FIND_VERSION_RANGE_MAX STREQUAL "INCLUDE"
+            AND version VERSION_LESS_EQUAL ${package}_FIND_VERSION_MAX)
+          OR (${package}_FIND_VERSION_RANGE_MAX STREQUAL "EXCLUDE"
+            AND version VERSION_LESS ${package}_FIND_VERSION_MAX)))
+      set(version_ok TRUE)
+      set(version_msg "(found suitable version \"${version}\", required range is \"${${package}_FIND_VERSION_RANGE}\")")
+    else()
+      set(version_msg "Found unsuitable version \"${version}\", required range is \"${${package}_FIND_VERSION_RANGE}\"")
+    endif()
+  elseif(DEFINED ${package}_FIND_VERSION)
+    if(${package}_FIND_VERSION_EXACT)       # exact version required
+      # count the dots in the version string
+      string(REGEX REPLACE "[^.]" "" version_dots "${version}")
+      # add one dot because there is one dot more than there are components
+      string(LENGTH "${version_dots}." version_dots)
+      if(version_dots GREATER ${package}_FIND_VERSION_COUNT)
+        # Because of the C++ implementation of find_package() ${package}_FIND_VERSION_COUNT
+        # is at most 4 here. Therefore a simple lookup table is used.
+        if(${package}_FIND_VERSION_COUNT EQUAL 1)
+          set(version_regex "[^.]*")
+        elseif(${package}_FIND_VERSION_COUNT EQUAL 2)
+          set(version_regex "[^.]*\\.[^.]*")
+        elseif(${package}_FIND_VERSION_COUNT EQUAL 3)
+          set(version_regex "[^.]*\\.[^.]*\\.[^.]*")
+        else()
+          set(version_regex "[^.]*\\.[^.]*\\.[^.]*\\.[^.]*")
+        endif()
+        string(REGEX REPLACE "^(${version_regex})\\..*" "\\1" version_head "${version}")
+        if(NOT ${package}_FIND_VERSION VERSION_EQUAL version_head)
+          set(version_msg "Found unsuitable version \"${version}\", but required is exact version \"${${package}_FIND_VERSION}\"")
+        else()
+          set(version_ok TRUE)
+          set(version_msg "(found suitable exact version \"${version}\")")
+        endif()
+      else()
+        if(NOT ${package}_FIND_VERSION VERSION_EQUAL version)
+          set(version_msg "Found unsuitable version \"${version}\", but required is exact version \"${${package}_FIND_VERSION}\"")
+        else()
+          set(version_ok TRUE)
+          set(version_msg "(found suitable exact version \"${version}\")")
+        endif()
+      endif()
+    else()     # minimum version
+      if(${package}_FIND_VERSION VERSION_GREATER version)
+        set(version_msg "Found unsuitable version \"${version}\", but required is at least \"${${package}_FIND_VERSION}\"")
+      else()
+        set(version_ok TRUE)
+        set(version_msg "(found suitable version \"${version}\", minimum required is \"${${package}_FIND_VERSION}\")")
+      endif()
+    endif()
+  else()
+    set(version_ok TRUE)
+    set(version_msg "(found version \"${version}\")")
+  endif()
+
+  set(${result} ${version_ok} PARENT_SCOPE)
+  if(FPCV_RESULT_MESSAGE_VARIABLE)
+    set(${FPCV_RESULT_MESSAGE_VARIABLE} "${version_msg}" PARENT_SCOPE)
+  endif()
+endfunction()
+
+
 function(FIND_PACKAGE_HANDLE_STANDARD_ARGS _NAME _FIRST_ARG)
+
   # Set up the arguments for `cmake_parse_arguments`.
-  set(options CONFIG_MODE HANDLE_COMPONENTS NAME_MISMATCHED)
-  set(oneValueArgs FAIL_MESSAGE REASON_FAILURE_MESSAGE VERSION_VAR FOUND_VAR)
+  set(options  CONFIG_MODE  HANDLE_COMPONENTS NAME_MISMATCHED HANDLE_VERSION_RANGE)
+  set(oneValueArgs  FAIL_MESSAGE  REASON_FAILURE_MESSAGE VERSION_VAR  FOUND_VAR)
   set(multiValueArgs REQUIRED_VARS)
 
   # Check whether we are in 'simple' or 'extended' mode:
-  set(_KEYWORDS_FOR_EXTENDED_MODE ${options} ${oneValueArgs} ${multiValueArgs})
+  set(_KEYWORDS_FOR_EXTENDED_MODE  ${options} ${oneValueArgs} ${multiValueArgs} )
   list(FIND _KEYWORDS_FOR_EXTENDED_MODE "${_FIRST_ARG}" INDEX)
 
   unset(FPHSA_NAME_MISMATCHED_override)
@@ -235,11 +382,9 @@ function(FIND_PACKAGE_HANDLE_STANDARD_ARGS _NAME _FIRST_ARG)
     # signatures.
     list(FIND ARGN "NAME_MISMATCHED" name_mismatched_idx)
     if(NOT name_mismatched_idx EQUAL "-1")
-      message(
-        FATAL_ERROR
-        "The `NAME_MISMATCHED` argument may only be specified by the argument or "
-        "the variable, not both."
-      )
+      message(FATAL_ERROR
+        "The NAME_MISMATCHED argument may only be specified by the argument or "
+        "the variable, not both.")
     endif()
 
     # But use the variable if it is not an argument to avoid forcing minimum
@@ -252,24 +397,14 @@ function(FIND_PACKAGE_HANDLE_STANDARD_ARGS _NAME _FIRST_ARG)
     set(FPHSA_REQUIRED_VARS ${ARGN})
     set(FPHSA_VERSION_VAR)
   else()
-    cmake_parse_arguments(
-      FPHSA
-      "${options}"
-      "${oneValueArgs}"
-      "${multiValueArgs}"
-      ${_FIRST_ARG}
-      ${ARGN}
-    )
+    cmake_parse_arguments(FPHSA "${options}" "${oneValueArgs}" "${multiValueArgs}"  ${_FIRST_ARG} ${ARGN})
 
     if(FPHSA_UNPARSED_ARGUMENTS)
-      message(
-        FATAL_ERROR
-        "Unknown keywords given to FIND_PACKAGE_HANDLE_STANDARD_ARGS(): \"${FPHSA_UNPARSED_ARGUMENTS}\""
-      )
+      message(FATAL_ERROR "Unknown keywords given to find_package_handle_standard_args(): \"${FPHSA_UNPARSED_ARGUMENTS}\"")
     endif()
 
     if(NOT FPHSA_FAIL_MESSAGE)
-      set(FPHSA_FAIL_MESSAGE "DEFAULT_MSG")
+      set(FPHSA_FAIL_MESSAGE  "DEFAULT_MSG")
     endif()
 
     # In config-mode, we rely on the variable <PackageName>_CONFIG, which is set by find_package()
@@ -281,10 +416,7 @@ function(FIND_PACKAGE_HANDLE_STANDARD_ARGS _NAME _FIRST_ARG)
     endif()
 
     if(NOT FPHSA_REQUIRED_VARS AND NOT FPHSA_HANDLE_COMPONENTS)
-      message(
-        FATAL_ERROR
-        "No REQUIRED_VARS specified for FIND_PACKAGE_HANDLE_STANDARD_ARGS()"
-      )
+      message(FATAL_ERROR "No REQUIRED_VARS specified for find_package_handle_standard_args()")
     endif()
   endif()
 
@@ -292,20 +424,26 @@ function(FIND_PACKAGE_HANDLE_STANDARD_ARGS _NAME _FIRST_ARG)
     set(FPHSA_NAME_MISMATCHED "${FPHSA_NAME_MISMATCHED_override}")
   endif()
 
-  if(
-    DEFINED CMAKE_FIND_PACKAGE_NAME
-    AND NOT FPHSA_NAME_MISMATCHED
-    AND NOT _NAME STREQUAL CMAKE_FIND_PACKAGE_NAME
-  )
-    message(
-      AUTHOR_WARNING
-      "The package name passed to `find_package_handle_standard_args` "
+  if(DEFINED CMAKE_FIND_PACKAGE_NAME
+      AND NOT FPHSA_NAME_MISMATCHED
+      AND NOT _NAME STREQUAL CMAKE_FIND_PACKAGE_NAME)
+    message(AUTHOR_WARNING
+      "The package name passed to find_package_handle_standard_args() "
       "(${_NAME}) does not match the name of the calling package "
       "(${CMAKE_FIND_PACKAGE_NAME}). This can lead to problems in calling "
-      "code that expects `find_package` result variables (e.g., `_FOUND`) "
-      "to follow a certain pattern."
-    )
+      "code that expects find_package() result variables (e.g., `_FOUND`) "
+      "to follow a certain pattern.")
   endif()
+
+  if(${_NAME}_FIND_VERSION_RANGE AND NOT FPHSA_HANDLE_VERSION_RANGE)
+    message(AUTHOR_WARNING
+      "find_package() specify a version range but the module ${_NAME} does "
+      "not support this capability. Only the lower endpoint of the range "
+      "will be used.")
+  endif()
+
+  # to propagate package name to FIND_PACKAGE_CHECK_VERSION
+  set(_CMAKE_FPHSA_PACKAGE_NAME "${_NAME}")
 
   # now that we collected all arguments, process them
 
@@ -324,18 +462,11 @@ function(FIND_PACKAGE_HANDLE_STANDARD_ARGS _NAME _FIRST_ARG)
     set(_FOUND_VAR_UPPER ${_NAME_UPPER}_FOUND)
     set(_FOUND_VAR_MIXED ${_NAME}_FOUND)
     if(
-      FPHSA_FOUND_VAR STREQUAL _FOUND_VAR_MIXED
-      OR FPHSA_FOUND_VAR STREQUAL _FOUND_VAR_UPPER
+      NOT FPHSA_FOUND_VAR STREQUAL _FOUND_VAR_MIXED
+      AND NOT FPHSA_FOUND_VAR STREQUAL _FOUND_VAR_UPPER
     )
-      set(_FOUND_VAR ${FPHSA_FOUND_VAR})
-    else()
-      message(
-        FATAL_ERROR
-        "The argument for FOUND_VAR is \"${FPHSA_FOUND_VAR}\", but only \"${_FOUND_VAR_MIXED}\" and \"${_FOUND_VAR_UPPER}\" are valid names."
-      )
+      message(FATAL_ERROR "The argument for FOUND_VAR is \"${FPHSA_FOUND_VAR}\", but only \"${_FOUND_VAR_MIXED}\" and \"${_FOUND_VAR_UPPER}\" are valid names.")
     endif()
-  else()
-    set(_FOUND_VAR ${_NAME_UPPER}_FOUND)
   endif()
 
   # collect all variables which were not found, so they can be printed, so the
@@ -367,11 +498,14 @@ function(FIND_PACKAGE_HANDLE_STANDARD_ARGS _NAME _FIRST_ARG)
   if(FPHSA_HANDLE_COMPONENTS)
     foreach(comp ${${_NAME}_FIND_COMPONENTS})
       if(${_NAME}_${comp}_FOUND)
+
         if(NOT DEFINED FOUND_COMPONENTS_MSG)
           set(FOUND_COMPONENTS_MSG "found components:")
         endif()
         string(APPEND FOUND_COMPONENTS_MSG " ${comp}")
+
       else()
+
         if(NOT DEFINED MISSING_COMPONENTS_MSG)
           set(MISSING_COMPONENTS_MSG "missing components:")
         endif()
@@ -381,100 +515,42 @@ function(FIND_PACKAGE_HANDLE_STANDARD_ARGS _NAME _FIRST_ARG)
           set(${_NAME}_FOUND FALSE)
           string(APPEND MISSING_VARS " ${comp}")
         endif()
+
       endif()
     endforeach()
     set(COMPONENT_MSG "${FOUND_COMPONENTS_MSG} ${MISSING_COMPONENTS_MSG}")
-    string(APPEND DETAILS "[c${COMPONENT_MSG}]")
+    string(APPEND DETAILS "[${COMPONENT_MSG}]")
   endif()
 
   # version handling:
   set(VERSION_MSG "")
   set(VERSION_OK TRUE)
 
-  # check with DEFINED here as the requested or found version may be "0"
+  # check that the version variable is not empty to avoid emitting a misleading
+  # message(i.e. `Found unsuitable version ""`)
   if(DEFINED ${_NAME}_FIND_VERSION)
     if(DEFINED ${FPHSA_VERSION_VAR})
-      set(_FOUND_VERSION ${${FPHSA_VERSION_VAR}})
-
-      if(${_NAME}_FIND_VERSION_EXACT) # exact version required
-        # count the dots in the version string
-        string(REGEX REPLACE "[^.]" "" _VERSION_DOTS "${_FOUND_VERSION}")
-        # add one dot because there is one dot more than there are components
-        string(LENGTH "${_VERSION_DOTS}." _VERSION_DOTS)
-        if(_VERSION_DOTS GREATER ${_NAME}_FIND_VERSION_COUNT)
-          # Because of the C++ implementation of find_package() ${_NAME}_FIND_VERSION_COUNT
-          # is at most 4 here. Therefore a simple lookup table is used.
-          if(${_NAME}_FIND_VERSION_COUNT EQUAL 1)
-            set(_VERSION_REGEX "[^.]*")
-          elseif(${_NAME}_FIND_VERSION_COUNT EQUAL 2)
-            set(_VERSION_REGEX "[^.]*\\.[^.]*")
-          elseif(${_NAME}_FIND_VERSION_COUNT EQUAL 3)
-            set(_VERSION_REGEX "[^.]*\\.[^.]*\\.[^.]*")
-          else()
-            set(_VERSION_REGEX "[^.]*\\.[^.]*\\.[^.]*\\.[^.]*")
-          endif()
-          string(
-            REGEX REPLACE
-            "^(${_VERSION_REGEX})\\..*"
-            "\\1"
-            _VERSION_HEAD
-            "${_FOUND_VERSION}"
-          )
-          unset(_VERSION_REGEX)
-          if(NOT ${_NAME}_FIND_VERSION VERSION_EQUAL _VERSION_HEAD)
-            set(
-              VERSION_MSG
-              "Found unsuitable version \"${_FOUND_VERSION}\", but required is exact version \"${${_NAME}_FIND_VERSION}\""
-            )
-            set(VERSION_OK FALSE)
-          else()
-            set(
-              VERSION_MSG
-              "(found suitable exact version \"${_FOUND_VERSION}\")"
-            )
-          endif()
-          unset(_VERSION_HEAD)
+      if(NOT "${${FPHSA_VERSION_VAR}}" STREQUAL "")
+        set(_FOUND_VERSION ${${FPHSA_VERSION_VAR}})
+        if(FPHSA_HANDLE_VERSION_RANGE)
+          set(FPCV_HANDLE_VERSION_RANGE HANDLE_VERSION_RANGE)
         else()
-          if(NOT ${_NAME}_FIND_VERSION VERSION_EQUAL _FOUND_VERSION)
-            set(
-              VERSION_MSG
-              "Found unsuitable version \"${_FOUND_VERSION}\", but required is exact version \"${${_NAME}_FIND_VERSION}\""
-            )
-            set(VERSION_OK FALSE)
-          else()
-            set(
-              VERSION_MSG
-              "(found suitable exact version \"${_FOUND_VERSION}\")"
-            )
-          endif()
+          set(FPCV_HANDLE_VERSION_RANGE NO_AUTHOR_WARNING_VERSION_RANGE)
         endif()
-        unset(_VERSION_DOTS)
-      else() # minimum version specified:
-        if(${_NAME}_FIND_VERSION VERSION_GREATER _FOUND_VERSION)
-          set(
-            VERSION_MSG
-            "Found unsuitable version \"${_FOUND_VERSION}\", but required is at least \"${${_NAME}_FIND_VERSION}\""
-          )
-          set(VERSION_OK FALSE)
-        else()
-          set(
-            VERSION_MSG
-            "(found suitable version \"${_FOUND_VERSION}\", minimum required is \"${${_NAME}_FIND_VERSION}\")"
-          )
-        endif()
+        find_package_check_version("${_FOUND_VERSION}" VERSION_OK RESULT_MESSAGE_VARIABLE VERSION_MSG
+          ${FPCV_HANDLE_VERSION_RANGE})
+      else()
+        set(VERSION_OK FALSE)
       endif()
-    else()
+    endif()
+    if("${${FPHSA_VERSION_VAR}}" STREQUAL "")
       # if the package was not found, but a version was given, add that to the output:
       if(${_NAME}_FIND_VERSION_EXACT)
-        set(
-          VERSION_MSG
-          "(Required is exact version \"${${_NAME}_FIND_VERSION}\")"
-        )
+        set(VERSION_MSG "(Required is exact version \"${${_NAME}_FIND_VERSION}\")")
+      elseif(FPHSA_HANDLE_VERSION_RANGE AND ${_NAME}_FIND_VERSION_RANGE)
+        set(VERSION_MSG "(Required is version range \"${${_NAME}_FIND_VERSION_RANGE}\")")
       else()
-        set(
-          VERSION_MSG
-          "(Required is at least version \"${${_NAME}_FIND_VERSION}\")"
-        )
+        set(VERSION_MSG "(Required is at least version \"${${_NAME}_FIND_VERSION}\")")
       endif()
     endif()
   else()
@@ -485,23 +561,17 @@ function(FIND_PACKAGE_HANDLE_STANDARD_ARGS _NAME _FIRST_ARG)
   endif()
 
   if(VERSION_OK)
-    string(
-      APPEND
-      DETAILS
-      "[v${${FPHSA_VERSION_VAR}}(${${_NAME}_FIND_VERSION})]"
-    )
+    string(APPEND DETAILS "[v${${FPHSA_VERSION_VAR}}(${${_NAME}_FIND_VERSION})]")
   else()
     set(${_NAME}_FOUND FALSE)
   endif()
 
+
   # print the result:
   if(${_NAME}_FOUND)
-    find_package_message(
-      ${_NAME}
-      "Found ${_NAME}: ${${_FIRST_REQUIRED_VAR}} ${VERSION_MSG} ${COMPONENT_MSG}"
-      "${DETAILS}"
-    )
+    FIND_PACKAGE_MESSAGE(${_NAME} "Found ${_NAME}: ${${_FIRST_REQUIRED_VAR}} ${VERSION_MSG} ${COMPONENT_MSG}" "${DETAILS}")
   else()
+
     if(FPHSA_CONFIG_MODE)
       _FPHSA_HANDLE_FAILURE_CONFIG_MODE()
     else()
@@ -516,15 +586,12 @@ function(FIND_PACKAGE_HANDLE_STANDARD_ARGS _NAME _FIRST_ARG)
           endif()
           string(APPEND RESULT_MSG "${FOUND_COMPONENTS_MSG}")
         endif()
-        _FPHSA_FAILURE_MESSAGE(
-          "${FPHSA_FAIL_MESSAGE}: ${VERSION_MSG} (${RESULT_MSG})"
-        )
+        _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE}: ${VERSION_MSG} (${RESULT_MSG})")
       else()
-        _FPHSA_FAILURE_MESSAGE(
-          "${FPHSA_FAIL_MESSAGE} (missing:${MISSING_VARS}) ${VERSION_MSG}"
-        )
+        _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE} (missing:${MISSING_VARS}) ${VERSION_MSG}")
       endif()
     endif()
+
   endif()
 
   set(${_NAME}_FOUND ${${_NAME}_FOUND} PARENT_SCOPE)

--- a/cmake/FindPackageMessage.cmake
+++ b/cmake/FindPackageMessage.cmake
@@ -1,5 +1,5 @@
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
-# file Copyright.txt or https://cmake.org/licensing for details.
+# file LICENSE.rst or https://cmake.org/licensing for details.
 
 #[=======================================================================[.rst:
 FindPackageMessage
@@ -37,16 +37,13 @@ function(find_package_message pkg msg details)
     set(DETAILS_VAR FIND_PACKAGE_MESSAGE_DETAILS_${pkg})
     if(NOT "${details}" STREQUAL "${${DETAILS_VAR}}")
       # The message has not yet been printed.
+      string(STRIP "${msg}" msg)
       message(STATUS "${msg}")
 
       # Save the find details in the cache to avoid printing the same
       # message again.
-      set(
-        "${DETAILS_VAR}"
-        "${details}"
-        CACHE INTERNAL
-        "Details about finding ${pkg}"
-      )
+      set("${DETAILS_VAR}" "${details}"
+        CACHE INTERNAL "Details about finding ${pkg}")
     endif()
   endif()
 endfunction()

--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -1,5 +1,5 @@
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
-# file Copyright.txt or https://cmake.org/licensing for details.
+# file LICENSE.rst or https://cmake.org/licensing for details.
 
 #[=======================================================================[.rst:
 FindPostgreSQL
@@ -7,8 +7,10 @@ FindPostgreSQL
 
 Find the PostgreSQL installation.
 
-IMPORTED Targets
+Imported Targets
 ^^^^^^^^^^^^^^^^
+
+.. versionadded:: 3.14
 
 This module defines :prop_tgt:`IMPORTED` target ``PostgreSQL::PostgreSQL``
 if PostgreSQL has been found.
@@ -28,6 +30,16 @@ This module will set the following variables in your project:
   the link directories for PostgreSQL libraries
 ``PostgreSQL_VERSION_STRING``
   the version of PostgreSQL found
+``PostgreSQL_TYPE_INCLUDE_DIR``
+  the directories of the PostgreSQL server headers
+
+Components
+^^^^^^^^^^
+
+This module contains additional ``Server`` component, that forcibly checks
+for the presence of server headers. Note that ``PostgreSQL_TYPE_INCLUDE_DIR``
+is set regardless of the presence of the ``Server`` component in find_package call.
+
 #]=======================================================================]
 
 # ----------------------------------------------------------------------------
@@ -41,7 +53,7 @@ This module will set the following variables in your project:
 # In Windows the default installation of PostgreSQL uses that as part of the path.
 # E.g C:\Program Files\PostgreSQL\8.4.
 # Currently, the following version numbers are known to this module:
-# "11" "10" "9.6" "9.5" "9.4" "9.3" "9.2" "9.1" "9.0" "8.4" "8.3" "8.2" "8.1" "8.0"
+# "17" "16" "15" "14" "13" "12" "11" "10" "9.6" "9.5" "9.4" "9.3" "9.2" "9.1" "9.0" "8.4" "8.3" "8.2" "8.1" "8.0"
 #
 # To use this variable just do something like this:
 # set(PostgreSQL_ADDITIONAL_VERSIONS "9.2" "8.4.4")
@@ -79,105 +91,59 @@ This module will set the following variables in your project:
 #
 # ----------------------------------------------------------------------------
 
-set(
-  PostgreSQL_INCLUDE_PATH_DESCRIPTION
-  "top-level directory containing the PostgreSQL include directories. E.g /usr/local/include/PostgreSQL/8.4 or C:/Program Files/PostgreSQL/8.4/include"
-)
-set(
-  PostgreSQL_INCLUDE_DIR_MESSAGE
-  "Set the PostgreSQL_INCLUDE_DIR cmake cache entry to the ${PostgreSQL_INCLUDE_PATH_DESCRIPTION}"
-)
-set(
-  PostgreSQL_LIBRARY_PATH_DESCRIPTION
-  "top-level directory containing the PostgreSQL libraries."
-)
-set(
-  PostgreSQL_LIBRARY_DIR_MESSAGE
-  "Set the PostgreSQL_LIBRARY_DIR cmake cache entry to the ${PostgreSQL_LIBRARY_PATH_DESCRIPTION}"
-)
-set(
-  PostgreSQL_ROOT_DIR_MESSAGE
-  "Set the PostgreSQL_ROOT system variable to where PostgreSQL is found on the machine E.g C:/Program Files/PostgreSQL/8.4"
-)
+cmake_policy(PUSH)
+cmake_policy(SET CMP0159 NEW) # file(STRINGS) with REGEX updates CMAKE_MATCH_<n>
 
-set(
-  PostgreSQL_KNOWN_VERSIONS
-  ${PostgreSQL_ADDITIONAL_VERSIONS}
-  "17"
-  "16"
-  "15"
-  "14"
-  "13"
-  "12"
-  "11"
-  "10"
-  "9.6"
-  "9.5"
-  "9.4"
-  "9.3"
-  "9.2"
-  "9.1"
-  "9.0"
-  "8.4"
-  "8.3"
-  "8.2"
-  "8.1"
-  "8.0"
-)
+set(PostgreSQL_INCLUDE_PATH_DESCRIPTION "top-level directory containing the PostgreSQL include directories. E.g /usr/local/include/PostgreSQL/8.4 or C:/Program Files/PostgreSQL/8.4/include")
+set(PostgreSQL_INCLUDE_DIR_MESSAGE "Set the PostgreSQL_INCLUDE_DIR cmake cache entry to the ${PostgreSQL_INCLUDE_PATH_DESCRIPTION}")
+set(PostgreSQL_LIBRARY_PATH_DESCRIPTION "top-level directory containing the PostgreSQL libraries.")
+set(PostgreSQL_LIBRARY_DIR_MESSAGE "Set the PostgreSQL_LIBRARY_DIR cmake cache entry to the ${PostgreSQL_LIBRARY_PATH_DESCRIPTION}")
+set(PostgreSQL_ROOT_DIR_MESSAGE "Set the PostgreSQL_ROOT system variable to where PostgreSQL is found on the machine E.g C:/Program Files/PostgreSQL/8.4")
+
+
+set(PostgreSQL_KNOWN_VERSIONS ${PostgreSQL_ADDITIONAL_VERSIONS}
+    "17" "16" "15" "14" "13" "12" "11" "10" "9.6" "9.5" "9.4" "9.3" "9.2" "9.1" "9.0" "8.4" "8.3" "8.2" "8.1" "8.0")
 
 # Define additional search paths for root directories.
-set(PostgreSQL_ROOT_DIRECTORIES ENV PostgreSQL_ROOT ${PostgreSQL_ROOT})
+set( PostgreSQL_ROOT_DIRECTORIES
+   ENV PostgreSQL_ROOT
+   ${PostgreSQL_ROOT}
+)
 foreach(suffix ${PostgreSQL_KNOWN_VERSIONS})
   if(WIN32)
-    list(
-      APPEND
-      PostgreSQL_LIBRARY_ADDITIONAL_SEARCH_SUFFIXES
-      "PostgreSQL/${suffix}/lib"
-    )
-    list(
-      APPEND
-      PostgreSQL_INCLUDE_ADDITIONAL_SEARCH_SUFFIXES
-      "PostgreSQL/${suffix}/include"
-    )
-    list(
-      APPEND
-      PostgreSQL_TYPE_ADDITIONAL_SEARCH_SUFFIXES
-      "PostgreSQL/${suffix}/include/server"
-    )
+    list(APPEND PostgreSQL_LIBRARY_ADDITIONAL_SEARCH_SUFFIXES
+        "PostgreSQL/${suffix}/lib")
+    list(APPEND PostgreSQL_INCLUDE_ADDITIONAL_SEARCH_SUFFIXES
+        "PostgreSQL/${suffix}/include")
+    list(APPEND PostgreSQL_TYPE_ADDITIONAL_SEARCH_SUFFIXES
+        "PostgreSQL/${suffix}/include/server")
   endif()
   if(UNIX)
-    list(
-      APPEND
-      PostgreSQL_LIBRARY_ADDITIONAL_SEARCH_SUFFIXES
-      "postgresql${suffix}"
-      "pgsql-${suffix}/lib"
-    )
-    list(
-      APPEND
-      PostgreSQL_INCLUDE_ADDITIONAL_SEARCH_SUFFIXES
-      "postgresql${suffix}"
-      "postgresql/${suffix}"
-      "pgsql-${suffix}/include"
-    )
-    list(
-      APPEND
-      PostgreSQL_TYPE_ADDITIONAL_SEARCH_SUFFIXES
-      "postgresql${suffix}/server"
-      "postgresql/${suffix}/server"
-      "pgsql-${suffix}/include/server"
-    )
+    list(APPEND PostgreSQL_LIBRARY_ADDITIONAL_SEARCH_SUFFIXES
+        "postgresql${suffix}"
+        "postgresql@${suffix}"
+        "pgsql-${suffix}/lib")
+    list(APPEND PostgreSQL_INCLUDE_ADDITIONAL_SEARCH_SUFFIXES
+        "postgresql${suffix}"
+        "postgresql@${suffix}"
+        "postgresql/${suffix}"
+        "pgsql-${suffix}/include")
+    list(APPEND PostgreSQL_TYPE_ADDITIONAL_SEARCH_SUFFIXES
+        "postgresql${suffix}/server"
+        "postgresql@${suffix}/server"
+        "postgresql/${suffix}/server"
+        "pgsql-${suffix}/include/server")
   endif()
 endforeach()
 
 #
 # Look for an installation.
 #
-find_path(
-  PostgreSQL_INCLUDE_DIR
+find_path(PostgreSQL_INCLUDE_DIR
   NAMES libpq-fe.h
   PATHS
-    # Look in other places.
-    ${PostgreSQL_ROOT_DIRECTORIES}
+   # Look in other places.
+   ${PostgreSQL_ROOT_DIRECTORIES}
   PATH_SUFFIXES
     pgsql
     postgresql
@@ -187,12 +153,11 @@ find_path(
   DOC "The ${PostgreSQL_INCLUDE_DIR_MESSAGE}"
 )
 
-find_path(
-  PostgreSQL_TYPE_INCLUDE_DIR
+find_path(PostgreSQL_TYPE_INCLUDE_DIR
   NAMES catalog/pg_type.h
   PATHS
-    # Look in other places.
-    ${PostgreSQL_ROOT_DIRECTORIES}
+   # Look in other places.
+   ${PostgreSQL_ROOT_DIRECTORIES}
   PATH_SUFFIXES
     postgresql
     pgsql/server
@@ -204,25 +169,24 @@ find_path(
 )
 
 # The PostgreSQL library.
-set(PostgreSQL_LIBRARY_TO_FIND pq)
+set (PostgreSQL_LIBRARY_TO_FIND pq)
 # Setting some more prefixes for the library
-set(PostgreSQL_LIB_PREFIX "")
-if(WIN32)
-  set(PostgreSQL_LIB_PREFIX ${PostgreSQL_LIB_PREFIX} "lib")
-  set(
-    PostgreSQL_LIBRARY_TO_FIND
-    ${PostgreSQL_LIB_PREFIX}${PostgreSQL_LIBRARY_TO_FIND}
-  )
+set (PostgreSQL_LIB_PREFIX "")
+if ( WIN32 )
+  set (PostgreSQL_LIB_PREFIX ${PostgreSQL_LIB_PREFIX} "lib")
+  set (PostgreSQL_LIBRARY_TO_FIND ${PostgreSQL_LIB_PREFIX}${PostgreSQL_LIBRARY_TO_FIND})
 endif()
 
 function(__postgresql_find_library _name)
-  find_library(
-    ${_name}
-    NAMES ${ARGN}
-    PATHS ${PostgreSQL_ROOT_DIRECTORIES}
-    PATH_SUFFIXES lib ${PostgreSQL_LIBRARY_ADDITIONAL_SEARCH_SUFFIXES}
-    # Help the user find it if we cannot.
-    DOC "The ${PostgreSQL_LIBRARY_DIR_MESSAGE}"
+  find_library(${_name}
+   NAMES ${ARGN}
+   PATHS
+     ${PostgreSQL_ROOT_DIRECTORIES}
+   PATH_SUFFIXES
+     lib
+     ${PostgreSQL_LIBRARY_ADDITIONAL_SEARCH_SUFFIXES}
+   # Help the user find it if we cannot.
+   DOC "The ${PostgreSQL_LIBRARY_DIR_MESSAGE}"
   )
 endfunction()
 
@@ -232,124 +196,83 @@ if(PostgreSQL_LIBRARY)
   set(PostgreSQL_LIBRARIES "${PostgreSQL_LIBRARY}")
   get_filename_component(PostgreSQL_LIBRARY_DIR "${PostgreSQL_LIBRARY}" PATH)
 else()
-  __postgresql_find_library(
-    PostgreSQL_LIBRARY_RELEASE
-    ${PostgreSQL_LIBRARY_TO_FIND}
-  )
-  __postgresql_find_library(
-    PostgreSQL_LIBRARY_DEBUG
-    ${PostgreSQL_LIBRARY_TO_FIND}d
-  )
+  __postgresql_find_library(PostgreSQL_LIBRARY_RELEASE ${PostgreSQL_LIBRARY_TO_FIND})
+  __postgresql_find_library(PostgreSQL_LIBRARY_DEBUG ${PostgreSQL_LIBRARY_TO_FIND}d)
   include(${CMAKE_CURRENT_LIST_DIR}/SelectLibraryConfigurations.cmake)
   select_library_configurations(PostgreSQL)
   mark_as_advanced(PostgreSQL_LIBRARY_RELEASE PostgreSQL_LIBRARY_DEBUG)
   if(PostgreSQL_LIBRARY_RELEASE)
-    get_filename_component(
-      PostgreSQL_LIBRARY_DIR
-      "${PostgreSQL_LIBRARY_RELEASE}"
-      PATH
-    )
+    get_filename_component(PostgreSQL_LIBRARY_DIR "${PostgreSQL_LIBRARY_RELEASE}" PATH)
   elseif(PostgreSQL_LIBRARY_DEBUG)
-    get_filename_component(
-      PostgreSQL_LIBRARY_DIR
-      "${PostgreSQL_LIBRARY_DEBUG}"
-      PATH
-    )
+    get_filename_component(PostgreSQL_LIBRARY_DIR "${PostgreSQL_LIBRARY_DEBUG}" PATH)
   else()
     set(PostgreSQL_LIBRARY_DIR "")
   endif()
 endif()
 
-if(PostgreSQL_INCLUDE_DIR)
+if (PostgreSQL_INCLUDE_DIR)
   # Some platforms include multiple pg_config.hs for multi-lib configurations
   # This is a temporary workaround.  A better solution would be to compile
   # a dummy c file and extract the value of the symbol.
   file(GLOB _PG_CONFIG_HEADERS "${PostgreSQL_INCLUDE_DIR}/pg_config*.h")
   foreach(_PG_CONFIG_HEADER ${_PG_CONFIG_HEADERS})
     if(EXISTS "${_PG_CONFIG_HEADER}")
-      file(
-        STRINGS
-        "${_PG_CONFIG_HEADER}"
-        pgsql_version_str
-        REGEX "^#define[\t ]+PG_VERSION_NUM[\t ]+.*"
-      )
+      file(STRINGS "${_PG_CONFIG_HEADER}" pgsql_version_str
+           REGEX "^#define[\t ]+PG_VERSION_NUM[\t ]+.*")
       if(pgsql_version_str)
-        string(
-          REGEX REPLACE
-          "^#define[\t ]+PG_VERSION_NUM[\t ]+([0-9]*).*"
-          "\\1"
-          _PostgreSQL_VERSION_NUM
-          "${pgsql_version_str}"
-        )
+        string(REGEX REPLACE "^#define[\t ]+PG_VERSION_NUM[\t ]+([0-9]*).*"
+               "\\1" _PostgreSQL_VERSION_NUM "${pgsql_version_str}")
         break()
       endif()
     endif()
   endforeach()
-  if(_PostgreSQL_VERSION_NUM)
+  if (_PostgreSQL_VERSION_NUM)
     # 9.x and older encoding
-    if(_PostgreSQL_VERSION_NUM LESS 100000)
+    if (_PostgreSQL_VERSION_NUM LESS 100000)
       math(EXPR _PostgreSQL_major_version "${_PostgreSQL_VERSION_NUM} / 10000")
-      math(
-        EXPR
-        _PostgreSQL_minor_version
-        "${_PostgreSQL_VERSION_NUM} % 10000 / 100"
-      )
+      math(EXPR _PostgreSQL_minor_version "${_PostgreSQL_VERSION_NUM} % 10000 / 100")
       math(EXPR _PostgreSQL_patch_version "${_PostgreSQL_VERSION_NUM} % 100")
-      set(
-        PostgreSQL_VERSION_STRING
-        "${_PostgreSQL_major_version}.${_PostgreSQL_minor_version}.${_PostgreSQL_patch_version}"
-      )
+      set(PostgreSQL_VERSION_STRING "${_PostgreSQL_major_version}.${_PostgreSQL_minor_version}.${_PostgreSQL_patch_version}")
       unset(_PostgreSQL_major_version)
       unset(_PostgreSQL_minor_version)
       unset(_PostgreSQL_patch_version)
-    else()
+    else ()
       math(EXPR _PostgreSQL_major_version "${_PostgreSQL_VERSION_NUM} / 10000")
       math(EXPR _PostgreSQL_minor_version "${_PostgreSQL_VERSION_NUM} % 10000")
-      set(
-        PostgreSQL_VERSION_STRING
-        "${_PostgreSQL_major_version}.${_PostgreSQL_minor_version}"
-      )
+      set(PostgreSQL_VERSION_STRING "${_PostgreSQL_major_version}.${_PostgreSQL_minor_version}")
       unset(_PostgreSQL_major_version)
       unset(_PostgreSQL_minor_version)
-    endif()
-  else()
+    endif ()
+  else ()
     foreach(_PG_CONFIG_HEADER ${_PG_CONFIG_HEADERS})
       if(EXISTS "${_PG_CONFIG_HEADER}")
-        file(
-          STRINGS
-          "${_PG_CONFIG_HEADER}"
-          pgsql_version_str
-          REGEX "^#define[\t ]+PG_VERSION[\t ]+\".*\""
-        )
+        file(STRINGS "${_PG_CONFIG_HEADER}" pgsql_version_str
+             REGEX "^#define[\t ]+PG_VERSION[\t ]+\".*\"")
         if(pgsql_version_str)
-          string(
-            REGEX REPLACE
-            "^#define[\t ]+PG_VERSION[\t ]+\"([^\"]*)\".*"
-            "\\1"
-            PostgreSQL_VERSION_STRING
-            "${pgsql_version_str}"
-          )
+          string(REGEX REPLACE "^#define[\t ]+PG_VERSION[\t ]+\"([^\"]*)\".*"
+                 "\\1" PostgreSQL_VERSION_STRING "${pgsql_version_str}")
           break()
         endif()
       endif()
     endforeach()
-  endif()
+  endif ()
   unset(_PostgreSQL_VERSION_NUM)
   unset(pgsql_version_str)
 endif()
 
+if("Server" IN_LIST PostgreSQL_FIND_COMPONENTS)
+  set(PostgreSQL_Server_FOUND TRUE)
+  if(NOT PostgreSQL_TYPE_INCLUDE_DIR)
+    set(PostgreSQL_Server_FOUND FALSE)
+  endif()
+endif()
+
 # Did we find anything?
-include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(
-  PostgreSQL
-  REQUIRED_VARS
-  PostgreSQL_LIBRARY
-  PostgreSQL_INCLUDE_DIR
-  PostgreSQL_TYPE_INCLUDE_DIR
-  VERSION_VAR
-  PostgreSQL_VERSION_STRING
-)
-set(PostgreSQL_FOUND ${POSTGRESQL_FOUND})
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(PostgreSQL
+                                  REQUIRED_VARS PostgreSQL_LIBRARY PostgreSQL_INCLUDE_DIR
+                                  HANDLE_COMPONENTS
+                                  VERSION_VAR PostgreSQL_VERSION_STRING)
 
 function(__postgresql_import_library _target _var _config)
   if(_config)
@@ -361,47 +284,31 @@ function(__postgresql_import_library _target _var _config)
   set(_lib "${${_var}${_config_suffix}}")
   if(EXISTS "${_lib}")
     if(_config)
-      set_property(
-        TARGET ${_target}
-        APPEND
-        PROPERTY IMPORTED_CONFIGURATIONS ${_config}
-      )
+      set_property(TARGET ${_target} APPEND PROPERTY
+        IMPORTED_CONFIGURATIONS ${_config})
     endif()
-    set_target_properties(
-      ${_target}
-      PROPERTIES IMPORTED_LOCATION${_config_suffix} "${_lib}"
-    )
+    set_target_properties(${_target} PROPERTIES
+      IMPORTED_LOCATION${_config_suffix} "${_lib}")
   endif()
 endfunction()
 
 # Now try to get the include and library path.
 if(PostgreSQL_FOUND)
-  if(NOT TARGET PostgreSQL::PostgreSQL)
-    add_library(PostgreSQL::PostgreSQL UNKNOWN IMPORTED)
-    set_target_properties(
-      PostgreSQL::PostgreSQL
-      PROPERTIES
-        INTERFACE_INCLUDE_DIRECTORIES
-          "${PostgreSQL_INCLUDE_DIR};${PostgreSQL_TYPE_INCLUDE_DIR}"
-    )
-    __postgresql_import_library(PostgreSQL::PostgreSQL PostgreSQL_LIBRARY "")
-    __postgresql_import_library(
-      PostgreSQL::PostgreSQL
-      PostgreSQL_LIBRARY
-      "RELEASE"
-    )
-    __postgresql_import_library(
-      PostgreSQL::PostgreSQL
-      PostgreSQL_LIBRARY
-      "DEBUG"
-    )
+  set(PostgreSQL_INCLUDE_DIRS ${PostgreSQL_INCLUDE_DIR})
+  if(PostgreSQL_TYPE_INCLUDE_DIR)
+    list(APPEND PostgreSQL_INCLUDE_DIRS ${PostgreSQL_TYPE_INCLUDE_DIR})
   endif()
-  set(
-    PostgreSQL_INCLUDE_DIRS
-    ${PostgreSQL_INCLUDE_DIR}
-    ${PostgreSQL_TYPE_INCLUDE_DIR}
-  )
   set(PostgreSQL_LIBRARY_DIRS ${PostgreSQL_LIBRARY_DIR})
+  if (NOT TARGET PostgreSQL::PostgreSQL)
+    add_library(PostgreSQL::PostgreSQL UNKNOWN IMPORTED)
+    set_target_properties(PostgreSQL::PostgreSQL PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${PostgreSQL_INCLUDE_DIRS}")
+    __postgresql_import_library(PostgreSQL::PostgreSQL PostgreSQL_LIBRARY "")
+    __postgresql_import_library(PostgreSQL::PostgreSQL PostgreSQL_LIBRARY "RELEASE")
+    __postgresql_import_library(PostgreSQL::PostgreSQL PostgreSQL_LIBRARY "DEBUG")
+  endif ()
 endif()
 
 mark_as_advanced(PostgreSQL_INCLUDE_DIR PostgreSQL_TYPE_INCLUDE_DIR)
+
+cmake_policy(POP)

--- a/cmake/SelectLibraryConfigurations.cmake
+++ b/cmake/SelectLibraryConfigurations.cmake
@@ -1,5 +1,5 @@
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
-# file Copyright.txt or https://cmake.org/licensing for details.
+# file LICENSE.rst or https://cmake.org/licensing for details.
 
 #[=======================================================================[.rst:
 SelectLibraryConfigurations
@@ -40,52 +40,41 @@ is not set.
 # Dicharry <wdicharry@stellarscience.com>.
 
 macro(select_library_configurations basename)
-  if(NOT ${basename}_LIBRARY_RELEASE)
-    set(
-      ${basename}_LIBRARY_RELEASE
-      "${basename}_LIBRARY_RELEASE-NOTFOUND"
-      CACHE FILEPATH
-      "Path to a library."
+    if(NOT ${basename}_LIBRARY_RELEASE)
+        set(${basename}_LIBRARY_RELEASE "${basename}_LIBRARY_RELEASE-NOTFOUND" CACHE FILEPATH "Path to a library.")
+    endif()
+    if(NOT ${basename}_LIBRARY_DEBUG)
+        set(${basename}_LIBRARY_DEBUG "${basename}_LIBRARY_DEBUG-NOTFOUND" CACHE FILEPATH "Path to a library.")
+    endif()
+
+    get_property(_isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+    if( ${basename}_LIBRARY_DEBUG AND ${basename}_LIBRARY_RELEASE AND
+           NOT ${basename}_LIBRARY_DEBUG STREQUAL ${basename}_LIBRARY_RELEASE AND
+           ( _isMultiConfig OR CMAKE_BUILD_TYPE ) )
+        # if the generator is multi-config or if CMAKE_BUILD_TYPE is set for
+        # single-config generators, set optimized and debug libraries
+        set( ${basename}_LIBRARY "" )
+        foreach( _libname IN LISTS ${basename}_LIBRARY_RELEASE )
+            list( APPEND ${basename}_LIBRARY optimized "${_libname}" )
+        endforeach()
+        foreach( _libname IN LISTS ${basename}_LIBRARY_DEBUG )
+            list( APPEND ${basename}_LIBRARY debug "${_libname}" )
+        endforeach()
+    elseif( ${basename}_LIBRARY_RELEASE )
+        set( ${basename}_LIBRARY ${${basename}_LIBRARY_RELEASE} )
+    elseif( ${basename}_LIBRARY_DEBUG )
+        set( ${basename}_LIBRARY ${${basename}_LIBRARY_DEBUG} )
+    else()
+        set( ${basename}_LIBRARY "${basename}_LIBRARY-NOTFOUND")
+    endif()
+
+    set( ${basename}_LIBRARIES "${${basename}_LIBRARY}" )
+
+    if( ${basename}_LIBRARY )
+        set( ${basename}_FOUND TRUE )
+    endif()
+
+    mark_as_advanced( ${basename}_LIBRARY_RELEASE
+        ${basename}_LIBRARY_DEBUG
     )
-  endif()
-  if(NOT ${basename}_LIBRARY_DEBUG)
-    set(
-      ${basename}_LIBRARY_DEBUG
-      "${basename}_LIBRARY_DEBUG-NOTFOUND"
-      CACHE FILEPATH
-      "Path to a library."
-    )
-  endif()
-
-  get_property(_isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
-  if(
-    ${basename}_LIBRARY_DEBUG
-    AND ${basename}_LIBRARY_RELEASE
-    AND NOT ${basename}_LIBRARY_DEBUG STREQUAL ${basename}_LIBRARY_RELEASE
-    AND (_isMultiConfig OR CMAKE_BUILD_TYPE)
-  )
-    # if the generator is multi-config or if CMAKE_BUILD_TYPE is set for
-    # single-config generators, set optimized and debug libraries
-    set(${basename}_LIBRARY "")
-    foreach(_libname IN LISTS ${basename}_LIBRARY_RELEASE)
-      list(APPEND ${basename}_LIBRARY optimized "${_libname}")
-    endforeach()
-    foreach(_libname IN LISTS ${basename}_LIBRARY_DEBUG)
-      list(APPEND ${basename}_LIBRARY debug "${_libname}")
-    endforeach()
-  elseif(${basename}_LIBRARY_RELEASE)
-    set(${basename}_LIBRARY ${${basename}_LIBRARY_RELEASE})
-  elseif(${basename}_LIBRARY_DEBUG)
-    set(${basename}_LIBRARY ${${basename}_LIBRARY_DEBUG})
-  else()
-    set(${basename}_LIBRARY "${basename}_LIBRARY-NOTFOUND")
-  endif()
-
-  set(${basename}_LIBRARIES "${${basename}_LIBRARY}")
-
-  if(${basename}_LIBRARY)
-    set(${basename}_FOUND TRUE)
-  endif()
-
-  mark_as_advanced(${basename}_LIBRARY_RELEASE ${basename}_LIBRARY_DEBUG)
 endmacro()


### PR DESCRIPTION
## What
Fixes #2451 build failure with CMake >= 4. Tested with CMake 3.31.8 & 4.0.3.

## Why
Build fix.

## References
See cmake files/modules of CMake 4.0.3 (https://github.com/Kitware/CMake/tree/v4.0.3/Modules).

## Misc
Would probably be nice to not ship copies of files included by CMake itself in the first place.

