### PR TITLE
Change: add dedicated .c and .h files for asset code

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -192,6 +192,7 @@ set(
   manage_sql_agents.c
   manage_sql_agent_installers.c
   manage_sql_alerts.c
+  manage_sql_assets.c
   manage_sql_events.c
   manage_sql_nvts.c
   manage_sql_secinfo.c
@@ -823,6 +824,7 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql_agent_installers.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql_alerts.c"
+  "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql_assets.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql_events.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql_configs.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql_nvts.c"

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -40536,39 +40536,6 @@ manage_empty_trashcan ()
  */
 
 /**
- * @brief Return the UUID of the asset associated with a result host.
- *
- * @param[in]  host    Host value from result.
- * @param[in]  result  Result.
- *
- * @return Asset UUID.
- */
-char *
-result_host_asset_id (const char *host, result_t result)
-{
-  gchar *quoted_host;
-  char *asset_id;
-
-  quoted_host = sql_quote (host);
-  asset_id = sql_string ("SELECT uuid FROM hosts"
-                         " WHERE id = (SELECT host FROM host_identifiers"
-                         "             WHERE source_type = 'Report Host'"
-                         "             AND name = 'ip'"
-                         "             AND source_id"
-                         "                 = (SELECT uuid"
-                         "                    FROM reports"
-                         "                    WHERE id = (SELECT report"
-                         "                                FROM results"
-                         "                                WHERE id = %llu))"
-                         "             AND value = '%s'"
-                         "             LIMIT 1);",
-                         result,
-                         quoted_host);
-  g_free (quoted_host);
-  return asset_id;
-}
-
-/**
  * @brief Return the UUID of a host.
  *
  * @param[in]  host  Host.

--- a/src/manage_sql_assets.c
+++ b/src/manage_sql_assets.c
@@ -1,0 +1,53 @@
+/* Copyright (C) 2009-2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "manage_sql_assets.h"
+#include "sql.h"
+
+/**
+ * @brief Return the UUID of the asset associated with a result host.
+ *
+ * @param[in]  host    Host value from result.
+ * @param[in]  result  Result.
+ *
+ * @return Asset UUID.
+ */
+char *
+result_host_asset_id (const char *host, result_t result)
+{
+  gchar *quoted_host;
+  char *asset_id;
+
+  quoted_host = sql_quote (host);
+  asset_id = sql_string ("SELECT uuid FROM hosts"
+                         " WHERE id = (SELECT host FROM host_identifiers"
+                         "             WHERE source_type = 'Report Host'"
+                         "             AND name = 'ip'"
+                         "             AND source_id"
+                         "                 = (SELECT uuid"
+                         "                    FROM reports"
+                         "                    WHERE id = (SELECT report"
+                         "                                FROM results"
+                         "                                WHERE id = %llu))"
+                         "             AND value = '%s'"
+                         "             LIMIT 1);",
+                         result,
+                         quoted_host);
+  g_free (quoted_host);
+  return asset_id;
+}

--- a/src/manage_sql_assets.h
+++ b/src/manage_sql_assets.h
@@ -1,0 +1,34 @@
+/* Copyright (C) 2009-2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _GVMD_MANAGE_SQL_ASSETS_H
+#define _GVMD_MANAGE_SQL_ASSETS_H
+
+#include "manage_resources.h"
+
+/**
+ * @file
+ * @brief GVM management layer: Asset SQL
+ *
+ * The Asset SQL for the GVM management layer.
+ */
+
+char *
+result_host_asset_id (const char *, result_t);
+
+#endif /* not _GVMD_MANAGE_SQL_ASSETS_H */


### PR DESCRIPTION
## What

Move `result_host_asset_id` into new file `manage_sql_assets.c`.

This is the first step in moving the assets code out of `manage_sql.c`.

## Why

Smaller `manage_sql.c`, better organisation of per-resource code.

## References

Similar to alert PRs that ended in /pull/2471.

## Testing

In GSA I downloaded an XML report for a scan that had errors, the asset ID in `REPORT/ERRORS` looks OK.
