### PR TITLE
Add: add asset_snapshots for agent counting

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -8134,6 +8134,7 @@ fork_agent_controller_scan_handler (task_t task, agent_group_t agent_group,
       hosts_set_identifiers (global_current_report);
       hosts_set_max_severity (global_current_report, NULL, NULL);
       hosts_set_details (global_current_report);
+      asset_snapshots_agent (global_current_report, task, agent_group);
       set_task_run_status (task, TASK_STATUS_DONE);
       set_report_scan_run_status (global_current_report, TASK_STATUS_DONE);
     }

--- a/src/manage_agents.h
+++ b/src/manage_agents.h
@@ -208,5 +208,8 @@ get_agent_controller_agents_from_uuids (scanner_t scanner,
 const gchar *
 agent_response_to_string (agent_response_t code);
 
+gchar *
+agent_id_by_uuid (const gchar *agent_uuid);
+
 #endif // _GVMD_MANAGE_AGENTS_H
 #endif // ENABLE_AGENTS

--- a/src/manage_assets.h
+++ b/src/manage_assets.h
@@ -156,4 +156,9 @@ asset_snapshot_add_report_host_identifier(const gchar*,
 int
 asset_snapshot_collect_report_identifiers (const char *);
 
+#if ENABLE_AGENTS
+void
+asset_snapshots_agent (report_t, task_t, agent_group_t);
+#endif
+
 #endif /* not _GVMD_MANAGE_ASSETS_H */

--- a/src/manage_sql_agents.c
+++ b/src/manage_sql_agents.c
@@ -781,6 +781,22 @@ agent_id_by_uuid_and_scanner (const gchar *agent_uuid, scanner_t scanner_id,
 }
 
 /**
+ * @brief Get an agent ID by agent UUID.
+ *
+ * @param[in]  agent_uuid  Agent UUID to look up.
+ *
+ * @return Newly allocated agent_id string (caller frees), or NULL.
+ */
+gchar *
+agent_id_by_uuid (const gchar *agent_uuid)
+{
+  g_return_val_if_fail (agent_uuid != NULL, NULL);
+
+  return sql_string ("SELECT agent_id FROM agents WHERE uuid = '%s';",
+                     agent_uuid);
+}
+
+/**
  * @brief Check if an agent is authorized.
  *
  * @param[in] agent_uuid   The UUID of the agent.


### PR DESCRIPTION
## What

- Added agent asset snapshots to store agents discovered during a scan in `asset_snapshots`.

## Why

- Agent asset counting requires snapshot data after a scan has completed.

## References

GEA-1468



