### PR TITLE
Add: Add support for creating tasks with OCI image targets.

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -60,6 +60,10 @@
 #include "manage_agents.h"
 #endif
 
+#if ENABLE_CONTAINER_SCANNING
+#include "manage_oci_image_targets.h"
+#endif
+
 /**
  * @brief OID of ping_host.nasl
  */
@@ -341,7 +345,8 @@ typedef enum scanner_type
   SCANNER_TYPE_AGENT_CONTROLLER = 7,
   SCANNER_TYPE_OPENVASD_SENSOR = 8,
   SCANNER_TYPE_AGENT_CONTROLLER_SENSOR = 9,
-  SCANNER_TYPE_MAX = 10,
+  SCANNER_TYPE_CONTAINER_IMAGE = 10,
+  SCANNER_TYPE_MAX = 11,
 } scanner_type_t;
 
 int
@@ -621,6 +626,19 @@ int
 set_task_schedule_and_periods (task_t task, const gchar *schedule_id,
                                const gchar *schedule_periods);
 
+#if ENABLE_CONTAINER_SCANNING
+
+oci_image_target_t
+task_oci_image_target (task_t);
+
+int
+task_oci_image_target_in_trash (task_t);
+
+void
+set_task_oci_image_target (task_t, oci_image_target_t);
+
+#endif /* ENABLE_CONTAINER_SCANNING */
+
 void
 set_task_hosts_ordering (task_t, const char *);
 
@@ -793,7 +811,8 @@ int
 modify_task (const gchar *, const gchar *, const gchar *, const gchar *,
              const gchar *, const gchar *, const gchar *, array_t *,
              const gchar *, array_t *, const gchar *, const gchar *,
-             array_t *, const gchar *, const gchar *, gchar **, gchar **);
+             array_t *, const gchar *, const gchar *, const gchar *,
+             gchar **, gchar **);
 
 void
 init_config_file_iterator (iterator_t*, const char*, const char*);

--- a/src/manage_configs.c
+++ b/src/manage_configs.c
@@ -644,6 +644,7 @@ scanner_type_requires_config (int scanner_type)
     case SCANNER_TYPE_CVE:
     case SCANNER_TYPE_AGENT_CONTROLLER:
     case SCANNER_TYPE_AGENT_CONTROLLER_SENSOR:
+    case SCANNER_TYPE_CONTAINER_IMAGE:
       return FALSE;
 
     default:

--- a/src/manage_oci_image_targets.h
+++ b/src/manage_oci_image_targets.h
@@ -14,7 +14,7 @@
 #define _GVMD_MANAGE_OCI_IMAGE_TARGETS_H
 
 #include "iterator.h"
-#include "manage.h"
+#include "manage_get.h"
 
 typedef resource_t oci_image_target_t;
 

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -2760,6 +2760,8 @@ create_task_check_scanner_type (scanner_t scanner)
     return 1;
   if (stype == SCANNER_TYPE_OPENVASD_SENSOR)
     return 1;
+  if (stype == SCANNER_TYPE_CONTAINER_IMAGE)
+    return 1;
 
   return 0;
 }
