### PR TITLE
Fix: Add validation to reject create_task requests with both target_id and agent_group_id

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -24206,6 +24206,14 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
               goto create_task_fail;
             }
 
+          if (create_task_data->target_id && create_task_data->agent_group_id)
+            {
+              SEND_TO_CLIENT_OR_FAIL
+               (XML_ERROR_SYNTAX ("create_task",
+                                  "Only one of target_id or agent_group_id must be provided"));
+              goto create_task_fail;
+            }
+
 #if ENABLE_AGENTS
           if (is_agent_task)
             {


### PR DESCRIPTION
## What

Added a check to ensure only one of target_id or agent_group_id is set when creating a task.


## Why

To prevent invalid task configurations and ensure clear task type behavior.