### PR TITLE
Complete a function prototype to fix C23 build

### DIFF
--- a/src/manage_sql_tickets.h
+++ b/src/manage_sql_tickets.h
@@ -50,7 +50,7 @@ void
 empty_trashcan_tickets ();
 
 void
-check_tickets ();
+check_tickets (task_t);
 
 void
 delete_tickets_user (user_t);


### PR DESCRIPTION
Fixes the build with compilers defaulting to C23, e.g. gcc 15.

Closes #2452.