### PR TITLE
Add: Functions using SQL prepared statement syntax

### DIFF
--- a/src/sql.c
+++ b/src/sql.c
@@ -15,6 +15,7 @@
  */
 
 #include "sql.h"
+
 #include "utils.h"
 
 #include <assert.h>
@@ -41,10 +42,10 @@
 /* Headers of internal symbols defined in backend files. */
 
 int
-sql_prepare_internal (int, int, const char*, va_list, sql_stmt_t **);
+sql_prepare_internal (int, int, const char *, va_list, sql_stmt_t **);
 
 int
-sql_prepare_ps_internal (int, int, const char*, va_list, sql_stmt_t **);
+sql_prepare_ps_internal (int, int, const char *, va_list, sql_stmt_t **);
 
 int
 sql_exec_internal (int, sql_stmt_t *);
@@ -88,8 +89,8 @@ int log_errors = 1;
  *
  * @return Freshly allocated, quoted string. Free with g_free.
  */
-gchar*
-sql_nquote (const char* string, size_t length)
+gchar *
+sql_nquote (const char *string, size_t length)
 {
   gchar *new, *new_start;
   const gchar *start, *end;
@@ -100,7 +101,8 @@ sql_nquote (const char* string, size_t length)
   /* Count number of apostrophes. */
 
   start = string;
-  while ((start = strchr (start, '\''))) start++, count++;
+  while ((start = strchr (start, '\'')))
+    start++, count++;
 
   /* Allocate new string. */
 
@@ -110,13 +112,13 @@ sql_nquote (const char* string, size_t length)
 
   start = string;
   end = string + length;
-  for (; start < end; start++, new++)
+  for (; start < end; start++, new ++)
     {
       char ch = *start;
       if (ch == '\'')
         {
           *new = '\'';
-          new++;
+          new ++;
           *new = '\'';
         }
       else
@@ -133,8 +135,8 @@ sql_nquote (const char* string, size_t length)
  *
  * @return Freshly allocated, quoted string. Free with g_free.
  */
-gchar*
-sql_quote (const char* string)
+gchar *
+sql_quote (const char *string)
 {
   assert (string);
   return sql_nquote (string, strlen (string));
@@ -151,8 +153,8 @@ sql_quote (const char* string)
  *
  * @return Freshly allocated, quoted string. Free with g_free.
  */
-gchar*
-sql_ascii_escape_and_quote (const char* string, const char* exceptions)
+gchar *
+sql_ascii_escape_and_quote (const char *string, const char *exceptions)
 {
   gchar *escaped_string;
   gchar *quoted_string;
@@ -213,12 +215,12 @@ sql_insert (const char *string)
  *         4 deadlock, -1 error.
  */
 int
-sqlv (int retry, int syntax, char* sql, va_list args)
+sqlv (int retry, int syntax, char *sql, va_list args)
 {
   while (1)
     {
       int ret;
-      sql_stmt_t* stmt;
+      sql_stmt_t *stmt;
       va_list args_copy;
 
       /* Prepare statement.
@@ -237,7 +239,8 @@ sqlv (int retry, int syntax, char* sql, va_list args)
 
       /* Run statement. */
 
-      while ((ret = sql_exec_internal (retry, stmt)) == 1);
+      while ((ret = sql_exec_internal (retry, stmt)) == 1)
+        ;
       if ((ret == -1) && log_errors)
         g_warning ("%s: sql_exec_internal failed", __func__);
       sql_finalize (stmt);
@@ -274,9 +277,9 @@ sqlv (int retry, int syntax, char* sql, va_list args)
  * @param[in]  args   Arguments to bind to template / format string.
  */
 static void
-sql_internal (int syntax, char* sql, va_list args)
+sql_internal (int syntax, char *sql, va_list args)
 {
-  unsigned int deadlock_amount =  0;
+  unsigned int deadlock_amount = 0;
   while (1)
     {
       int ret;
@@ -289,14 +292,14 @@ sql_internal (int syntax, char* sql, va_list args)
         {
           if (deadlock_amount++ > DEADLOCK_THRESHOLD)
             {
-              g_warning("%s: %d deadlocks detected, waiting and retrying %s",
-                        __func__, deadlock_amount, sql);
+              g_warning ("%s: %d deadlocks detected, waiting and retrying %s",
+                         __func__, deadlock_amount, sql);
             }
           gvm_usleep (DEADLOCK_SLEEP);
           continue;
         }
       else if (ret)
-        abort();
+        abort ();
       break;
     }
 }
@@ -308,7 +311,7 @@ sql_internal (int syntax, char* sql, va_list args)
  * @param[in]  ...    Arguments for format string.
  */
 void
-sql (char* sql, ...)
+sql (char *sql, ...)
 {
   va_list args;
   va_start (args, sql);
@@ -328,7 +331,7 @@ sql (char* sql, ...)
  * @param[in]  ...    Statement parameters, terminated with NULL sentinel.
  */
 void
-sql_ps (char* sql, ...)
+sql_ps (char *sql, ...)
 {
   va_list args;
   va_start (args, sql);
@@ -359,7 +362,7 @@ sql_ps (char* sql, ...)
  *         3 unique constraint violation, -1 error.
  */
 static int
-sql_error_internal (int syntax, char* sql, va_list args)
+sql_error_internal (int syntax, char *sql, va_list args)
 {
   int ret;
 
@@ -389,7 +392,7 @@ sql_error_internal (int syntax, char* sql, va_list args)
  *         3 unique constraint violation, -1 error.
  */
 int
-sql_error (char* sql, ...)
+sql_error (char *sql, ...)
 {
   int ret;
   va_list args;
@@ -416,7 +419,7 @@ sql_error (char* sql, ...)
  *         3 unique constraint violation, -1 error.
  */
 int
-sql_error_ps (char* sql, ...)
+sql_error_ps (char *sql, ...)
 {
   int ret;
   va_list args;
@@ -448,7 +451,7 @@ sql_error_ps (char* sql, ...)
  *         -1 error.
  */
 static int
-sql_giveup_internal (int syntax, char* sql, va_list args)
+sql_giveup_internal (int syntax, char *sql, va_list args)
 {
   int ret;
   ret = sqlv (0, syntax, sql, args);
@@ -466,7 +469,7 @@ sql_giveup_internal (int syntax, char* sql, va_list args)
  *         -1 error.
  */
 int
-sql_giveup (char* sql, ...)
+sql_giveup (char *sql, ...)
 {
   int ret;
   va_list args;
@@ -492,7 +495,7 @@ sql_giveup (char* sql, ...)
  *         -1 error.
  */
 int
-sql_giveup_ps (char* sql, ...)
+sql_giveup_ps (char *sql, ...)
 {
   int ret;
   va_list args;
@@ -523,10 +526,10 @@ sql_giveup_ps (char* sql, ...)
  * @return 0 success, 1 too few rows, -1 error.
  */
 int
-sql_x (int syntax, char* sql, va_list args, sql_stmt_t** stmt_return)
+sql_x (int syntax, char *sql, va_list args, sql_stmt_t **stmt_return)
 {
   int ret;
-  unsigned int deadlock_amount =  0;
+  unsigned int deadlock_amount = 0;
 
   assert (stmt_return);
 
@@ -571,8 +574,8 @@ sql_x (int syntax, char* sql, va_list args, sql_stmt_t** stmt_return)
         {
           if (deadlock_amount++ > DEADLOCK_THRESHOLD)
             {
-              g_warning("%s: %d deadlocks detected, waiting and retrying %s",
-                        __func__, deadlock_amount, sql);
+              g_warning ("%s: %d deadlocks detected, waiting and retrying %s",
+                         __func__, deadlock_amount, sql);
             }
           gvm_usleep (DEADLOCK_SLEEP);
           continue;
@@ -609,9 +612,9 @@ sql_x (int syntax, char* sql, va_list args, sql_stmt_t** stmt_return)
  * @return Result of the query as an integer.
  */
 double
-sql_double_internal (int syntax, char* sql, va_list args)
+sql_double_internal (int syntax, char *sql, va_list args)
 {
-  sql_stmt_t* stmt;
+  sql_stmt_t *stmt;
   double ret;
 
   int sql_x_ret;
@@ -640,7 +643,7 @@ sql_double_internal (int syntax, char* sql, va_list args)
  * @return Result of the query as an integer.
  */
 double
-sql_double (char* sql, ...)
+sql_double (char *sql, ...)
 {
   va_list args;
   double ret;
@@ -670,7 +673,7 @@ sql_double (char* sql, ...)
  * @return Result of the query as an integer.
  */
 double
-sql_double_ps (char* sql, ...)
+sql_double_ps (char *sql, ...)
 {
   va_list args;
   double ret;
@@ -706,9 +709,9 @@ sql_double_ps (char* sql, ...)
  * @return Result of the query as an integer.
  */
 static int
-sql_int_internal (int syntax, char* sql, va_list args)
+sql_int_internal (int syntax, char *sql, va_list args)
 {
-  sql_stmt_t* stmt;
+  sql_stmt_t *stmt;
   int ret;
 
   int sql_x_ret;
@@ -737,7 +740,7 @@ sql_int_internal (int syntax, char* sql, va_list args)
  * @return Result of the query as an integer.
  */
 int
-sql_int (char* sql, ...)
+sql_int (char *sql, ...)
 {
   va_list args;
   int ret;
@@ -767,7 +770,7 @@ sql_int (char* sql, ...)
  * @return Result of the query as an integer.
  */
 int
-sql_int_ps (char* sql, ...)
+sql_int_ps (char *sql, ...)
 {
   va_list args;
   int ret;
@@ -799,12 +802,12 @@ sql_int_ps (char* sql, ...)
  *         NULL means that either the selected value was NULL or there were
  *         no rows in the result.
  */
-char*
-sql_string_internal (int syntax, char* sql, va_list args)
+char *
+sql_string_internal (int syntax, char *sql, va_list args)
 {
-  sql_stmt_t* stmt;
-  const char* ret2;
-  char* ret;
+  sql_stmt_t *stmt;
+  const char *ret2;
+  char *ret;
   int sql_x_ret;
 
   sql_x_ret = sql_x (syntax, sql, args, &stmt);
@@ -829,11 +832,11 @@ sql_string_internal (int syntax, char* sql, va_list args)
  *         NULL means that either the selected value was NULL or there were
  *         no rows in the result.
  */
-char*
-sql_string (char* sql, ...)
+char *
+sql_string (char *sql, ...)
 {
   va_list args;
-  char* ret;
+  char *ret;
 
   va_start (args, sql);
   ret = sql_string_internal (FALSE, sql, args);
@@ -856,11 +859,11 @@ sql_string (char* sql, ...)
  *         NULL means that either the selected value was NULL or there were
  *         no rows in the result.
  */
-char*
-sql_string_ps (char* sql, ...)
+char *
+sql_string_ps (char *sql, ...)
 {
   va_list args;
-  char* ret;
+  char *ret;
 
   va_start (args, sql);
   ret = sql_string_internal (TRUE, sql, args);
@@ -889,28 +892,27 @@ sql_string_ps (char* sql, ...)
  * @return 0 success, 1 too few rows, -1 error.
  */
 static int
-sql_int64_internal (int syntax, long long int* ret, char* sql,
-                    va_list args)
+sql_int64_internal (int syntax, long long int *ret, char *sql, va_list args)
 {
-  sql_stmt_t* stmt;
+  sql_stmt_t *stmt;
   int sql_x_ret;
 
   sql_x_ret = sql_x (syntax, sql, args, &stmt);
   switch (sql_x_ret)
     {
-      case  0:
-        break;
-      case  1:
-        sql_finalize (stmt);
-        return 1;
-        break;
-      default:
-        assert (0);
-        /* Fall through. */
-      case -1:
-        sql_finalize (stmt);
-        return -1;
-        break;
+    case 0:
+      break;
+    case 1:
+      sql_finalize (stmt);
+      return 1;
+      break;
+    default:
+      assert (0);
+      /* Fall through. */
+    case -1:
+      sql_finalize (stmt);
+      return -1;
+      break;
     }
   *ret = sql_column_int64 (stmt, 0);
   sql_finalize (stmt);
@@ -986,9 +988,9 @@ sql_int64_ps (long long int *ret, char *sql, ...)
  * @return Column value.  0 if no row.
  */
 static long long int
-sql_int64_0_internal (int syntax, char* sql, va_list args)
+sql_int64_0_internal (int syntax, char *sql, va_list args)
 {
-  sql_stmt_t* stmt;
+  sql_stmt_t *stmt;
   int sql_x_ret;
   long long int ret;
 
@@ -1052,7 +1054,7 @@ sql_int64_0_ps (char *sql, ...)
   return ret;
 }
 
-
+
 /* Iterators. */
 
 /**
@@ -1073,11 +1075,11 @@ sql_int64_0_ps (char *sql, ...)
  * @param[in]  args   Arguments to bind to template / format string.
  */
 static void
-init_iterator_internal (int syntax, iterator_t* iterator,
-                        const char* sql, va_list args)
+init_iterator_internal (int syntax, iterator_t *iterator, const char *sql,
+                        va_list args)
 {
   int ret;
-  sql_stmt_t* stmt;
+  sql_stmt_t *stmt;
 
   iterator->done = FALSE;
   iterator->crypt_ctx = NULL;
@@ -1101,7 +1103,7 @@ init_iterator_internal (int syntax, iterator_t* iterator,
  * @param[in]  sql       Format string for SQL.
  */
 void
-init_iterator (iterator_t* iterator, const char* sql, ...)
+init_iterator (iterator_t *iterator, const char *sql, ...)
 {
   va_list args;
   va_start (args, sql);
@@ -1122,7 +1124,7 @@ init_iterator (iterator_t* iterator, const char* sql, ...)
  * @param[in]  ...       Statement parameters, terminated with NULL sentinel.
  */
 void
-init_ps_iterator (iterator_t* iterator, const char* sql, ...)
+init_ps_iterator (iterator_t *iterator, const char *sql, ...)
 {
   va_list args;
   va_start (args, sql);
@@ -1139,9 +1141,10 @@ init_ps_iterator (iterator_t* iterator, const char* sql, ...)
  * @return Value of given column.
  */
 double
-iterator_double (iterator_t* iterator, int col)
+iterator_double (iterator_t *iterator, int col)
 {
-  if (iterator->done) abort ();
+  if (iterator->done)
+    abort ();
   return sql_column_double (iterator->stmt, col);
 }
 
@@ -1154,9 +1157,10 @@ iterator_double (iterator_t* iterator, int col)
  * @return Value of given column.
  */
 int
-iterator_int (iterator_t* iterator, int col)
+iterator_int (iterator_t *iterator, int col)
 {
-  if (iterator->done) abort ();
+  if (iterator->done)
+    abort ();
   return sql_column_int (iterator->stmt, col);
 }
 
@@ -1169,9 +1173,10 @@ iterator_int (iterator_t* iterator, int col)
  * @return Value of given column.
  */
 long long int
-iterator_int64 (iterator_t* iterator, int col)
+iterator_int64 (iterator_t *iterator, int col)
 {
-  if (iterator->done) abort ();
+  if (iterator->done)
+    abort ();
   return sql_column_int64 (iterator->stmt, col);
 }
 
@@ -1183,10 +1188,11 @@ iterator_int64 (iterator_t* iterator, int col)
  *
  * @return Value of given column.
  */
-const char*
-iterator_string (iterator_t* iterator, int col)
+const char *
+iterator_string (iterator_t *iterator, int col)
 {
-  if (iterator->done) abort ();
+  if (iterator->done)
+    abort ();
   return sql_column_text (iterator->stmt, col);
 }
 
@@ -1203,9 +1209,10 @@ iterator_string (iterator_t* iterator, int col)
  * @return Value of given column.
  */
 gchar **
-iterator_array (iterator_t* iterator, int col)
+iterator_array (iterator_t *iterator, int col)
 {
-  if (iterator->done) abort ();
+  if (iterator->done)
+    abort ();
   return sql_column_array (iterator->stmt, col);
 }
 
@@ -1215,7 +1222,7 @@ iterator_array (iterator_t* iterator, int col)
  * @param[in]  iterator  Iterator.
  */
 void
-cleanup_iterator (iterator_t* iterator)
+cleanup_iterator (iterator_t *iterator)
 {
   if (iterator == NULL)
     {
@@ -1239,11 +1246,12 @@ cleanup_iterator (iterator_t* iterator)
  * @return TRUE if there was a next item, else FALSE.
  */
 gboolean
-next (iterator_t* iterator)
+next (iterator_t *iterator)
 {
   int ret;
 
-  if (iterator->done) return FALSE;
+  if (iterator->done)
+    return FALSE;
 
   if (iterator->crypt_ctx)
     lsc_crypt_flush (iterator->crypt_ctx);

--- a/src/sql.h
+++ b/src/sql.h
@@ -32,11 +32,11 @@ typedef struct
  */
 typedef enum
 {
-  SQL_PARAM_TYPE_NULL = 0,  ///< null value
-  SQL_PARAM_TYPE_DOUBLE,    ///< double precision floating point number
-  SQL_PARAM_TYPE_INT,       ///< integer
-  SQL_PARAM_TYPE_STRING,    ///< string
-  SQL_PARAM_TYPE_RESOURCE,  ///< resource row id (resource_t)
+  SQL_PARAM_TYPE_NULL = 0, ///< null value
+  SQL_PARAM_TYPE_DOUBLE,   ///< double precision floating point number
+  SQL_PARAM_TYPE_INT,      ///< integer
+  SQL_PARAM_TYPE_STRING,   ///< string
+  SQL_PARAM_TYPE_RESOURCE, ///< resource row id (resource_t)
 } sql_param_type_t;
 
 /**
@@ -44,10 +44,10 @@ typedef enum
  */
 typedef union
 {
-  double      double_value;   ///< double precision floating point value
-  int         int_value;      ///< integer value
-  char        *str_value;     ///< string value
-  resource_t  resource_value; ///< resource row id (resource_t) value
+  double double_value;       ///< double precision floating point value
+  int int_value;             ///< integer value
+  char *str_value;           ///< string value
+  resource_t resource_value; ///< resource row id (resource_t) value
 } sql_param_value_t;
 
 /**
@@ -73,45 +73,39 @@ typedef union
  */
 typedef struct
 {
-  sql_param_type_t  type;   ///< The data type of the parameter
-  sql_param_value_t value;  ///< The value of the parameter
+  sql_param_type_t type;   ///< The data type of the parameter
+  sql_param_value_t value; ///< The value of the parameter
 } sql_param_t;
 
 /**
  * @brief Macro for a sql_param_t* literal representing a null value.
  */
-#define SQL_NULL_PARAM &((sql_param_t)                                \
-  {.type = SQL_PARAM_TYPE_NULL}                                       \
-)
+#define SQL_NULL_PARAM &((sql_param_t){.type = SQL_PARAM_TYPE_NULL})
 
 /**
  * @brief Macro for a sql_param_t* literal representing a double value.
  */
-#define SQL_DOUBLE_PARAM(p_value) &((sql_param_t)                     \
-  {.type = SQL_PARAM_TYPE_DOUBLE, .value.double_value = p_value}      \
-)
+#define SQL_DOUBLE_PARAM(p_value) \
+  &((sql_param_t){.type = SQL_PARAM_TYPE_DOUBLE, .value.double_value = p_value})
 
 /**
  * @brief Macro for a sql_param_t* literal representing an int value.
  */
-#define SQL_INT_PARAM(p_value) &((sql_param_t)                        \
-  {.type = SQL_PARAM_TYPE_INT, .value.int_value = p_value}            \
-)
+#define SQL_INT_PARAM(p_value) \
+  &((sql_param_t){.type = SQL_PARAM_TYPE_INT, .value.int_value = p_value})
 
 /**
  * @brief Macro for a sql_param_t* literal representing a string value.
  */
-#define SQL_STR_PARAM(p_value) &((sql_param_t)                        \
-  {.type = SQL_PARAM_TYPE_STRING, .value.str_value = p_value}         \
-)
+#define SQL_STR_PARAM(p_value) \
+  &((sql_param_t){.type = SQL_PARAM_TYPE_STRING, .value.str_value = p_value})
 
 /**
  * @brief Macro for a sql_param_t* literal representing a resource_t value.
  */
-#define SQL_RESOURCE_PARAM(p_value) &((sql_param_t)                   \
-  {.type = SQL_PARAM_TYPE_RESOURCE, .value.resource_value = p_value}  \
-)
-
+#define SQL_RESOURCE_PARAM(p_value)                \
+  &((sql_param_t){.type = SQL_PARAM_TYPE_RESOURCE, \
+                  .value.resource_value = p_value})
 
 /* Helpers. */
 

--- a/src/sql_pg.c
+++ b/src/sql_pg.c
@@ -13,18 +13,17 @@
 #include "ipc.h"
 #include "sql.h"
 
+#include <arpa/inet.h>
 #include <assert.h>
 #include <endian.h>
 #include <errno.h>
-#include <arpa/inet.h>
 #include <glib.h>
+#include <gvm/base/array.h>
 #include <inttypes.h>
 #include <netinet/in.h>
 #include <postgresql/libpq-fe.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <gvm/base/array.h>
 
 #undef G_LOG_DOMAIN
 /**
@@ -36,7 +35,7 @@
 /* Headers of sql.c symbols used only here. */
 
 int
-sql_x (gboolean ps_syntax, char*, va_list args, sql_stmt_t**);
+sql_x (gboolean ps_syntax, char *, va_list args, sql_stmt_t **);
 
 
 /* Types. */
@@ -46,13 +45,13 @@ sql_x (gboolean ps_syntax, char*, va_list args, sql_stmt_t**);
  */
 struct sql_stmt
 {
-  gchar *sql;             ///< SQL statement.
-  PGresult *result;       ///< Result set.
-  int current_row;        ///< Row position in results.
-  int executed;           ///< Whether statement has been executed.
-  array_t *param_values;  ///< Parameter values.
-  GArray *param_lengths;  ///< Parameter lengths (int's).
-  GArray *param_formats;  ///< Parameter formats (int's).
+  gchar *sql;            ///< SQL statement.
+  PGresult *result;      ///< Result set.
+  int current_row;       ///< Row position in results.
+  int executed;          ///< Whether statement has been executed.
+  array_t *param_values; ///< Parameter values.
+  GArray *param_lengths; ///< Parameter lengths (int's).
+  GArray *param_formats; ///< Parameter formats (int's).
 };
 
 
@@ -191,7 +190,8 @@ log_notice (void *arg, const PGresult *result)
 #ifndef NDEBUG
   char *verbose;
 
-  verbose = PQresultVerboseErrorMessage (result, PQERRORS_VERBOSE, PQSHOW_CONTEXT_ALWAYS);
+  verbose = PQresultVerboseErrorMessage (result, PQERRORS_VERBOSE,
+                                         PQSHOW_CONTEXT_ALWAYS);
   g_debug ("PQ notice: verbose: %s", verbose);
   PQfreemem (verbose);
 #endif
@@ -265,23 +265,19 @@ sql_open (const db_conn_info_t *database)
   PostgresPollingStatusType poll_status;
   int socket;
 
-  conn_info = g_strdup_printf ("dbname='%s'"
-                               " host='%s'"
-                               " port='%s'"
-                               " user='%s'"
-                               " application_name='%s'",
-                               database->name
-                                ? database->name
-                                : sql_default_database (),
-                               database->host ? database->host : "",
-                               database->port ? database->port : "",
-                               database->user ? database->user : "",
-                               "gvmd");
+  conn_info = g_strdup_printf (
+    "dbname='%s'"
+    " host='%s'"
+    " port='%s'"
+    " user='%s'"
+    " application_name='%s'",
+    database->name ? database->name : sql_default_database (),
+    database->host ? database->host : "", database->port ? database->port : "",
+    database->user ? database->user : "", "gvmd");
 
   if (semaphore_op (SEMAPHORE_DB_CONNECTIONS, -1, database->semaphore_timeout))
     {
-      g_warning ("%s: error signaling database connection semaphore",
-                 __func__);
+      g_warning ("%s: error signaling database connection semaphore", __func__);
       g_free (conn_info);
       return -1;
     }
@@ -289,15 +285,13 @@ sql_open (const db_conn_info_t *database)
   g_free (conn_info);
   if (conn == NULL)
     {
-      g_warning ("%s: PQconnectStart failed to allocate conn",
-                 __func__);
+      g_warning ("%s: PQconnectStart failed to allocate conn", __func__);
       semaphore_op (SEMAPHORE_DB_CONNECTIONS, +1, 0);
       return -1;
     }
   if (PQstatus (conn) == CONNECTION_BAD)
     {
-      g_warning ("%s: PQconnectStart to '%s' failed: %s",
-                 __func__,
+      g_warning ("%s: PQconnectStart to '%s' failed: %s", __func__,
                  database->name ? database->name : sql_default_database (),
                  PQerrorMessage (conn));
       goto fail;
@@ -329,8 +323,8 @@ sql_open (const db_conn_info_t *database)
             continue;
           if (ret < 0)
             {
-              g_warning ("%s: write select failed: %s",
-                         __func__, strerror (errno));
+              g_warning ("%s: write select failed: %s", __func__,
+                         strerror (errno));
               goto fail;
             }
           /* Poll again. */
@@ -348,16 +342,15 @@ sql_open (const db_conn_info_t *database)
             continue;
           if (ret < 0)
             {
-              g_warning ("%s: read select failed: %s",
-                         __func__, strerror (errno));
+              g_warning ("%s: read select failed: %s", __func__,
+                         strerror (errno));
               goto fail;
             }
           /* Poll again. */
         }
       else if (poll_status == PGRES_POLLING_FAILED)
         {
-          g_warning ("%s: PQconnectPoll failed",
-                     __func__);
+          g_warning ("%s: PQconnectPoll failed", __func__);
           g_warning ("%s: PQerrorMessage (conn): %s", __func__,
                      PQerrorMessage (conn));
           goto fail;
@@ -382,14 +375,13 @@ sql_open (const db_conn_info_t *database)
     {
       g_warning ("%s: PostgreSQL version 9.6 (90600) or higher is required",
                  __func__);
-      g_warning ("%s: Current version is %i", __func__,
-                 PQserverVersion (conn));
+      g_warning ("%s: Current version is %i", __func__, PQserverVersion (conn));
       goto fail;
     }
 
   return 0;
 
- fail:
+fail:
   PQfinish (conn);
   conn = NULL;
   semaphore_op (SEMAPHORE_DB_CONNECTIONS, +1, 0);
@@ -451,12 +443,12 @@ sql_last_insert_id ()
  * @return 0 success, 1 gave up, -1 error.
  */
 int
-sql_prepare_internal (int retry, int log, const char* sql, va_list args,
+sql_prepare_internal (int retry, int log, const char *sql, va_list args,
                       sql_stmt_t **stmt)
 {
   assert (stmt);
 
-  *stmt = (sql_stmt_t*) g_malloc (sizeof (sql_stmt_t));
+  *stmt = (sql_stmt_t *) g_malloc (sizeof (sql_stmt_t));
   sql_stmt_init (*stmt);
   (*stmt)->sql = g_strdup_vprintf (sql, args);
 
@@ -483,7 +475,7 @@ sql_prepare_internal (int retry, int log, const char* sql, va_list args,
  * @return 0 success, 1 gave up, -1 error.
  */
 int
-sql_prepare_ps_internal (int retry, int log, const char* sql, va_list args,
+sql_prepare_ps_internal (int retry, int log, const char *sql, va_list args,
                          sql_stmt_t **stmt)
 {
   assert (stmt);
@@ -491,7 +483,7 @@ sql_prepare_ps_internal (int retry, int log, const char* sql, va_list args,
   sql_param_t *param;
   int n_params = 0;
 
-  *stmt = (sql_stmt_t*) g_malloc (sizeof (sql_stmt_t));
+  *stmt = (sql_stmt_t *) g_malloc (sizeof (sql_stmt_t));
   sql_stmt_init (*stmt);
   (*stmt)->sql = g_strdup (sql);
 
@@ -499,8 +491,8 @@ sql_prepare_ps_internal (int retry, int log, const char* sql, va_list args,
     g_debug ("   sql: %s", (*stmt)->sql);
 
   va_copy (args_copy, args);
-  while ((param = va_arg (args_copy, sql_param_t*)) != NULL)
-    n_params ++;
+  while ((param = va_arg (args_copy, sql_param_t *)) != NULL)
+    n_params++;
   va_end (args_copy);
 
   g_ptr_array_set_size ((*stmt)->param_values, n_params);
@@ -511,36 +503,36 @@ sql_prepare_ps_internal (int retry, int log, const char* sql, va_list args,
   for (int i = 0; i < n_params; i++)
     {
       gchar *pq_value = NULL;
-      param = va_arg (args_copy, sql_param_t*);
+      param = va_arg (args_copy, sql_param_t *);
 
       switch (param->type)
-      {
+        {
         case SQL_PARAM_TYPE_NULL:
           // Send a null pointer for null values
           if (log)
-            g_debug ("sql param $%d (null)", i+1);
+            g_debug ("sql param $%d (null)", i + 1);
           break;
         case SQL_PARAM_TYPE_DOUBLE:
           pq_value = g_strdup_printf ("%lg", param->value.double_value);
           if (log)
-            g_debug ("sql param $%d (double) = %s", i+1, pq_value);
+            g_debug ("sql param $%d (double) = %s", i + 1, pq_value);
           break;
         case SQL_PARAM_TYPE_INT:
           pq_value = g_strdup_printf ("%d", param->value.int_value);
           if (log)
-            g_debug ("sql param $%d (int) = %s", i+1, pq_value);
+            g_debug ("sql param $%d (int) = %s", i + 1, pq_value);
           break;
         case SQL_PARAM_TYPE_STRING:
           pq_value = g_strdup (param->value.str_value ?: "");
           if (log)
-            g_debug ("sql param $%d (string) = %s", i+1, pq_value);
+            g_debug ("sql param $%d (string) = %s", i + 1, pq_value);
           break;
         case SQL_PARAM_TYPE_RESOURCE:
           pq_value = g_strdup_printf ("%llu", param->value.resource_value);
           if (log)
-            g_debug ("sql param $%d (resource) = %s", i+1, pq_value);
+            g_debug ("sql param $%d (resource) = %s", i + 1, pq_value);
           break;
-      }
+        }
 
       (*stmt)->param_values->pdata[i] = pq_value;
       if (pq_value)
@@ -569,18 +561,15 @@ sql_exec_internal (int retry, sql_stmt_t *stmt)
 
   if (stmt->executed == 0)
     {
-      result = PQexecParams (conn,
-                             stmt->sql,
-                             stmt->param_values->len,
-                             NULL,                 /* Default param types. */
-                             (const char* const*) stmt->param_values->pdata,
-                             (const int*) stmt->param_lengths->data,
-                             (const int*) stmt->param_formats->data,
-                             0);                   /* Results as text. */
+      result = PQexecParams (conn, stmt->sql, stmt->param_values->len,
+                             NULL, /* Default param types. */
+                             (const char *const *) stmt->param_values->pdata,
+                             (const int *) stmt->param_lengths->data,
+                             (const int *) stmt->param_formats->data,
+                             0); /* Results as text. */
       ExecStatusType status = PQresultStatus (result);
 
-      if (status != PGRES_TUPLES_OK
-          && status != PGRES_COMMAND_OK
+      if (status != PGRES_TUPLES_OK && status != PGRES_COMMAND_OK
           && status != PGRES_COPY_IN)
         {
           char *sqlstate;
@@ -596,35 +585,30 @@ sql_exec_internal (int retry, sql_stmt_t *stmt)
           else if (sqlstate && (strcmp (sqlstate, "55P03") == 0))
             {
               /* lock_not_available */
-              g_debug ("%s: lock unavailable: %s",
-                       __func__,
-                       PQresultErrorMessage(result));
+              g_debug ("%s: lock unavailable: %s", __func__,
+                       PQresultErrorMessage (result));
               return -3;
             }
           else if (sqlstate && (strcmp (sqlstate, "23505") == 0))
             {
               /* unique_violation */
-              g_warning ("%s: constraint violation: %s",
-                         __func__,
+              g_warning ("%s: constraint violation: %s", __func__,
                          PQresultErrorMessage (result));
               g_warning ("%s: SQL: %s", __func__, stmt->sql);
               return -4;
             }
-            else if (sqlstate && (strcmp (sqlstate, "40P01") == 0))
-              {
-                /* deadlock_detected */
-                g_debug ("%s: deadlock: %s",
-                         __func__,
-                         PQresultErrorMessage (result));
-                g_debug ("%s: SQL: %s", __func__, stmt->sql);
-                return -5;
-              }
+          else if (sqlstate && (strcmp (sqlstate, "40P01") == 0))
+            {
+              /* deadlock_detected */
+              g_debug ("%s: deadlock: %s", __func__,
+                       PQresultErrorMessage (result));
+              g_debug ("%s: SQL: %s", __func__, stmt->sql);
+              return -5;
+            }
           if (log_errors)
             {
-              g_warning ("%s: PQexec failed: %s (%i)",
-                         __func__,
-                         PQresultErrorMessage (result),
-                         status);
+              g_warning ("%s: PQexec failed: %s (%i)", __func__,
+                         PQresultErrorMessage (result), status);
               g_warning ("%s: SQL: %s", __func__, stmt->sql);
             }
           return -1;
@@ -722,9 +706,10 @@ sql_table_lock_wait (const char *table, int lock_timeout)
  * @return 1 if NULL, else 0.
  */
 int
-iterator_null (iterator_t* iterator, int col)
+iterator_null (iterator_t *iterator, int col)
 {
-  if (iterator->done) abort ();
+  if (iterator->done)
+    abort ();
   assert (iterator->stmt->result);
   return PQgetisnull (iterator->stmt->result, iterator->stmt->current_row, col);
 }
@@ -737,7 +722,7 @@ iterator_null (iterator_t* iterator, int col)
  * @param[in]  iterator  Iterator.
  */
 void
-iterator_rewind (iterator_t* iterator)
+iterator_rewind (iterator_t *iterator)
 {
   iterator->done = FALSE;
   iterator->stmt->current_row = -1;
@@ -797,7 +782,7 @@ sql_column_text (sql_stmt_t *stmt, int position)
   if (PQgetisnull (stmt->result, stmt->current_row, position))
     return NULL;
 
-  return (const char*) PQgetvalue (stmt->result, stmt->current_row, position);
+  return (const char *) PQgetvalue (stmt->result, stmt->current_row, position);
 }
 
 /**
@@ -822,11 +807,11 @@ sql_column_int (sql_stmt_t *stmt, int position)
 
   switch (PQftype (stmt->result, position))
     {
-      case 16:  /* BOOLOID */
-        return strcmp (cell, "f") ? 1 : 0;
+    case 16: /* BOOLOID */
+      return strcmp (cell, "f") ? 1 : 0;
 
-      default:
-        return atoi (cell);
+    default:
+      return atoi (cell);
     }
 }
 
@@ -852,11 +837,11 @@ sql_column_int64 (sql_stmt_t *stmt, int position)
 
   switch (PQftype (stmt->result, position))
     {
-      case 16:  /* BOOLOID */
-        return strcmp (cell, "f") ? 1 : 0;
+    case 16: /* BOOLOID */
+      return strcmp (cell, "f") ? 1 : 0;
 
-      default:
-        return atol (cell);
+    default:
+      return atol (cell);
     }
 }
 
@@ -880,7 +865,7 @@ sql_column_array (sql_stmt_t *stmt, int position)
 
   /* {DFN-CERT-2017-1238,DFN-CERT-2014-1366,DFN-CERT-2014-1354} */
 
-  text = (const char*) PQgetvalue (stmt->result, stmt->current_row, position);
+  text = (const char *) PQgetvalue (stmt->result, stmt->current_row, position);
   if (text && text[0] == '{')
     {
       gchar **array, **point, **last;
@@ -917,8 +902,7 @@ sql_column_array (sql_stmt_t *stmt, int position)
 
   /* This shouldn't happen. */
   assert (0);
-  g_warning ("%s: array column not NULL and does not contain array",
-             __func__);
+  g_warning ("%s: array column not NULL and does not contain array", __func__);
   return NULL;
 }
 
@@ -969,9 +953,8 @@ sql_cancel_internal ()
 int
 sql_copy_write_str (const char *str, int len)
 {
-  int put_copy_data_ret = PQputCopyData(conn,
-                                        str,
-                                        len >= 0 ? len : strlen(str));
+  int put_copy_data_ret =
+    PQputCopyData (conn, str, len >= 0 ? len : strlen (str));
   if (put_copy_data_ret == 0)
     {
       g_warning ("%s: could not send data: queue blocked", __func__);
@@ -979,8 +962,8 @@ sql_copy_write_str (const char *str, int len)
     }
   else if (put_copy_data_ret != 1)
     {
-      g_warning ("%s: could not send data: %s",
-                 __func__, PQerrorMessage(conn));
+      g_warning ("%s: could not send data: %s", __func__,
+                 PQerrorMessage (conn));
     }
 
   return 0;
@@ -1005,18 +988,16 @@ sql_copy_end ()
     }
   else if (put_copy_end_ret != 1)
     {
-      g_warning ("%s: could not send end of data: %s",
-                 __func__, PQerrorMessage(conn));
+      g_warning ("%s: could not send end of data: %s", __func__,
+                 PQerrorMessage (conn));
       return -1;
     }
 
   result = PQgetResult (conn);
   if (PQresultStatus (result) != PGRES_COMMAND_OK)
     {
-      g_warning ("%s: PQexec failed: %s (%i)",
-                  __func__,
-                  PQresultErrorMessage (result),
-                  PQresultStatus (result));
+      g_warning ("%s: PQexec failed: %s (%i)", __func__,
+                 PQresultErrorMessage (result), PQresultStatus (result));
       PQclear (result);
       return -1;
     }
@@ -1042,9 +1023,10 @@ sql_copy_escape (const char *str)
   gssize len = strlen (str);
   GString *escaped = g_string_sized_new (len);
 
-  for (i = 0; i < len; i++) {
-    switch (str[i])
-      {
+  for (i = 0; i < len; i++)
+    {
+      switch (str[i])
+        {
         case '\\':
           g_string_append (escaped, "\\\\");
           break;
@@ -1068,7 +1050,7 @@ sql_copy_escape (const char *str)
           break;
         default:
           g_string_append_c (escaped, str[i]);
-      }
-  }
+        }
+    }
   return g_string_free (escaped, FALSE);
 }


### PR DESCRIPTION
## What
Functions are added that run SQL statements using the prepared statement syntax with numbered parameters starting with a dollar sign, e.g "$1", and passing the values to the SQL library function.

## Why
These are meant to replace the current SQL statement functions that insert values directly into the SQL string in printf style. The new method is more secure because it does not require strings to be quoted explicitly.

## References
GEA-1430