### PR TITLE
Docs: Expand on gvm-libs prerequisite

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,7 +14,7 @@ Prerequisites:
 * glib-2.0 >= 2.42
 * gnutls >= 3.2.15
 * gpgme
-* [gvm-libs](https://github.com/greenbone/gvm-libs/) >= 22.34
+* [gvm-libs](https://github.com/greenbone/gvm-libs/) >= 22.34 (or 22.35 if you ENABLE_AGENTS or ENABLE_CONTAINER_SCANNING)
 * libical >= 1.0.0
 * libbsd
 * pkg-config


### PR DESCRIPTION
## What

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

Expand install instructions regarding gvm-libs prerequisite.

Compared the install instructions with the cmake lists.

## Why

<!-- Describe why are these changes necessary? -->

0ce5accf7 and a4ce00ae4 bumped the required version for parts of lib-gvm if ENABLE_AGENTS or ENABLE_CONTAINER_SCANNING are set. Note that in the install instructions to keep the surprise factor low.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->