### PR TITLE
Add: tag discovery NVTs during fork_update_nvt_cache

### DIFF
--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1299,6 +1299,8 @@ fork_update_nvt_cache (pid_t *child_pid_out)
             update_nvt_cache_retry ();
           }
 
+        manage_discovery_nvts ();
+
         /* Exit. */
 
         cleanup_manage_process (FALSE);


### PR DESCRIPTION
## What

- Label NVTs that are used for discovery with a `discovery` tag during `fork_update_nvt_cache`.


## Why

- We need a reliable way to distinguish discovery-only NVTs from vulnerability-scanning NVTs.

## References

GEA-1439


