### PR TITLE
Fix: Temporarily remove check for agent installers

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -5520,7 +5520,8 @@ manage_gvmd_data_feed_dirs_exist ()
 {
   return gvm_file_is_readable (GVMD_FEED_DIR)
 #if ENABLE_AGENTS
-         && agent_installers_feed_metadata_file_exists ()
+// TODO: Add this check once the agent installers are added to the feed
+//         && agent_installers_feed_metadata_file_exists ()
 #endif
          && configs_feed_dir_exists ()
          && port_lists_feed_dir_exists ()


### PR DESCRIPTION
## What
The check if the agent installer metadata file exists in the feed directory check is commented out for now. 

## Why
This should allow loading the other gvmd data objects from the feed while the feed does not contain the installers and the metadata yet.
