### PR TITLE
Doc: remove names from @file

### DIFF
--- a/src/debug_utils.c
+++ b/src/debug_utils.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file debug_utils.c
+ * @file
  * @brief Debug utilties and Sentry integration
  */
 

--- a/src/debug_utils.h
+++ b/src/debug_utils.h
@@ -18,7 +18,7 @@
 
 
 /**
- * @file debug_utils.h
+ * @file
  * @brief Headers for debug utilties and Sentry integration
  */
 

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file  gmp.c
+ * @file
  * @brief The Greenbone Vulnerability Manager GMP library.
  *
  * This file defines a Greenbone Management Protocol (GMP) library, for

--- a/src/gmp.h
+++ b/src/gmp.h
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file gmp.h
+ * @file
  * @brief Headers for the GMP library.
  */
 

--- a/src/gmp_agent_groups.c
+++ b/src/gmp_agent_groups.c
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file gmp_agent_groups.c
+ * @file
  * @brief GVM GMP layer: Agent groups.
  *
  * GMP Handlers for reading, creating, modifying and deleting agent groups.

--- a/src/gmp_agent_groups.h
+++ b/src/gmp_agent_groups.h
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file gmp_agent_groups.h
+ * @file
  * @brief GVM GMP layer: Agent Group headers.
  *
  * Header for GMP Agent Group handlers

--- a/src/gmp_agent_installers.c
+++ b/src/gmp_agent_installers.c
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file gmp_agent_installers.c
+ * @file
  * @brief GVM GMP layer: Agent installers.
  *
  * GMP handlers for agent installers.

--- a/src/gmp_agent_installers.h
+++ b/src/gmp_agent_installers.h
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file gmp_agent_installers.c
+ * @file
  * @brief GVM GMP layer: Agent installer headers.
  *
  * Headers for GMP handlers for agent installers.

--- a/src/gmp_agents.c
+++ b/src/gmp_agents.c
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file gmp_agents.c
+ * @file
  * @brief GVM GMP layer: Agent management
  *
  * This file contains GMP command implementations for managing agents,

--- a/src/gmp_agents.h
+++ b/src/gmp_agents.h
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file gmp_agents.h
+ * @file
  * @brief GVM GMP layer: Agent headers.
  *
  * Headers for GMP handlers for agent control commands.

--- a/src/gmp_base.c
+++ b/src/gmp_base.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file gmp_base.c
+ * @file
  * @brief GVM GMP layer: Base facilities.
  *
  * GMP base facilities used by all modules, but not exported for users of the GMP

--- a/src/gmp_configs.c
+++ b/src/gmp_configs.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file gmp_configs.c
+ * @file
  * @brief GVM GMP layer: Configs
  *
  * GMP configs.

--- a/src/gmp_delete.c
+++ b/src/gmp_delete.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file gmp_delete.c
+ * @file
  * @brief GVM GMP layer: DELETE commands
  *
  * Common DELETE command code for the GVM GMP layer.

--- a/src/gmp_get.c
+++ b/src/gmp_get.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file gmp_get.c
+ * @file
  * @brief GVM GMP layer: GET commands
  *
  * Common GET command code for the GVM GMP layer.

--- a/src/gmp_license.c
+++ b/src/gmp_license.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file gmp_license.c
+ * @file
  * @brief GVM GMP layer: License information
  *
  * This includes function and variable definitions for GMP handling

