### PR TITLE
Change: add scanner type to get_aggregates and adjust agent response handling

### DIFF
--- a/src/gmp_agents.c
+++ b/src/gmp_agents.c
@@ -584,12 +584,13 @@ modify_agent_run (gmp_parser_t *gmp_parser, GError **error)
       log_event_fail ("agents", "Agents", NULL, "modified");
       break;
 
-    case AGENT_RESPONSE_INTERNAL_ERROR:
-      SEND_TO_CLIENT_OR_FAIL (XML_INTERNAL_ERROR ("modify_agent"));
+    case AGENT_RESPONSE_IN_USE_ERROR:
+      SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX (
+        "modify_agent", "Resource is in use"));
       log_event_fail ("agents", "Agents", NULL, "modified");
       break;
 
-    case AGENT_RESPONSE_IN_USE_ERROR:
+    case AGENT_RESPONSE_INTERNAL_ERROR:
     default:
       SEND_TO_CLIENT_OR_FAIL (XML_INTERNAL_ERROR ("modify_agent"));
       log_event_fail ("agents", "Agents", NULL, "modified");

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -4763,7 +4763,7 @@ append_to_task_string (task_t task, const char* field, const char* value)
     "first", "last", SEVERITY_FILTER_COLUMNS, "hosts", "result_hosts",       \
     "fp_per_host", "log_per_host", "low_per_host", "medium_per_host",        \
     "high_per_host", "critical_per_host", "target", "usage_type",            \
-    "first_report_created", "last_report_created",                           \
+    "first_report_created", "last_report_created", "scanner_type",           \
     TASK_AGENT_GROUP_FILTER_COLUMNS                                          \
     NULL}
 
@@ -5219,6 +5219,11 @@ append_to_task_string (task_t task, const char* field, const char* value)
      " AND scan_run_status = 1"                                              \
      " ORDER BY creation_time DESC LIMIT 1)",                                \
      "last_report_created",                                                  \
+     KEYWORD_TYPE_INTEGER                                                    \
+   },                                                                        \
+   {                                                                         \
+     "(SELECT type FROM scanners WHERE scanners.id = tasks.scanner)",        \
+     "scanner_type",                                                         \
      KEYWORD_TYPE_INTEGER                                                    \
    } TASK_AGENT_GROUP_ITERATOR_COLUMNS
 #endif


### PR DESCRIPTION


## What

Extended the `get_aggregates` command to include scanner type and updated the response handling for agents. Verified changes through usage in the agent management flow.


## Why

This is needed to support the agent management page in GSA, where scanner type information is required for correct display and handling.

## References

GEA-1278



