### PR TITLE
Add: Extend agent sync scheduling to include AGENT_CONTROLLER_SENSOR scanners

### DIFF
--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -1609,7 +1609,10 @@ fork_agents_sync ()
           while (next (&scanner_iterator))
             {
               scanner_t scanner = get_iterator_resource (&scanner_iterator);
-              if (scanner && scanner_type (scanner) == SCANNER_TYPE_AGENT_CONTROLLER)
+              if (scanner && (scanner_type (scanner) ==
+                              SCANNER_TYPE_AGENT_CONTROLLER
+                              || scanner_type (scanner) ==
+                              SCANNER_TYPE_AGENT_CONTROLLER_SENSOR))
                 {
                   gvmd_agent_connector_t connector =
                     gvmd_agent_connector_new_from_scanner (scanner);


### PR DESCRIPTION


## What

This PR allows agent sync scheduling to include scanners of type `SCANNER_TYPE_AGENT_CONTROLLER_SENSOR`.

## Why

Agent controller sensor scanners also require agent synchronization and were previously excluded from the scheduling logic.

