### PR TITLE
Fix: Avoid double free on vt parsing error

### DIFF
--- a/src/manage_sql_nvts_openvasd.c
+++ b/src/manage_sql_nvts_openvasd.c
@@ -249,7 +249,6 @@ update_nvts_from_openvasd_vts (http_scanner_connector_t connector,
               gvm_json_pull_event_cleanup (&event);
               gvm_json_pull_parser_cleanup (&parser);
               fclose (stream);
-              g_free(nvti);
               http_scanner_response_cleanup (resp);
               sql_rollback ();
               return -1;


### PR DESCRIPTION
## What

Avoid double free on VT parsing error.

## Why

The NVT info structure is already freed in the `parse_vt_json` library in case of error.


