### PR TITLE
Fix uploading agents container to ghcr.io only

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -43,7 +43,7 @@ jobs:
       prefix: ${{ matrix.build.prefix }}
       images: |
         ghcr.io/${{ github.repository }},enable=true
-        ${{ vars.GREENBONE_REGISTRY }}/community/${{ github.event.repository.name }},enable=${{ github.event_name != 'pull_request' && matrix.build.name != 'default' }}
+        ${{ vars.GREENBONE_REGISTRY }}/community/${{ github.event.repository.name }},enable=${{ github.event_name != 'pull_request' && matrix.build.name == 'default' }}
     secrets: inherit
 
   notify:


### PR DESCRIPTION

## What
Fix uploading agents container to ghcr.io only

## Why

Only upload the feature based container image to gchr.io and not to our public container repository because it is intended for development and testing purposes.
