### PR TITLE
Fix: Remove unused agent_installers_sql parameters

### DIFF
--- a/src/manage_agent_installers.c
+++ b/src/manage_agent_installers.c
@@ -473,9 +473,7 @@ agent_installers_json_handle_list_items (gvm_json_pull_parser_t *parser,
               cJSON_Delete (entry);
               return -1;
             }
-          else if (agent_installers_json_handle_entry (entry,
-                                                       rebuild,
-                                                       installers_list_sql)) {
+          else if (agent_installers_json_handle_entry (entry, rebuild)) {
             cJSON_Delete (entry);
             return -1;
           }


### PR DESCRIPTION
## What
The agent_installers_sql parameter / variable has been removed from the agent installer sync functions.

## Why
The variable was an unused leftover from a discarded approach for syncing the agent installers.
