### PR TITLE
Change: Use get_agent_installer permission for files

### DIFF
--- a/src/gmp_agent_installers.c
+++ b/src/gmp_agent_installers.c
@@ -428,7 +428,7 @@ get_agent_installer_file_run (gmp_parser_t *gmp_parser, GError **error)
   get.type = "agent_installer";
   get.id = get_agent_installer_file_data.agent_installer_id;
 
-  if (!acl_user_may ("get_agent_installer_file"))
+  if (!acl_user_may ("get_agent_installer"))
     {
       SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX ("get_agent_installer_file",
                               "Permission denied"));


### PR DESCRIPTION
## What
The get_agent_installer_file command now requires the get_agent_installer permission instead of its own one.

## Why
This simplifies the permission handling as only one permission has to be granted to share access to the installer file.

