### PR TITLE
Change: use a cmake macro to add unit tests

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -283,21 +283,6 @@ add_library(all-misc-obj OBJECT ${ALL_MISC_SRC})
 ## Program
 
 set(TEST_TARGET_EXTRA_SRC ${ALL_MANAGE_SRC})
-list(REMOVE_ITEM TEST_TARGET_EXTRA_SRC manage_utils.c)
-add_executable(
-  manage-utils-test
-  EXCLUDE_FROM_ALL
-  manage_utils_tests.c
-  $<TARGET_OBJECTS:all-gmp-obj>
-  $<TARGET_OBJECTS:all-manage-sql-obj>
-  $<TARGET_OBJECTS:all-misc-obj>
-  $<TARGET_OBJECTS:all-sql-obj>
-  ${TEST_TARGET_EXTRA_SRC}
-)
-
-add_test(manage-utils-test manage-utils-test)
-
-set(TEST_TARGET_EXTRA_SRC ${ALL_MANAGE_SRC})
 list(REMOVE_ITEM TEST_TARGET_EXTRA_SRC manage_oci_image_targets.c)
 add_executable(
   manage-oci-image-targets-test
@@ -476,32 +461,6 @@ target_link_libraries(
   ${OPT_THEIA_TGT}
 )
 target_link_libraries(
-  manage-utils-test
-  cgreen
-  m
-  ${GNUTLS_LDFLAGS}
-  ${GPGME_LDFLAGS}
-  ${CMAKE_THREAD_LIBS_INIT}
-  ${LINKER_HARDENING_FLAGS}
-  ${LINKER_DEBUG_FLAGS}
-  ${PostgreSQL_LIBRARIES}
-  ${LIBBSD_LDFLAGS}
-  ${CJSON_LDFLAGS}
-  ${GLIB_LDFLAGS}
-  ${GTHREAD_LDFLAGS}
-  ${LIBGVM_AGENT_CONTROLLER_LDFLAGS}
-  ${LIBGVM_BASE_LDFLAGS}
-  ${LIBGVM_UTIL_LDFLAGS}
-  ${LIBGVM_OSP_LDFLAGS}
-  ${LIBGVM_OPENVASD_LDFLAGS}
-  ${LIBGVM_GMP_LDFLAGS}
-  ${LIBGVM_HTTP_LDFLAGS}
-  ${LIBGVM_HTTP_SCANNER_LDFLAGS}
-  ${LIBICAL_LDFLAGS}
-  ${LINKER_HARDENING_FLAGS}
-  ${OPT_THEIA_TGT}
-)
-target_link_libraries(
   gmp-tickets-test
   cgreen
   m
@@ -632,6 +591,7 @@ if(ENABLE_AGENTS)
   add_unit_test(manage-agent-installers manage_sql_agent_installers.c)
 endif()
 add_unit_test(manage-filter-utils)
+add_unit_test(manage-utils)
 
 add_custom_target(tests DEPENDS ${TEST_DEPENDENCIES})
 
@@ -640,7 +600,6 @@ set_target_properties(
   PROPERTIES LINKER_LANGUAGE C
 )
 set_target_properties(manage-sql-test PROPERTIES LINKER_LANGUAGE C)
-set_target_properties(manage-utils-test PROPERTIES LINKER_LANGUAGE C)
 set_target_properties(gmp-tickets-test PROPERTIES LINKER_LANGUAGE C)
 
 if(DEBUG_FUNCTION_NAMES)
@@ -658,7 +617,6 @@ if(NOT CMAKE_BUILD_TYPE MATCHES "Release")
     PUBLIC ${C_FLAGS_DEBUG_GVMD}
   )
   target_compile_options(manage-sql-test PUBLIC ${C_FLAGS_DEBUG_GVMD})
-  target_compile_options(manage-utils-test PUBLIC ${C_FLAGS_DEBUG_GVMD})
   target_compile_options(gmp-tickets-test PUBLIC ${C_FLAGS_DEBUG_GVMD})
 
   # If we got GIT_REVISION at configure time,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -283,21 +283,6 @@ add_library(all-misc-obj OBJECT ${ALL_MISC_SRC})
 ## Program
 
 set(TEST_TARGET_EXTRA_SRC ${ALL_MANAGE_SRC})
-list(REMOVE_ITEM TEST_TARGET_EXTRA_SRC manage_filter_utils.c)
-add_executable(
-  manage-filter-utils-test
-  EXCLUDE_FROM_ALL
-  manage_filter_utils_tests.c
-  $<TARGET_OBJECTS:all-gmp-obj>
-  $<TARGET_OBJECTS:all-manage-sql-obj>
-  $<TARGET_OBJECTS:all-misc-obj>
-  $<TARGET_OBJECTS:all-sql-obj>
-  ${TEST_TARGET_EXTRA_SRC}
-)
-
-add_test(manage-filter-utils-test manage-filter-utils-test)
-
-set(TEST_TARGET_EXTRA_SRC ${ALL_MANAGE_SRC})
 list(REMOVE_ITEM TEST_TARGET_EXTRA_SRC manage_utils.c)
 add_executable(
   manage-utils-test
@@ -412,7 +397,6 @@ add_test(utils-test utils-test)
 set(
   TEST_DEPENDENCIES
   gmp-tickets-test
-  manage-filter-utils-test
   manage-test
   manage-oci-image-targets-test
   manage-sql-test
@@ -423,8 +407,6 @@ set(
 if(ENABLE_AGENTS)
   list(APPEND TEST_DEPENDENCIES manage-agent-installers-test)
 endif()
-
-add_custom_target(tests DEPENDS ${TEST_DEPENDENCIES})
 
 if(ENABLE_COVERAGE)
   add_custom_target(
@@ -537,32 +519,6 @@ if(ENABLE_AGENTS)
     ${OPT_THEIA_TGT}
   )
 endif()
-target_link_libraries(
-  manage-filter-utils-test
-  cgreen
-  m
-  ${GNUTLS_LDFLAGS}
-  ${GPGME_LDFLAGS}
-  ${CMAKE_THREAD_LIBS_INIT}
-  ${LINKER_HARDENING_FLAGS}
-  ${LINKER_DEBUG_FLAGS}
-  ${PostgreSQL_LIBRARIES}
-  ${LIBBSD_LDFLAGS}
-  ${CJSON_LDFLAGS}
-  ${GLIB_LDFLAGS}
-  ${GTHREAD_LDFLAGS}
-  ${LIBGVM_AGENT_CONTROLLER_LDFLAGS}
-  ${LIBGVM_BASE_LDFLAGS}
-  ${LIBGVM_UTIL_LDFLAGS}
-  ${LIBGVM_OSP_LDFLAGS}
-  ${LIBGVM_OPENVASD_LDFLAGS}
-  ${LIBGVM_GMP_LDFLAGS}
-  ${LIBGVM_HTTP_LDFLAGS}
-  ${LIBGVM_HTTP_SCANNER_LDFLAGS}
-  ${LIBICAL_LDFLAGS}
-  ${LINKER_HARDENING_FLAGS}
-  ${OPT_THEIA_TGT}
-)
 target_link_libraries(
   manage-oci-image-targets-test
   cgreen
@@ -714,7 +670,68 @@ if(ENABLE_AGENTS)
     PROPERTIES LINKER_LANGUAGE C
   )
 endif()
-set_target_properties(manage-filter-utils-test PROPERTIES LINKER_LANGUAGE C)
+
+macro(add_unit_test _baseName)
+  string(REPLACE "-" "_" _testSource "${_baseName}")
+  # manage_filter_utils.c
+  set(_source "${_testSource}.c")
+  # manage_filter_utils_tests.c
+  set(_testSource "${_testSource}_tests.c")
+  # manage-filter-utils-test
+  set(_testName "${_baseName}-test")
+
+  list(APPEND TEST_DEPENDENCIES ${_testName})
+  set(TEST_TARGET_EXTRA_SRC ${ALL_MANAGE_SRC})
+  list(REMOVE_ITEM TEST_TARGET_EXTRA_SRC ${_source})
+  add_executable(
+    ${_testName}
+    EXCLUDE_FROM_ALL
+    ${_testSource}
+    $<TARGET_OBJECTS:all-gmp-obj>
+    $<TARGET_OBJECTS:all-manage-sql-obj>
+    $<TARGET_OBJECTS:all-misc-obj>
+    $<TARGET_OBJECTS:all-sql-obj>
+    ${TEST_TARGET_EXTRA_SRC}
+  )
+  add_test(${_testName} ${_testName})
+  target_link_libraries(
+    ${_testName}
+    cgreen
+    m
+    ${GNUTLS_LDFLAGS}
+    ${GPGME_LDFLAGS}
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${LINKER_HARDENING_FLAGS}
+    ${LINKER_DEBUG_FLAGS}
+    ${PostgreSQL_LIBRARIES}
+    ${LIBBSD_LDFLAGS}
+    ${CJSON_LDFLAGS}
+    ${GLIB_LDFLAGS}
+    ${GTHREAD_LDFLAGS}
+    ${LIBGVM_AGENT_CONTROLLER_LDFLAGS}
+    ${LIBGVM_BASE_LDFLAGS}
+    ${LIBGVM_UTIL_LDFLAGS}
+    ${LIBGVM_OSP_LDFLAGS}
+    ${LIBGVM_OPENVASD_LDFLAGS}
+    ${LIBGVM_GMP_LDFLAGS}
+    ${LIBGVM_HTTP_LDFLAGS}
+    ${LIBGVM_HTTP_SCANNER_LDFLAGS}
+    ${LIBICAL_LDFLAGS}
+    ${LINKER_HARDENING_FLAGS}
+    ${OPT_THEIA_TGT}
+  )
+  set_target_properties(${_testName} PROPERTIES LINKER_LANGUAGE C)
+  if(NOT CMAKE_BUILD_TYPE MATCHES "Release")
+    target_compile_options(${_testName} PUBLIC ${C_FLAGS_DEBUG_GVMD})
+  endif(NOT CMAKE_BUILD_TYPE MATCHES "Release")
+endmacro()
+
+add_unit_test(
+  manage-filter-utils
+)
+
+add_custom_target(tests DEPENDS ${TEST_DEPENDENCIES})
+
 set_target_properties(
   manage-oci-image-targets-test
   PROPERTIES LINKER_LANGUAGE C

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -485,7 +485,7 @@ target_link_libraries(
 
 set_target_properties(gvmd PROPERTIES LINKER_LANGUAGE C)
 
-macro(add_unit_test _baseName)
+macro(add_unit_test _baseName _objects)
   string(REPLACE "-" "_" _testSource "${_baseName}")
   # manage_filter_utils.c
   set(_source "${_testSource}.c")
@@ -505,10 +505,7 @@ macro(add_unit_test _baseName)
     ${_testName}
     EXCLUDE_FROM_ALL
     ${_testSource}
-    $<TARGET_OBJECTS:all-gmp-obj>
-    $<TARGET_OBJECTS:all-manage-sql-obj>
-    $<TARGET_OBJECTS:all-misc-obj>
-    $<TARGET_OBJECTS:all-sql-obj>
+    ${_objects}
     ${TEST_TARGET_EXTRA_SRC}
   )
   add_test(${_testName} ${_testName})
@@ -544,13 +541,56 @@ macro(add_unit_test _baseName)
   endif(NOT CMAKE_BUILD_TYPE MATCHES "Release")
 endmacro()
 
-add_unit_test(manage)
+set(
+  ALL_OBJECTS
+  $<TARGET_OBJECTS:all-gmp-obj>
+  $<TARGET_OBJECTS:all-manage-sql-obj>
+  $<TARGET_OBJECTS:all-misc-obj>
+  $<TARGET_OBJECTS:all-sql-obj>
+)
+add_unit_test(manage "${ALL_OBJECTS}")
+
 if(ENABLE_AGENTS)
-  add_unit_test(manage-agent-installers manage_sql_agent_installers.c)
+  set(
+    ALL_OBJECTS
+    $<TARGET_OBJECTS:all-gmp-obj>
+    $<TARGET_OBJECTS:all-manage-sql-obj>
+    $<TARGET_OBJECTS:all-misc-obj>
+    $<TARGET_OBJECTS:all-sql-obj>
+  )
+  add_unit_test(
+    manage-agent-installers
+    "${ALL_OBJECTS}"
+    manage_sql_agent_installers.c
+  )
 endif()
-add_unit_test(manage-filter-utils)
-add_unit_test(manage-oci-image-targets)
-add_unit_test(manage-utils)
+
+set(
+  ALL_OBJECTS
+  $<TARGET_OBJECTS:all-gmp-obj>
+  $<TARGET_OBJECTS:all-manage-sql-obj>
+  $<TARGET_OBJECTS:all-misc-obj>
+  $<TARGET_OBJECTS:all-sql-obj>
+)
+add_unit_test(manage-filter-utils "${ALL_OBJECTS}")
+
+set(
+  ALL_OBJECTS
+  $<TARGET_OBJECTS:all-gmp-obj>
+  $<TARGET_OBJECTS:all-manage-sql-obj>
+  $<TARGET_OBJECTS:all-misc-obj>
+  $<TARGET_OBJECTS:all-sql-obj>
+)
+add_unit_test(manage-oci-image-targets "${ALL_OBJECTS}")
+
+set(
+  ALL_OBJECTS
+  $<TARGET_OBJECTS:all-gmp-obj>
+  $<TARGET_OBJECTS:all-manage-sql-obj>
+  $<TARGET_OBJECTS:all-misc-obj>
+  $<TARGET_OBJECTS:all-sql-obj>
+)
+add_unit_test(manage-utils "${ALL_OBJECTS}")
 
 add_custom_target(tests DEPENDS ${TEST_DEPENDENCIES})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -282,21 +282,6 @@ add_library(all-misc-obj OBJECT ${ALL_MISC_SRC})
 
 ## Program
 
-set(TEST_TARGET_EXTRA_SRC ${ALL_GMP_SRC})
-list(REMOVE_ITEM TEST_TARGET_EXTRA_SRC gmp_tickets.c)
-add_executable(
-  gmp-tickets-test
-  EXCLUDE_FROM_ALL
-  gmp_tickets_tests.c
-  $<TARGET_OBJECTS:all-manage-obj>
-  $<TARGET_OBJECTS:all-manage-sql-obj>
-  $<TARGET_OBJECTS:all-misc-obj>
-  $<TARGET_OBJECTS:all-sql-obj>
-  ${TEST_TARGET_EXTRA_SRC}
-)
-
-add_test(gmp-tickets-test gmp-tickets-test)
-
 set(TEST_TARGET_EXTRA_SRC ${ALL_MISC_SRC})
 list(REMOVE_ITEM TEST_TARGET_EXTRA_SRC utils.c)
 add_executable(
@@ -314,7 +299,6 @@ add_test(utils-test utils-test)
 
 set(
   TEST_DEPENDENCIES
-  gmp-tickets-test
   manage-utils-test
   utils-test
 )
@@ -353,32 +337,6 @@ add_executable(
 
 target_link_libraries(
   gvmd
-  m
-  ${GNUTLS_LDFLAGS}
-  ${GPGME_LDFLAGS}
-  ${CMAKE_THREAD_LIBS_INIT}
-  ${LINKER_HARDENING_FLAGS}
-  ${LINKER_DEBUG_FLAGS}
-  ${PostgreSQL_LIBRARIES}
-  ${LIBBSD_LDFLAGS}
-  ${CJSON_LDFLAGS}
-  ${GLIB_LDFLAGS}
-  ${GTHREAD_LDFLAGS}
-  ${LIBGVM_AGENT_CONTROLLER_LDFLAGS}
-  ${LIBGVM_BASE_LDFLAGS}
-  ${LIBGVM_UTIL_LDFLAGS}
-  ${LIBGVM_OSP_LDFLAGS}
-  ${LIBGVM_OPENVASD_LDFLAGS}
-  ${LIBGVM_GMP_LDFLAGS}
-  ${LIBGVM_HTTP_LDFLAGS}
-  ${LIBGVM_HTTP_SCANNER_LDFLAGS}
-  ${LIBICAL_LDFLAGS}
-  ${LINKER_HARDENING_FLAGS}
-  ${OPT_THEIA_TGT}
-)
-target_link_libraries(
-  gmp-tickets-test
-  cgreen
   m
   ${GNUTLS_LDFLAGS}
   ${GPGME_LDFLAGS}
@@ -498,6 +456,15 @@ endmacro()
 
 set(
   ALL_OBJECTS
+  $<TARGET_OBJECTS:all-manage-obj>
+  $<TARGET_OBJECTS:all-manage-sql-obj>
+  $<TARGET_OBJECTS:all-misc-obj>
+  $<TARGET_OBJECTS:all-sql-obj>
+)
+add_unit_test(gmp-tickets "${ALL_OBJECTS}" "${ALL_GMP_SRC}")
+
+set(
+  ALL_OBJECTS
   $<TARGET_OBJECTS:all-gmp-obj>
   $<TARGET_OBJECTS:all-manage-sql-obj>
   $<TARGET_OBJECTS:all-misc-obj>
@@ -560,8 +527,6 @@ add_unit_test(manage-utils "${ALL_OBJECTS}" "${ALL_MANAGE_SRC}")
 
 add_custom_target(tests DEPENDS ${TEST_DEPENDENCIES})
 
-set_target_properties(gmp-tickets-test PROPERTIES LINKER_LANGUAGE C)
-
 if(DEBUG_FUNCTION_NAMES)
   add_definitions(-DDEBUG_FUNCTION_NAMES)
 endif(DEBUG_FUNCTION_NAMES)
@@ -572,7 +537,6 @@ endif(GVMD_VERSION)
 
 if(NOT CMAKE_BUILD_TYPE MATCHES "Release")
   target_compile_options(gvmd PUBLIC ${C_FLAGS_DEBUG_GVMD})
-  target_compile_options(gmp-tickets-test PUBLIC ${C_FLAGS_DEBUG_GVMD})
 
   # If we got GIT_REVISION at configure time,
   # assume we can get it at build time as well

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -282,27 +282,6 @@ add_library(all-misc-obj OBJECT ${ALL_MISC_SRC})
 
 ## Program
 
-set(TEST_TARGET_EXTRA_SRC ${ALL_MISC_SRC})
-list(REMOVE_ITEM TEST_TARGET_EXTRA_SRC utils.c)
-add_executable(
-  utils-test
-  EXCLUDE_FROM_ALL
-  utils_tests.c
-  $<TARGET_OBJECTS:all-gmp-obj>
-  $<TARGET_OBJECTS:all-manage-obj>
-  $<TARGET_OBJECTS:all-manage-sql-obj>
-  $<TARGET_OBJECTS:all-sql-obj>
-  ${TEST_TARGET_EXTRA_SRC}
-)
-
-add_test(utils-test utils-test)
-
-set(
-  TEST_DEPENDENCIES
-  manage-utils-test
-  utils-test
-)
-
 if(ENABLE_COVERAGE)
   add_custom_target(
     coverage-html
@@ -337,32 +316,6 @@ add_executable(
 
 target_link_libraries(
   gvmd
-  m
-  ${GNUTLS_LDFLAGS}
-  ${GPGME_LDFLAGS}
-  ${CMAKE_THREAD_LIBS_INIT}
-  ${LINKER_HARDENING_FLAGS}
-  ${LINKER_DEBUG_FLAGS}
-  ${PostgreSQL_LIBRARIES}
-  ${LIBBSD_LDFLAGS}
-  ${CJSON_LDFLAGS}
-  ${GLIB_LDFLAGS}
-  ${GTHREAD_LDFLAGS}
-  ${LIBGVM_AGENT_CONTROLLER_LDFLAGS}
-  ${LIBGVM_BASE_LDFLAGS}
-  ${LIBGVM_UTIL_LDFLAGS}
-  ${LIBGVM_OSP_LDFLAGS}
-  ${LIBGVM_OPENVASD_LDFLAGS}
-  ${LIBGVM_GMP_LDFLAGS}
-  ${LIBGVM_HTTP_LDFLAGS}
-  ${LIBGVM_HTTP_SCANNER_LDFLAGS}
-  ${LIBICAL_LDFLAGS}
-  ${LINKER_HARDENING_FLAGS}
-  ${OPT_THEIA_TGT}
-)
-target_link_libraries(
-  utils-test
-  cgreen
   m
   ${GNUTLS_LDFLAGS}
   ${GPGME_LDFLAGS}
@@ -524,6 +477,15 @@ set(
   $<TARGET_OBJECTS:all-sql-obj>
 )
 add_unit_test(manage-utils "${ALL_OBJECTS}" "${ALL_MANAGE_SRC}")
+
+set(
+  ALL_OBJECTS
+  $<TARGET_OBJECTS:all-gmp-obj>
+  $<TARGET_OBJECTS:all-manage-obj>
+  $<TARGET_OBJECTS:all-manage-sql-obj>
+  $<TARGET_OBJECTS:all-sql-obj>
+)
+add_unit_test(utils "${ALL_OBJECTS}" "${ALL_MISC_SRC}")
 
 add_custom_target(tests DEPENDS ${TEST_DEPENDENCIES})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -485,7 +485,7 @@ target_link_libraries(
 
 set_target_properties(gvmd PROPERTIES LINKER_LANGUAGE C)
 
-macro(add_unit_test _baseName _objects)
+macro(add_unit_test _baseName _objects _extraSource)
   string(REPLACE "-" "_" _testSource "${_baseName}")
   # manage_filter_utils.c
   set(_source "${_testSource}.c")
@@ -495,11 +495,8 @@ macro(add_unit_test _baseName _objects)
   set(_testName "${_baseName}-test")
 
   list(APPEND TEST_DEPENDENCIES ${_testName})
-  set(TEST_TARGET_EXTRA_SRC ${ALL_MANAGE_SRC})
+  set(TEST_TARGET_EXTRA_SRC ${_extraSource})
   list(REMOVE_ITEM TEST_TARGET_EXTRA_SRC ${_source})
-  foreach(_extraArg ${ARGN})
-    list(REMOVE_ITEM TEST_TARGET_EXTRA_SRC ${_extraArg})
-  endforeach(_extraArg ${ARGN})
 
   add_executable(
     ${_testName}
@@ -548,7 +545,7 @@ set(
   $<TARGET_OBJECTS:all-misc-obj>
   $<TARGET_OBJECTS:all-sql-obj>
 )
-add_unit_test(manage "${ALL_OBJECTS}")
+add_unit_test(manage "${ALL_OBJECTS}" "${ALL_MANAGE_SRC}")
 
 if(ENABLE_AGENTS)
   set(
@@ -558,10 +555,12 @@ if(ENABLE_AGENTS)
     $<TARGET_OBJECTS:all-misc-obj>
     $<TARGET_OBJECTS:all-sql-obj>
   )
+  set(EXTRA_SRC ${ALL_MANAGE_SRC})
+  list(REMOVE_ITEM EXTRA_SRC manage_sql_agent_installers.c)
   add_unit_test(
     manage-agent-installers
     "${ALL_OBJECTS}"
-    manage_sql_agent_installers.c
+    "${EXTRA_SRC}"
   )
 endif()
 
@@ -572,7 +571,7 @@ set(
   $<TARGET_OBJECTS:all-misc-obj>
   $<TARGET_OBJECTS:all-sql-obj>
 )
-add_unit_test(manage-filter-utils "${ALL_OBJECTS}")
+add_unit_test(manage-filter-utils "${ALL_OBJECTS}" "${ALL_MANAGE_SRC}")
 
 set(
   ALL_OBJECTS
@@ -581,7 +580,7 @@ set(
   $<TARGET_OBJECTS:all-misc-obj>
   $<TARGET_OBJECTS:all-sql-obj>
 )
-add_unit_test(manage-oci-image-targets "${ALL_OBJECTS}")
+add_unit_test(manage-oci-image-targets "${ALL_OBJECTS}" "${ALL_MANAGE_SRC}")
 
 set(
   ALL_OBJECTS
@@ -590,7 +589,7 @@ set(
   $<TARGET_OBJECTS:all-misc-obj>
   $<TARGET_OBJECTS:all-sql-obj>
 )
-add_unit_test(manage-utils "${ALL_OBJECTS}")
+add_unit_test(manage-utils "${ALL_OBJECTS}" "${ALL_MANAGE_SRC}")
 
 add_custom_target(tests DEPENDS ${TEST_DEPENDENCIES})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -297,28 +297,6 @@ add_executable(
 
 add_test(manage-utils-test manage-utils-test)
 
-if(ENABLE_AGENTS)
-  set(TEST_TARGET_EXTRA_SRC ${ALL_MANAGE_SRC})
-  list(
-    REMOVE_ITEM
-    TEST_TARGET_EXTRA_SRC
-    manage_agent_installers.c
-    manage_sql_agent_installers.c
-  )
-  add_executable(
-    manage-agent-installers-test
-    EXCLUDE_FROM_ALL
-    manage_agent_installers_tests.c
-    $<TARGET_OBJECTS:all-gmp-obj>
-    $<TARGET_OBJECTS:all-manage-sql-obj>
-    $<TARGET_OBJECTS:all-misc-obj>
-    $<TARGET_OBJECTS:all-sql-obj>
-    ${TEST_TARGET_EXTRA_SRC}
-  )
-
-  add_test(manage-agent-installers-test manage-agent-installers-test)
-endif()
-
 set(TEST_TARGET_EXTRA_SRC ${ALL_MANAGE_SRC})
 list(REMOVE_ITEM TEST_TARGET_EXTRA_SRC manage_oci_image_targets.c)
 add_executable(
@@ -388,10 +366,6 @@ set(
   utils-test
 )
 
-if(ENABLE_AGENTS)
-  list(APPEND TEST_DEPENDENCIES manage-agent-installers-test)
-endif()
-
 if(ENABLE_COVERAGE)
   add_custom_target(
     coverage-html
@@ -449,34 +423,6 @@ target_link_libraries(
   ${LINKER_HARDENING_FLAGS}
   ${OPT_THEIA_TGT}
 )
-if(ENABLE_AGENTS)
-  target_link_libraries(
-    manage-agent-installers-test
-    cgreen
-    m
-    ${GNUTLS_LDFLAGS}
-    ${GPGME_LDFLAGS}
-    ${CMAKE_THREAD_LIBS_INIT}
-    ${LINKER_HARDENING_FLAGS}
-    ${LINKER_DEBUG_FLAGS}
-    ${PostgreSQL_LIBRARIES}
-    ${LIBBSD_LDFLAGS}
-    ${CJSON_LDFLAGS}
-    ${GLIB_LDFLAGS}
-    ${GTHREAD_LDFLAGS}
-    ${LIBGVM_AGENT_CONTROLLER_LDFLAGS}
-    ${LIBGVM_BASE_LDFLAGS}
-    ${LIBGVM_OPENVASD_LDFLAGS}
-    ${LIBGVM_UTIL_LDFLAGS}
-    ${LIBGVM_OSP_LDFLAGS}
-    ${LIBGVM_GMP_LDFLAGS}
-    ${LIBGVM_HTTP_LDFLAGS}
-    ${LIBGVM_HTTP_SCANNER_LDFLAGS}
-    ${LIBICAL_LDFLAGS}
-    ${LINKER_HARDENING_FLAGS}
-    ${OPT_THEIA_TGT}
-  )
-endif()
 target_link_libraries(
   manage-oci-image-targets-test
   cgreen
@@ -621,12 +567,6 @@ target_link_libraries(
 )
 
 set_target_properties(gvmd PROPERTIES LINKER_LANGUAGE C)
-if(ENABLE_AGENTS)
-  set_target_properties(
-    manage-agent-installers-test
-    PROPERTIES LINKER_LANGUAGE C
-  )
-endif()
 
 macro(add_unit_test _baseName)
   string(REPLACE "-" "_" _testSource "${_baseName}")
@@ -640,6 +580,10 @@ macro(add_unit_test _baseName)
   list(APPEND TEST_DEPENDENCIES ${_testName})
   set(TEST_TARGET_EXTRA_SRC ${ALL_MANAGE_SRC})
   list(REMOVE_ITEM TEST_TARGET_EXTRA_SRC ${_source})
+  foreach(_extraArg ${ARGN})
+    list(REMOVE_ITEM TEST_TARGET_EXTRA_SRC ${_extraArg})
+  endforeach(_extraArg ${ARGN})
+
   add_executable(
     ${_testName}
     EXCLUDE_FROM_ALL
@@ -684,6 +628,9 @@ macro(add_unit_test _baseName)
 endmacro()
 
 add_unit_test(manage)
+if(ENABLE_AGENTS)
+  add_unit_test(manage-agent-installers manage_sql_agent_installers.c)
+endif()
 add_unit_test(manage-filter-utils)
 
 add_custom_target(tests DEPENDS ${TEST_DEPENDENCIES})
@@ -706,12 +653,6 @@ endif(GVMD_VERSION)
 
 if(NOT CMAKE_BUILD_TYPE MATCHES "Release")
   target_compile_options(gvmd PUBLIC ${C_FLAGS_DEBUG_GVMD})
-  if(ENABLE_AGENTS)
-    target_compile_options(
-      manage-agent-installers-test
-      PUBLIC ${C_FLAGS_DEBUG_GVMD}
-    )
-  endif()
   target_compile_options(
     manage-oci-image-targets-test
     PUBLIC ${C_FLAGS_DEBUG_GVMD}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -282,21 +282,6 @@ add_library(all-misc-obj OBJECT ${ALL_MISC_SRC})
 
 ## Program
 
-set(TEST_TARGET_EXTRA_SRC ${ALL_MANAGE_SRC})
-list(REMOVE_ITEM TEST_TARGET_EXTRA_SRC manage_oci_image_targets.c)
-add_executable(
-  manage-oci-image-targets-test
-  EXCLUDE_FROM_ALL
-  manage_oci_image_targets_tests.c
-  $<TARGET_OBJECTS:all-gmp-obj>
-  $<TARGET_OBJECTS:all-manage-sql-obj>
-  $<TARGET_OBJECTS:all-misc-obj>
-  $<TARGET_OBJECTS:all-sql-obj>
-  ${TEST_TARGET_EXTRA_SRC}
-)
-
-add_test(manage-oci-image-targets-test manage-oci-image-targets-test)
-
 set(TEST_TARGET_EXTRA_SRC ${ALL_MANAGE_SQL_SRC})
 list(REMOVE_ITEM TEST_TARGET_EXTRA_SRC manage_sql.c)
 add_executable(
@@ -345,7 +330,6 @@ add_test(utils-test utils-test)
 set(
   TEST_DEPENDENCIES
   gmp-tickets-test
-  manage-oci-image-targets-test
   manage-sql-test
   manage-utils-test
   utils-test
@@ -401,32 +385,6 @@ target_link_libraries(
   ${LIBGVM_UTIL_LDFLAGS}
   ${LIBGVM_OSP_LDFLAGS}
   ${LIBGVM_OPENVASD_LDFLAGS}
-  ${LIBGVM_GMP_LDFLAGS}
-  ${LIBGVM_HTTP_LDFLAGS}
-  ${LIBGVM_HTTP_SCANNER_LDFLAGS}
-  ${LIBICAL_LDFLAGS}
-  ${LINKER_HARDENING_FLAGS}
-  ${OPT_THEIA_TGT}
-)
-target_link_libraries(
-  manage-oci-image-targets-test
-  cgreen
-  m
-  ${GNUTLS_LDFLAGS}
-  ${GPGME_LDFLAGS}
-  ${CMAKE_THREAD_LIBS_INIT}
-  ${LINKER_HARDENING_FLAGS}
-  ${LINKER_DEBUG_FLAGS}
-  ${PostgreSQL_LIBRARIES}
-  ${LIBBSD_LDFLAGS}
-  ${CJSON_LDFLAGS}
-  ${GLIB_LDFLAGS}
-  ${GTHREAD_LDFLAGS}
-  ${LIBGVM_AGENT_CONTROLLER_LDFLAGS}
-  ${LIBGVM_BASE_LDFLAGS}
-  ${LIBGVM_OPENVASD_LDFLAGS}
-  ${LIBGVM_UTIL_LDFLAGS}
-  ${LIBGVM_OSP_LDFLAGS}
   ${LIBGVM_GMP_LDFLAGS}
   ${LIBGVM_HTTP_LDFLAGS}
   ${LIBGVM_HTTP_SCANNER_LDFLAGS}
@@ -591,14 +549,11 @@ if(ENABLE_AGENTS)
   add_unit_test(manage-agent-installers manage_sql_agent_installers.c)
 endif()
 add_unit_test(manage-filter-utils)
+add_unit_test(manage-oci-image-targets)
 add_unit_test(manage-utils)
 
 add_custom_target(tests DEPENDS ${TEST_DEPENDENCIES})
 
-set_target_properties(
-  manage-oci-image-targets-test
-  PROPERTIES LINKER_LANGUAGE C
-)
 set_target_properties(manage-sql-test PROPERTIES LINKER_LANGUAGE C)
 set_target_properties(gmp-tickets-test PROPERTIES LINKER_LANGUAGE C)
 
@@ -612,10 +567,6 @@ endif(GVMD_VERSION)
 
 if(NOT CMAKE_BUILD_TYPE MATCHES "Release")
   target_compile_options(gvmd PUBLIC ${C_FLAGS_DEBUG_GVMD})
-  target_compile_options(
-    manage-oci-image-targets-test
-    PUBLIC ${C_FLAGS_DEBUG_GVMD}
-  )
   target_compile_options(manage-sql-test PUBLIC ${C_FLAGS_DEBUG_GVMD})
   target_compile_options(gmp-tickets-test PUBLIC ${C_FLAGS_DEBUG_GVMD})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -297,21 +297,6 @@ add_executable(
 
 add_test(manage-utils-test manage-utils-test)
 
-set(TEST_TARGET_EXTRA_SRC ${ALL_MANAGE_SRC})
-list(REMOVE_ITEM TEST_TARGET_EXTRA_SRC manage.c)
-add_executable(
-  manage-test
-  EXCLUDE_FROM_ALL
-  manage_tests.c
-  $<TARGET_OBJECTS:all-gmp-obj>
-  $<TARGET_OBJECTS:all-manage-sql-obj>
-  $<TARGET_OBJECTS:all-misc-obj>
-  $<TARGET_OBJECTS:all-sql-obj>
-  ${TEST_TARGET_EXTRA_SRC}
-)
-
-add_test(manage-test manage-test)
-
 if(ENABLE_AGENTS)
   set(TEST_TARGET_EXTRA_SRC ${ALL_MANAGE_SRC})
   list(
@@ -397,7 +382,6 @@ add_test(utils-test utils-test)
 set(
   TEST_DEPENDENCIES
   gmp-tickets-test
-  manage-test
   manage-oci-image-targets-test
   manage-sql-test
   manage-utils-test
@@ -458,32 +442,6 @@ target_link_libraries(
   ${LIBGVM_UTIL_LDFLAGS}
   ${LIBGVM_OSP_LDFLAGS}
   ${LIBGVM_OPENVASD_LDFLAGS}
-  ${LIBGVM_GMP_LDFLAGS}
-  ${LIBGVM_HTTP_LDFLAGS}
-  ${LIBGVM_HTTP_SCANNER_LDFLAGS}
-  ${LIBICAL_LDFLAGS}
-  ${LINKER_HARDENING_FLAGS}
-  ${OPT_THEIA_TGT}
-)
-target_link_libraries(
-  manage-test
-  cgreen
-  m
-  ${GNUTLS_LDFLAGS}
-  ${GPGME_LDFLAGS}
-  ${CMAKE_THREAD_LIBS_INIT}
-  ${LINKER_HARDENING_FLAGS}
-  ${LINKER_DEBUG_FLAGS}
-  ${PostgreSQL_LIBRARIES}
-  ${LIBBSD_LDFLAGS}
-  ${CJSON_LDFLAGS}
-  ${GLIB_LDFLAGS}
-  ${GTHREAD_LDFLAGS}
-  ${LIBGVM_AGENT_CONTROLLER_LDFLAGS}
-  ${LIBGVM_BASE_LDFLAGS}
-  ${LIBGVM_OPENVASD_LDFLAGS}
-  ${LIBGVM_UTIL_LDFLAGS}
-  ${LIBGVM_OSP_LDFLAGS}
   ${LIBGVM_GMP_LDFLAGS}
   ${LIBGVM_HTTP_LDFLAGS}
   ${LIBGVM_HTTP_SCANNER_LDFLAGS}
@@ -663,7 +621,6 @@ target_link_libraries(
 )
 
 set_target_properties(gvmd PROPERTIES LINKER_LANGUAGE C)
-set_target_properties(manage-test PROPERTIES LINKER_LANGUAGE C)
 if(ENABLE_AGENTS)
   set_target_properties(
     manage-agent-installers-test
@@ -726,9 +683,8 @@ macro(add_unit_test _baseName)
   endif(NOT CMAKE_BUILD_TYPE MATCHES "Release")
 endmacro()
 
-add_unit_test(
-  manage-filter-utils
-)
+add_unit_test(manage)
+add_unit_test(manage-filter-utils)
 
 add_custom_target(tests DEPENDS ${TEST_DEPENDENCIES})
 
@@ -750,7 +706,6 @@ endif(GVMD_VERSION)
 
 if(NOT CMAKE_BUILD_TYPE MATCHES "Release")
   target_compile_options(gvmd PUBLIC ${C_FLAGS_DEBUG_GVMD})
-  target_compile_options(manage-test PUBLIC ${C_FLAGS_DEBUG_GVMD})
   if(ENABLE_AGENTS)
     target_compile_options(
       manage-agent-installers-test

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -282,21 +282,6 @@ add_library(all-misc-obj OBJECT ${ALL_MISC_SRC})
 
 ## Program
 
-set(TEST_TARGET_EXTRA_SRC ${ALL_MANAGE_SQL_SRC})
-list(REMOVE_ITEM TEST_TARGET_EXTRA_SRC manage_sql.c)
-add_executable(
-  manage-sql-test
-  EXCLUDE_FROM_ALL
-  manage_sql_tests.c
-  $<TARGET_OBJECTS:all-gmp-obj>
-  $<TARGET_OBJECTS:all-misc-obj>
-  $<TARGET_OBJECTS:all-manage-obj>
-  $<TARGET_OBJECTS:all-sql-obj>
-  ${TEST_TARGET_EXTRA_SRC}
-)
-
-add_test(manage-sql-test manage-sql-test)
-
 set(TEST_TARGET_EXTRA_SRC ${ALL_GMP_SRC})
 list(REMOVE_ITEM TEST_TARGET_EXTRA_SRC gmp_tickets.c)
 add_executable(
@@ -330,7 +315,6 @@ add_test(utils-test utils-test)
 set(
   TEST_DEPENDENCIES
   gmp-tickets-test
-  manage-sql-test
   manage-utils-test
   utils-test
 )
@@ -369,32 +353,6 @@ add_executable(
 
 target_link_libraries(
   gvmd
-  m
-  ${GNUTLS_LDFLAGS}
-  ${GPGME_LDFLAGS}
-  ${CMAKE_THREAD_LIBS_INIT}
-  ${LINKER_HARDENING_FLAGS}
-  ${LINKER_DEBUG_FLAGS}
-  ${PostgreSQL_LIBRARIES}
-  ${LIBBSD_LDFLAGS}
-  ${CJSON_LDFLAGS}
-  ${GLIB_LDFLAGS}
-  ${GTHREAD_LDFLAGS}
-  ${LIBGVM_AGENT_CONTROLLER_LDFLAGS}
-  ${LIBGVM_BASE_LDFLAGS}
-  ${LIBGVM_UTIL_LDFLAGS}
-  ${LIBGVM_OSP_LDFLAGS}
-  ${LIBGVM_OPENVASD_LDFLAGS}
-  ${LIBGVM_GMP_LDFLAGS}
-  ${LIBGVM_HTTP_LDFLAGS}
-  ${LIBGVM_HTTP_SCANNER_LDFLAGS}
-  ${LIBICAL_LDFLAGS}
-  ${LINKER_HARDENING_FLAGS}
-  ${OPT_THEIA_TGT}
-)
-target_link_libraries(
-  manage-sql-test
-  cgreen
   m
   ${GNUTLS_LDFLAGS}
   ${GPGME_LDFLAGS}
@@ -585,6 +543,15 @@ add_unit_test(manage-oci-image-targets "${ALL_OBJECTS}" "${ALL_MANAGE_SRC}")
 set(
   ALL_OBJECTS
   $<TARGET_OBJECTS:all-gmp-obj>
+  $<TARGET_OBJECTS:all-manage-obj>
+  $<TARGET_OBJECTS:all-misc-obj>
+  $<TARGET_OBJECTS:all-sql-obj>
+)
+add_unit_test(manage-sql "${ALL_OBJECTS}" "${ALL_MANAGE_SQL_SRC}")
+
+set(
+  ALL_OBJECTS
+  $<TARGET_OBJECTS:all-gmp-obj>
   $<TARGET_OBJECTS:all-manage-sql-obj>
   $<TARGET_OBJECTS:all-misc-obj>
   $<TARGET_OBJECTS:all-sql-obj>
@@ -593,7 +560,6 @@ add_unit_test(manage-utils "${ALL_OBJECTS}" "${ALL_MANAGE_SRC}")
 
 add_custom_target(tests DEPENDS ${TEST_DEPENDENCIES})
 
-set_target_properties(manage-sql-test PROPERTIES LINKER_LANGUAGE C)
 set_target_properties(gmp-tickets-test PROPERTIES LINKER_LANGUAGE C)
 
 if(DEBUG_FUNCTION_NAMES)
@@ -606,7 +572,6 @@ endif(GVMD_VERSION)
 
 if(NOT CMAKE_BUILD_TYPE MATCHES "Release")
   target_compile_options(gvmd PUBLIC ${C_FLAGS_DEBUG_GVMD})
-  target_compile_options(manage-sql-test PUBLIC ${C_FLAGS_DEBUG_GVMD})
   target_compile_options(gmp-tickets-test PUBLIC ${C_FLAGS_DEBUG_GVMD})
 
   # If we got GIT_REVISION at configure time,

--- a/src/manage.c
+++ b/src/manage.c
@@ -8138,7 +8138,7 @@ launch_agent_control_task (task_t task,
     }
 
   // Create scan
-  http_scanner_resp = http_scanner_create_scan (connection, payload, NULL);
+  http_scanner_resp = http_scanner_create_scan (connection, payload);
   if (!http_scanner_resp || http_scanner_resp->code != 201)
     {
       if (error) *error = g_strdup ("Scanner failed to create the scan");


### PR DESCRIPTION
## What

Add a macro `add_unit_test` and use it to define the tests.

## Why

This collects the test definitions in one place, making it easier to add options to all tests. For example, I plan to add `-fsanitize=address` so now I can just do it in the macro.


