### PR TITLE
Fix: remove stray headers

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -914,21 +914,6 @@ int
 move_task (const char*, const char*);
 
 
-/* Access control. */
-
-int
-user_may (const char *);
-
-extern int
-user_can_everything (const char *);
-
-extern int
-user_can_super_everyone (const char *);
-
-extern int
-user_has_super (const char *, user_t);
-
-
 /* Results. */
 
 /**


### PR DESCRIPTION
## What

Remove stray ACL headers.

## Why

I moved these to manage_acl.h in 2013 in
a3ec7f200564c57ce96b4885a6722d8715b66054, but I forgot to remove them from manage.h.

Note that the moved headers got an acl_ prefix later, in 7631003e59b4b49450ec43ff418db221a4a81c27.

## Testing

Compiles fine.