### PR TITLE
Fix: missing cleanup on fail in print_report_xml_start

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -17792,8 +17792,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
           g_free (search_phrase);
           g_free (min_qod);
           g_free (delta_states);
-          tz_revert (ctx.zone, ctx.tz, ctx.old_tz_override);
-          return -1;
+          goto fail;
         }
       PRINT (out,
              "<timestamp>%s</timestamp>",
@@ -18197,8 +18196,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
     {
       free (uuid);
       g_free (term);
-      tz_revert (ctx.zone, ctx.tz, ctx.old_tz_override);
-      return -1;
+      goto fail;
     }
   free (uuid);
   PRINT (out,
@@ -18251,9 +18249,8 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
                                  sort_order, sort_field, f_host_ports, &results))
         {
           g_free (term);
-          tz_revert (ctx.zone, ctx.tz, ctx.old_tz_override);
           g_hash_table_destroy (f_host_ports);
-          return -1;
+          goto fail;
         }
     }
 
@@ -18324,7 +18321,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
         {
           g_free (term);
           g_hash_table_destroy (f_host_ports);
-          return -1;
+          goto fail;
         }
     }
   else if (get->details)
@@ -18339,7 +18336,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
           if (res)
             {
               g_hash_table_destroy (f_host_ports);
-              return -1;
+              goto fail;
             }
         }
     }
@@ -18824,10 +18821,8 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
                                                          result_host,
                                                          out))
                 {
-                  fclose (out);
                   cleanup_iterator (&hosts);
-                  tz_revert (ctx.zone, ctx.tz, ctx.old_tz_override);
-                  return -1;
+                  goto fail;
                 }
             }
           cleanup_iterator (&hosts);
@@ -18852,10 +18847,8 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
                                                      host,
                                                      out))
             {
-              fclose (out);
               cleanup_iterator (&hosts);
-              tz_revert (ctx.zone, ctx.tz, ctx.old_tz_override);
-              return -1;
+              goto fail;
             }
         }
       cleanup_iterator (&hosts);
@@ -18870,10 +18863,9 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
 
   if (delta == 0 && print_report_errors_xml (report, out))
     {
-      tz_revert (ctx.zone, ctx.tz, ctx.old_tz_override);
       if (host_summary_buffer)
         g_string_free (host_summary_buffer, TRUE);
-      return -1;
+      goto fail;
     }
 
   g_free (sort_field);
@@ -18898,7 +18890,6 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
   return 0;
 
   failed_delta_report:
-    fclose (out);
     g_free (sort_field);
     g_free (levels);
     g_free (search_phrase);
@@ -18909,7 +18900,6 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
   failed_print_report_host:
     if (host_summary_buffer)
         g_string_free (host_summary_buffer, TRUE);
-    tz_revert (ctx.zone, ctx.tz, ctx.old_tz_override);
     g_hash_table_destroy (f_host_ports);
 
     g_free (compliance_levels);
@@ -18929,6 +18919,9 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
         g_hash_table_destroy (f_host_logs);
         g_hash_table_destroy (f_host_false_positives);
       }
+  fail:
+    tz_revert (ctx.zone, ctx.tz, ctx.old_tz_override);
+    fclose (out);
     return -1;
 }
 


### PR DESCRIPTION
## What

Use a simple fail jump instead of trying to do the cleanup at every return.

## Why

This catches a few error exits that were not calling tz_revert and/or where not closing "out". Having so many separate returns was error prone.

Part of reducing the size of `print_report_xml_start`.

## References

Follows /pull/2662.

## Testing

I got a single report with the PR, then got the same report on the `main` branch. I made sure they were the same. I did that with two timezones just to be sure (using the `timezone` term in the filter). 

```sh
o m m '<get_reports report_id="92a09ffd-a5bd-464b-9f2c-54b78ec5ebcf" details="1" filter="timezone=Pacific/Auckland rows=3 apply_overrides=1 min_qod=60"/>' > /tmp/r-auk-main
o m m '<get_reports report_id="92a09ffd-a5bd-464b-9f2c-54b78ec5ebcf" details="1" filter="timezone=Europe/Berlin rows=3 apply_overrides=1 min_qod=60"/>' > /tmp/r-ber-main
diff /tmp/r-auk /tmp/r-auk-main
diff /tmp/r-ber /tmp/r-ber-main
```
