### PR TITLE
Fix: check ENABLE_OPENVASD instead of OPENVASD

### DIFF
--- a/src/manage_runtime_flags.c
+++ b/src/manage_runtime_flags.c
@@ -35,11 +35,11 @@
 #define ENABLE_CONTAINER_SCANNING 0
 #endif
 
-#ifndef OPENVASD
+#ifndef ENABLE_OPENVASD
 /**
  * @brief Whether to enable openvasd scanners.
  */
-#define OPENVASD 0
+#define ENABLE_OPENVASD 0
 #endif
 
 #ifndef ENABLE_CREDENTIAL_STORES


### PR DESCRIPTION
## What

Check `ENABLE_OPENVASD` instead of `OPENVASD` in `manage_runtime_flags.c`.

## Why

It's ENABLE_OPENVASD everywhere else. 

## References

Looks like this was missed in a57e5e7c8c63a00d60290c6b52e3a4d2a30bde85.

## Testing

I compiled it both ways, checking with GET_FEATURES, looks OK.