### PR TITLE
Change: move create_asset_report out of manage_sql.c

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -2384,9 +2384,6 @@ int
 delete_asset (const char *, const char *, int);
 
 int
-create_asset_report (const char *, const char *);
-
-int
 add_assets_from_host_in_report (report_t report, const char *host);
 
 

--- a/src/manage_assets.h
+++ b/src/manage_assets.h
@@ -31,4 +31,7 @@ report_host_set_end_time (report_host_t, time_t);
 int
 create_asset_host (const char *, const char *, resource_t* );
 
+int
+create_asset_report (const char *, const char *);
+
 #endif /* not _GVMD_MANAGE_ASSETS_H */

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -290,12 +290,6 @@ static gchar *
 reports_extra_where (int, const char *, const char *);
 
 static int
-report_host_dead (report_host_t);
-
-static int
-report_host_result_count (report_host_t);
-
-static int
 set_credential_data (credential_t, const char*, const char*);
 
 static void
@@ -16139,7 +16133,7 @@ init_report_host_iterator (iterator_t* iterator, report_t report, const char *ho
  *
  * @return Report host.
  */
-static report_host_t
+report_host_t
 host_iterator_report_host (iterator_t* iterator)
 {
   if (iterator->done) return 0;
@@ -16353,7 +16347,7 @@ report_errors_iterator_result (iterator_t* iterator)
  * @param[in]  report_host  Report host whose details the iterator loops over.
  *                          All report_hosts if NULL.
  */
-static void
+void
 init_report_host_details_iterator (iterator_t* iterator,
                                    report_host_t report_host)
 {
@@ -16386,7 +16380,6 @@ init_report_host_details_iterator (iterator_t* iterator,
  * @return The name of the report host detail.  Caller must use only before
  *         calling cleanup_iterator.
  */
-static
 DEF_ACCESS (report_host_details_iterator_name, 1);
 
 /**
@@ -16397,7 +16390,6 @@ DEF_ACCESS (report_host_details_iterator_name, 1);
  * @return The value of the report host detail.  Caller must use only before
  *         calling cleanup_iterator.
  */
-static
 DEF_ACCESS (report_host_details_iterator_value, 2);
 
 /**
@@ -16419,7 +16411,6 @@ DEF_ACCESS (report_host_details_iterator_source_type, 3);
  * @return The source name of the report host detail.  Caller must use only
  *         before calling cleanup_iterator.
  */
-static
 DEF_ACCESS (report_host_details_iterator_source_name, 4);
 
 /**
@@ -40774,7 +40765,7 @@ manage_empty_trashcan ()
  *
  * @return 1 if the host is marked as dead, 0 otherwise.
  */
-static int
+int
 report_host_dead (report_host_t report_host)
 {
   return sql_int ("SELECT count(*) != 0 FROM report_host_details"
@@ -40791,7 +40782,7 @@ report_host_dead (report_host_t report_host)
  *
  * @return 1 if the host is marked as dead, 0 otherwise.
  */
-static int
+int
 report_host_result_count (report_host_t report_host)
 {
   return sql_int ("SELECT count(*) FROM report_hosts, results"
@@ -42245,140 +42236,6 @@ find_host_with_permission (const char* uuid, host_t* host,
                            const char *permission)
 {
   return find_resource_with_permission ("host", uuid, host, permission, 0);
-}
-
-/**
- * @brief Check whether a string is an identifier name.
- *
- * @param[in]  name  Possible identifier name.
- *
- * @return 1 if an identifier name, else 0.
- */
-static int
-identifier_name (const char *name)
-{
-  return (strcmp ("hostname", name) == 0)
-         || (strcmp ("MAC", name) == 0)
-         || (strcmp ("OS", name) == 0)
-         || (strcmp ("ssh-key", name) == 0);
-}
-
-/**
- * @brief Create all available assets from a report.
- *
- * @param[in]  report_id  UUID of report.
- * @param[in]  term       Filter term, for min_qod and apply_overrides.
- *
- * @return 0 success, 1 failed to find report, 99 permission denied, -1 error.
- */
-int
-create_asset_report (const char *report_id, const char *term)
-{
-  resource_t report;
-  iterator_t hosts;
-  gchar *quoted_report_id;
-  int apply_overrides, min_qod;
-
-  if (report_id == NULL)
-    return -1;
-
-  sql_begin_immediate ();
-
-  if (acl_user_may ("create_asset") == 0)
-    {
-      sql_rollback ();
-      return 99;
-    }
-
-  report = 0;
-  if (find_report_with_permission (report_id, &report, "get_reports"))
-    {
-      sql_rollback ();
-      return -1;
-    }
-
-  if (report == 0)
-    {
-      sql_rollback ();
-      return 1;
-    }
-
-  /* These are freed by hosts_set_identifiers. */
-  if (identifiers == NULL)
-    identifiers = make_array ();
-  if (identifier_hosts == NULL)
-    identifier_hosts = make_array ();
-
-  quoted_report_id = sql_quote (report_id);
-  sql ("DELETE FROM host_identifiers WHERE source_id = '%s';",
-       quoted_report_id);
-  sql ("DELETE FROM host_oss WHERE source_id = '%s';",
-       quoted_report_id);
-  sql ("DELETE FROM host_max_severities WHERE source_id = '%s';",
-       quoted_report_id);
-  sql ("DELETE FROM host_details WHERE source_id = '%s';",
-       quoted_report_id);
-  g_free (quoted_report_id);
-
-  init_report_host_iterator (&hosts, report, NULL, 0);
-  while (next (&hosts))
-    {
-      const char *host;
-      report_host_t report_host;
-      iterator_t details;
-
-      host = host_iterator_host (&hosts);
-      report_host = host_iterator_report_host (&hosts);
-
-      if (report_host_dead (report_host)
-          || report_host_result_count (report_host) == 0)
-        continue;
-
-      host_notice (host, "ip", host, "Report Host", report_id, 0, 0);
-
-      init_report_host_details_iterator (&details, report_host);
-      while (next (&details))
-        {
-          const char *name;
-
-          name = report_host_details_iterator_name (&details);
-
-          if (identifier_name (name))
-            {
-              const char *value;
-              identifier_t *identifier;
-
-              value = report_host_details_iterator_value (&details);
-
-              if ((strcmp (name, "OS") == 0)
-                  && (g_str_has_prefix (value, "cpe:") == 0))
-                continue;
-
-              identifier = g_malloc (sizeof (identifier_t));
-              identifier->ip = g_strdup (host);
-              identifier->name = g_strdup (name);
-              identifier->value = g_strdup (value);
-              identifier->source_id = g_strdup (report_id);
-              identifier->source_type = g_strdup ("Report Host Detail");
-              identifier->source_data
-               = g_strdup (report_host_details_iterator_source_name (&details));
-
-              array_add (identifiers, identifier);
-              array_add_new_string (identifier_hosts, g_strdup (host));
-            }
-        }
-      cleanup_iterator (&details);
-    }
-  cleanup_iterator (&hosts);
-  hosts_set_identifiers (report);
-  apply_overrides = filter_term_apply_overrides (term);
-  min_qod = filter_term_min_qod (term);
-  hosts_set_max_severity (report, &apply_overrides, &min_qod);
-  hosts_set_details (report);
-
-  sql_commit ();
-
-  return 0;
 }
 
 /**

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -193,6 +193,9 @@ manage_db_empty ();
 gboolean
 host_nthlast_report_host (const char *, report_host_t *, int);
 
+report_host_t
+host_iterator_report_host (iterator_t *);
+
 char *
 report_host_ip (const char *);
 
@@ -204,6 +207,24 @@ report_host_best_os_cpe (report_host_t);
 
 gchar *
 report_host_best_os_txt (report_host_t);
+
+int
+report_host_dead (report_host_t);
+
+int
+report_host_result_count (report_host_t);
+
+void
+init_report_host_details_iterator (iterator_t *, report_host_t);
+
+const char *
+report_host_details_iterator_name (iterator_t *);
+
+const char *
+report_host_details_iterator_value (iterator_t *);
+
+const char *
+report_host_details_iterator_source_name (iterator_t *);
 
 gchar *
 report_creation_time (report_t);


### PR DESCRIPTION
## What

Move `create_asset_report` to asset files.

## Why

Reducing size of `manage_sql.c`.

## References

Follows /pull/2501.

## Testing

I removed the relevant host, then ran `o m m '<create_asset><report id="2a88a92c-04a8-4edb-8279-1f4a162f99ac"/></create_asset>'` and finally checked that the host had been created.