### PR TITLE
Fix: Re-init before scanner type check in VT sync

### DIFF
--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1135,6 +1135,11 @@ update_nvt_cache_retry ()
           scanner_type_t sc_type;
           init_sentry ();
 
+          /* Re-open DB after fork. */
+
+          reinit_manage_process ();
+          manage_session_init (current_credentials.uuid);
+
           sc_type = get_scanner_type_by_uuid (SCANNER_UUID_DEFAULT);
           switch (sc_type)
           {

--- a/src/manage_sql_nvts_openvasd.c
+++ b/src/manage_sql_nvts_openvasd.c
@@ -555,11 +555,6 @@ manage_update_nvt_cache_openvasd ()
   gchar *db_feed_version, *scanner_feed_version;
   int ret;
 
-  /* Re-open DB after fork. */
-
-  reinit_manage_process ();
-  manage_session_init (current_credentials.uuid);
-
   /* Try update VTs. */
 
   ret = nvts_feed_version_status_internal_openvasd (&db_feed_version,

--- a/src/manage_sql_nvts_osp.c
+++ b/src/manage_sql_nvts_osp.c
@@ -938,11 +938,6 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
   gchar *db_feed_version, *scanner_feed_version;
   int ret;
 
-  /* Re-open DB after fork. */
-
-  reinit_manage_process ();
-  manage_session_init (current_credentials.uuid);
-
   /* Try update VTs. */
 
   ret = nvts_feed_version_status_internal_osp (update_socket,


### PR DESCRIPTION
## What
In update_nvt_cache the process is reinitialized before attempting to get the type of the default scanner, not in the type specific manage_update_nvt_cache_... functions.

## Why
This fixes the scanner type check not working because the database connection is not reopened after the fork.

## References
GEA-1243