### PR TITLE
Change: move delete_group to group files

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -2869,9 +2869,6 @@ set_schedule_timeout (int);
 int
 init_group_iterator (iterator_t *, get_data_t *);
 
-int
-delete_group (const char *, int);
-
 gchar *
 group_users (group_t);
 

--- a/src/manage_groups.h
+++ b/src/manage_groups.h
@@ -29,4 +29,7 @@ group_writable (group_t);
 int
 create_group (const char *, const char *, const char *, int, group_t *);
 
+int
+delete_group (const char *, int);
+
 #endif /* not _GVMD_MANAGE_GROUPS_H */

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -471,6 +471,12 @@ permissions_set_locations (const char *, resource_t, resource_t, int);
 void
 permissions_set_orphans (const char *, resource_t, int);
 
+void
+permissions_set_subjects (const char *, resource_t, resource_t, int);
+
+void
+cache_all_permissions_for_users (GArray *);
+
 int
 copy_resource (const char *, const char *, const char *, const char *,
                const char *, int, resource_t *, resource_t *);


### PR DESCRIPTION
## What

Move `delete_group` out of `manage_sql.c`.

## Why

Reducing the size of manage_sql.c. Better organisation.

## References

Follows /pull/2661.

## Testing

I removed a group in GSA, seems OK. (Needs https://github.com/greenbone/gsad/pull/283 though.)