--- a/src/gmp_license.h
+++ b/src/gmp_license.h
@@ -23,7 +23,7 @@
 
 
 /**
- * @file gmp_tls_certificates.h
+ * @file
  * @brief GVM GMP layer: License information headers
  *
  * Headers for GMP handling of license information.

--- a/src/gmp_logout.c
+++ b/src/gmp_logout.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file gmp_logout.c
+ * @file
  * @brief GVM GMP layer: Logout handling
  *
  * This includes functions for GMP handling of the user logout.

--- a/src/gmp_oci_image_targets.c
+++ b/src/gmp_oci_image_targets.c
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file gmp_oci_image_targets.c
+ * @file
  * @brief GVM GMP layer: OCI Image Targets
  *
  * GMP handlers for OCI Image Targets

--- a/src/gmp_oci_image_targets.h
+++ b/src/gmp_oci_image_targets.h
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file gmp_oci_image_targets.h
+ * @file
  * @brief GVM GMP layer: OCI Image Target headers.
  *
  * Headers for GMP handlers for OCI image target commands.

--- a/src/gmp_port_lists.c
+++ b/src/gmp_port_lists.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file gmp_port_lists.c
+ * @file
  * @brief GVM GMP layer: Port Lists
  *
  * GMP port lists.

--- a/src/gmp_report_configs.c
+++ b/src/gmp_report_configs.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file gmp_report_configs.c
+ * @file
  * @brief GVM GMP layer: Report Configs
  *
  * GMP report configurations.

--- a/src/gmp_report_configs.h
+++ b/src/gmp_report_configs.h
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file gmp_report_formats.h
+ * @file
  * @brief GVM GMP layer: Report Configs headers
  *
  * Headers for GMP report configurations.

--- a/src/gmp_report_formats.c
+++ b/src/gmp_report_formats.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file gmp_report_formats.c
+ * @file
  * @brief GVM GMP layer: Report Formats
  *
  * GMP report formats.

--- a/src/gmp_tickets.c
+++ b/src/gmp_tickets.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file gmp_tickets.c
+ * @file
  * @brief GVM GMP layer: Tickets
  *
  * GMP tickets.

--- a/src/gmp_tls_certificates.c
+++ b/src/gmp_tls_certificates.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file gmp_tls_certificates.c
+ * @file
  * @brief GVM GMP layer: TLS certificates
  *
  * This includes function and variable definitions for GMP handling

--- a/src/gmp_tls_certificates.h
+++ b/src/gmp_tls_certificates.h
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file gmp_tls_certificates.h
+ * @file
  * @brief GVM GMP layer: TLS Certificates headers
  *
  * Headers for GMP handling of TLS Certificates.

--- a/src/gmpd.c
+++ b/src/gmpd.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file  gmpd.c
+ * @file
  * @brief The Greenbone Vulnerability Manager GMP daemon.
  *
  * This file defines the Greenbone Vulnerability Manager daemon.  The Manager

--- a/src/gmpd.h
+++ b/src/gmpd.h
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file gmpd.h
+ * @file
  * @brief Headers for the GMP daemon.
  */
 

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file  gvmd.c
+ * @file
  * @brief The Greenbone Vulnerability Manager daemon.
  *
  * This file defines the Greenbone Vulnerability Manager daemon.  The Manager

--- a/src/gvmd.h
+++ b/src/gvmd.h
@@ -17,7 +17,7 @@
  */
 
 /*
- * @file gvmd.h
+ * @file
  * @brief Headers for Greenbone Vulnerability Manager entry point.
  */
 

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file ipc.c
+ * @file
  * @brief Inter-process communitcation (IPC)
  */
 

--- a/src/ipc.h
+++ b/src/ipc.h
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file ipc.h
+ * @file
  * @brief Headers for inter-process communitcation (IPC)
  */
 

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file iterator.h
+ * @file
  * @brief Headers for Iterators.
  *
  * The interface here is for "external" use.  The SQL parts of the interface

--- a/src/lsc_crypt.c
+++ b/src/lsc_crypt.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file  lsc_crypt.c
+ * @file
  * @brief GVM: Utilities for LSC credential encryption
  *
  * This file provides support for encrypting LSC credentials.

--- a/src/lsc_crypt.h
+++ b/src/lsc_crypt.h
@@ -17,7 +17,7 @@
  */
 
 /*
- * @file lsc_crypt.h
+ * @file
  * @brief LSC credentials encryption support
  */
 

--- a/src/lsc_user.c
+++ b/src/lsc_user.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file  lsc_user.c
+ * @file
  * @brief GVM: Utilities for LSC credential package generation
  *
  * This file provides support for generating packages for LSC credentials.

--- a/src/lsc_user.h
+++ b/src/lsc_user.h
@@ -17,7 +17,7 @@
  */
 
 /*
- * @file lsc_user.h
+ * @file
  * @brief LSC user credentials package generation.
  */
 

--- a/src/main.c
+++ b/src/main.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file  main.c
+ * @file
  * @brief Main function of gvmd.
  *
  * This file separates out the "main" function of gvmd.

--- a/src/manage.c
+++ b/src/manage.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file  manage.c
+ * @file
  * @brief The Greenbone Vulnerability Manager management layer.
  *
  * This file defines a management layer, for implementing

