### PR TITLE
Change: start moving asset functions out of manage_sql.c

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -102,6 +102,7 @@
 #include "manage.h"
 #include "manage_acl.h"
 #include "manage_alerts.h"
+#include "manage_assets.h"
 #include "manage_port_lists.h"
 #include "manage_report_configs.h"
 #include "manage_report_formats.h"

--- a/src/manage.c
+++ b/src/manage.c
@@ -52,6 +52,7 @@
 #include "manage.h"
 #include "manage_acl.h"
 #include "manage_agent_installers.h"
+#include "manage_assets.h"
 #include "manage_configs.h"
 #include "manage_osp.h"
 #include "manage_port_lists.h"

--- a/src/manage.h
+++ b/src/manage.h
@@ -2283,9 +2283,6 @@ credential_encrypted_value (credential_t, const char*);
 
 /* Assets. */
 
-char *
-result_host_asset_id (const char *, result_t);
-
 char*
 host_uuid (resource_t);
 

--- a/src/manage.h
+++ b/src/manage.h
@@ -2283,9 +2283,6 @@ credential_encrypted_value (credential_t, const char*);
 
 /* Assets. */
 
-char*
-host_uuid (resource_t);
-
 host_t
 host_notice (const char *, const char *, const char *, const char *,
              const char *, int, int);

--- a/src/manage.h
+++ b/src/manage.h
@@ -1091,9 +1091,6 @@ insert_report_host_detail (report_t, const char *, const char *, const char *,
                            const char *, const char *, const char *,
                            const char *);
 
-int
-manage_report_host_detail (report_t, const char *, const char *, GHashTable *);
-
 void
 hosts_set_identifiers (report_t);
 

