### PR TITLE
Remove separate default openvasd scanner

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -356,6 +356,12 @@ scanner_type_valid (scanner_type_t);
 int
 scanner_type_supports_unix_sockets (scanner_type_t);
 
+scanner_type_t
+get_scanner_type (scanner_t);
+
+scanner_type_t
+get_scanner_type_by_uuid (const char *);
+
 
 /* Resources. */
 

--- a/src/manage_sql_nvts.h
+++ b/src/manage_sql_nvts.h
@@ -26,9 +26,8 @@
 
 #if OPENVASD
 #include "manage_sql_nvts_openvasd.h"
-#else
-#include "manage_sql_nvts_osp.h"
 #endif
+#include "manage_sql_nvts_osp.h"
 
 /**
  * @brief Filter columns for NVT info iterator.

--- a/src/manage_sql_nvts_openvasd.c
+++ b/src/manage_sql_nvts_openvasd.c
@@ -326,7 +326,7 @@ update_scanner_preferences_openvasd (scanner_t scan)
   if (!connector)
     {
       g_warning ("%s: failed to connect to scanner (%s)", __func__,
-                 SCANNER_UUID_OPENVASD_DEFAULT);
+                 SCANNER_UUID_DEFAULT);
       return -1;
     }
 
@@ -411,7 +411,7 @@ update_nvt_cache_openvasd (gchar *db_feed_version,
       = (time_t) sql_int64_0 ("SELECT max(modification_time) FROM nvts");
 
   /* Update NVTs. */
-  if (find_resource_no_acl ("scanner", SCANNER_UUID_OPENVASD_DEFAULT, &scan))
+  if (find_resource_no_acl ("scanner", SCANNER_UUID_DEFAULT, &scan))
     return -1;
   if (scan == 0)
     return -1;
@@ -420,7 +420,7 @@ update_nvt_cache_openvasd (gchar *db_feed_version,
   if (!connector)
     {
       g_warning ("%s: failed to connect to scanner (%s)", __func__,
-                 SCANNER_UUID_OPENVASD_DEFAULT);
+                 SCANNER_UUID_DEFAULT);
       return -1;
     }
 
@@ -517,7 +517,7 @@ nvts_feed_version_status_internal_openvasd (gchar **db_feed_version_out,
   if (db_feed_version_out && db_feed_version)
     *db_feed_version_out = g_strdup (db_feed_version);
 
-  nvts_feed_info_internal_from_openvasd (SCANNER_UUID_OPENVASD_DEFAULT,
+  nvts_feed_info_internal_from_openvasd (SCANNER_UUID_DEFAULT,
                                          &scanner_feed_version);
 
   g_debug ("%s: scanner_feed_version: %s", __func__, scanner_feed_version);


### PR DESCRIPTION
## What
The gvmd startup will no longer create a separate openvasd scanner, but for new databases the "OpenVAS default" scanner will be of the openvasd type if the OPENVASD build flag is set.
Actions that require the default scanner like checking the VTs feed status will check the type of the default scanner instead of determining the type of scanner to connect to based on the build flag.

## Why
This makes the behavior easier to understand by having only one default OpenVAS based scanner and discourages the use of using both ospd-openvas and openvasd on the same system, which may not work correctly.

## References
GEA-1241
