### PR TITLE
Fix: Set default SIGCHLD handler for scan handlers

### DIFF
--- a/src/manage_scan_handler.c
+++ b/src/manage_scan_handler.c
@@ -215,9 +215,12 @@ fork_scan_handler (const char *report_id, report_t report, task_t task,
                 close (pipe_fds[1]);
                 reinit_manage_process ();
 
+                // Reset SIGCHLD handler to default so the process can
+                // use common functions to wait for its own child processes.
                 memset (&action, '\0', sizeof (action));
                 sigemptyset (&action.sa_mask);
                 action.sa_handler = SIG_DFL;
+                action.sa_flags = 0;
                 if (sigaction (SIGCHLD, &action, NULL) == -1)
                   {
                     g_critical ("%s: failed to set SIGCHLD handler: %s",


### PR DESCRIPTION
## What
When forking the scan handler process in fork_scan_handler the signal handler for SIGCHLD is now set to SIG_DFL.

## Why
This fixes not being able to run sub-processes like the relay mapper with g_spawn_sync.

## References
GEA-1208