--- a/src/manage.h
+++ b/src/manage.h
@@ -17,7 +17,7 @@
  */
 
 /*
- * @file manage.h
+ * @file
  * @brief Headers for Greenbone Vulnerability Manager: the Manage library.
  */
 

--- a/src/manage_acl.c
+++ b/src/manage_acl.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file  manage_acl.c
+ * @file
  * @brief The Greenbone Vulnerability Manager management library (Access
  * Control Layer).
  *

--- a/src/manage_acl.h
+++ b/src/manage_acl.h
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_acl.h
+ * @file
  * @brief Headers for Greenbone Vulnerability Manager: the Manage library.
  */
 

--- a/src/manage_agent_common.c
+++ b/src/manage_agent_common.c
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_agent_common.c
+ * @file
  * @brief Implementation of shared agent utilities for GVMD.
  */
 

--- a/src/manage_agent_common.h
+++ b/src/manage_agent_common.h
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_agent_common.h
+ * @file
  * @brief Common utilities for agent management in GVMD.
  *
  * This header provides shared data structures and utility functions

--- a/src/manage_agent_groups.c
+++ b/src/manage_agent_groups.c
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_agent_groups.c
+ * @file
  * @brief Agent group data utilities and access control checks for GVMD.
  */
 

--- a/src/manage_agent_groups.h
+++ b/src/manage_agent_groups.h
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_agent_groups.h
+ * @file
  * @brief Agent group management interface for GVMD.
  *
  * This header defines core data structures and function prototypes

--- a/src/manage_agent_installers.c
+++ b/src/manage_agent_installers.c
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_agent_installers.c
+ * @file
  * @brief GVM manage layer: Agent installers.
  *
  * General management of agent installers.

--- a/src/manage_agent_installers.h
+++ b/src/manage_agent_installers.h
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_agent_installers.h
+ * @file
  * @brief GVM manage layer headers: Agent installers.
  *
  * General management headers of agent installers.

--- a/src/manage_agents.c
+++ b/src/manage_agents.c
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_agents.c
+ * @file
  * @brief Agent management implementation for GVMD.
  *
  * This file contains the logic for synchronizing, modifying, and deleting agents

--- a/src/manage_agents.h
+++ b/src/manage_agents.h
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_agents.h
+ * @file
  * @brief Agent management interface for GVMD.
  *
  * This header defines core data structures and function prototypes

--- a/src/manage_alerts.c
+++ b/src/manage_alerts.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_alerts.c
+ * @file
  * @brief GVM management layer: Alerts.
  *
  * General functions for managing alerts.

--- a/src/manage_commands.c
+++ b/src/manage_commands.c
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_commands.c
+ * @file
  * @brief GVM management layer: Generic command handling.
  *
  * Non-SQL generic command handling code for the GVM management layer.

--- a/src/manage_commands.h
+++ b/src/manage_commands.h
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_commands.h
+ * @file
  * @brief GVM management layer: Generic command handling headers.
  *
  * Non-SQL generic command handling headers for the GVM management layer.

--- a/src/manage_events.c
+++ b/src/manage_events.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_events.c
+ * @file
  * @brief GVM management layer: Events.
  *
  * General functions for managing events.

--- a/src/manage_filter_utils.c
+++ b/src/manage_filter_utils.c
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_filter_utils.c
+ * @file
  * @brief GVM management layer: Filter utilities.
  *
  * Filter parser and handling utilities code for the GVM management layer.

--- a/src/manage_filter_utils.h
+++ b/src/manage_filter_utils.h
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_filter_utils.h
+ * @file
  * @brief GVM management layer: Filter utilities headers.
  *
  * Filter parser and handling utilities headers for the GVM management layer.

--- a/src/manage_get.h
+++ b/src/manage_get.h
@@ -17,7 +17,7 @@
  */
 
 /*
- * @file manage_get.h
+ * @file
  * @brief Headers for Greenbone Vulnerability Manager: Manage lib: GET support.
  */
 

--- a/src/manage_license.c
+++ b/src/manage_license.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_license.c
+ * @file
  * @brief GVM management layer: License information.
  *
  * Non-SQL license information code for the GVM management layer.

