### PR TITLE
Fix: handle 0 ports case in get_port_lists filter

### DIFF
--- a/src/manage_sql_port_lists.c
+++ b/src/manage_sql_port_lists.c
@@ -1826,39 +1826,45 @@ delete_port_range (const char *port_range_id, int dummy)
    GET_ITERATOR_COLUMNS (port_lists),                              \
    {                                                               \
      /* COUNT ALL ports */                                         \
-     "(SELECT"                                                     \
-     " sum ((CASE"                                                 \
-     "       WHEN \"end\" IS NULL THEN start ELSE \"end\""         \
-     "       END)"                                                 \
-     "      - start"                                               \
-     "      + 1)"                                                  \
-     " FROM port_ranges WHERE port_list = port_lists.id)",         \
+     "coalesce ("                                                   \
+     " (SELECT"                                                    \
+     "  sum ((CASE"                                                \
+     "        WHEN \"end\" IS NULL THEN start ELSE \"end\""        \
+     "        END)"                                                \
+     "       - start"                                              \
+     "       + 1)"                                                 \
+     "  FROM port_ranges WHERE port_list = port_lists.id),"        \
+     " 0)",                                                        \
      "total",                                                      \
      KEYWORD_TYPE_INTEGER                                          \
    },                                                              \
    {                                                               \
      /* COUNT TCP ports */                                         \
-     "(SELECT"                                                     \
-     " sum ((CASE"                                                 \
-     "       WHEN \"end\" IS NULL THEN start ELSE \"end\""         \
-     "       END)"                                                 \
-     "      - start"                                               \
-     "      + 1)"                                                  \
-     " FROM port_ranges WHERE port_list = port_lists.id"           \
-     "                  AND   type = 0)",                          \
+     "coalesce ("                                                  \
+     " (SELECT"                                                    \
+     "  sum ((CASE"                                                \
+     "        WHEN \"end\" IS NULL THEN start ELSE \"end\""        \
+     "        END)"                                                \
+     "       - start"                                              \
+     "       + 1)"                                                 \
+     "  FROM port_ranges WHERE port_list = port_lists.id"          \
+     "                   AND   type = 0),"                         \
+     " 0)",                          \
      "tcp",                                                        \
      KEYWORD_TYPE_INTEGER                                          \
    },                                                              \
    {                                                               \
      /* COUNT UDP ports */                                         \
-     "(SELECT"                                                     \
-     " sum ((CASE"                                                 \
-     "       WHEN \"end\" IS NULL THEN start ELSE \"end\""         \
-     "       END)"                                                 \
-     "      - start"                                               \
-     "      + 1)"                                                  \
-     " FROM port_ranges WHERE port_list = port_lists.id"           \
-     "                  AND   type = 1)",                          \
+     "coalesce("                                                   \
+     " (SELECT"                                                    \
+     "  sum ((CASE"                                                \
+     "        WHEN \"end\" IS NULL THEN start ELSE \"end\""        \
+     "        END)"                                                \
+     "       - start"                                              \
+     "       + 1)"                                                 \
+     "  FROM port_ranges WHERE port_list = port_lists.id"          \
+     "                   AND   type = 1),"                         \
+     " 0)",                                                        \
      "udp",                                                        \
      KEYWORD_TYPE_INTEGER                                          \
    },                                                              \


### PR DESCRIPTION
## What
The SQL for getting the port counts is adjusted to correctly handle the cases where there are no TCP, UDP or any ports.

## Why
Without this fix, sorting using the "tcp", "udp" or "total" filter column would return port lists with no ports of the selected type in the wrong order.

## References
GEA-1218