### PR TITLE
Fix: use filtered FPs when calculating filtered_result_count

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -18705,7 +18705,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
         {
           if (count_filtered)
             filtered_result_count = f_criticals + f_holes + f_infos + f_logs
-                                    + f_warnings + false_positives;
+                                    + f_warnings + f_false_positives;
 
           PRINT (out,
                 "<result_count>"


### PR DESCRIPTION
## What

In `print_report_xml_start` use the filtered false positive variable in the `filtered_result_count` calculation when `count_filtered` is true.

Note that `count_filtered` is true when getting the details and ignoring pagination.

## Why

Like the other counts, the false positives must use the filtered count, otherwise the `RESULT_COUNT/FILTERED` element includes all the FPs, even when they've been filtered out.

For example with main below only **Lows** are being included (`levels=l`). There are only 2 low results but FILTERED is 4. This is because the FALSE_POSITIVES/FULL count is being included in FILTERED.
```
$ o m m '<get_reports report_id="82f3531c-43cd-4453-8300-990dc423d96b" details="1" ignore_pagination="1" filter="apply_overrides=1 levels=l"/>'
    <result_count>
      <filtered>4</filtered>
      ...
      <low>
        <full>2</full>
        <filtered>2</filtered>
      </low>
      <false_positive>
        <full>2</full>
        <filtered>0</filtered>
      </false_positive>
    </result_count>
```
Below is the result with the PR, where FILTERED is correctly 2.
```
$ o m m '<get_reports report_id="82f3531c-43cd-4453-8300-990dc423d96b" details="1" ignore_pagination="1" filter="apply_overrides=1 levels=l"/>'
    <result_count>
      <filtered>2</filtered>
      ...
      <low>
        <full>2</full>
        <filtered>2</filtered>
      </low>
      <false_positive>
        <full>2</full>
        <filtered>0</filtered>
      </false_positive>
    </result_count>
```