### PR TITLE
Add: Add create_agent_task_current_report for agent task reports

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -8002,7 +8002,7 @@ make_report:
   // Always create a report with TASK_STATUS_REQUESTED
   {
     int report_resp = create_agent_task_current_report (
-      task, report_id, TASK_STATUS_REQUESTED);
+      task, *report_id, TASK_STATUS_REQUESTED);
     if (report_resp != 0)
       {
         if (error && !*error) *error = g_strdup ("Could not create current report");

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -9714,32 +9714,25 @@ create_current_report (task_t task, char **report_id, task_status_t status)
  * @brief Create the current report for an agent task.
  *
  * @param[in]   task       The agent task.
- * @param[out]  report_id  Report ID.
+ * @param[in]   report_id  Report ID.
  * @param[in]   status     Run status of scan associated with report.
  *
- * @return 0 success, -1 global_current_report is already set, -2 failed to
- *         generate ID.
+ * @return 0 success, -1 global_current_report is already set, -2 failed if
+ *         there is no report ID.
  */
 int
-create_agent_task_current_report (task_t task, char **report_id, task_status_t status)
+create_agent_task_current_report (task_t task, char *report_id, task_status_t status)
 {
-  char *id;
 
   assert (global_current_report == (report_t) 0);
 
   if (global_current_report) return -1;
 
-  if (report_id == NULL) report_id = &id;
-
-  if (*report_id == NULL)
-    /* Generate report UUID. */
-    *report_id = gvm_uuid_make ();
-
-  if (*report_id == NULL) return -2;
+  if (report_id == NULL) return -2;
 
   /* Create the report. */
 
-  global_current_report = make_report (task, *report_id, status);
+  global_current_report = make_report (task, report_id, status);
 
   set_report_scheduled (global_current_report);
 

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -291,7 +291,7 @@ int
 create_current_report (task_t, char **, task_status_t);
 
 int
-create_agent_task_current_report (task_t, char **, task_status_t);
+create_agent_task_current_report (task_t, char *, task_status_t);
 
 int
 init_task_schedule_iterator (iterator_t *);


### PR DESCRIPTION
## What

Add `create_agent_task_current_report` for handling reports of agent-based tasks.
## Why

The existing `create_current_report` always generates a new UUID and starts a scan with that ID.
Agent tasks work differently: the agent controller creates the scan first and gives us a scan_id.
We then need to create a report using that existing scan_id, not a new one.

## References

GEA-1407


