### PR TITLE
docs: fix get_features command example in documentation

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -14168,8 +14168,7 @@ END:VCALENDAR
     <example>
       <summary>Get the optional features</summary>
       <request>
-        <get_feeds>
-        </get_feeds>
+        <get_features/>
       </request>
       <response>
         <get_features_response status="200" status_text="OK">


### PR DESCRIPTION
## What

This PR updates the documentation example for the get_features command by replacing the outdated get_feed example.

## Why

The existing documentation references get_feed, which is not the correct command and may confuse users.



