### PR TITLE
Fix: free feed_owner_uuid in check_db_credential_stores

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -5050,6 +5050,7 @@ check_db_credential_stores ()
     {
       g_message ("%s: No feed owner set, skipping credential store creation",
                __func__);
+      g_free (feed_owner_uuid);
       return;
     }
 
@@ -5063,7 +5064,6 @@ check_db_credential_stores ()
   current_credentials.uuid = old_user_uuid;
   current_credentials.username = old_username;
   g_free (feed_owner_uuid);
-  
 #endif /* ENABLE_CREDENTIAL_STORES */
 }
 


### PR DESCRIPTION
## What

Close a leak in `check_db_credential_stores`.

## Why

Cleaner.

## Testing

I just started gvmd without a feed owner. Looks OK, the error message appeared.
