### PR TITLE
Change: Update libgvm container image scanner version.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,7 +46,7 @@ if(ENABLE_CONTAINER_SCANNING)
   pkg_check_modules(
     LIBGVM_CONTAINER_IMAGE_SCANNER
     REQUIRED
-    libgvm_container_image_scanner>=22.30
+    libgvm_container_image_scanner>=22.35
   )
 else(ENABLE_CONTAINER_SCANNING)
   message(STATUS "ENABLE_CONTAINER_SCANNING flag is not enabled")


### PR DESCRIPTION
## What
Update libgvm container image scanner version to latest

## Why
The changes are necessary for pause/resume functionality in container scanning

## References
GEA-1519

