### PR TITLE
Fix: Check runtime flag for agent_installers sync

### DIFF
--- a/src/manage_agent_installers.c
+++ b/src/manage_agent_installers.c
@@ -12,6 +12,7 @@
 
 #include "gmp_base.h"
 #include "manage_agent_installers.h"
+#include "manage_runtime_flags.h"
 #include "manage_sql_agent_installers.h"
 #include "manage_users.h"
 
@@ -605,7 +606,9 @@ should_sync_agent_installers ()
 #if ENABLE_AGENTS
   time_t db_last_update;
   GStatBuf state;
-  if (! agent_installers_feed_metadata_file_exists ())
+
+  if (! feature_enabled (FEATURE_ID_AGENTS)
+      || ! agent_installers_feed_metadata_file_exists ())
     return FALSE;
 
   db_last_update = get_meta_agent_installers_last_update ();


### PR DESCRIPTION
## What
The should_sync_agent_installers function now always returns FALSE if the agents runtime feature flag is disabled.

## Why
This fixes gvmd trying to sync the agent installers indefinitely when the build flag for agents is enabled flag, an installers metadata file exists but the runtime flag is disabled. As a side effect the discovery NVTs update would also be triggered repeatedly.

## References
GEA-1508

