### PR TITLE
Don't run container workflow for PRs from forks

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   build:
-    if: ${{ github.repository == 'greenbone/gvmd' }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION

## What

Don't run container workflow for PRs from forks
## Why

Container images should not be build for PRs from GitHub forks.

## References

https://github.com/orgs/community/discussions/25217
