### PR TITLE
Fix: free progress_xml in agent case of print_report_xml_start

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -18315,6 +18315,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
           g_free (ag_name);
           g_free (ag_comment);
 
+          g_free (progress_xml);
           progress_xml = g_strdup_printf ("%i", 100);
         }
 #endif /* ENABLE_AGENTS */


### PR DESCRIPTION
## What

Free `progress_xml`.

## Why

`progress_xml` is always allocated before this at line 18248, so it must be freed before being reallocated. 

## References

Introduced in /pull/2581.

## Testing

I ran `GET_REPORTS` with a fake agent task, and check the `AGENT_GROUP` and `PROGRESS` elements. Seems OK.


