### PR TITLE
Add 'Arch Linux Local Security Checks' family

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -931,6 +931,7 @@ move_task (const char*, const char*);
   "'AIX Local Security Checks',"                   \
   " 'AlmaLinux Local Security Checks',"            \
   " 'Amazon Linux Local Security Checks',"         \
+  " 'Arch Linux Local Security Checks',"           \
   " 'CentOS Local Security Checks',"               \
   " 'Citrix Xenserver Local Security Checks',"     \
   " 'Debian Local Security Checks',"               \
@@ -967,6 +968,7 @@ move_task (const char*, const char*);
   { "AIX Local Security Checks",                   \
     "AlmaLinux Local Security Checks",             \
     "Amazon Linux Local Security Checks",          \
+    "Arch Linux Local Security Checks",            \
     "CentOS Local Security Checks",                \
     "Debian Local Security Checks",                \
     "Fedora Local Security Checks",                \


### PR DESCRIPTION
## What
Add 'Arch Linux Local Security Checks' whole-only LSC VT family.

## Why
These LSCs were deployed in version 20250902T0700 and GVMD should start supporting it as well.

## References
https://jira.greenbone.net/browse/GEA-1264