### PR TITLE
Prevent sql injection in acl_role_can_super_everyone()

### DIFF
--- a/src/manage_acl.c
+++ b/src/manage_acl.c
@@ -172,12 +172,12 @@ acl_role_can_super_everyone (const char *role_id)
         /*                    Super on everyone. */
         "                AND (resource = 0)"
         "                AND subject_location"
-        "                    = " G_STRINGIFY (
-          LOCATION_TABLE) "                AND (subject_type = 'role'"
-                          "                     AND subject"
-                          "                         = (SELECT id"
-                          "                            FROM roles"
-                          "                            WHERE uuid = $1)));",
+        "                    = " G_STRINGIFY (LOCATION_TABLE)
+        "                AND (subject_type = 'role'"
+        "                     AND subject"
+        "                         = (SELECT id"
+        "                            FROM roles"
+        "                            WHERE uuid = $1)));",
         SQL_STR_PARAM (role_id), NULL))
     {
       return 1;


### PR DESCRIPTION
## What

Use prepared statements in acl_role_can_super_everyone()

## Why

Prevent SQL injection attack

## References

GEA-1421