--- a/src/manage.h
+++ b/src/manage.h
@@ -3457,14 +3457,8 @@ manage_delete_user (GSList *, const db_conn_info_t *, const gchar *,
 int
 manage_get_users (GSList *, const db_conn_info_t *, const gchar *, int);
 
-report_host_t
-manage_report_host_add (report_t, const char *, time_t, time_t);
-
 int
 report_host_noticeable (report_t, const gchar *);
-
-void
-report_host_set_end_time (report_host_t, time_t);
 
 gchar*
 host_routes_xml (host_t);

--- a/src/manage_assets.h
+++ b/src/manage_assets.h
@@ -22,4 +22,10 @@
 char*
 host_uuid (resource_t);
 
+report_host_t
+manage_report_host_add (report_t, const char *, time_t, time_t);
+
+void
+report_host_set_end_time (report_host_t, time_t);
+
 #endif /* not _GVMD_MANAGE_ASSETS_H */

--- a/src/manage_assets.h
+++ b/src/manage_assets.h
@@ -1,0 +1,25 @@
+/* Copyright (C) 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _GVMD_MANAGE_ASSETS_H
+#define _GVMD_MANAGE_ASSETS_H
+
+char*
+host_uuid (resource_t);
+
+#endif /* not _GVMD_MANAGE_ASSETS_H */

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -40783,20 +40783,6 @@ manage_empty_trashcan ()
  */
 
 /**
- * @brief Return the UUID of a host.
- *
- * @param[in]  host  Host.
- *
- * @return Host UUID.
- */
-char*
-host_uuid (resource_t host)
-{
-  return sql_string ("SELECT uuid FROM hosts WHERE id = %llu;",
-                     host);
-}
-
-/**
  * @brief Add a report host.
  *
  * @param[in]  report   UUID of resource.

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -37,6 +37,7 @@
 #include "manage_osp.h"
 #include "manage_sql.h"
 #include "manage_alerts.h"
+#include "manage_assets.h"
 #include "manage_port_lists.h"
 #include "manage_report_formats.h"
 #include "manage_sql_copy.h"
@@ -40783,37 +40784,6 @@ manage_empty_trashcan ()
  */
 
 /**
- * @brief Add a report host.
- *
- * @param[in]  report   UUID of resource.
- * @param[in]  host     Host.
- * @param[in]  start    Start time.
- * @param[in]  end      End time.
- *
- * @return Report host.
- */
-report_host_t
-manage_report_host_add (report_t report, const char *host, time_t start,
-                        time_t end)
-{
-  char *quoted_host = sql_quote (host);
-  resource_t report_host;
-  
-  sql ("INSERT INTO report_hosts"
-       " (report, host, start_time, end_time, current_port, max_port)"
-       " SELECT %llu, '%s', %lld, %lld, 0, 0"
-       " WHERE NOT EXISTS (SELECT 1 FROM report_hosts WHERE report = %llu"
-       "                   AND host = '%s');",
-       report, quoted_host, (long long) start, (long long) end, report,
-       quoted_host);
-  report_host = sql_int64_0 ("SELECT id FROM report_hosts"
-                             " WHERE report = %llu AND host = '%s';",
-                             report, quoted_host);
-  g_free (quoted_host);
-  return report_host;
-}
-
-/**
  * @brief Tests if a report host is marked as dead.
  *
  * @param[in]  report_host  Report host.
@@ -40845,19 +40815,6 @@ report_host_result_count (report_host_t report_host)
                   "   AND results.report = report_hosts.report"
                   "   AND report_hosts.host = results.host;",
                   report_host);
-}
-
-/**
- * @brief Set end time of a report host.
- *
- * @param[in]  report_host  Report host.
- * @param[in]  end_time     End time.
- */
-void
-report_host_set_end_time (report_host_t report_host, time_t end_time)
-{
-  sql ("UPDATE report_hosts SET end_time = %lld WHERE id = %llu;",
-       end_time, report_host);
 }
 
 /**

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -45,6 +45,7 @@
 #include "manage_tickets.h"
 #include "manage_scan_queue.h"
 #include "manage_sql_alerts.h"
+#include "manage_sql_assets.h"
 #include "manage_sql_configs.h"
 #include "manage_sql_oci_image_targets.h"
 #include "manage_sql_port_lists.h"

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -187,126 +187,194 @@ extern manage_connection_forker_t manage_fork_connection;
 
 typedef long long int rowid_t;
 
-int manage_db_empty ();
+int
+manage_db_empty ();
 
 gboolean
 host_nthlast_report_host (const char *, report_host_t *, int);
 
-char*
+char *
 report_host_ip (const char *);
 
-gchar *report_host_hostname (report_host_t);
+gchar *
+report_host_hostname (report_host_t);
 
-gchar *report_host_best_os_cpe (report_host_t);
+gchar *
+report_host_best_os_cpe (report_host_t);
 
-gchar *report_host_best_os_txt (report_host_t);
+gchar *
+report_host_best_os_txt (report_host_t);
 
-gchar *report_creation_time (report_t);
+gchar *
+report_creation_time (report_t);
 
-gchar *report_modification_time (report_t);
+gchar *
+report_modification_time (report_t);
 
-gchar *report_start_time (report_t);
+gchar *
+report_start_time (report_t);
 
-gchar *report_end_time (report_t);
+gchar *
+report_end_time (report_t);
 
-void trim_report (report_t);
+void
+trim_report (report_t);
 
-int delete_report_internal (report_t);
+int
+delete_report_internal (report_t);
 
-int set_report_scan_run_status (report_t, task_status_t);
+int
+set_report_scan_run_status (report_t, task_status_t);
 
-int update_report_modification_time (report_t);
+int
+update_report_modification_time (report_t);
 
-int set_report_slave_progress (report_t, int);
+int
+set_report_slave_progress (report_t, int);
 
-void init_task_file_iterator (iterator_t *, task_t, const char *);
-const char *task_file_iterator_name (iterator_t *);
-const char *task_file_iterator_content (iterator_t *);
+void
+init_task_file_iterator (iterator_t *, task_t, const char *);
 
-void set_task_schedule_next_time (task_t, time_t);
+const char *
+task_file_iterator_name (iterator_t *);
 
-void set_task_schedule_next_time_uuid (const gchar *, time_t);
+const char *
+task_file_iterator_content (iterator_t *);
 
-void init_preference_iterator (iterator_t *, config_t, const char *);
-const char *preference_iterator_name (iterator_t *);
-const char *preference_iterator_value (iterator_t *);
+void
+set_task_schedule_next_time (task_t, time_t);
 
-port_list_t target_port_list (target_t);
-credential_t target_ssh_credential (target_t);
-credential_t target_smb_credential (target_t);
-credential_t target_esxi_credential (target_t);
-credential_t target_ssh_elevate_credential (target_t);
-credential_t target_krb5_credential (target_t);
+void
+set_task_schedule_next_time_uuid (const gchar *, time_t);
 
-int create_current_report (task_t, char **, task_status_t);
+void
+init_preference_iterator (iterator_t *, config_t, const char *);
 
-int init_task_schedule_iterator (iterator_t *);
+const char *
+preference_iterator_name (iterator_t *);
 
-void cleanup_task_schedule_iterator (iterator_t *);
+const char *
+preference_iterator_value (iterator_t *);
 
-task_t task_schedule_iterator_task (iterator_t *);
+port_list_t
+target_port_list (target_t);
 
-const char *task_schedule_iterator_task_uuid (iterator_t *);
+credential_t
+target_ssh_credential (target_t);
+
+credential_t
+target_smb_credential (target_t);
+
+credential_t
+target_esxi_credential (target_t);
+
+credential_t
+target_ssh_elevate_credential (target_t);
+
+credential_t
+target_krb5_credential (target_t);
+
+int
+create_current_report (task_t, char **, task_status_t);
+
+int
+init_task_schedule_iterator (iterator_t *);
+
+void
+cleanup_task_schedule_iterator (iterator_t *);
+
+task_t
+task_schedule_iterator_task (iterator_t *);
+
+const char *
+task_schedule_iterator_task_uuid (iterator_t *);
 
 schedule_t task_schedule_iterator_schedule (iterator_t *);
 
-const char *task_schedule_iterator_icalendar (iterator_t *);
+const char *
+task_schedule_iterator_icalendar (iterator_t *);
 
-const char *task_schedule_iterator_timezone (iterator_t *);
+const char *
+task_schedule_iterator_timezone (iterator_t *);
 
-const char *task_schedule_iterator_owner_uuid (iterator_t *);
+const char *
+task_schedule_iterator_owner_uuid (iterator_t *);
 
-const char *task_schedule_iterator_owner_name (iterator_t *);
+const char *
+task_schedule_iterator_owner_name (iterator_t *);
 
-gboolean task_schedule_iterator_timed_out (iterator_t *);
+gboolean
+task_schedule_iterator_timed_out (iterator_t *);
 
-gboolean task_schedule_iterator_start_due (iterator_t *);
+gboolean
+task_schedule_iterator_start_due (iterator_t *);
 
-gboolean task_schedule_iterator_stop_due (iterator_t *);
+gboolean
+task_schedule_iterator_stop_due (iterator_t *);
 
-time_t task_schedule_iterator_initial_offset (iterator_t *);
+time_t
+task_schedule_iterator_initial_offset (iterator_t *);
 
-int set_task_schedule_uuid (const gchar*, schedule_t, int);
+int
+set_task_schedule_uuid (const gchar*, schedule_t, int);
 
-void reinit_manage_process ();
+void
+reinit_manage_process ();
 
-int manage_update_nvti_cache ();
+int
+manage_update_nvti_cache ();
 
-int manage_report_host_details (report_t, const char *, entity_t, GHashTable *);
+int
+manage_report_host_details (report_t, const char *, entity_t, GHashTable *);
 
-const char *run_status_name_internal (task_status_t);
+const char *
+run_status_name_internal (task_status_t);
 
-void update_config_cache_init (const char *);
+void
+update_config_cache_init (const char *);
 
-alive_test_t target_alive_tests (target_t);
+alive_test_t
+target_alive_tests (target_t);
 
-void manage_session_init (const char *);
+void
+manage_session_init (const char *);
 
-void check_generate_scripts ();
+void
+check_generate_scripts ();
 
-void auto_delete_reports ();
+void
+auto_delete_reports ();
 
-int parse_iso_time (const char *);
+int
+parse_iso_time (const char *);
 
-void set_report_scheduled (report_t);
+void
+set_report_scheduled (report_t);
 
-gchar *resource_uuid (const gchar *, resource_t);
+gchar *
+resource_uuid (const gchar *, resource_t);
 
-gboolean find_resource_with_permission (const char *, const char *,
+gboolean
+find_resource_with_permission (const char *, const char *,
                                         resource_t *, const char *, int);
 
 int
 resource_predefined (const gchar *, resource_t);
 
-void parse_osp_report (task_t, report_t, const char *);
+void
+parse_osp_report (task_t, report_t, const char *);
 
-void reschedule_task (const gchar *);
+void
+reschedule_task (const gchar *);
 
-void insert_port_range (port_list_t, port_protocol_t, int, int);
+void
+insert_port_range (port_list_t, port_protocol_t, int, int);
 
-int manage_cert_db_exists ();
+int
+manage_cert_db_exists ();
 
-int manage_scap_db_exists ();
+int
+manage_scap_db_exists ();
 
 int
 cert_check_time ();
@@ -326,11 +394,11 @@ init_get_iterator (iterator_t*, const char *, const get_data_t *, column_t *,
                    column_t *, const char **, int, const char *, const char *,
                    int);
 
-int openvasd_get_details_from_iterator (iterator_t *, char **, GSList **);
+int
+openvasd_get_details_from_iterator (iterator_t *, char **, GSList **);
 
 int
-agent_control_get_details_from_iterator (iterator_t *iterator, char **desc,
-                                         GSList **params);
+agent_control_get_details_from_iterator (iterator_t *, char **, GSList **);
 
 gchar *
 columns_build_select (column_t *);

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -324,9 +324,6 @@ reinit_manage_process ();
 int
 manage_update_nvti_cache ();
 
-int
-manage_report_host_details (report_t, const char *, entity_t, GHashTable *);
-
 const char *
 run_status_name_internal (task_status_t);
 
@@ -528,6 +525,25 @@ report_set_processing_required (report_t, int, int);
 
 int
 process_report_import (report_t);
+
+int
+check_host_detail_exists (report_t, const char *, const char *, const char *,
+                          const char *, const char *, const char *, char **,
+                          GHashTable *);
+
+// FIX moved here for now, until more code goes to manage*_assets.c
+/**
+ * @brief Host identifier type.
+ */
+typedef struct
+{
+  gchar *ip;                ///< IP of host.
+  gchar *name;              ///< Name of identifier, like "hostname".
+  gchar *value;             ///< Value of identifier.
+  gchar *source_type;       ///< Type of identifier source, like "Report Host".
+  gchar *source_id;         ///< ID of source.
+  gchar *source_data;       ///< Extra data for source.
+} identifier_t;
 
 #if OPENVASD
 void

--- a/src/manage_sql_assets.c
+++ b/src/manage_sql_assets.c
@@ -51,3 +51,17 @@ result_host_asset_id (const char *host, result_t result)
   g_free (quoted_host);
   return asset_id;
 }
