### PR TITLE
Fix: Add missing and amend G_LOG_DOMAIN #defines

### DIFF
--- a/src/debug_utils.c
+++ b/src/debug_utils.c
@@ -27,6 +27,12 @@
 #include <stdio.h> /* for snprintf */
 #include <stdlib.h>
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md  utils"
+
 /**
  * @brief Initialize Sentry using the current gvmd version and DSN.
  *

--- a/src/gmp_agent_groups.c
+++ b/src/gmp_agent_groups.c
@@ -17,7 +17,7 @@
 /**
  * @brief GLib log domain.
  */
-#define G_LOG_DOMAIN "md gmp"
+#define G_LOG_DOMAIN "md    gmp"
 
 /* GET_AGENT_GROUPS */
 

--- a/src/gmp_agents.c
+++ b/src/gmp_agents.c
@@ -18,7 +18,7 @@
 #include "manage.h"
 
 #undef G_LOG_DOMAIN
-#define G_LOG_DOMAIN "md gmp"
+#define G_LOG_DOMAIN "md    gmp"
 
 /* GET_AGENTS. */
 

--- a/src/gmp_logout.c
+++ b/src/gmp_logout.c
@@ -26,6 +26,12 @@
 #include "gmp_logout.h"
 #include "manage.h"
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md    gmp"
+
 /**
  * @brief The logout command.
  */

--- a/src/gmp_oci_image_targets.c
+++ b/src/gmp_oci_image_targets.c
@@ -20,7 +20,7 @@
 /**
  * @brief GLib log domain.
  */
-#define G_LOG_DOMAIN "md gmp"
+#define G_LOG_DOMAIN "md    gmp"
 
 /* CREATE_OCI_IMAGE_TARGET. */
 

--- a/src/gmp_port_lists.c
+++ b/src/gmp_port_lists.c
@@ -33,6 +33,12 @@
 #include <string.h>
 #include <strings.h>
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md    gmp"
+
 
 /* CREATE_PORT_LIST. */
 

--- a/src/gmp_report_configs.c
+++ b/src/gmp_report_configs.c
@@ -33,6 +33,11 @@
 #include <string.h>
 #include <strings.h>
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md    gmp"
 
 /* General helper functions */
 

--- a/src/gmp_report_formats.c
+++ b/src/gmp_report_formats.c
@@ -33,6 +33,12 @@
 #include <string.h>
 #include <strings.h>
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md    gmp"
+
 
 /* CREATE_REPORT_FORMAT. */
 

--- a/src/manage_authentication.c
+++ b/src/manage_authentication.c
@@ -22,6 +22,13 @@
 #include <stdlib.h>
 #include <string.h>
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md manage"
+
+
 // prefer stack rather than heap so that we use the defaults on usage failure
 // rather than having to check and fail.
 struct PBASettings settings = {{0}, COUNT_DEFAULT, PREFIX_DEFAULT};

--- a/src/manage_commands.c
+++ b/src/manage_commands.c
@@ -16,6 +16,13 @@
 #include "manage_commands.h"
 #include "manage_resources.h"
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md manage"
+
+
 /**
  * @brief The GMP command list.
  */

--- a/src/manage_filter_utils.c
+++ b/src/manage_filter_utils.c
@@ -17,6 +17,12 @@
 #include "manage_utils.h"
 #include "manage_filter_utils.h"
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md  utils"
+
 /**
  * @brief Internal function for getting a filter term by UUID.
  */

--- a/src/manage_get.c
+++ b/src/manage_get.c
@@ -27,6 +27,13 @@
 #include <stdlib.h>
 #include <string.h>
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md manage"
+
+
 /**
  * @brief Reset command data.
  *

--- a/src/manage_preferences.c
+++ b/src/manage_preferences.c
@@ -25,6 +25,13 @@
 
 #include <stdlib.h>
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md manage"
+
+
 /**
  * @brief Create a new preference.
  *

--- a/src/manage_resources.c
+++ b/src/manage_resources.c
@@ -12,6 +12,12 @@
 
 #include "manage_resources.h"
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md manage"
+
 
 
 /* Resource type information. */

--- a/src/manage_settings.c
+++ b/src/manage_settings.c
@@ -13,6 +13,13 @@
 #include <assert.h>
 #include "manage_settings.h"
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md manage"
+
+
 /**
  * @brief Internal function for getting a setting value as a string.
  *

--- a/src/manage_sql_alerts.c
+++ b/src/manage_sql_alerts.c
@@ -26,6 +26,12 @@
 
 #include <gvm/base/hosts.h>
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md manage"
+
 /**
  * @file
  * @brief GVM management layer: Alert SQL

--- a/src/manage_sql_assets.c
+++ b/src/manage_sql_assets.c
@@ -27,6 +27,13 @@
 #include <gvm/base/hosts.h>
 #include <gvm/util/xmlutils.h>
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md manage"
+
+
 static int
 report_host_dead (report_host_t);
 

--- a/src/manage_sql_events.c
+++ b/src/manage_sql_events.c
@@ -30,6 +30,13 @@
 
 #include <gvm/base/array.h>
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md manage"
+
+
 /**
  * @brief Initialise an event alert iterator.
  *

--- a/src/manage_sql_scan_queue.c
+++ b/src/manage_sql_scan_queue.c
@@ -13,6 +13,13 @@
 #include "sql.h"
 #include "time.h"
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md manage"
+
+
 /**
  * @brief Remove all entries from the scan queue.
  */

--- a/src/manage_tls_certificates.c
+++ b/src/manage_tls_certificates.c
@@ -34,6 +34,13 @@
 
 #include <string.h>
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md manage"
+
+
 /**
  * @brief Extract data from a SSLDetails:[...] host detail value
  *


### PR DESCRIPTION
## What
Several G_LOG_DOMAIN #defines are added to non-test .c files where they were previously missing and some existing ones are amended to be consistent with the domains in the log configuration.

## Why
This fixes log messages not being filtered correctly, which could for example result in unwanted debug messages with the default log configuration.

## References
GEA-1233