### PR TITLE
Fix: increase gvm-libs version requirement

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,17 +27,17 @@ find_package(Threads)
 ## might occur.
 
 pkg_check_modules(CJSON REQUIRED libcjson>=1.7.14)
-pkg_check_modules(LIBGVM_BASE REQUIRED libgvm_base>=22.28)
-pkg_check_modules(LIBGVM_UTIL REQUIRED libgvm_util>=22.28)
-pkg_check_modules(LIBGVM_OSP REQUIRED libgvm_osp>=22.28)
-pkg_check_modules(LIBGVM_GMP REQUIRED libgvm_gmp>=22.28)
+pkg_check_modules(LIBGVM_BASE REQUIRED libgvm_base>=22.29)
+pkg_check_modules(LIBGVM_UTIL REQUIRED libgvm_util>=22.29)
+pkg_check_modules(LIBGVM_OSP REQUIRED libgvm_osp>=22.29)
+pkg_check_modules(LIBGVM_GMP REQUIRED libgvm_gmp>=22.29)
 
 if(ENABLE_HTTP_SCANNER)
-  pkg_check_modules(LIBGVM_HTTP REQUIRED libgvm_http>=22.28)
-  pkg_check_modules(LIBGVM_HTTP_SCANNER REQUIRED libgvm_http_scanner>=22.28)
+  pkg_check_modules(LIBGVM_HTTP REQUIRED libgvm_http>=22.29)
+  pkg_check_modules(LIBGVM_HTTP_SCANNER REQUIRED libgvm_http_scanner>=22.29)
 endif(ENABLE_HTTP_SCANNER)
 if(OPENVASD)
-  pkg_check_modules(LIBGVM_OPENVASD REQUIRED libgvm_openvasd>=22.28)
+  pkg_check_modules(LIBGVM_OPENVASD REQUIRED libgvm_openvasd>=22.29)
 else(OPENVASD)
   message(STATUS "OPENVASD flag is not enabled")
 endif(OPENVASD)
@@ -45,7 +45,7 @@ if(ENABLE_AGENTS)
   pkg_check_modules(
     LIBGVM_AGENT_CONTROLLER
     REQUIRED
-    libgvm_agent_controller>=22.28
+    libgvm_agent_controller>=22.29
   )
 else(ENABLE_AGENTS)
   message(STATUS "ENABLE_AGENTS flag is not enabled")


### PR DESCRIPTION
## What

Increase gvm-libs required version.

## Why

Required for change to http_scanner_create_scan.

## References

API was changed in 7a802604825f31758c008ea858d6c59e5a6c4cc6 from https://github.com/greenbone/gvm-libs/pull/981.
