### PR TITLE
Fix: Allow @ in container image references

### DIFF
--- a/src/manage_oci_image_targets.c
+++ b/src/manage_oci_image_targets.c
@@ -175,7 +175,7 @@ valid_oci_url (const gchar *oci_url)
   g_free (port);
 
   const gchar *url_component_regex = "^[a-zA-Z0-9_\\-.]+$";
-  const gchar *url_component_with_tag_regex = "^[a-zA-Z0-9_\\-.:]+$";
+  const gchar *url_component_with_tag_regex = "^[a-zA-Z0-9_\\-.:@]+$";
 
   for (int i = 1; i < parts_len; i++)
     {


### PR DESCRIPTION
## What

Allow @ in container image references when creating/modifying an OCI image target

## Why

To allow to manually specify images with sha256sum instead of a tag.

## References

GEA-1501