+
+/**
+ * @brief Return the UUID of a host.
+ *
+ * @param[in]  host  Host.
+ *
+ * @return Host UUID.
+ */
+char*
+host_uuid (resource_t host)
+{
+  return sql_string ("SELECT uuid FROM hosts WHERE id = %llu;",
+                     host);
+}

--- a/src/manage_sql_assets.h
+++ b/src/manage_sql_assets.h
@@ -31,4 +31,7 @@
 char *
 result_host_asset_id (const char *, result_t);
 
+int
+manage_report_host_detail (report_t, const char *, const char *, GHashTable *);
+
 #endif /* not _GVMD_MANAGE_SQL_ASSETS_H */

--- a/src/utils.c
+++ b/src/utils.c
@@ -1049,3 +1049,22 @@ phys_mem_total ()
 {
   return sysconf(_SC_PHYS_PAGES) * sysconf(_SC_PAGESIZE);
 }
+
+
+/* Arrays. */
+
+/**
+ * @brief Ensure a string is in an array.
+ *
+ * @param[in]  array   Array.
+ * @param[in]  string  String.  Copied into array.
+ */
+void
+array_add_new_string (array_t *array, const gchar *string)
+{
+  guint index;
+  for (index = 0; index < array->len; index++)
+    if (strcmp (g_ptr_array_index (array, index), string) == 0)
+      return;
+  array_add (array, g_strdup (string));
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -25,6 +25,7 @@
 #define _GVMD_UTILS_H
 
 #include <glib.h>
+#include <gvm/base/array.h>
 #include <gvm/util/xmlutils.h>
 #include <time.h>
 
@@ -114,5 +115,8 @@ phys_mem_available ();
 
 guint64
 phys_mem_total ();
+
+void
+array_add_new_string (array_t *, const gchar *);
 
 #endif /* not _GVMD_UTILS_H */


### PR DESCRIPTION
## What

Move a few functions to the dedicated asset files.

## Why

Part of moving the `Assets` section out of `manage_sql.c`, to reduce the size of that file.

## References

Follows /pull/2495.

## Testing

For `host_uuid`, I ran `o m m "<create_asset><asset><type>host</type><name>0.0.0.0</name><comment>test</comment></asset></create_asset>"` and confirmed the UUID was in the response.

For `manage_report_host_add` and `report_host_set_end_time` I ran a CVE scan and checked that the host was added to the db with an end time.

For `manage_report_host_detail` I ran a Full and Fast scan and checked that the host details ended up in the db.