### PR TITLE
Fix: Fix passing parameter for sql_string_ps

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -1339,7 +1339,7 @@ resource_name (const char *type, const char *uuid, int location, char **name)
                              "             FROM tasks WHERE id = task)"
                              "    END)"
                              " FROM reports"
-                             " WHERE uuid = '$1';",
+                             " WHERE uuid = $1;",
                              SQL_STR_PARAM (uuid), NULL);
     }
   else if (strcasecmp (type, "result") == 0)
@@ -1356,7 +1356,7 @@ resource_name (const char *type, const char *uuid, int location, char **name)
                              "             FROM tasks WHERE id = task)"
                              "    END)"
                              " FROM results"
-                             " WHERE uuid = '$1';",
+                             " WHERE uuid = $1;",
                              SQL_STR_PARAM (uuid), NULL);
     }
   else if (location == LOCATION_TABLE)


### PR DESCRIPTION
## What
Fix passing the `uuid` to `sql_string_ps` by removing the quoting.

## Why
Before the fix, the following warning appears when deleting a report:
```
md manage:WARNING:2026-01-20 17h39.10 utc:121223: sql_exec_internal: PQexec failed: ERROR:  bind message supplies 1 parameters, but prepared statement "" requires 0
 (7)
md manage:WARNING:2026-01-20 17h39.10 utc:121223: sql_exec_internal: SQL: SELECT (SELECT name FROM tasks WHERE id = task) || ' - ' || (SELECT       CASE (SELECT end_time FROM tasks             WHERE id = task)       WHEN 0 THEN 'N/A'       ELSE (SELECT iso_time (end_time)             FROM tasks WHERE id = task)    END) FROM reports WHERE uuid = '$1';
md manage:WARNING:2026-01-20 17h39.10 utc:121223: sql_x: sql_exec_internal failed
```
