### PR TITLE
Fix: Avoid duplicate results when resuming a stopped http scanner task

### DIFF
--- a/src/manage_container_image_scanner.c
+++ b/src/manage_container_image_scanner.c
@@ -126,13 +126,12 @@ add_container_image_scan_result (http_scanner_result_t res,
 
   struct report_aux *rep_aux = *results_aux;
   result_t result;
-  char *type, *severity, *host, *hostname, *test_id;
-  char *port = NULL, *path = NULL;
-  char *desc = NULL, *nvt_id = NULL, *severity_str = NULL;
+  char *type, *host, *hostname, *test_id;
+  char *port = NULL, *desc = NULL;
+  char *nvt_id = NULL, *severity_str = NULL;
   int qod_int;
 
   type = convert_http_scanner_type_to_osp_type (res->type);
-  severity = NULL;
   test_id = res->oid;
   host = res->ip_address;
   hostname = res->hostname;
@@ -154,9 +153,9 @@ add_container_image_scan_result (http_scanner_result_t res,
                                 type ?: "",
                                 desc ?: "",
                                 port ?: "",
-                                severity_str ?: severity,
+                                severity_str ?: NULL,
                                 qod_int,
-                                path ?: "",
+                                NULL,
                                 hash_value);
       g_array_append_val (rep_aux->results_array, result);
     }

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -45011,27 +45011,24 @@ check_http_scanner_result_exists (report_t report,
                    report, *entity_hash_value))
         {
           const char *desc, *type, *severity = NULL, *host;
-          const char *hostname, *port = NULL, *path = NULL;
+          const char *hostname, *port = NULL;
           gchar *quoted_desc, *quoted_type, *quoted_host;
-          gchar *quoted_hostname, *quoted_port, *quoted_path;
+          gchar *quoted_hostname, *quoted_port;
           double severity_double = 0.0;
           int qod_int = get_http_scanner_nvti_qod (res->oid);
 
           host = res->ip_address;
           hostname = res->hostname;
-          type = res->type;
+          type = convert_http_scanner_type_to_osp_type(res->type);
           desc = res->message;
+          severity = nvt_severity (res->oid, type);
+          port = res->port;
 
-          if (!severity || !strcmp (severity, ""))
+          if (!severity)
             {
-              if (!strcmp (type, severity_to_type (SEVERITY_ERROR)))
-                severity_double = SEVERITY_ERROR;
-              else
-                {
-                  g_debug ("%s: Result without severity", __func__);
-                  g_string_free (result_string, TRUE);
-                  return 0;
-                }
+              g_debug ("%s: Result without severity", __func__);
+              g_string_free (result_string, TRUE);
+              return 0;
             }
           else
             {
@@ -45043,21 +45040,20 @@ check_http_scanner_result_exists (report_t report,
           quoted_type = sql_quote (type ?: "");
           quoted_desc = sql_quote (desc ?: "");
           quoted_port = sql_quote (port ?: "");
-          quoted_path = sql_quote (path ?: "");
 
           if (sql_int ("SELECT EXISTS"
                        " (SELECT * FROM results"
                        "   WHERE report = %llu and hash_value = '%s'"
                        "    and host = '%s' and hostname = '%s'"
                        "    and type = '%s' and description = '%s'"
-                       "    and port = '%s' and severity = %1.1f"
-                       "    and qod = %d and path = '%s'"
+                       "    and port = '%s' and severity = %1.1f::real"
+                       "    and qod = %d"
                        " );",
                        report, *entity_hash_value,
                        quoted_host, quoted_hostname,
                        quoted_type, quoted_desc,
                        quoted_port, severity_double,
-                       qod_int, quoted_path))
+                       qod_int))
             {
               g_info ("Captured duplicate result, report: %llu hash_value: %s",
                       report, *entity_hash_value);
@@ -45070,7 +45066,6 @@ check_http_scanner_result_exists (report_t report,
           g_free (quoted_type);
           g_free (quoted_desc);
           g_free (quoted_port);
-          g_free (quoted_path);
         }
     }
   if (return_value)


### PR DESCRIPTION
## What
Avoid duplicate results when resuming a stopped http scanner task.

## Why
Severity, type and port were not set correctly when checking if a result exists. 

Additionally, using severity as a double value was implicitly casted by Postgres as double precision instead of real which was affecting the query result and leading to duplicates

## References
GEA-1263


