### PR TITLE
Change: move first functions to dedicated permissions files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -171,6 +171,7 @@ set(
   manage_license.c
   manage_openvas.c
   manage_osp.c
+  manage_permissions.c
   manage_port_lists.c
   manage_preferences.c
   manage_resources.c
@@ -183,6 +184,7 @@ set(
   manage_tls_certificates.c
   manage_utils.c
   manage_migrators.c
+  manage_permissions.c
   manage_pg.c
   manage_scan_handler.c
   manage_scan_queue.c
@@ -214,6 +216,7 @@ set(
   manage_sql_groups.c
   manage_sql_nvts.c
   manage_sql_secinfo.c
+  manage_sql_permissions.c
   manage_sql_port_lists.c
   manage_sql_configs.c
   manage_sql_report_configs.c
@@ -675,6 +678,7 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_get.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_groups.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_oci_image_targets.c"
+  "${CMAKE_CURRENT_SOURCE_DIR}/manage_permissions.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_port_lists.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_preferences.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_runtime_flags.c"
@@ -691,6 +695,7 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql_configs.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql_nvts.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql_oci_image_targets.c"
+  "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql_permissions.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql_port_lists.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql_report_formats.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/manage_sql_roles.c"

--- a/src/gmp_get.c
+++ b/src/gmp_get.c
@@ -14,6 +14,7 @@
 #include "gmp_base.h"
 #include "manage_acl.h"
 #include "manage_filters.h"
+#include "manage_permissions.h"
 
 #include <stdlib.h>
 #include <string.h>

--- a/src/manage.h
+++ b/src/manage.h
@@ -2898,9 +2898,6 @@ char*
 permission_uuid (permission_t);
 
 int
-permission_is_admin (const char *);
-
-int
 permission_in_use (permission_t);
 
 int

--- a/src/manage_permissions.c
+++ b/src/manage_permissions.c
@@ -1,0 +1,29 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "manage_sql_permissions.h"
+
+#include <string.h>
+
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md manage"
+
+/**
+ * @brief Test whether a permission is the special Admin permission.
+ *
+ * @param[in]  permission_id  UUID of permission.
+ *
+ * @return 1 permission is Admin, else 0.
+ */
+int
+permission_is_admin (const char *permission_id)
+{
+  if (permission_id)
+    return strcmp (permission_id, PERMISSION_UUID_ADMIN_EVERYTHING);
+  return 0;
+}

--- a/src/manage_permissions.h
+++ b/src/manage_permissions.h
@@ -1,0 +1,12 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef _GVMD_MANAGE_PERMISSIONS_H
+#define _GVMD_MANAGE_PERMISSIONS_H
+
+int
+permission_is_admin (const char *);
+
+#endif /* not _GVMD_MANAGE_PERMISSIONS_H */

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -46,6 +46,7 @@
 #include "manage_sql_filters.h"
 #include "manage_sql_groups.h"
 #include "manage_sql_oci_image_targets.h"
+#include "manage_sql_permissions.h"
 #include "manage_sql_port_lists.h"
 #include "manage_sql_report_configs.h"
 #include "manage_sql_report_formats.h"
@@ -33092,36 +33093,6 @@ modify_schedule (const char *schedule_id, const char *name, const char *comment,
 /* Permissions. */
 
 /**
- * @brief Adjust location of resource in permissions.
- *
- * @param[in]   type  Type.
- * @param[in]   old   Resource ID in old table.
- * @param[in]   new   Resource ID in new table.
- * @param[in]   to    Destination, trash or table.
- */
-void
-permissions_set_locations (const char *type, resource_t old, resource_t new,
-                           int to)
-{
-  sql ("UPDATE permissions SET resource_location = %i, resource = %llu"
-       " WHERE resource_type = '%s' AND resource = %llu"
-       " AND resource_location = %i;",
-       to,
-       new,
-       type,
-       old,
-       to == LOCATION_TABLE ? LOCATION_TRASH : LOCATION_TABLE);
-  sql ("UPDATE permissions_trash SET resource_location = %i, resource = %llu"
-       " WHERE resource_type = '%s' AND resource = %llu"
-       " AND resource_location = %i;",
-       to,
-       new,
-       type,
-       old,
-       to == LOCATION_TABLE ? LOCATION_TRASH : LOCATION_TABLE);
-}
-
-/**
  * @brief Set permissions to orphan.
  *
  * @param[in]  type      Type.
@@ -33934,21 +33905,6 @@ permission_is_predefined (permission_t permission)
                     "                  OR uuid = '" ROLE_UUID_SUPER_ADMIN "'"
                     "                  OR uuid = '" ROLE_UUID_OBSERVER "')))",
                     permission);
-}
-
-/**
- * @brief Test whether a permission is the special Admin permission.
- *
- * @param[in]  permission_id  UUID of permission.
- *
- * @return 1 permission is Admin, else 0.
- */
-int
-permission_is_admin (const char *permission_id)
-{
-  if (permission_id)
-    return strcmp (permission_id, PERMISSION_UUID_ADMIN_EVERYTHING);
-  return 0;
 }
 
 /**

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -38,16 +38,6 @@
 /**
  * @brief Predefined role UUID.
  */
-#define PERMISSION_UUID_ADMIN_EVERYTHING "b3b56a8c-c2fd-11e2-a135-406186ea4fc5"
-
-/**
- * @brief Predefined role UUID.
- */
-#define PERMISSION_UUID_SUPER_ADMIN_EVERYTHING "a9801074-6fe2-11e4-9d81-406186ea4fc5"
-
-/**
- * @brief Predefined role UUID.
- */
 #define ROLE_UUID_ADMIN "7a8cb5b4-b74d-11e2-8187-406186ea4fc5"
 
 /**
@@ -471,9 +461,6 @@ tags_remove_resource (const char *, resource_t, int);
 
 void
 tags_set_locations (const char *, resource_t, resource_t, int);
-
-void
-permissions_set_locations (const char *, resource_t, resource_t, int);
 
 void
 permissions_set_orphans (const char *, resource_t, int);

--- a/src/manage_sql_agent_groups.c
+++ b/src/manage_sql_agent_groups.c
@@ -18,6 +18,7 @@
 #include "manage_sql_agent_groups.h"
 #include "manage_sql_agents.h"
 #include "manage_sql_copy.h"
+#include "manage_sql_permissions.h"
 
 #include <util/uuidutils.h>
 

--- a/src/manage_sql_alerts.c
+++ b/src/manage_sql_alerts.c
@@ -7,6 +7,7 @@
 #include "manage_acl.h"
 #include "manage_sql.h"
 #include "manage_sql_filters.h"
+#include "manage_sql_permissions.h"
 #include "manage_sql_report_formats.h"
 
 #include <ctype.h>

--- a/src/manage_sql_configs.c
+++ b/src/manage_sql_configs.c
@@ -14,6 +14,7 @@
 #include "manage_acl.h"
 #include "manage_sql.h"
 #include "manage_sql_nvts.h"
+#include "manage_sql_permissions.h"
 #include "sql.h"
 
 #include <assert.h>

--- a/src/manage_sql_filters.c
+++ b/src/manage_sql_filters.c
@@ -8,6 +8,7 @@
 #include "manage_filter_utils.h"
 #include "manage_settings.h"
 #include "manage_sql.h"
+#include "manage_sql_permissions.h"
 
 #include <ctype.h>
 

--- a/src/manage_sql_groups.c
+++ b/src/manage_sql_groups.c
@@ -6,6 +6,7 @@
 #include "manage_sql_groups.h"
 #include "manage_acl.h"
 #include "manage_sql.h"
+#include "manage_sql_permissions.h"
 #include "manage_sql_users.h"
 #include "sql.h"
 

--- a/src/manage_sql_oci_image_targets.c
+++ b/src/manage_sql_oci_image_targets.c
@@ -8,6 +8,7 @@
 #include "debug_utils.h"
 #include "manage_sql_oci_image_targets.h"
 #include "manage_acl.h"
+#include "manage_sql_permissions.h"
 #include "sql.h"
 #include "utils.h"
 

--- a/src/manage_sql_permissions.c
+++ b/src/manage_sql_permissions.c
@@ -1,0 +1,45 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "manage_sql_permissions.h"
+#include "manage_acl.h"
+#include "sql.h"
+
+/**
+ * @file
+ * @brief GVM management layer: Permissions SQL
+ *
+ * The Permissions SQL for the GVM management layer.
+ */
+
+/**
+ * @brief Adjust location of resource in permissions.
+ *
+ * @param[in]   type  Type.
+ * @param[in]   old   Resource ID in old table.
+ * @param[in]   new   Resource ID in new table.
+ * @param[in]   to    Destination, trash or table.
+ */
+void
+permissions_set_locations (const char *type, resource_t old, resource_t new,
+                           int to)
+{
+  sql ("UPDATE permissions SET resource_location = %i, resource = %llu"
+       " WHERE resource_type = '%s' AND resource = %llu"
+       " AND resource_location = %i;",
+       to,
+       new,
+       type,
+       old,
+       to == LOCATION_TABLE ? LOCATION_TRASH : LOCATION_TABLE);
+  sql ("UPDATE permissions_trash SET resource_location = %i, resource = %llu"
+       " WHERE resource_type = '%s' AND resource = %llu"
+       " AND resource_location = %i;",
+       to,
+       new,
+       type,
+       old,
+       to == LOCATION_TABLE ? LOCATION_TRASH : LOCATION_TABLE);
+}

--- a/src/manage_sql_permissions.h
+++ b/src/manage_sql_permissions.h
@@ -1,0 +1,25 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef _GVMD_MANAGE_SQL_PERMISSIONS_H
+#define _GVMD_MANAGE_SQL_PERMISSIONS_H
+
+#include "manage_permissions.h"
+#include "manage_resources.h"
+
+/**
+ * @brief Predefined role UUID.
+ */
+#define PERMISSION_UUID_ADMIN_EVERYTHING "b3b56a8c-c2fd-11e2-a135-406186ea4fc5"
+
+/**
+ * @brief Predefined role UUID.
+ */
+#define PERMISSION_UUID_SUPER_ADMIN_EVERYTHING "a9801074-6fe2-11e4-9d81-406186ea4fc5"
+
+void
+permissions_set_locations (const char *, resource_t, resource_t, int);
+
+#endif //_GVMD_MANAGE_SQL_PERMISSIONS_H

--- a/src/manage_sql_port_lists.c
+++ b/src/manage_sql_port_lists.c
@@ -12,6 +12,7 @@
 
 #include "manage_sql_port_lists.h"
 #include "manage_acl.h"
+#include "manage_sql_permissions.h"
 #include "sql.h"
 
 #include <errno.h>

--- a/src/manage_sql_report_configs.c
+++ b/src/manage_sql_report_configs.c
@@ -13,6 +13,7 @@
 #include "debug_utils.h"
 #include "manage_sql_report_configs.h"
 #include "manage_acl.h"
+#include "manage_sql_permissions.h"
 #include "manage_sql_report_formats.h"
 #include "sql.h"
 #include "utils.h"

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -13,6 +13,7 @@
 #include "debug_utils.h"
 #include "manage_sql_report_formats.h"
 #include "manage_acl.h"
+#include "manage_sql_permissions.h"
 #include "manage_sql_report_configs.h"
 #include "manage_sql_users.h"
 #include "sql.h"

--- a/src/manage_sql_roles.c
+++ b/src/manage_sql_roles.c
@@ -6,6 +6,7 @@
 #include "manage_sql_roles.h"
 #include "manage_acl.h"
 #include "manage_sql.h"
+#include "manage_sql_permissions.h"
 #include "manage_sql_users.h"
 #include "sql.h"
 

--- a/src/manage_sql_tickets.c
+++ b/src/manage_sql_tickets.c
@@ -13,6 +13,7 @@
 #include "manage_sql_tickets.h"
 #include "manage_acl.h"
 #include "manage_sql.h"
+#include "manage_sql_permissions.h"
 #include "sql.h"
 
 #include <stdlib.h>


### PR DESCRIPTION
## What

Move first two functions out of the Permissions section of `manage_sql.c`. 

## Why

Next small step in reducing the size of `manage_sql.c`. Also for better organisation of resources. 

## References

Like /pull/2723 for Users.

## Testing

Moved a permission in and out of the trash. Browsed permissions. Looks OK.