### PR TITLE
Clean up auth doc and indenting

### DIFF
--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -2030,7 +2030,8 @@ parse_authentication_goption_arg (const gchar *opt, const gchar *arg,
 {
   if (strcmp (opt, "--pepper") == 0)
     {
-      if (manage_authentication_setup(arg, strlen(arg), 0, NULL) != GMA_SUCCESS)
+      if (manage_authentication_setup (arg, strlen (arg), 0, NULL)
+          != GMA_SUCCESS)
         {
           g_set_error (
             err, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
@@ -2041,7 +2042,8 @@ parse_authentication_goption_arg (const gchar *opt, const gchar *arg,
     }
   else if (strcmp (opt, "--hashcount") == 0)
     {
-      if (manage_authentication_setup(NULL, 0, strtol(arg, NULL, 0), NULL) != GMA_SUCCESS)
+      if (manage_authentication_setup (NULL, 0, strtol(arg, NULL, 0), NULL)
+          != GMA_SUCCESS)
         {
           g_set_error (
             err, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,

--- a/src/manage_authentication.c
+++ b/src/manage_authentication.c
@@ -28,7 +28,6 @@
  */
 #define G_LOG_DOMAIN "md manage"
 
-
 // prefer stack rather than heap so that we use the defaults on usage failure
 // rather than having to check and fail.
 struct PBASettings settings = {{0}, COUNT_DEFAULT, PREFIX_DEFAULT};
@@ -72,7 +71,7 @@ manage_authentication_setup (const char *pepper, unsigned int pepper_size,
     settings.pepper[i] = tmp->pepper[i];
   settings.count = count > 0 ? tmp->count : settings.count;
   settings.prefix = prefix != NULL ? tmp->prefix : settings.prefix;
-  pba_finalize(tmp);
+  pba_finalize (tmp);
   rc = GMA_SUCCESS;
 
 exit:
@@ -89,7 +88,7 @@ exit:
 char *
 manage_authentication_hash (const char *password)
 {
-    return pba_hash(&settings, password);
+  return pba_hash (&settings, password);
 }
 
 /**
@@ -107,23 +106,23 @@ manage_authentication_hash (const char *password)
 enum manage_authentication_rc
 manage_authentication_verify (const char *hash, const char *password)
 {
-    enum pba_rc pba_rc = pba_verify_hash(&settings, hash, password);
-    enum manage_authentication_rc rc;
-    switch (pba_rc){
-        case VALID:
-            rc = GMA_SUCCESS;
-            break;
-        case INVALID:
-            rc = GMA_HASH_INVALID;
-            break;
-        case UPDATE_RECOMMENDED:
-            rc = GMA_HASH_VALID_BUT_DATED;
-            break;
-        default:
-            rc = GMA_ERR;
-            break;
-
+  enum pba_rc pba_rc = pba_verify_hash (&settings, hash, password);
+  enum manage_authentication_rc rc;
+  switch (pba_rc)
+    {
+    case VALID:
+      rc = GMA_SUCCESS;
+      break;
+    case INVALID:
+      rc = GMA_HASH_INVALID;
+      break;
+    case UPDATE_RECOMMENDED:
+      rc = GMA_HASH_VALID_BUT_DATED;
+      break;
+    default:
+      rc = GMA_ERR;
+      break;
     }
 
-    return rc;
+  return rc;
 }

--- a/src/manage_authentication.c
+++ b/src/manage_authentication.c
@@ -34,25 +34,24 @@
 struct PBASettings settings = {{0}, COUNT_DEFAULT, PREFIX_DEFAULT};
 
 /**
- * @brief manage_authentication_setup sets the pepper, count and prefix used
- * by the authentication implementation.
+ * @brief Set the pepper, count and prefix used by authentication.
  *
  * When pepper is a NULL pointer, prefix is a NULL pointer or count is 0 then
  * the previous setting of that setting will be kept.
  *
  * This is mainly to allow easier configuration within gvmd.c so that it can
- * used parameterized without restore the same information there.
+ * used parameterized without repeating the same information there.
  *
  * The initial defaults are set to no-pepper, COUNT_DEFAULT and PREFIX_DEFAULT
  * of gvm-libs.
  *
- * @param[in] pepper - a static hidden addition to the randomely generated salt
- * @param[in] pepper_size - the size of pepper; it must not larger then
- * MAX_PEPPER_SIZE
- * @param[in] count - the amount of rounds used to calculate the hash; if 0 then
- * COUNT_DEFAULT will be used
- * @param[in] prefix - the used algorithm, if NULL pointer then the most secure
- * available algorithm will be used.
+ * @param[in] pepper  A static hidden addition to the randomly generated salt
+ * @param[in] pepper_size  The size of pepper; it must not be larger than
+ *                         MAX_PEPPER_SIZE
+ * @param[in] count   The amount of rounds used to calculate the hash; if 0 then
+ *                    COUNT_DEFAULT will be used
+ * @param[in] prefix  the used algorithm, if NULL pointer then the most secure
+ *                    available algorithm will be used.
  *
  * @return GMA_SUCCESS when the settings are set or GMA_ERR if there was a
  * failure.
@@ -81,12 +80,12 @@ exit:
 }
 
 /**
- * @brief creates a hash based on the settings set by
- * manage_authentication_setup and the password.
+ * @brief Create a hash based on the settings from manage_authentication_setup.
  *
- * @param[in] password - the password to be hashed
+ * @param[in] password  The password to be hashed.
+ *
  * @return The hash, or a NULL pointer on failure. Caller must free.
- * */
+ */
 char *
 manage_authentication_hash (const char *password)
 {
@@ -94,17 +93,17 @@ manage_authentication_hash (const char *password)
 }
 
 /**
- * @brief manage_authentication_verify verifies given password with given hash.
+ * @brief Verify a password with a hash.
  *
- * @param[in] password - the clear text password to be verified
- * @param[in] hash - the stored hash to verify the password against.
+ * @param[in] password  The clear text password to be verified.
+ * @param[in] hash      The stored hash to verify the password against.
  *
  * @return GMA_SUCCESS when password is valid,
- *          GMA_HASH_VALID_BUT_DATED when password is valid but a new hash
- *          should ne created and stored.
- *          GMA_HASH_INVALID when password is invalid
- *          GMA_ERR when an unexpected error occurs.
- **/
+ *         GMA_HASH_VALID_BUT_DATED when password is valid but a new hash
+ *                                  should be created and stored.
+ *         GMA_HASH_INVALID when password is invalid
+ *         GMA_ERR when an unexpected error occurs.
+ */
 enum manage_authentication_rc
 manage_authentication_verify (const char *hash, const char *password)
 {

--- a/src/manage_authentication.c
+++ b/src/manage_authentication.c
@@ -16,6 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/**
+ * @file
+ * @brief GVM management layer: authentication.
+ *
+ * General authentication functions.
+ */
+
 #include "manage_authentication.h"
 #include <gvm/util/passwordbasedauthentication.h>
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -8037,21 +8037,22 @@ auth_cache_find (const char *username, const char *password, int method)
     return -1;
 
   // verify for VALID or OUTDATED but don't update
-  ret = manage_authentication_verify(hash, password);
-  switch(ret){
-      case GMA_HASH_INVALID:
-          ret = 1;
-          break;
-       case GMA_HASH_VALID_BUT_DATED:
-          ret = 0;
-          break;
-        case GMA_SUCCESS:
-          ret = 0;
-          break;
-        default:
-          ret = -1;
-          break;
-  }
+  ret = manage_authentication_verify (hash, password);
+  switch (ret)
+    {
+    case GMA_HASH_INVALID:
+      ret = 1;
+      break;
+    case GMA_HASH_VALID_BUT_DATED:
+      ret = 0;
+      break;
+    case GMA_SUCCESS:
+      ret = 0;
+      break;
+    default:
+      ret = -1;
+      break;
+    }
   g_free (hash);
   return ret;
 }
@@ -8205,27 +8206,28 @@ authenticate_any_method (const gchar *username, const gchar *password,
       return 0;
     }
   hash = manage_user_hash (username);
-  ret = manage_authentication_verify(hash, password);
-  switch(ret){
-      case GMA_HASH_INVALID:
-          ret = 1;
-          break;
-       case GMA_HASH_VALID_BUT_DATED:
-          g_free(hash);
-          hash = manage_authentication_hash(password);
-          sql ("UPDATE users SET password = '%s', modification_time = m_now () WHERE name = '%s';",
-               hash, username);
-          auth_cache_insert (username, password, 2);
-          ret = 0;
-          break;
-        case GMA_SUCCESS:
-          auth_cache_insert (username, password, 2);
-          ret = 0;
-          break;
-        default:
-          ret = -1;
-          break;
-  }
+  ret = manage_authentication_verify (hash, password);
+  switch (ret)
+    {
+    case GMA_HASH_INVALID:
+      ret = 1;
+      break;
+    case GMA_HASH_VALID_BUT_DATED:
+      g_free(hash);
+      hash = manage_authentication_hash (password);
+      sql ("UPDATE users SET password = '%s', modification_time = m_now () WHERE name = '%s';",
+           hash, username);
+      auth_cache_insert (username, password, 2);
+      ret = 0;
+      break;
+    case GMA_SUCCESS:
+      auth_cache_insert (username, password, 2);
+      ret = 0;
+      break;
+    default:
+      ret = -1;
+      break;
+    }
 
   if (ret)
     sql_rollback ();


### PR DESCRIPTION
## What

Clean up doc and auth around `manage_authentication.c`.

## Why

Easier to follow, eg what must be freed.