--- a/src/manage_license.h
+++ b/src/manage_license.h
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_license.c
+ * @file
  * @brief GVM management layer: License information headers.
  *
  * Headers for non-SQL license information code for the GVM management layer.

--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file  manage_migrators.c
+ * @file
  * @brief The Greenbone Vulnerability Manager DB Migrators file.
  *
  * This file defines the functions used by the manager to migrate the DB to the

--- a/src/manage_migrators_219_to_220_names.h
+++ b/src/manage_migrators_219_to_220_names.h
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file  manage_migrators_219_to_220_names.h
+ * @file
  * @brief The Greenbone Vulnerability Manager DB Migrators support.
  *
  * This file the preference names used by migrate_219_to_220.

--- a/src/manage_oci_image_targets.c
+++ b/src/manage_oci_image_targets.c
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_oci_image_targets.c
+ * @file
  * @brief GVM manage layer: OCI Image Targets.
  *
  * General management of OCI Image Targets.

--- a/src/manage_oci_image_targets.h
+++ b/src/manage_oci_image_targets.h
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_oci_image_targets.h
+ * @file
  * @brief GVM manage layer headers: OCI Image Targets.
  *
  * General management headers of OCI Image Targets.

--- a/src/manage_openvas.c
+++ b/src/manage_openvas.c
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_osp_credentials.c
+ * @file
  * @brief Greenbone Vulnerability Manager OSP-style credentials handling.
  */
 

--- a/src/manage_openvas.h
+++ b/src/manage_openvas.h
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_openvas.h
+ * @file
  * @brief Greenbone Vulnerability Manager OpenVAS scan handling headers.
  * 
  * This contains functions common to setting up OSP and openvasd scans.

--- a/src/manage_osp.c
+++ b/src/manage_osp.c
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file scan_handler.c
+ * @file
  * @brief Headers for Greenbone Vulnerability Manager OSP scan handling.
  */
 

--- a/src/manage_osp.h
+++ b/src/manage_osp.h
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_osp.h
+ * @file
  * @brief Greenbone Vulnerability Manager OSP scan handling.
  */
 

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file  manage_pg.c
+ * @file
  * @brief GVM management layer: PostgreSQL specific facilities
  *
  * This file contains the parts of the GVM management layer that need

--- a/src/manage_pg_server.c
+++ b/src/manage_pg_server.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file  manage_pg_server.c
+ * @file
  * @brief GVM management layer: Postgres server-side functions.
  *
  * This file contains a server-side module for Postgres, that defines SQL

--- a/src/manage_port_lists.c
+++ b/src/manage_port_lists.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_sql_port_lists.c
+ * @file
  * @brief GVM management layer: Port list SQL
  *
  * The Port List SQL for the GVM management layer.

--- a/src/manage_preferences.h
+++ b/src/manage_preferences.h
@@ -17,7 +17,7 @@
  */
 
 /*
- * @file manage_preferences.h
+ * @file
  * @brief Headers for Greenbone Vulnerability Manager: Manage lib: Preferences.
  */
 

--- a/src/manage_report_configs.c
+++ b/src/manage_report_configs.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_report_configs.c
+ * @file
  * @brief GVM management layer: Report configs.
  *
  * Non-SQL report config code for the GVM management layer.

--- a/src/manage_report_configs.h
+++ b/src/manage_report_configs.h
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_report_configs.h
+ * @file
  * @brief GVM management layer: Report configs.
  *
  * Non-SQL report config code for the GVM management layer.

--- a/src/manage_report_formats.c
+++ b/src/manage_report_formats.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_report_formats.c
+ * @file
  * @brief GVM management layer: Report formats.
  *
  * Non-SQL report format code for the GVM management layer.

--- a/src/manage_resources.c
+++ b/src/manage_resources.c
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_resources.c
+ * @file
  * @brief GVM management layer: Generic resource type handling.
  *
  * Non-SQL generic resource type handling code for the GVM management layer.

--- a/src/manage_resources.h
+++ b/src/manage_resources.h
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_resources.h
+ * @file
  * @brief GVM management layer: Generic resource type handling headers.
  *
  * Non-SQL generic resource type handling headers for the GVM management layer.

--- a/src/manage_scan_handler.c
+++ b/src/manage_scan_handler.c
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file scan_handler.c
+ * @file
  * @brief Greenbone Vulnerability Manager scan handler.
  */
 

