### PR TITLE
Change: Include oid when hashing results for duplicates detection

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -44990,8 +44990,9 @@ check_http_scanner_result_exists (report_t report,
                           "hostname:%s\n"
                           "type:%s\n"
                           "description:%s\n"
-                          "port:%s",res->ip_address, res->hostname,
-                          res->type, res->message, res->port);
+                          "port:%s\n"
+                          "oid:%s",res->ip_address, res->hostname,
+                          res->type, res->message, res->port, res->oid);
 
  *entity_hash_value = get_md5_hash_from_string (result_string->str);
   if (g_hash_table_contains (hashed_results, *entity_hash_value))


### PR DESCRIPTION
## What
Include oid when hasing results for duplicates detection

## Why
Results with the same message but different oid appear identical and are incorrectly filtered out leading to inconsistent number of results in reports of the same task.

## References
GEA-1263




