### PR TITLE
Build all versions of gvmd even if one job fails

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,15 +49,26 @@ jobs:
           retention-days: 7
 
   build-gvmd:
-    name: Build gvmd
+    name: Build gvmd (${{ matrix.build.name }})
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        container:
-          - stable
-          - oldstable
-          - testing
-    container: ${{ vars.SELF_HOSTED_REGISTRY || 'registry.community.greenbone.net' }}/community/gvm-libs:${{ matrix.container }}
+        include:
+          - build:
+              name: stable
+              container: stable
+          - build:
+              name: oldstable
+              container: oldstable
+          - build:
+              name: testing
+              container: testing
+          - build:
+              name: "with openvasd"
+              container: stable
+              flags: "-DOPENVASD=1"
+    container: ${{ vars.SELF_HOSTED_REGISTRY || 'registry.community.greenbone.net' }}/community/gvm-libs:${{ matrix.build.container }}
     steps:
       - uses: actions/checkout@v5
       - name: Install build dependencies
@@ -65,26 +76,7 @@ jobs:
       - name: Configure and compile gvmd
         run: |
           rm -rf .git
-          cmake -B build -DCMAKE_BUILD_TYPE=Release
-          cmake --build build -j $(nproc) -- install
-
-  build-gvmd-with-openvasd:
-    name: Build gvmd with openvasd
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        container:
-          - stable
-          - testing
-    container: ${{ vars.SELF_HOSTED_REGISTRY || 'registry.community.greenbone.net' }}/community/gvm-libs:${{ matrix.container }}
-    steps:
-      - uses: actions/checkout@v5
-      - name: Install build dependencies
-        run: sh .github/install-dependencies.sh .github/build-dependencies.list
-      - name: Configure and compile gvmd
-        run: |
-          rm -rf .git
-          cmake -B build -DCMAKE_BUILD_TYPE=Release -DOPENVASD=1
+          cmake -B build -DCMAKE_BUILD_TYPE=Release ${{ matrix.build.flags || '' }}
           cmake --build build -j $(nproc) -- install
 
   test-units:


### PR DESCRIPTION


## What

Build all versions of gvmd even if one job fails

## Why

Use a single workflow for building all variants of gvmd and set fail-fast to false to always build all versions. Currently testing is broken and we might remove this build job completely.