### PR TITLE
Fix: clear in-progress flag in parent after fork

### DIFF
--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1611,7 +1611,7 @@ fork_agents_sync ()
 
       default:
         g_debug ("%s: %i forked %i", __func__, getpid (), pid);
-        agent_sync_in_progress = TRUE;
+        agent_sync_in_progress = FALSE;
         if (pthread_sigmask (SIG_SETMASK, &sigmask_current, NULL))
           g_warning ("%s: Error resetting signal mask", __func__);
         return 0;


### PR DESCRIPTION
## What

Clear `agent_sync_in_progress` in the **parent** branch after a successful `fork_with_handlers()` so the scheduler can start a new sync on the next interval

## Why

Previously, the flag was set to `TRUE` before `fork()` and never reset in the parent, so `serve_and_schedule()` believed a sync was always “in progress” and only ran it once.




