### PR TITLE
Change: move copy_group and create_group to group files

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -2864,9 +2864,6 @@ int
 init_group_iterator (iterator_t *, get_data_t *);
 
 int
-create_group (const char *, const char *, const char *, int, group_t *);
-
-int
 delete_group (const char *, int);
 
 gchar *

--- a/src/manage_groups.h
+++ b/src/manage_groups.h
@@ -26,4 +26,7 @@ trash_group_writable (group_t);
 int
 group_writable (group_t);
 
+int
+create_group (const char *, const char *, const char *, int, group_t *);
+
 #endif /* not _GVMD_MANAGE_GROUPS_H */

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -579,4 +579,7 @@ convert_http_scanner_type_to_osp_type (const char *);
 int
 vector_find_filter (const gchar **, const gchar *);
 
+int
+add_users (const gchar *, resource_t, const char *);
+
 #endif /* not _GVMD_MANAGE_SQL_H */

--- a/src/manage_sql_groups.c
+++ b/src/manage_sql_groups.c
@@ -4,6 +4,7 @@
  */
 
 #include "manage_groups.h"
+#include "manage_acl.h"
 #include "manage_sql.h"
 #include "sql.h"
 
@@ -66,4 +67,98 @@ copy_group (const char *name, const char *comment, const char *group_id,
   if (new_group_return)
     *new_group_return = new;
   return 0;
+}
+
+/**
+ * @brief Find a group for a specific permission, given a UUID.
+ *
+ * @param[in]   uuid        UUID of group.
+ * @param[out]  group       Group return, 0 if successfully failed to find group.
+ * @param[in]   permission  Permission.
+ *
+ * @return FALSE on success (including if failed to find group), TRUE on error.
+ */
+gboolean
+find_group_with_permission (const char* uuid, group_t* group,
+                            const char *permission)
+{
+  return find_resource_with_permission ("group", uuid, group, permission, 0);
+}
+
+/**
+ * @brief Create a group.
+ *
+ * @param[in]   group_name       Group name.
+ * @param[in]   comment          Comment on group.
+ * @param[in]   users            Users group applies to.
+ * @param[in]   special_full     Whether to give group super on itself (full
+ *                               sharing between members).
+ * @param[out]  group            Group return.
+ *
+ * @return 0 success, 1 group exists already, 2 failed to find user, 4 user
+ *         name validation failed, 99 permission denied, -1 error.
+ */
+int
+create_group (const char *group_name, const char *comment, const char *users,
+              int special_full, group_t* group)
+{
+  int ret;
+  gchar *quoted_group_name, *quoted_comment;
+
+  assert (current_credentials.uuid);
+  assert (group_name);
+  assert (group);
+
+  sql_begin_immediate ();
+
+  if (acl_user_may ("create_group") == 0)
+    {
+      sql_rollback ();
+      return 99;
+    }
+
+  if (resource_with_name_exists (group_name, "group", 0))
+    {
+      sql_rollback ();
+      return 1;
+    }
+  quoted_group_name = sql_quote (group_name);
+  quoted_comment = comment ? sql_quote (comment) : g_strdup ("");
+  sql ("INSERT INTO groups"
+       " (uuid, name, owner, comment, creation_time, modification_time)"
+       " VALUES"
+       " (make_uuid (), '%s',"
+       "  (SELECT id FROM users WHERE uuid = '%s'),"
+       "  '%s', m_now (), m_now ());",
+       quoted_group_name,
+       current_credentials.uuid,
+       quoted_comment);
+  g_free (quoted_comment);
+  g_free (quoted_group_name);
+
+  *group = sql_last_insert_id ();
+  ret = add_users ("group", *group, users);
+
+  if (ret)
+    sql_rollback ();
+  else
+    {
+      if (special_full)
+        {
+          char *group_id;
+
+          group_id = group_uuid (*group);
+          ret = create_permission_internal (1, "Super", NULL, "group", group_id,
+                                            "group", group_id, NULL);
+          g_free (group_id);
+          if (ret)
+            {
+              sql_rollback ();
+              return ret;
+            }
+        }
+      sql_commit ();
+    }
+
+  return ret;
 }

--- a/src/manage_sql_groups.h
+++ b/src/manage_sql_groups.h
@@ -1,0 +1,13 @@
+/* Copyright (C) 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef _GVMD_MANAGE_SQL_GROUPS_H
+#define _GVMD_MANAGE_SQL_GROUPS_H
+
+gboolean
+find_group_with_permission (const char *, group_t *,
+                            const char *);
+
+#endif //_GVMD_MANAGE_SQL_GROUPS_H


### PR DESCRIPTION
## What

Move two more group functions out of `manage_sql.c`.

## Why

Reducing size of `manage_sql.c`. Better organisation.

## References
 
Follows #2658.

## Testing

Copied and created groups in GSA, looks OK.