### PR TITLE
Add: Extends the task element in get_reports XML output to include agent_group block

### DIFF
--- a/src/manage_agent_groups.h
+++ b/src/manage_agent_groups.h
@@ -96,6 +96,9 @@ agent_group_uuid (agent_group_t group_id);
 char *
 agent_group_name (agent_group_t group_id);
 
+char *
+agent_group_comment (agent_group_t group_id);
+
 agent_group_t
 agent_group_id_by_uuid (const gchar *agent_group_uuid);
 
@@ -142,6 +145,9 @@ trash_agent_group_uuid (agent_group_t agent_group);
 
 char *
 trash_agent_group_name (agent_group_t agent_group);
+
+char *
+trash_agent_group_comment (agent_group_t agent_group);
 
 #endif // _GVMD_MANAGE_AGENT_GROUPS_H
 #endif // ENABLE_AGENTS

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -18265,23 +18265,62 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
              "<trash>%i</trash>"
              "<name>%s</name>"
              "<comment>%s</comment>"
-             "</target>"
-             "<progress>%s</progress>",
+             "</target>",
              tsk_uuid,
              tsk_name ? tsk_name : "",
              comment ? comment : "",
              task_target_uuid ? task_target_uuid : "",
              task_target_in_trash (task),
              task_target_name ? task_target_name : "",
-             task_target_comment ? task_target_comment : "",
-             progress_xml);
-      g_free (progress_xml);
+             task_target_comment ? task_target_comment : "");
+
       free (comment);
       free (tsk_name);
       free (tsk_uuid);
       free (task_target_uuid);
       free (task_target_name);
       free (task_target_comment);
+
+#if ENABLE_AGENTS
+      agent_group_t agent_group = task_agent_group (task);
+      if (agent_group)
+        {
+          char *ag_uuid, *ag_name, *ag_comment;
+          int in_trash;
+
+          in_trash = task_agent_group_in_trash (task);
+
+          ag_uuid = in_trash
+                      ? trash_agent_group_uuid (agent_group)
+                      : agent_group_uuid (agent_group);
+          ag_name = in_trash
+                      ? trash_agent_group_name (agent_group)
+                      : agent_group_name (agent_group);
+          ag_comment = in_trash
+                         ? trash_agent_group_comment (agent_group)
+                         : agent_group_comment (agent_group);
+
+          PRINT (out,
+                 "<agent_group id=\"%s\">"
+                 "<trash>%i</trash>"
+                 "<name>%s</name>"
+                 "<comment>%s</comment>"
+                 "</agent_group>",
+                 ag_uuid ? ag_uuid : "",
+                 in_trash,
+                 ag_name ? ag_name : "",
+                 ag_comment ? ag_comment : "");
+
+          g_free (ag_uuid);
+          g_free (ag_name);
+          g_free (ag_comment);
+
+          progress_xml = g_strdup_printf ("%i", 100);
+        }
+#endif /* ENABLE_AGENTS */
+      PRINT (out, "<progress>%s</progress>", progress_xml);
+
+      g_free (progress_xml);
 
       if (task_tag_count)
         {

--- a/src/manage_sql_agent_groups.c
+++ b/src/manage_sql_agent_groups.c
@@ -718,6 +718,20 @@ agent_group_name (agent_group_t group_id)
 }
 
 /**
+ * @brief Return the comment of an agent group.
+ *
+ * @param[in]  group_id  Agent group ID.
+ *
+ * @return Newly allocated comment  if found, else NULL.
+ */
+char *
+agent_group_comment (agent_group_t group_id)
+{
+  g_return_val_if_fail (group_id, NULL);
+  return sql_string ("SELECT comment FROM agent_groups WHERE id = %llu;", group_id);
+}
+
+/**
  * @brief Return the row_id of an agent group.
  *
  * @param[in]  group_uuid  Agent group UUID.
@@ -977,6 +991,23 @@ trash_agent_group_name (agent_group_t agent_group)
     return NULL;
 
   return sql_string ("SELECT name FROM agent_groups_trash WHERE id = %llu;",
+                     agent_group);
+}
+
+/**
+ * @brief Return the comment of a trashed agent group.
+ *
+ * @param[in]  agent_group  Row id in agent_groups_trash.
+ *
+ * @return Newly allocated comment (caller must g_free) or NULL if not found.
+ */
+char *
+trash_agent_group_comment (agent_group_t agent_group)
+{
+  if (!agent_group)
+    return NULL;
+
+  return sql_string ("SELECT comment FROM agent_groups_trash WHERE id = %llu;",
                      agent_group);
 }
 


### PR DESCRIPTION

## What

Add an <agent_group> block under each <task> when compiled with ENABLE_AGENTS and when the task has an associated agent group.

## Why

Expose agent group metadata in reports so GSA does not need an extra round trip to resolve the task’s agent group.

## References

GEA-1278



