### PR TITLE
Add: Support update_to_latest in GMP agent update command

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,7 +32,7 @@ if(ENABLE_AGENTS)
   pkg_check_modules(
     LIBGVM_AGENT_CONTROLLER
     REQUIRED
-    libgvm_agent_controller>=22.30
+    libgvm_agent_controller>=22.35
   )
 else(ENABLE_AGENTS)
   message(STATUS "ENABLE_AGENTS flag is not enabled")

--- a/src/gmp_agents.c
+++ b/src/gmp_agents.c
@@ -480,6 +480,8 @@ modify_agent_run (gmp_parser_t *gmp_parser, GError **error)
   entity_t e = NULL;
   if ((e = entity_child (root, "authorized")))
     update->authorized = atoi (entity_text (e));
+  if ((e = entity_child (root, "update_to_latest")))
+    update->update_to_latest = atoi (entity_text (e));
   entity_t cfg_e = entity_child (root, "config");
 
   if (cfg_e)

--- a/src/manage_agents.c
+++ b/src/manage_agents.c
@@ -184,6 +184,7 @@ convert_agent_control_list_to_agent_data_list (
       dest->operating_system = g_strdup (src->operating_system);
       dest->architecture = g_strdup (src->architecture);
       dest->update_to_latest = src->update_to_latest;
+      dest->last_updater_heartbeat = src->last_updater_heartbeat;
 
       dest->scanner = scanner;
 

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -30082,6 +30082,7 @@ END:VCALENDAR
     <pattern>
       <e>agents</e>
       <o><e>authorized</e></o>
+      <o><e>update_to_latest</e></o>
       <o><e>config</e></o>
       <o><e>comment</e></o>
     </pattern>
@@ -30105,6 +30106,12 @@ END:VCALENDAR
     <ele>
       <name>authorized</name>
       <summary>Authorization flag (1 for authorized, 0 for not)</summary>
+      <pattern><t>integer</t></pattern>
+      <required>0</required>
+    </ele>
+    <ele>
+      <name>update_to_latest</name>
+      <summary>Enable auto update for agent flag (1 for enable to auto update, 0 for not)</summary>
       <pattern><t>integer</t></pattern>
       <required>0</required>
     </ele>
@@ -30199,6 +30206,7 @@ END:VCALENDAR
             <agent id="fb6451bf-ec5a-45a8-8bab-5cf4b862e51b"/>
           </agents>
           <authorized>1</authorized>
+          <update_to_latest>1</update_to_latest>
           <config>
             <agent_control>
               <retry>


### PR DESCRIPTION
## What

Updates gvmd to align with gvm-libs changes and extends the GMP agent update command by adding the update_to_latest XML tag.

## Why

This enables clients to explicitly request updating agents to the latest available version via the GMP interface.

## References

GEA-1512


