### PR TITLE
docs: fix scheduler_cron_time docs, use "item" instead of "cron"

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -9695,9 +9695,9 @@ END:VCALENDAR
             </ele>
             <ele>
               <name>scheduler_cron_time</name>
-              <pattern><any><e>cron</e></any></pattern>
+              <pattern><any><e>item</e></any></pattern>
               <ele>
-                <name>cron</name>
+                <name>item</name>
                 <summary>A cron expression defining execution schedule</summary>
                 <pattern><type>text</type></pattern>
               </ele>
@@ -9867,8 +9867,7 @@ END:VCALENDAR
                 <bulk_throttle_time_in_ms>250</bulk_throttle_time_in_ms>
                 <indexer_dir_depth>3</indexer_dir_depth>
                 <scheduler_cron_time>
-                  <cron>@every 8h</cron>
-                  <cron>0 0 * * *</cron>
+                  <item>0 0 * * *</item>
                 </scheduler_cron_time>
               </agent_script_executor>
               <heartbeat>
@@ -23190,9 +23189,9 @@ END:VCALENDAR
             </ele>
             <ele>
               <name>scheduler_cron_time</name>
-              <pattern><any><e>cron</e></any></pattern>
+              <pattern><any><e>item</e></any></pattern>
               <ele>
-                <name>cron</name>
+                <name>item</name>
                 <summary>A cron expression defining execution schedule</summary>
                 <pattern><type>text</type></pattern>
               </ele>


### PR DESCRIPTION
## What

Updated the documentation for `scheduler_cron_time`:  
- Replaced the reference to the `cron` field with `item`. 

## Why

To avoid confusion and keep the documentation aligned with the current implementation, the field should be referred to as `item`.

## References

GEA-1278


