### PR TITLE
replicate images community to openvas-enterprise-container-dev

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -52,7 +52,7 @@ jobs:
       images: |
         ghcr.io/${{ github.repository }},enable=true
         ${{ vars.GREENBONE_REGISTRY }}/community/${{ github.event.repository.name }},enable=${{ github.event_name != 'pull_request' && matrix.build.name == 'default' }}
-        ${{ vars.GREENBONE_REGISTRY }}/enterprise/${{ github.event.repository.name }},enable=${{ github.event_name != 'pull_request' && matrix.build.name == 'default' }}
+        ${{ vars.GREENBONE_REGISTRY }}/openvas-enterprise-container-dev/${{ github.event.repository.name }},enable=${{ github.event_name != 'pull_request' && matrix.build.name == 'default' }}
     secrets: inherit
 
   notify:


### PR DESCRIPTION
## What

add path for openvas-enterprise-container-dev

## Why

upload images also to the openvas-enterprise-container-dev project.

## References

[DEVOPS-1808](https://jira.greenbone.net/browse/DEVOPS-1808)

## Checklist


- [ ] Tests