@@ -2836,6 +2838,9 @@ modify_task_check_config_scanner (task_t task, const char *config_id,
     return 0;
 
   if (stype == SCANNER_TYPE_AGENT_CONTROLLER_SENSOR)
+    return 0;
+
+  if (stype == SCANNER_TYPE_CONTAINER_IMAGE)
     return 0;
 
   /* Default Scanner with OpenVAS Config. */

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -6467,6 +6467,9 @@ END:VCALENDAR
       @IF_ENABLE_AGENTS@
       <e>agent_group</e>
       @ENDIF_ENABLE_AGENTS@
+      @IF_ENABLE_CONTAINER_SCANNNING@
+      <e>oci_image_target</e>
+      @ENDIF_ENABLE_CONTAINER_SCANNNING@
       <e>target</e>
       <o><e>hosts_ordering</e></o>
       <e>scanner</e>
@@ -6545,6 +6548,19 @@ END:VCALENDAR
       </pattern>
     </ele>
     @ENDIF_ENABLE_AGENTS@
+    @IF_ENABLE_CONTAINER_SCANNNING@
+    <ele>
+      <name>oci_image_target</name>
+      <summary>The OCI images scanned by the task</summary>
+      <pattern>
+        <attrib>
+          <name>id</name>
+          <type>uuid</type>
+          <required>1</required>
+        </attrib>
+      </pattern>
+    </ele>
+    @ENDIF_ENABLE_CONTAINER_SCANNNING@
     <ele>
       <name>hosts_ordering</name>
       <summary>The order hosts are scanned in</summary>
@@ -6707,6 +6723,26 @@ END:VCALENDAR
       </response>
     </example>
     @ENDIF_ENABLE_AGENTS@
+    @IF_ENABLE_CONTAINER_SCANNNING@
+    <example>
+      <summary>Create an OCI image task</summary>
+      <request>
+        <create_task>
+          <name>OCI Image Task</name>
+          <comment>Task with OCI image target assigned</comment>
+          <usage_type>scan</usage_type>
+          <oci_image_target id="fd9bd047-fac8-49e7-bd45-64652f713a41"/>
+          <scanner id="8154d8e3-30ee-4959-9151-1863c89a8e62"/>
+        </create_task>
+      </request>
+      <response>
+        <create_task_response status="201"
+                              status_text="OK, resource created"
+                              id="b7f0afbe-bdb3-11e9-9847-28d24461215b">
+        </create_task_response>
+      </response>
+    </example>
+    @ENDIF_ENABLE_CONTAINER_SCANNNING@
   </command>
   <command>
     <name>create_ticket</name>
@@ -25484,6 +25520,9 @@ END:VCALENDAR
               <e>usage_type</e>
               <e>config</e>
               <e>target</e>
+              @IF_ENABLE_CONTAINER_SCANNNING@
+              <o><e>oci_image_target</e></o>
+              @ENDIF_ENABLE_CONTAINER_SCANNNING@
               <e>hosts_ordering</e>
               <e>scanner</e>
               <e>alert</e>
@@ -25699,6 +25738,38 @@ END:VCALENDAR
             <pattern><t>boolean</t></pattern>
           </ele>
         </ele>
+        @IF_ENABLE_CONTAINER_SCANNNING@
+        <ele>
+          <name>oci_image_target</name>
+          <summary>The OCI images scanned by the task</summary>
+          <pattern>
+            <attrib>
+              <name>id</name>
+              <type>uuid</type>
+              <required>1</required>
+              <summary>ID of OCI image target</summary>
+            </attrib>
+            <e>name</e>
+            <o><e>permissions</e></o>
+            <e>trash</e>
+          </pattern>
+          <ele>
+            <name>name</name>
+            <summary>The name of the OCI image target</summary>
+            <pattern><t>name</t></pattern>
+          </ele>
+          <ele>
+            <name>permissions</name>
+            <summary>Permissions the user has on the target</summary>
+            <pattern></pattern>
+          </ele>
+          <ele>
+            <name>trash</name>
+            <summary>Whether the target is in the trashcan</summary>
+            <pattern><t>boolean</t></pattern>
+          </ele>
+        </ele>
+        @ENDIF_ENABLE_CONTAINER_SCANNNING@
         <ele>
           <name>hosts_ordering</name>
           <summary>The order hosts are scanned in</summary>
@@ -31503,6 +31574,9 @@ END:VCALENDAR
         @IF_ENABLE_AGENTS@
         <e>agent_group</e>
         @ENDIF_ENABLE_AGENTS@
+        @IF_ENABLE_CONTAINER_SCANNNING@
+        <e>oci_image_target</e>
+        @ENDIF_ENABLE_CONTAINER_SCANNNING@
         <e>file</e>
       </or>
     </pattern>
@@ -31622,6 +31696,19 @@ END:VCALENDAR
       </pattern>
     </ele>
     @ENDIF_ENABLE_AGENTS@
+    @IF_ENABLE_CONTAINER_SCANNNING@
+    <ele>
+      <name>oci_image_target</name>
+      <summary>The OCI images scanned by the task</summary>
+      <pattern>
+        <attrib>
+          <name>id</name>
+          <type>uuid</type>
+          <required>1</required>
+        </attrib>
+      </pattern>
+    </ele>
+    @ENDIF_ENABLE_CONTAINER_SCANNNING@
     <ele>
       <name>file</name>
       <summary>File to attach to task</summary>


### PR DESCRIPTION
## What
Add support for creating tasks with OCI image targets.

Changes are behind a toggle `ENABLE_CONTAINER_SCANNING`.

## Why
Required for container scanning.

## References
GEA-1184