### PR TITLE
docs: remove token like examples in the integration-authentication.md

### DIFF
--- a/docs/integration-authentication.md
+++ b/docs/integration-authentication.md
@@ -5,7 +5,7 @@ The current `gvmd` implementation supports two authentication methods for commun
 ## Supported Methods
 
 - **Certificates (mTLS)**
-- **API Key–like tokens** (`X-API-KEY` or `Authorization: Bearer`)
+- **API Key** (`X-API-KEY`)
 
 ---
 
@@ -42,10 +42,10 @@ gvmd --modify-scanner <scanner_uuid> \
 ## 2. API Key–like Tokens
 
 This method uses a static token that must be provided with each request.
-Depending on the component, the token is included in the request header as either:
+Depending on the component, the token is included in the request header:
 
 * **HTTP Scanner:** `X-API-KEY: <token>`
-* **Agent Controller:** `Authorization: Bearer <token>`
+* **Agent Controller:** `X-API-KEY: <token>`
 
 Both behave the same way for authentication/authorization.
 
@@ -72,31 +72,8 @@ X-API-KEY: <your_api_key_here>
 
 ---
 
-### Example: Agent Controller request with Bearer Token
-
-```c
-if (bearer_token && *bearer_token)
-  {
-    GString *auth = g_string_new ("Authorization: Bearer ");
-    g_string_append (auth, bearer_token);
-
-    if (!gvm_http_add_header (headers, auth->str))
-      g_warning ("%s: Failed to set Authorization header", __func__);
-
-    g_string_free (auth, TRUE);
-  }
-```
-
-HTTP Header example:
-
-```http
-Authorization: Bearer <your_bearer_token_here>
-```
-
----
-
 ## Notes
 
-* For the **HTTP Scanner**, both **Certificates (mTLS)** and **API Key** are supported.
-* For the **Agent Controller**, **API Key–like tokens** are currently used (via `Authorization: Bearer`).
+* For the **HTTP Scanner**, **Certificates (mTLS)** is currently supported.
+* For the **Agent Controller**, **Certificates (mTLS)** is currently supported.
 * Authentication modes are configured either via **configuration files** or by passing arguments when starting `gvmd`.


### PR DESCRIPTION
## What

Removed the token-based authentication examples (`Authorization: Bearer …`) from `integration-authentication.md`.  

## Why

Bearer token examples were removed to avoid confusion and to keep the documentation consistent with the latest changes in `gvm-libs`.  



