### PR TITLE
Docs: generate to docs instead of doc

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = @CMAKE_BINARY_DIR@/doc/generated
+OUTPUT_DIRECTORY       = @CMAKE_BINARY_DIR@/docs/generated
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and

--- a/docs/Doxyfile_full.in
+++ b/docs/Doxyfile_full.in
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = @CMAKE_BINARY_DIR@/doc/generated
+OUTPUT_DIRECTORY       = @CMAKE_BINARY_DIR@/docs/generated
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and

--- a/docs/Doxyfile_xml.in
+++ b/docs/Doxyfile_xml.in
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = @CMAKE_BINARY_DIR@/doc/generated
+OUTPUT_DIRECTORY       = @CMAKE_BINARY_DIR@/docs/generated
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and


### PR DESCRIPTION
## What

Set Doxygen output to `docs/generated` instead of `doc/generated`.

## Why

In bdcd9ce doc/ was renamed to docs/, which caused Doxygen to fail because it was trying to build in doc/.

## References

bdcd9ce is from /pull/2505.

