### PR TITLE
Remove: last_update from agent installers

### DIFF
--- a/src/gmp_agent_installers.c
+++ b/src/gmp_agent_installers.c
@@ -143,7 +143,6 @@ get_agent_installers_run (gmp_parser_t *gmp_parser, GError **error)
   SEND_GET_START ("agent_installer");
   while (1)
     {
-      time_t last_update;
       ret = get_next (&agent_installers, &get_agent_installers_data.get, &first,
                       &count, init_agent_installer_iterator);
       if (ret == 1)
@@ -172,11 +171,6 @@ get_agent_installers_run (gmp_parser_t *gmp_parser, GError **error)
         agent_installer_iterator_version (&agent_installers),
         agent_installer_iterator_checksum (&agent_installers)
       );
-
-      last_update 
-        = agent_installer_iterator_last_update (&agent_installers);
-      SENDF_TO_CLIENT_OR_FAIL ("<last_update>%s</last_update>",
-                               iso_if_time (last_update));
 
       SENDF_TO_CLIENT_OR_FAIL ("</agent_installer>");
 

--- a/src/manage_agent_installers.h
+++ b/src/manage_agent_installers.h
@@ -111,9 +111,6 @@ agent_installer_iterator_version (iterator_t*);
 const char *
 agent_installer_iterator_checksum (iterator_t*);
 
-time_t
-agent_installer_iterator_last_update (iterator_t*);
-
 int
 agent_installer_in_use (agent_installer_t);
 

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -2820,8 +2820,7 @@ create_tables ()
     "  file_extension text,"
     "  installer_path text,"
     "  version text,"
-    "  checksum text,"
-    "  last_update integer);");
+    "  checksum text);");
 
   sql ("CREATE TABLE IF NOT EXISTS agent_groups"
     " (id SERIAL PRIMARY KEY,"

--- a/src/manage_sql_agent_installers.c
+++ b/src/manage_sql_agent_installers.c
@@ -148,14 +148,12 @@ create_agent_installer_from_data (agent_installer_data_t *agent_installer_data)
                " (uuid, name, owner,"
                "  creation_time, modification_time,"
                "  description, content_type, file_extension,"
-               "  installer_path, version, checksum,"
-               "  last_update)"
+               "  installer_path, version, checksum)"
                " VALUES"
                " (%s, %s, %llu,"
                "  %ld, %ld,"
                "  %s, %s, %s,"
-               "  %s, %s, %s,"
-               "  m_now())"
+               "  %s, %s, %s)"
                " RETURNING id;",
                data_inserts->uuid,
                data_inserts->name,
@@ -214,8 +212,7 @@ update_agent_installer_from_data (agent_installer_t installer,
        "   file_extension = %s,"
        "   installer_path = %s,"
        "   version = %s,"
-       "   checksum = %s,"
-       "   last_update = m_now()"
+       "   checksum = %s"
        " WHERE id = %llu;",
        data_inserts->name,
        data_inserts->creation_time,
@@ -421,21 +418,6 @@ DEF_ACCESS (agent_installer_iterator_version,
  */
 DEF_ACCESS (agent_installer_iterator_checksum,
             GET_ITERATOR_COLUMN_COUNT + 5);
-
-/**
- * @brief Get the last update time from an agent installer iterator.
- *
- * @param[in]  iterator  Iterator.
- *
- * @return The last update time of the agent installer.
- *         Caller must only use before calling cleanup_iterator.
- */
-time_t
-agent_installer_iterator_last_update (iterator_t *iterator)
-{
-  if (iterator->done) return 0;
-  return iterator_int64 (iterator,  GET_ITERATOR_COLUMN_COUNT + 6);
-}
 
 /**
  * @brief Return whether an agent installer is in use.

--- a/src/manage_sql_agent_installers.h
+++ b/src/manage_sql_agent_installers.h
@@ -21,7 +21,7 @@
  */
 #define AGENT_INSTALLER_ITERATOR_FILTER_COLUMNS                             \
  { GET_ITERATOR_FILTER_COLUMNS, "description", "content_type",              \
-   "file_extension", "version", "last_update",                              \
+   "file_extension", "version",                              \
    NULL }
 
 /**
@@ -49,7 +49,6 @@
    { "installer_path", NULL, KEYWORD_TYPE_STRING },                         \
    { "version", NULL, KEYWORD_TYPE_STRING },                                \
    { "checksum", NULL, KEYWORD_TYPE_STRING },                               \
-   { "last_update", NULL, KEYWORD_TYPE_INTEGER },                           \
    { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                                     \
  }
 

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -8808,7 +8808,6 @@ END:VCALENDAR
           <e>file_extension</e>
           <e>version</e>
           <e>checksum</e>
-          <e>last_update</e>
         </pattern>
         <ele>
           <name>owner</name>
@@ -8945,11 +8944,6 @@ END:VCALENDAR
           <name>file_size</name>
           <summary>File size of the agent installer</summary>
           <pattern><t>integer</t></pattern>
-        </ele>
-        <ele>
-          <name>last_update</name>
-          <summary>Time the agent installer was last updated from the feed</summary>
-          <pattern><t>iso_time</t></pattern>
         </ele>
       </ele>
       <ele>
@@ -9099,8 +9093,6 @@ END:VCALENDAR
             <file_extension>zip</file_extension>
             <version>1.3.0</version>
             <checksum>sha256:3bbd04dd65dbb8b3f272bd8013d0d4b12fe54be30bb81f3e5df66306fe0fa0d3</checksum>
-            <last_update>2025-05-06T11:12:57Z</last_update>
-            <file_validity>valid</file_validity>
           </agent_installer>
         </get_agent_installers_response>
       </response>


### PR DESCRIPTION
## What
The last_update field is removed from the agent_installers table and the get_agent_installers GMP command.

## Why
This is done as a simplification.

## References
GEA-1310