### PR TITLE
Fix: Do not auto NULL-terminate alive_tests array

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -4987,7 +4987,7 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
         else if (strcasecmp ("CREATE_TARGET", element_name) == 0)
           {
             create_target_data->alive_tests
-              = g_ptr_array_new_null_terminated (0, free, TRUE);
+              = g_ptr_array_new_full (0, free);
             gvm_append_string (&create_target_data->comment, "");
             set_client_state (CLIENT_CREATE_TARGET);
           }
@@ -6189,7 +6189,7 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
             append_attribute (attribute_names, attribute_values, "target_id",
                               &modify_target_data->target_id);
             modify_target_data->alive_tests
-              = g_ptr_array_new_null_terminated (0, free, TRUE);
+              = g_ptr_array_new_full (0, free);
             set_client_state (CLIENT_MODIFY_TARGET);
           }
         else if (strcasecmp ("MODIFY_TASK", element_name) == 0)


### PR DESCRIPTION
## What
The alive_tests GArray are created with g_ptr_array_new_full instead of g_ptr_array_new_null_terminated.

## Why
The automatic NULL-termination is not really needed and using it raise the GLib version requirement.

