### PR TITLE
Fix: Guard oci_image_targets and agents ALTER with IF EXISTS

### DIFF
--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -3524,7 +3524,8 @@ migrate_264_to_265 ()
 
   // Add exclude_images field to oci_image_targets
 
-  sql ("ALTER TABLE oci_image_targets ADD COLUMN exclude_images text;");
+  sql ("ALTER TABLE oci_image_targets IF EXISTS"
+       " ADD COLUMN IF NOT EXISTS exclude_images text;");
 
   /* Set the database version to 265. */
 
@@ -3558,12 +3559,12 @@ migrate_265_to_266 ()
   // Add agent_update_available and updater_update_available fields to agents
 
   sql (
-    "ALTER TABLE agents"
-    " ADD COLUMN agent_update_available INTEGER NOT NULL DEFAULT 0;"
+    "ALTER TABLE agents IF EXISTS"
+    " ADD COLUMN IF NOT EXISTS agent_update_available INTEGER NOT NULL DEFAULT 0;"
     );
   sql (
-    "ALTER TABLE agents"
-    " ADD COLUMN updater_update_available INTEGER NOT NULL DEFAULT 0;"
+    "ALTER TABLE agents IF EXISTS"
+    " ADD COLUMN IF NOT EXISTS updater_update_available INTEGER NOT NULL DEFAULT 0;"
     );
 
   /* Set the database version to 266. */


### PR DESCRIPTION
## What

Guard the agents and oci_image_targets migration steps by using `IF EXISTS `(and `IF NOT EXISTS` where applicable) so the DB migration does not fail when feature-flag tables are missing.

## Why

Some databases don’t have these feature-flag tables, and migrations run before `check_db()/create_tables()`, so unguarded `ALTER TABLE` statements can abort the upgrade.

## References

GEA-1529



