### PR TITLE
Fix: build failure in launch_openvasd_openvas_task due to missing credential functions

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -5487,7 +5487,7 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
             set_client_state (CLIENT_GET_CREDENTIALS);
           }
 #if ENABLE_CREDENTIAL_STORES
-        ELSE_GET_START (credential_stores, FEATURE_ID_CREDENTIAL_STORES)
+        ELSE_GET_START (credential_stores, CREDENTIAL_STORES)
 #endif /* ENABLE_CREDENTIAL_STORES */
         else if (strcasecmp ("GET_FEATURES", element_name) == 0)
           {
@@ -21618,7 +21618,7 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
         break;
 
 #if ENABLE_CREDENTIAL_STORES
-      CASE_GET_END (FEATURE_ID_CREDENTIAL_STORES, credential_stores);
+      CASE_GET_END (CREDENTIAL_STORES, credential_stores);
 #endif
 
       case CLIENT_GET_FEATURES:

--- a/src/manage.c
+++ b/src/manage.c
@@ -7245,7 +7245,6 @@ launch_openvasd_openvas_task (task_t task, target_t target, const char *scan_id,
   openvasd_target_t *openvasd_target;
   GSList *openvasd_targets, *vts;
   GHashTable *vts_hash_table;
-  openvasd_credential_t *ssh_credential, *smb_credential, *esxi_credential;
   openvasd_credential_t *snmp_credential;
   gchar *max_checks, *max_hosts, *hosts_ordering;
   GHashTable *scanner_options;
@@ -7337,6 +7336,10 @@ launch_openvasd_openvas_task (task_t task, target_t target, const char *scan_id,
   g_free (clean_finished_hosts_str);
   openvasd_targets = g_slist_append (NULL, openvasd_target);
 
+#if ENABLE_CREDENTIAL_STORES == 0
+
+  openvasd_credential_t *ssh_credential, *smb_credential, *esxi_credential;
+
   ssh_credential = (openvasd_credential_t *) target_osp_ssh_credential_db (target);
   if (ssh_credential)
     openvasd_target_add_credential (openvasd_target, ssh_credential);
@@ -7349,6 +7352,7 @@ launch_openvasd_openvas_task (task_t task, target_t target, const char *scan_id,
     (openvasd_credential_t *) target_osp_esxi_credential_db (target);
   if (esxi_credential)
     openvasd_target_add_credential (openvasd_target, esxi_credential);
+#endif
 
   snmp_credential =
     (openvasd_credential_t *) target_osp_snmp_credential (target);


### PR DESCRIPTION
## What

This change fixes a build failure in launch_openvasd_openvas_task() when compiling with ENABLE_CREDENTIAL_STORES=1.

## Why

The legacy _db credential helpers are not part of the credential-store build configuration, so compiling them with ENABLE_CREDENTIAL_STORES=1 causes build failures.