--- a/src/manage_scan_handler.h
+++ b/src/manage_scan_handler.h
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file scan_handler.h
+ * @file
  * @brief Headers for Greenbone Vulnerability Manager scan handler.
  */
 

--- a/src/manage_scan_queue.c
+++ b/src/manage_scan_queue.c
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_scan_queue.c
+ * @file
  * @brief Greenbone Vulnerability Manager scan queue.
  */
 

--- a/src/manage_scan_queue.h
+++ b/src/manage_scan_queue.h
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_scan_queue.h
+ * @file
  * @brief Headers for Greenbone Vulnerability Manager scan queue.
  */
 

--- a/src/manage_settings.c
+++ b/src/manage_settings.c
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_filter_utils.c
+ * @file
  * @brief GVM management layer: Filter utilities.
  *
  * Filter parser and handling utilities code for the GVM management layer.

--- a/src/manage_settings.h
+++ b/src/manage_settings.h
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_settings.h
+ * @file
  * @brief GVM management layer: User Settings headers.
  *
  * User settings headers for the GVM management layer.

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file  manage_sql.c
+ * @file
  * @brief The Greenbone Vulnerability Manager management library.
  */
 

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -17,7 +17,7 @@
  */
 
 /*
- * @file manage_sql.h
+ * @file
  * @brief Manager Manage library: SQL backend headers.
  */
 

--- a/src/manage_sql_agent_groups.c
+++ b/src/manage_sql_agent_groups.c
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_sql_agent_groups.c
+ * @file
  * @brief SQL backend implementation for agent group management in GVMD.
  *
  * This file provides the implementation of SQL interactions related to

--- a/src/manage_sql_agent_groups.h
+++ b/src/manage_sql_agent_groups.h
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_sql_agent_groups.h
+ * @file
  * @brief SQL management functions and iterator definitions for agent groups.
  *
  * This header provides iterator macros and function declarations used

--- a/src/manage_sql_agent_installers.c
+++ b/src/manage_sql_agent_installers.c
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_sql_agent_installers.c
+ * @file
  * @brief GVM SQL layer: Agent installers.
  *
  * SQL handlers of agent installers.

--- a/src/manage_sql_agent_installers.h
+++ b/src/manage_sql_agent_installers.h
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_sql_agent_installers.h
+ * @file
  * @brief GVM SQL layer: Agent installer headers.
  *
  * Headers for SQL handlers of agent installers.

--- a/src/manage_sql_agents.c
+++ b/src/manage_sql_agents.c
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_sql_agents.c
+ * @file
  * @brief SQL backend implementation for agent management in GVMD.
  *
  * This file provides the implementation of SQL interactions related to

--- a/src/manage_sql_agents.h
+++ b/src/manage_sql_agents.h
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_sql_agents.h
+ * @file
  * @brief SQL interaction layer for agent data in GVMD.
  *
  * This header defines SQL-related operations for managing agents,

--- a/src/manage_sql_alerts.c
+++ b/src/manage_sql_alerts.c
@@ -27,7 +27,7 @@
 #include <gvm/base/hosts.h>
 
 /**
- * @file manage_sql_alerts.c
+ * @file
  * @brief GVM management layer: Alert SQL
  *
  * The Alert SQL for the GVM management layer.

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_sql_configs.c
+ * @file
  * @brief GVM management layer: Config SQL
  *
  * The Config SQL for the GVM management layer.

--- a/src/manage_sql_copy.c
+++ b/src/manage_sql_copy.c
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_sql_copy.c
+ * @file
  * @brief GVM management layer: SQL COPY.
  *
  * Helper functions for using SQL COPY statements.

--- a/src/manage_sql_copy.h
+++ b/src/manage_sql_copy.h
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_sql_copy.h
+ * @file
  * @brief GVM management layer: SQL COPY headers.
  *
  * SQL COPY headers for the GVM management layer.

--- a/src/manage_sql_events.c
+++ b/src/manage_sql_events.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_sql_events.c
+ * @file
  * @brief GVM management layer: Events SQL
  *
  * The Events SQL for the GVM management layer.

--- a/src/manage_sql_nvts.c
+++ b/src/manage_sql_nvts.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_sql_nvts.c
+ * @file
  * @brief GVM management layer: NVTs
  *
  * The NVT parts of the GVM management layer.

--- a/src/manage_sql_nvts.h
+++ b/src/manage_sql_nvts.h
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_sql_nvts.h
+ * @file
  * @brief Manager Manage library: SQL backend headers.
  */
 

