### PR TITLE
Fix: Add check if UUID exists when creating config

### DIFF
--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -2454,11 +2454,21 @@ create_config_internal (int check_access, const char *config_id,
 
   assert (current_credentials.uuid);
 
-  if (config_id
-      && (g_regex_match_simple ("^[-0123456789abcdef]{36}$",
+  if (config_id)
+    {
+      if (g_regex_match_simple ("^[-0123456789abcdef]{36}$",
                                 config_id, 0, 0)
-          == FALSE))
-    return -5;
+          == FALSE)
+        return -5;
+
+      if (find_config_no_acl (config_id, config))
+        {
+          g_warning ("%s: Error looking up config '%s'", __func__, config_id);
+          return -1;
+        }
+      if (*config)
+        return 1;
+    }
 
   if (proposed_name == NULL || strlen (proposed_name) == 0) return -2;
 


### PR DESCRIPTION
## What
The create_config_internal function checks if a config with the given UUID already exists.

## Why
This makes the import from the feed fail more gracefully if a duplicate UUID in the file content is not caught by the previous check using the UUID from the filename.

## References
GEA-1043