### PR TITLE
Add: New --secinfo-update-strategy option

### DIFF
--- a/docs/gvmd.8
+++ b/docs/gvmd.8
@@ -223,8 +223,11 @@ Time out tasks that are more than TIME minutes overdue. -1 to disable, 0 for min
 \fB--secinfo-commit-size=\fINUMBER\fB\f1
 During CERT and SCAP sync, commit updates to the database every NUMBER items, 0 for unlimited.
 .TP
-\fB--secinfo-fast_init=\fINUMBER\fB\f1
+\fB--secinfo-fast-init=\fINUMBER\fB\f1
 Whether to prefer faster SQL with less checks for non-incremental SecInfo updates. 0 to use statements with more checks, 1 to use faster statements, default: 1
+.TP
+\fB--secinfo-update-strategy=\fINUMBER\fB\f1
+The strategy how to handle SecInfo updates: 0 (default) = keep old schemas and replace them at the end, 1 = drop old schemas at update start, swap them in at the end. 
 .TP
 \fB-c, --unix-socket=\fIFILENAME\fB\f1
 Listen on UNIX socket at FILENAME.

--- a/docs/gvmd.8.xml
+++ b/docs/gvmd.8.xml
@@ -526,11 +526,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       </optdesc>
     </option>
     <option>
-      <p><opt>--secinfo-fast_init=<arg>NUMBER</arg></opt></p>
+      <p><opt>--secinfo-fast-init=<arg>NUMBER</arg></opt></p>
       <optdesc>
         <p>Whether to prefer faster SQL with less checks for non-incremental
            SecInfo updates. 0 to use statements with more checks, 1 to use
            faster statements, default: 1</p>
+      </optdesc>
+    </option>
+    <option>
+      <p><opt>--secinfo-update-strategy=<arg>NUMBER</arg></opt></p>
+      <optdesc>
+        <p>
+          The strategy how to handle SecInfo updates:
+          0 (default) = keep old schemas and replace them at the end,
+          1 = drop old schemas at update start, swap them in at the end.
+        </p>
       </optdesc>
     </option>
     <option>

--- a/docs/gvmd.html
+++ b/docs/gvmd.html
@@ -473,6 +473,14 @@
       
     
     
+      <p><b>--secinfo-update-strategy=<em>NUMBER</em></b></p>
+      
+        <p>The strategy how to handle SecInfo updates:
+           0 (default) = keep old schemas and replace them at the end,
+           1 = drop old schemas at update start, swap them in at the end.</p>
+      
+    
+    
       <p><b>--slave-commit-size=<em>NUMBER</em></b></p>
       
         <p>During slave updates, commit after every NUMBER updated results and

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -2127,6 +2127,7 @@ gvmd (int argc, char** argv, char *env[])
     = AFFECTED_PRODUCTS_QUERY_SIZE_DEFAULT;
   static int secinfo_fast_init = SECINFO_FAST_INIT_DEFAULT;
   static int secinfo_commit_size = SECINFO_COMMIT_SIZE_DEFAULT;
+  static int secinfo_update_strategy = 0;
   static gchar *delete_scanner = NULL;
   static gchar *verify_scanner = NULL;
   static gchar *priorities = "NORMAL";
@@ -2559,6 +2560,13 @@ gvmd (int argc, char** argv, char *env[])
           " 0 to use statements with more checks, 1 to use faster statements,"
           " default: "
           G_STRINGIFY (SECINFO_FAST_INIT_DEFAULT), "<number>" },
+        { "secinfo-update-strategy", '\0', 0, G_OPTION_ARG_INT,
+          &secinfo_update_strategy,
+          "The strategy how to handle SecInfo updates:"
+          " 0 (default) = keep old schemas and replace them at the end,"
+          " 1 = drop old schemas at update start, swap them in at the end.",
+          "<number>"
+          },
         { "set-encryption-key", '\0', 0, G_OPTION_ARG_STRING,
           &set_encryption_key,
           "Set the encryption key with the given UID as the new default"
@@ -2714,6 +2722,8 @@ gvmd (int argc, char** argv, char *env[])
   set_affected_products_query_size (affected_products_query_size);
 
   set_secinfo_commit_size (secinfo_commit_size);
+
+  set_secinfo_update_strategy (secinfo_update_strategy);
 
   set_vt_ref_insert_size (vt_ref_insert_size);
 

--- a/src/manage_sql_secinfo.h
+++ b/src/manage_sql_secinfo.h
@@ -26,6 +26,14 @@
 #define _GVMD_MANAGE_SQL_SECINFO_H
 
 /**
+ * @brief Strategies to handle SecInfo updates
+ */
+typedef enum {
+  SECINFO_UPDATE_STRATEGY_KEEP_SCHEMA = 0,
+  SECINFO_UPDATE_STRATEGY_DROP_SCHEMA = 1,
+} secinfo_update_strategy_t;
+
+/**
  * @brief SQL to check if a result has CERT Bunds.
  */
 #define SECINFO_SQL_RESULT_HAS_CERT_BUNDS                          \
@@ -180,6 +188,11 @@
  */
 #define SECINFO_COMMIT_SIZE_DEFAULT 0
 
+/**
+ * @brief Default for secinfo_update_strategy.
+ */
+#define SECINFO_UPDATE_STRATEGY_DEFAULT SECINFO_UPDATE_STRATEGY_KEEP_SCHEMA
+
 int
 secinfo_feed_version_status (const char *);
 
@@ -206,6 +219,9 @@ set_affected_products_query_size (int);
 
 void
 set_secinfo_commit_size (int);
+
+void
+set_secinfo_update_strategy (int);
 
 void
 set_secinfo_fast_init (int);


### PR DESCRIPTION
## What
The new command line option is added to give control over how the SecInfo data is updated.
Currently the two options are the default of dropping the old database schema at the end and dropping it at the start of the update.

## Why
The new non-default option is there to allow updating the SecInfo when there is not enough database storage space for two versions of the schema at the same time.

## References
GEA-1286