--- a/src/manage_sql_nvts_common.c
+++ b/src/manage_sql_nvts_common.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_sql_nvts_common.c
+ * @file
  * @brief GVM management layer: Common NVT logic
  *
  * Shared NVT logic for the GVM management layer.

--- a/src/manage_sql_nvts_common.h
+++ b/src/manage_sql_nvts_common.h
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_sql_nvts_common.h
+ * @file
  * @brief Manager Manage library: Common SQL backend headers.
  */
 

--- a/src/manage_sql_nvts_openvasd.c
+++ b/src/manage_sql_nvts_openvasd.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_sql_nvts_openvasd.c
+ * @file
  * @brief GVM management layer: openvasd NVT logic
  *
  * NVT logic specific to openvasd in the GVM management layer.

--- a/src/manage_sql_nvts_openvasd.h
+++ b/src/manage_sql_nvts_openvasd.h
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_sql_nvts_openvasd.h
+ * @file
  * @brief Manager Manage library: openvasd SQL backend headers.
  */
 

--- a/src/manage_sql_nvts_osp.c
+++ b/src/manage_sql_nvts_osp.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_sql_nvts_osp.c
+ * @file
  * @brief GVM management layer: OSP NVT logic
  *
  * NVT logic specific to OSP in the GVM management layer.

--- a/src/manage_sql_nvts_osp.h
+++ b/src/manage_sql_nvts_osp.h
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_sql_nvts_osp.h
+ * @file
  * @brief Manager Manage library: OSP SQL backend headers.
  */
 

--- a/src/manage_sql_oci_image_targets.h
+++ b/src/manage_sql_oci_image_targets.h
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_sql_oci_image_targets.h
+ * @file
  * @brief GVM management layer: OCI Image Targets SQL.
  *
  * SQL OCI image targets code for the GVM management layer.

--- a/src/manage_sql_port_lists.c
+++ b/src/manage_sql_port_lists.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_sql_port_lists.c
+ * @file
  * @brief GVM management layer: Port list SQL
  *
  * The Port List SQL for the GVM management layer.

--- a/src/manage_sql_report_configs.c
+++ b/src/manage_sql_report_configs.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_sql_report_configs.c
+ * @file
  * @brief GVM management layer: Report configs SQL.
  *
  * SQL report config code for the GVM management layer.

--- a/src/manage_sql_report_configs.h
+++ b/src/manage_sql_report_configs.h
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_sql_report_configs.h
+ * @file
  * @brief GVM management layer: Report configs SQL.
  *
  * SQL report config code for the GVM management layer.

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_sql_report_formats.c
+ * @file
  * @brief GVM management layer: Report format SQL
  *
  * The report format SQL for the GVM management layer.

--- a/src/manage_sql_scan_queue.c
+++ b/src/manage_sql_scan_queue.c
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_sql_scan_queue.c
+ * @file
  * @brief Greenbone Vulnerability Manager scan queue SQL.
  */
 

--- a/src/manage_sql_scan_queue.h
+++ b/src/manage_sql_scan_queue.h
@@ -4,7 +4,7 @@
  */
 
 /**
- * @file manage_sql_scan_queue.h
+ * @file
  * @brief Headers for Greenbone Vulnerability Manager scan queue SQL.
  */
 

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_sql_secinfo.c
+ * @file
  * @brief GVM management layer: SecInfo
  *
  * The SecInfo parts of the GVM management layer.

--- a/src/manage_sql_secinfo.h
+++ b/src/manage_sql_secinfo.h
@@ -17,7 +17,7 @@
  */
 
 /*
- * @file manage_sql_secinfo.h
+ * @file
  * @brief Manager Manage library: SQL backend headers.
  */
 

--- a/src/manage_sql_tickets.c
+++ b/src/manage_sql_tickets.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_sql_tickets.c
+ * @file
  * @brief GVM management layer: Ticket SQL
  *
  * The Ticket SQL for the GVM management layer.

