### PR TITLE
Change: Use hostnames as hosts for container image scanning

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -25072,6 +25072,8 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                 }
               set_task_oci_image_target (create_task_data->task,
                                          oci_image_target);
+
+              clear_task_asset_preferences (create_task_data->task);
             }
 #endif /* ENABLE_CONTAINER_SCANNING */
 
@@ -25278,6 +25280,12 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                                       "Auto Delete count out of range"
                                       " (must be from %d to %d)"),
                     AUTO_DELETE_KEEP_MIN, AUTO_DELETE_KEEP_MAX);
+                  goto create_task_fail;
+                case 3:
+                  SENDF_TO_CLIENT_OR_FAIL
+                   (XML_ERROR_SYNTAX ("create_task",
+                                      "Asset preferences cannot be set for"
+                                      " Container Scanning tasks"));
                   goto create_task_fail;
                 default:
                   SEND_TO_CLIENT_OR_FAIL
@@ -28118,6 +28126,15 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                       error_send_to_client (error);
                       return;
                     }
+                  log_event_fail ("task", "Task",
+                                  modify_task_data->task_id,
+                                  "modified");
+                  break;
+                case 20:
+                  SEND_TO_CLIENT_OR_FAIL
+                   (XML_ERROR_SYNTAX ("modify_task",
+                                      "Asset preferences cannot be set for"
+                                      " Container Image tasks"));
                   log_event_fail ("task", "Task",
                                   modify_task_data->task_id,
                                   "modified");

--- a/src/manage.h
+++ b/src/manage.h
@@ -660,6 +660,9 @@ task_oci_image_target_in_trash (task_t);
 void
 set_task_oci_image_target (task_t, oci_image_target_t);
 
+void
+clear_task_asset_preferences (task_t);
+
 #endif /* ENABLE_CONTAINER_SCANNING */
 
 void

--- a/src/manage_container_image_scanner.c
+++ b/src/manage_container_image_scanner.c
@@ -12,6 +12,7 @@
 #if ENABLE_CONTAINER_SCANNING
 
 #include "debug_utils.h"
+#include "manage_assets.h"
 #include "manage_container_image_scanner.h"
 #include "manage_runtime_flags.h"
 #include "manage_sql.h"
@@ -134,7 +135,11 @@ add_container_image_scan_result (http_scanner_result_t res,
 
   type = convert_http_scanner_type_to_osp_type (res->type);
   test_id = res->oid;
-  host = res->ip_address;
+  // hostname is used as host since there is no IP
+  if (res->hostname && g_str_has_prefix (res->hostname, "oci://"))
+    host = res->hostname + strlen ("oci://");
+  else
+    host = res->hostname;
   hostname = res->hostname;
   port = res->port;
 
@@ -142,6 +147,9 @@ add_container_image_scan_result (http_scanner_result_t res,
   severity_str = nvt_severity (test_id, type);
   desc = res->message;
   qod_int = get_http_scanner_nvti_qod (test_id);
+
+  if (host)
+    manage_report_host_add (rep_aux->report, host, 0, 0);
 
   char *hash_value;
   if (!check_http_scanner_result_exists (rep_aux->report, rep_aux->task, res,

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -6759,6 +6759,31 @@ set_task_oci_image_target (task_t task, oci_image_target_t oci_image_target)
        task);
 }
 
+/**
+ * @brief Clear default asset preferences if set.
+ *
+ * @param[in]  task  Task.
+ */
+void
+clear_task_asset_preferences (task_t task)
+{
+  if (sql_int ("SELECT COUNT(*) FROM task_preferences"
+                " WHERE task = %llu AND name = 'in_assets';",
+                task))
+    sql ("UPDATE task_preferences"
+          " SET value = 'no'"
+          " WHERE task = %llu AND name = 'in_assets';",
+          task);
+
+  if (sql_int ("SELECT COUNT(*) FROM task_preferences"
+                " WHERE task = %llu AND name = 'assets_apply_overrides';",
+                task))
+    sql ("UPDATE task_preferences"
+          " SET value = 'no'"
+          " WHERE task = %llu AND name = 'assets_apply_overrides';",
+          task);
+}
+
 #endif
 
 /**
@@ -20812,7 +20837,9 @@ DEF_ACCESS (task_file_iterator_content, 1);
  *         delete count out of range, 15 config and scanner types mismatch,
  *         16 status must be new to edit target, 17 for import tasks only
  *         certain fields may be edited, 18 failed to find agent group,
-           19 failed to find OCI image target, -1 error.
+           19 failed to find OCI image target,
+           20 cannot set asset preferences for container image task,
+           -1 error.
  */
 int
 modify_task (const gchar *task_id, const gchar *name,
@@ -21062,6 +21089,8 @@ modify_task (const gchar *task_id, const gchar *name,
           return 13;
         case 2:
           return 14;
+        case 3:
+          return 20;
         default:
           return -1;
       }

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -2000,7 +2000,7 @@ task_preference_value (task_t task, const char *name)
  * @param[in]  preferences  Preferences.
  *
  * @return 0 success, 1 invalid auto_delete value, 2 auto_delete_data out of
- *         range.
+ *         range, 3 in_assets cannot be set for Container Image scanners.
  */
 int
 set_task_preferences (task_t task, array_t *preferences)
@@ -2035,9 +2035,12 @@ set_task_preferences (task_t task, array_t *preferences)
                           || keep > AUTO_DELETE_KEEP_MAX)
                         return 2;
                     }
-
+                  int type = scanner_type (task_scanner (task));
                   if ((strcmp (pair->name, "in_assets") == 0)
-                      && scanner_type (task_scanner (task)) == SCANNER_TYPE_CVE)
+                      && type == SCANNER_TYPE_CONTAINER_IMAGE)
+                      return 3;
+                  else if ((strcmp (pair->name, "in_assets") == 0)
+                      && type == SCANNER_TYPE_CVE)
                     quoted_value = g_strdup ("no");
                   else
                     quoted_value = sql_quote (pair->value);


### PR DESCRIPTION
## What

Use hostnames as hosts for container image scanning.
Disable adding results to assets for container image scanning tasks.

## Why
Hosts are required for exporting reports in different formats.

## References
GEA-1454

