### PR TITLE
Remove: file_validity field from agent installers

### DIFF
--- a/src/gmp_agent_installers.c
+++ b/src/gmp_agent_installers.c
@@ -177,23 +177,6 @@ get_agent_installers_run (gmp_parser_t *gmp_parser, GError **error)
         = agent_installer_iterator_last_update (&agent_installers);
       SENDF_TO_CLIENT_OR_FAIL ("<last_update>%s</last_update>",
                                iso_if_time (last_update));
-      
-      if (get_agent_installers_data.get.details)
-        {
-          gchar *file_validity;
-          
-          agent_installer_file_is_valid (
-              agent_installer_iterator_installer_path (&agent_installers),
-              agent_installer_iterator_checksum (&agent_installers),
-              &file_validity
-            );
-
-          SENDF_TO_CLIENT_OR_FAIL (
-            "<file_validity>%s</file_validity>",
-            file_validity
-          );
-          g_free (file_validity);
-        }
 
       SENDF_TO_CLIENT_OR_FAIL ("</agent_installer>");
 

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -8809,7 +8809,6 @@ END:VCALENDAR
           <e>version</e>
           <e>checksum</e>
           <e>last_update</e>
-          <o><e>file_validity</e></o>
         </pattern>
         <ele>
           <name>owner</name>
@@ -8951,11 +8950,6 @@ END:VCALENDAR
           <name>last_update</name>
           <summary>Time the agent installer was last updated from the feed</summary>
           <pattern><t>iso_time</t></pattern>
-        </ele>
-        <ele>
-          <name>file_validity</name>
-          <summary>Text indicating if the installer file is valid</summary>
-          <pattern>text</pattern>
         </ele>
       </ele>
       <ele>


### PR DESCRIPTION
## What
The details returned by get_agent_installers no longer includes the file validity.

## Why
For simplicity, the validity is only checked when getting the file.

## References
GEA-1319
