### PR TITLE
Fix: respond gracefully when asked to stop inactive task

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -2704,10 +2704,13 @@ stop_osp_task (task_t task)
   task_t previous_task;
   report_t previous_report;
 
+  scan_report = task_running_report (task);
+  if (!scan_report)
+    return 0;
+
   previous_task = current_scanner_task;
   previous_report = global_current_report;
 
-  scan_report = task_running_report (task);
   scan_id = report_uuid (scan_report);
   if (!scan_id)
     goto end_stop_osp;
@@ -7066,9 +7069,13 @@ stop_openvasd_task (task_t task)
   openvasd_resp_t response;
   openvasd_connector_t connector = NULL;
 
+  scan_report = task_running_report (task);
+  if (!scan_report)
+    return 0;
+
   previous_task = current_scanner_task;
   previous_report = global_current_report;
-  scan_report = task_running_report (task);
+
   scan_id = report_uuid (scan_report);
   if (!scan_id)
     {


### PR DESCRIPTION
## What

Return 0 immediately from `stop_osp_task` and `stop_openvasd_task` when the task is inactive.

## Why

Returning 0 ensures that the GMP layer sends a response to the client, instead of just aborting.

Doing the return immediately prevents the task from being put into `Stopped` (which is weird eg if the task was `New`). 

Both these choices match the existing behaviour of `stop_task_internal`, which is used to stop all other task types.

## References

Closes #2459.

## Testing

Ran `o m m '<stop_task task_id="24f92e96-5784-43ca-bfa0-e2dd75a075a8"/>'` on various running, stopped and new tasks. Also checked stopping in GSA.