### PR TITLE
Change: move remaining iterators to the asset files

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -2295,12 +2295,6 @@ host_notice (const char *, const char *, const char *, const char *,
              const char *, int, int);
 
 int
-asset_iterator_writable (iterator_t *);
-
-int
-asset_iterator_in_use (iterator_t *);
-
-int
 asset_host_count (const get_data_t *);
 
 int

--- a/src/manage_assets.h
+++ b/src/manage_assets.h
@@ -123,4 +123,10 @@ init_resource_names_host_iterator (iterator_t *, get_data_t *);
 int
 init_resource_names_os_iterator (iterator_t *, get_data_t *);
 
+int
+asset_iterator_writable (iterator_t *);
+
+int
+asset_iterator_in_use (iterator_t *);
+
 #endif /* not _GVMD_MANAGE_ASSETS_H */

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -40942,34 +40942,6 @@ host_routes_xml (host_t host)
 }
 
 /**
- * @brief Get the writable status from an asset iterator.
- *
- * @param[in]  iterator  Iterator.
- *
- * @return 1 if writable, else 0.
- */
-int
-asset_iterator_writable (iterator_t* iterator)
-{
-  if (iterator->done) return 0;
-  return iterator_int64 (iterator, GET_ITERATOR_COLUMN_COUNT);
-}
-
-/**
- * @brief Get the "in use" status from an asset iterator.
- *
- * @param[in]  iterator  Iterator.
- *
- * @return 1 if in use, else 0.
- */
-int
-asset_iterator_in_use (iterator_t* iterator)
-{
-  if (iterator->done) return 0;
-  return iterator_int64 (iterator, GET_ITERATOR_COLUMN_COUNT + 1);
-}
-
-/**
  * @brief Count number of hosts.
  *
  * @param[in]  get  GET params.

--- a/src/manage_sql_assets.c
+++ b/src/manage_sql_assets.c
@@ -1513,3 +1513,31 @@ init_resource_names_os_iterator (iterator_t *iterator, get_data_t *get)
 
   return ret;
 }
+
+/**
+ * @brief Get the writable status from an asset iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return 1 if writable, else 0.
+ */
+int
+asset_iterator_writable (iterator_t* iterator)
+{
+  if (iterator->done) return 0;
+  return iterator_int64 (iterator, GET_ITERATOR_COLUMN_COUNT);
+}
+
+/**
+ * @brief Get the "in use" status from an asset iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return 1 if in use, else 0.
+ */
+int
+asset_iterator_in_use (iterator_t* iterator)
+{
+  if (iterator->done) return 0;
+  return iterator_int64 (iterator, GET_ITERATOR_COLUMN_COUNT + 1);
+}


### PR DESCRIPTION
## What

Move the rest of the asset iterator code out of `manage_sql.c`.

## Why

Smaller files. Better separation.

## References

Follows /pull/2515.

## Testing

Ran `o m m '<get_assets type="host"/>'` and checked  host details, IN_USE and WRITABLE.
Ran `o m m '<get_assets type="os"/>'` and checked that there were OS/HOSTS.
Ran GET_RESOURCE_NAMES with type `os` and `host`, and checked for names.
