### PR TITLE
Change: move first few role functions to dedicated files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -176,6 +176,7 @@ set(
   manage_resources.c
   manage_report_configs.c
   manage_report_formats.c
+  manage_roles.c
   manage_runtime_flags.c
   manage_authentication.c
   manage_settings.c
@@ -216,6 +217,7 @@ set(
   manage_sql_configs.c
   manage_sql_report_configs.c
   manage_sql_report_formats.c
+  manage_sql_roles.c
   manage_sql_tickets.c
   manage_sql_tls_certificates.c
   manage_sql_nvts_osp.c
@@ -675,6 +677,7 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_preferences.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_runtime_flags.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_report_formats.c"
+  "${CMAKE_CURRENT_SOURCE_DIR}/manage_roles.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_authentication.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql_agent_installers.c"
@@ -688,6 +691,7 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql_oci_image_targets.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql_port_lists.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql_report_formats.c"
+  "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql_roles.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql_secinfo.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql_tickets.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql_tls_certificates.c"

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -102,6 +102,7 @@
 #include "manage_port_lists.h"
 #include "manage_report_configs.h"
 #include "manage_report_formats.h"
+#include "manage_roles.h"
 #include "manage_runtime_flags.h"
 #include "manage_tls_certificates.h"
 #include "sql.h"

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -95,6 +95,7 @@
 #include "manage_sql_secinfo.h"
 #include "manage_authentication.h"
 #include "manage_runtime_flags.h"
+#include "manage_roles.h"
 #include "manage_scan_queue.h"
 #include "gmpd.h"
 #include "utils.h"

--- a/src/manage.h
+++ b/src/manage.h
@@ -2949,9 +2949,6 @@ delete_permissions_cache_for_user (user_t);
 /* Roles. */
 
 int
-manage_get_roles (GSList *, const db_conn_info_t *, int);
-
-int
 init_role_iterator (iterator_t *, get_data_t *);
 
 int
@@ -2968,12 +2965,6 @@ role_uuid (role_t);
 
 gchar *
 role_users (role_t);
-
-int
-trash_role_in_use (role_t);
-
-int
-role_in_use (role_t);
 
 int
 trash_role_writable (role_t);

--- a/src/manage_roles.c
+++ b/src/manage_roles.c
@@ -1,0 +1,38 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "manage_roles.h"
+
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md manage"
+
+/**
+ * @brief Check whether a role is in use.
+ *
+ * @param[in]  role  Role.
+ *
+ * @return 1 yes, 0 no.
+ */
+int
+role_in_use (role_t role)
+{
+  return 0;
+}
+
+/**
+ * @brief Check whether a trashcan role is in use.
+ *
+ * @param[in]  role  Role.
+ *
+ * @return 1 yes, 0 no.
+ */
+int
+trash_role_in_use (role_t role)
+{
+  return 0;
+}

--- a/src/manage_roles.h
+++ b/src/manage_roles.h
@@ -1,0 +1,22 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef _GVMD_MANAGE_ROLES_H
+#define _GVMD_MANAGE_ROLES_H
+
+#include "manage_get.h"
+#include "manage_resources.h"
+#include "sql.h" // Sadly, for db_conn_info_t
+
+int
+manage_get_roles (GSList *, const db_conn_info_t *, int);
+
+int
+trash_role_in_use (role_t);
+
+int
+role_in_use (role_t);
+
+#endif /* not _GVMD_MANAGE_ROLES_H */

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -33,6 +33,7 @@
 #include "manage_groups.h"
 #include "manage_port_lists.h"
 #include "manage_report_formats.h"
+#include "manage_roles.h"
 #include "manage_runtime_flags.h"
 #include "manage_sql_credential_stores.h"
 #include "manage_sql_copy.h"
@@ -35105,43 +35106,6 @@ clean_feed_role_permissions (const char *type,
 /* Roles. */
 
 /**
- * @brief List roles.
- *
- * @param[in]  log_config  Log configuration.
- * @param[in]  database    Location of manage database.
- * @param[in]  verbose     Whether to print UUID.
- *
- * @return 0 success, -1 error.
- */
-int
-manage_get_roles (GSList *log_config, const db_conn_info_t *database,
-                  int verbose)
-{
-  iterator_t roles;
-  int ret;
-
-  g_info ("   Getting roles.");
-
-  ret = manage_option_setup (log_config, database,
-                             0 /* avoid_db_check_inserts */);
-  if (ret)
-    return ret;
-
-  init_iterator (&roles, "SELECT name, uuid FROM roles;");
-  while (next (&roles))
-    if (verbose)
-      printf ("%s %s\n", iterator_string (&roles, 0), iterator_string (&roles, 1));
-    else
-      printf ("%s\n", iterator_string (&roles, 0));
-
-  cleanup_iterator (&roles);
-
-  manage_option_cleanup ();
-
-  return 0;
-}
-
-/**
  * @brief Create a role from an existing role.
  *
  * @param[in]  name       Name of new role.  NULL to copy from existing.
@@ -35558,32 +35522,6 @@ int
 trash_role_writable (role_t role)
 {
   return 1;
-}
-
-/**
- * @brief Check whether a role is in use.
- *
- * @param[in]  role  Role.
- *
- * @return 1 yes, 0 no.
- */
-int
-role_in_use (role_t role)
-{
-  return 0;
-}
-
-/**
- * @brief Check whether a trashcan role is in use.
- *
- * @param[in]  role  Role.
- *
- * @return 1 yes, 0 no.
- */
-int
-trash_role_in_use (role_t role)
-{
-  return 0;
 }
 
 /**

--- a/src/manage_sql_roles.c
+++ b/src/manage_sql_roles.c
@@ -1,0 +1,53 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "manage_roles.h"
+#include "manage_acl.h"
+#include "manage_sql.h"
+#include "sql.h"
+
+/**
+ * @file
+ * @brief GVM management layer: Roles SQL
+ *
+ * The Roles SQL for the GVM management layer.
+ */
+
+/**
+ * @brief List roles.
+ *
+ * @param[in]  log_config  Log configuration.
+ * @param[in]  database    Location of manage database.
+ * @param[in]  verbose     Whether to print UUID.
+ *
+ * @return 0 success, -1 error.
+ */
+int
+manage_get_roles (GSList *log_config, const db_conn_info_t *database,
+                  int verbose)
+{
+  iterator_t roles;
+  int ret;
+
+  g_info ("   Getting roles.");
+
+  ret = manage_option_setup (log_config, database,
+                             0 /* avoid_db_check_inserts */);
+  if (ret)
+    return ret;
+
+  init_iterator (&roles, "SELECT name, uuid FROM roles;");
+  while (next (&roles))
+    if (verbose)
+      printf ("%s %s\n", iterator_string (&roles, 0), iterator_string (&roles, 1));
+    else
+      printf ("%s\n", iterator_string (&roles, 0));
+
+  cleanup_iterator (&roles);
+
+  manage_option_cleanup ();
+
+  return 0;
+}


### PR DESCRIPTION
## What

Move first few functions out of the `Roles` section of `manage_sql.c`.

## Why

Reduces the size of `manage_sql.c` to make it easier to work with. Also for better organization of the resources.

## References

Similar to #2694 for Groups.

## Testing

I ran gvmd --get-roles. Looked OK.

I also ran GET_GROUPS, comparing the output to main:
``` sh
# on main
o m m '<get_roles/>' > /tmp/r-main
o m m '<get_roles trash="1"/>' > /tmp/r-main-trash
# with pr
o m m '<get_roles/>' > /tmp/r-pr
o m m '<get_roles trash="1"/>' > /tmp/r-pr-trash
diff /tmp/r-main /tmp/r-pr
diff /tmp
```