### PR TITLE
Add: Add asset snapshot count output to gvmd command option

### DIFF
--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -2223,6 +2223,7 @@ gvmd (int argc, char** argv, char *env[])
   static gboolean disable_password_policy = FALSE;
   static gboolean disable_scheduling = FALSE;
   static gboolean dump_vt_verification = FALSE;
+  static gboolean dump_asset_snapshot_counts = FALSE;
   static gchar *encryption_key_type = NULL;
   static int encryption_key_length = 0;
   static gchar *set_encryption_key = NULL;
@@ -2406,6 +2407,10 @@ gvmd (int argc, char** argv, char *env[])
         { "dump-vt-verification", '\0', 0, G_OPTION_ARG_NONE,
           &dump_vt_verification,
           "Dump the string the VTs verification hash is calculated from.",
+          NULL },
+        { "dump-asset-snapshot-counts", '\0', 0, G_OPTION_ARG_NONE,
+          &dump_asset_snapshot_counts,
+          "Dump the string the Asset snapshot counts are calculated from.",
           NULL },
         { "encryption-key-length", '\0', 0, G_OPTION_ARG_INT,
           &encryption_key_length,
@@ -3306,6 +3311,25 @@ gvmd (int argc, char** argv, char *env[])
       if (ret)
         {
           printf ("Failed to dump VT verification data.\n");
+          return EXIT_FAILURE;
+        }
+      return EXIT_SUCCESS;
+    }
+
+  if (dump_asset_snapshot_counts)
+    {
+      int ret;
+
+      setproctitle ("--dump-asset-snapshot-counts");
+
+      if (option_lock (&lockfile_checking))
+        return EXIT_FAILURE;
+
+      ret = manage_dump_asset_snapshot_counts (log_config, &database);
+      log_config_free ();
+      if (ret)
+        {
+          printf ("Failed to dump Asset snapshot counts.\n");
           return EXIT_FAILURE;
         }
       return EXIT_SUCCESS;

--- a/src/manage.h
+++ b/src/manage.h
@@ -3530,6 +3530,9 @@ manage_rebuild (GSList *, const db_conn_info_t *);
 int
 manage_dump_vt_verification (GSList *, const db_conn_info_t *);
 
+int
+manage_dump_asset_snapshot_counts(GSList *, const db_conn_info_t *);
+
 
 /* Wizards. */
 


### PR DESCRIPTION
## What

Adds a gvmd command helper that queries `asset_snapshots` and logs **distinct** `asset_key` counts, including the total count and a per-asset-type breakdown (target, agent, container image).

## Why

This information is required in a dedicated log that is included in the support package to help diagnose asset snapshot counts.
 
## References

GEA-1505