--- a/src/manage_sql_tls_certificates.c
+++ b/src/manage_sql_tls_certificates.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_sql_tls_certificates.c
+ * @file
  * @brief GVM management layer: TLS Certificates SQL
  *
  * The TLS Certificates SQL for the GVM management layer.

--- a/src/manage_sql_tls_certificates.h
+++ b/src/manage_sql_tls_certificates.h
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_sql_tls_certificates.h
+ * @file
  * @brief GVM management layer: TLS Certificates SQL headers
  *
  * Headers for TLS Certificates SQL for the GVM management layer.

--- a/src/manage_tls_certificates.c
+++ b/src/manage_tls_certificates.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_tls_certificates.c
+ * @file
  * @brief GVM management layer: TLS Certificates
  *
  * The TLS Certificates helper functions for the GVM management layer.

--- a/src/manage_tls_certificates.h
+++ b/src/manage_tls_certificates.h
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_sql_tls_certificates.h
+ * @file
  * @brief GVM management layer: TLS Certificates SQL headers
  *
  * Headers for TLS Certificates SQL for the GVM management layer.

--- a/src/manage_utils.c
+++ b/src/manage_utils.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file manage_utils.c
+ * @file
  * @brief Module for Greenbone Vulnerability Manager: Manage library utilities.
  */
 
@@ -44,7 +44,7 @@
 #define SECS_PER_DAY 86400
 
 /**
- * @file  manage_utils.c
+ * @file
  * @brief The Greenbone Vulnerability Manager management library.
  *
  * Utilities used by the manage library that do not depend on anything.

--- a/src/manage_utils.c
+++ b/src/manage_utils.c
@@ -19,6 +19,8 @@
 /**
  * @file
  * @brief Module for Greenbone Vulnerability Manager: Manage library utilities.
+ *
+ * Utilities used by the manage library that do not depend on anything.
  */
 
 #include "manage_utils.h"
@@ -42,13 +44,6 @@
  * @brief Number of seconds in a day.
  */
 #define SECS_PER_DAY 86400
-
-/**
- * @file
- * @brief The Greenbone Vulnerability Manager management library.
- *
- * Utilities used by the manage library that do not depend on anything.
- */
 
 /**
  * @brief Get the current offset from UTC of a timezone.

--- a/src/manage_utils.h
+++ b/src/manage_utils.h
@@ -17,7 +17,7 @@
  */
 
 /*
- * @file manage_utils.h
+ * @file
  * @brief Module for Greenbone Vulnerability Manager: Manage library utilities.
  */
 

--- a/src/sql.c
+++ b/src/sql.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file sql.c
+ * @file
  * @brief Generic SQL interface
  *
  * This is a small generic interface for SQL database access.

--- a/src/sql.h
+++ b/src/sql.h
@@ -17,7 +17,7 @@
  */
 
 /*
- * @file sql.h
+ * @file
  * @brief Headers for Greenbone Vulnerability Manager: the SQL library.
  */
 

--- a/src/sql_pg.c
+++ b/src/sql_pg.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file sql_pg.c
+ * @file
  * @brief Generic SQL interface: PostgreSQL backend
  *
  * PostreSQL backend of the SQL interface.

--- a/src/theia_dummy.h
+++ b/src/theia_dummy.h
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file theia_dummy.h
+ * @file
  * @brief Dummy definitions and headers for libtheia.
  */
 

--- a/src/types.h
+++ b/src/types.h
@@ -17,7 +17,7 @@
  */
 
 /*
- * @file types.h
+ * @file
  * @brief Headers for Greenbone Vulnerability Manager: types.
  */
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file utils.c
+ * @file
  * @brief Generic utilities
  *
  * Generic helper utilities.  None of these are GVM specific.  They could

--- a/src/utils.h
+++ b/src/utils.h
@@ -17,7 +17,7 @@
  */
 
 /**
- * @file utils.h
+ * @file
  * @brief Headers for Greenbone Vulnerability Manager: General utilities.
  */
 


### PR DESCRIPTION
## What

Remove the explicit file names from the Doxygen `@file` commands.

## Why

Doxygen will automatically use the current file, and this is easier to maintain. We had some already leaving out the file names, and some of the names were wrong.

## References

Doxygen [manual entry](https://doxygen.nl/manual/commands.html#cmdfile) about `@file`.

## Testing

I ran `make -B doc`. File descriptions in the HTML looked OK.

