### PR TITLE
Allow to get the usage type of scanner tasks

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -17759,11 +17759,13 @@ handle_get_scanners (gmp_parser_t *gmp_parser, GError **error)
                 /* Only show tasks the user may see. */
                 continue;
 
-              SENDF_TO_CLIENT_OR_FAIL
-               ("<task id=\"%s\">"
-                "<name>%s</name>",
+              SENDF_TO_CLIENT_OR_FAIL (
+                "<task id=\"%s\">"
+                "<name>%s</name>"
+                "<usage_type>%s</usage_type>",
                 scanner_task_iterator_uuid (&tasks),
-                scanner_task_iterator_name (&tasks));
+                scanner_task_iterator_name (&tasks),
+                scanner_task_iterator_usage_type (&tasks));
 
               if (scanner_task_iterator_readable (&tasks))
                 SEND_TO_CLIENT_OR_FAIL ("</task>");

--- a/src/manage.h
+++ b/src/manage.h
@@ -2668,6 +2668,9 @@ scanner_task_iterator_uuid (iterator_t *);
 const char*
 scanner_task_iterator_name (iterator_t *);
 
+const char *
+scanner_task_iterator_usage_type (iterator_t *);
+
 int
 scanner_task_iterator_readable (iterator_t *);
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -30765,7 +30765,7 @@ init_scanner_task_iterator (iterator_t* iterator, scanner_t scanner)
 
   init_iterator (iterator,
                  "%s"
-                 " SELECT id, uuid, name, %s FROM tasks"
+                 " SELECT id, uuid, name, usage_type, %s FROM tasks"
                  " WHERE scanner = %llu AND hidden = 0"
                  " ORDER BY name ASC;",
                  with_clause ? with_clause : "",
@@ -30795,6 +30795,15 @@ DEF_ACCESS (scanner_task_iterator_uuid, 1);
 DEF_ACCESS (scanner_task_iterator_name, 2);
 
 /**
+ * @brief Get the usage type from a scanner task iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return Name, or NULL if iteration is complete. Freed by cleanup_iterator.
+ */
+DEF_ACCESS (scanner_task_iterator_usage_type, 3);
+
+/**
  * @brief Get the read permission status from a GET iterator.
  *
  * @param[in]  iterator  Iterator.
@@ -30805,7 +30814,7 @@ int
 scanner_task_iterator_readable (iterator_t* iterator)
 {
   if (iterator->done) return 0;
-  return iterator_int (iterator, 3);
+  return iterator_int (iterator, 4);
 }
 
 /**

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -23445,12 +23445,23 @@ END:VCALENDAR
                 <required>1</required>
               </attrib>
               <e>name</e>
+              <e>usage_type</e>
               <o><e>permissions</e></o>
             </pattern>
             <ele>
               <name>name</name>
               <summary>The name of the task</summary>
               <pattern><t>name</t></pattern>
+            </ele>
+            <ele>
+              <name>usage_type</name>
+              <summary>The usage type of the task</summary>
+              <pattern>
+                <alts>
+                  <alt>scan</alt>
+                  <alt>policy</alt>
+                </alts>
+              </pattern>
             </ele>
             <ele>
               <name>permissions</name>
@@ -23756,6 +23767,7 @@ END:VCALENDAR
             <tasks>
               <task id="813864a9-d3fd-44b3-8717-972bfb01dfc0">
                 <name>Debian desktops</name>
+                <usage_type>scan</usage_type>
               </task>
               <truncated>...</truncated>
             </tasks>


### PR DESCRIPTION


## What

Allow to get the usage type of scanner tasks

## Why

To be able to link in the UI to an audit or a task we need to know the actual usage type of the linked tasks of a scanner.

## References

https://jira.greenbone.net/browse/GEA-1321


