### PR TITLE
Change: move filter cleaning out of print_report_xml_start

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -17444,6 +17444,28 @@ ensure_term_has_qod_and_overrides (gchar *clean)
 }
 
 /**
+ * @brief Clean a filter term string for print_report_xml_start.
+ *
+ * @param[in]  term  Pointer to filter term, which will be reallocated.
+ * @param[in]  get   GET command data.
+ */
+static void
+print_report_clean_filter (gchar **term, const get_data_t *get)
+{
+  gchar *clean;
+
+  assert (term);
+
+  clean = manage_clean_filter (*term
+                                ? *term
+                                : (get->filter ? get->filter : ""),
+                               get->ignore_max_rows_per_page);
+
+  g_free (*term);
+  *term = ensure_term_has_qod_and_overrides (clean);
+}
+
+/**
  * @brief Print the main XML content for a report to a file.
  *
  * @param[in]  report      The report.
@@ -17476,7 +17498,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
   int first_result, max_results, sort_order;
 
   FILE *out;
-  gchar *clean, *term, *sort_field, *levels, *search_phrase;
+  gchar *term, *sort_field, *levels, *search_phrase;
   gchar *min_qod, *compliance_levels;
   gchar *delta_states, *timestamp;
   int min_qod_int;
@@ -17760,13 +17782,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
       report_scan_run_status (report, &run_status);
     }
 
-  clean = manage_clean_filter (term
-                                ? term
-                                : (get->filter ? get->filter : ""),
-                               get->ignore_max_rows_per_page);
-
-  g_free (term);
-  term = ensure_term_has_qod_and_overrides (clean);
+  print_report_clean_filter (&term, get);
 
   if (filter_term_return)
     *filter_term_return = g_strdup (term);


### PR DESCRIPTION
## What

Move the filter cleaning out of `print_report_xml_start`.

## Why

To reduce the size of `print_report_xml_start`, which is very large and quite hard to follow.

## References

Follows /pull/2604.

## Manual Testing

I ran some GET_REPORTS command and checked that the terms were OK.
```sh
o m m '<get_reports report_id="3aafe571-86cb-4ecb-afc8-b405cb3c5519" filter="rows=3 apply_overrides=1 min_qod=60"/>'
#      <term>rows=3 apply_overrides=1 min_qod=60 first=1

o m m '<get_reports report_id="3aafe571-86cb-4ecb-afc8-b405cb3c5519" filter="rows=3 min_qod=60"/>'
#      <term>apply_overrides=0 rows=3 min_qod=60 first=1

o m m '<get_reports report_id="3aafe571-86cb-4ecb-afc8-b405cb3c5519" filter="rows=3 apply_overrides=1"/>'
#      <term>min_qod=70 rows=3 apply_overrides=1 first=1

o m m '<get_reports report_id="3aafe571-86cb-4ecb-afc8-b405cb3c5519" filter="rows=3"/>'
#      <term>apply_overrides=0 min_qod=70 rows=3 first=1
```

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


