### PR TITLE
Clear password from memory

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -554,6 +554,9 @@ typedef struct
 static void
 create_credential_data_reset (create_credential_data_t *data)
 {
+  memset (data->password, 0, strlen (data->password));
+  memset (data->privacy_password, 0, strlen (data->privacy_password));
+
   free (data->allow_insecure);
   free (data->certificate);
   free (data->comment);
@@ -1211,6 +1214,8 @@ typedef struct
 static void
 create_user_data_reset (create_user_data_t * data)
 {
+  memset (data->password, 0, strlen (data->password));
+
   g_free (data->copy);
   array_free (data->groups);
   g_free (data->name);
@@ -2644,6 +2649,9 @@ typedef struct
 static void
 modify_credential_data_reset (modify_credential_data_t *data)
 {
+  memset (data->password, 0, strlen (data->password));
+  memset (data->privacy_password, 0, strlen (data->password));
+
   free (data->allow_insecure);
   free (data->auth_algorithm);
   free (data->certificate);
@@ -3220,6 +3228,8 @@ typedef struct
 static void
 modify_user_data_reset (modify_user_data_t * data)
 {
+  memset (data->password, 0, strlen (data->password));
+
   array_free (data->groups);
   g_free (data->name);
   g_free (data->new_name);
@@ -12866,7 +12876,8 @@ handle_get_credentials (gmp_parser_t *gmp_parser, GError **error)
   SEND_GET_START("credential");
   while (1)
     {
-      const char *login, *type, *cert, *private_key, *password, *public_key;
+      char *cert, *private_key, *password;
+      const char *login, *type, *public_key;
       gchar *formats_xml;
 
       ret = get_next (&credentials, &get_credentials_data->get,
@@ -13193,6 +13204,10 @@ handle_get_credentials (gmp_parser_t *gmp_parser, GError **error)
 #endif
       SEND_TO_CLIENT_OR_FAIL ("</credential>");
       count++;
+
+      memset (cert, 0, strlen (cert));
+      memset (private_key, 0, strlen (private_key));
+      memset (password, 0, strlen (password));
     }
 
   cleanup_iterator (&credentials);

--- a/src/manage_alerts.c
+++ b/src/manage_alerts.c
@@ -2033,6 +2033,8 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
 
   if (!gvm_file_is_readable (script))
     {
+      memset (clean_password, 0, strlen (clean_password));
+
       g_free (report_file);
       g_free (pkcs12_file);
       g_free (clean_password);
@@ -2054,6 +2056,9 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
         g_warning ("%s: Failed to getcwd: %s",
                    __func__,
                    strerror (errno));
+
+        memset (clean_password, 0, strlen (clean_password));
+
         g_free (report_file);
         g_free (pkcs12_file);
         g_free (clean_password);
@@ -2068,6 +2073,9 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
         g_warning ("%s: Failed to chdir: %s",
                    __func__,
                    strerror (errno));
+
+        memset (clean_password, 0, strlen (clean_password));
+
         g_free (report_file);
         g_free (pkcs12_file);
         g_free (clean_password);
@@ -2091,6 +2099,10 @@ send_to_sourcefire (const char *ip, const char *port, const char *pkcs12_64,
                                pkcs12_file,
                                report_file,
                                clean_password);
+
+
+    memset (clean_password, 0, strlen (clean_password));
+    
     g_free (script);
     g_free (clean_ip);
     g_free (clean_port);
@@ -2423,6 +2435,9 @@ send_to_verinice (const char *url, const char *username, const char *password,
                                    clean_url,
                                    clean_username,
                                    archive_file);
+
+    memset (clean_password, 0, strlen (clean_password));
+
     g_free (script);
     g_free (clean_url);
     g_free (clean_username);
@@ -4402,6 +4417,9 @@ trigger_to_vfire (alert_t alert, task_t task, report_t report, event_t event,
       get_data_reset (alert_filter_get);
       g_free (alert_filter_get);
     }
+
+  memset (password, 0, strlen (password));
+
   free (base_url);
   free (session_type);
   free (client_id);
@@ -4938,6 +4956,8 @@ trigger (alert_t alert, task_t task, report_t report, event_t event,
                                      message, strlen (message),
                                      script_message);
 
+                  memset (password, 0, strlen (password));
+
                   g_free (message);
                   free (private_key);
                   free (password);
@@ -5004,6 +5024,8 @@ trigger (alert_t alert, task_t task, report_t report, event_t event,
                                  host, port, alert_path, known_hosts,
                                  report_content, content_length,
                                  script_message);
+
+              memset (password, 0, strlen (password));
 
               free (private_key);
               free (password);
@@ -5215,6 +5237,8 @@ trigger (alert_t alert, task_t task, report_t report, event_t event,
                                   max_protocol, report_content, content_length,
                                   script_message);
 
+          memset (password, 0, strlen (password));
+
           g_free (username);
           g_free (password);
           free (credential_id);
@@ -5377,6 +5401,8 @@ trigger (alert_t alert, task_t task, report_t report, event_t event,
           ret = send_to_sourcefire (ip, port, pkcs12, pkcs12_password,
                                     report_content);
 
+          memset (pkcs12_password, 0, strlen (pkcs12_password));
+
           free (ip);
           g_free (port);
           free (pkcs12);
@@ -5486,6 +5512,8 @@ trigger (alert_t alert, task_t task, report_t report, event_t event,
           g_free (extension);
           if (ret)
             {
+              memset (password, 0, strlen (password));
+
               g_free (username);
               g_free (password);
               g_free (hostname);
@@ -5498,6 +5526,8 @@ trigger (alert_t alert, task_t task, report_t report, event_t event,
                                       username, password, hostname,
                                       certificate, tls_cert_workaround,
                                       script_message);
+
+          memset (password, 0, strlen (password));
 
           g_free (username);
           g_free (password);
@@ -5576,6 +5606,8 @@ trigger (alert_t alert, task_t task, report_t report, event_t event,
 
               ret = send_to_verinice (url, username, password, report_content,
                                       content_length);
+
+              memset (password, 0, strlen (password));
 
               free (url);
               g_free (username);

--- a/src/manage_openvas.c
+++ b/src/manage_openvas.c
@@ -268,7 +268,7 @@ set_auth_data_ssh_from_credential_store (iterator_t *iter,
     = credential_iterator_host_identifier (iter);
 
   if (cyberark_login_password_credential_data (cred_store_uuid,
-                                               vault_id,
+                                               vault_id,gm
                                                host_identifier,
                                                &login,
                                                &password))
@@ -306,6 +306,8 @@ set_auth_data_ssh_from_credential_store (iterator_t *iter,
                                     "priv_password",
                                     password);
     }
+
+  memset (password, 0, strlen (password));
 
   g_free (login);
   g_free (password);
@@ -390,6 +392,8 @@ set_auth_data_up_from_credential_store (iterator_t *iter,
   osp_credential_set_auth_data (osp_credential, "username", login);
   osp_credential_set_auth_data (osp_credential, "password", password);
 
+  memset (password, 0, strlen (password));
+
   g_free (login);
   g_free (password);
   return 0;
@@ -440,6 +444,9 @@ set_auth_data_snmp_from_credential_store (iterator_t *iter,
       g_debug ("%s: Error retrieving SNMP privacy password from"
                " CyberArk credential store '%s'.",
                __func__, cred_store_uuid);
+
+      password (password, 0, strlen (password));
+
       g_free (login);
       g_free (password);
       g_free (privacy_password);
@@ -450,6 +457,9 @@ set_auth_data_snmp_from_credential_store (iterator_t *iter,
   osp_credential_set_auth_data (osp_credential, "password", password);
   osp_credential_set_auth_data (osp_credential, "privacy_password",
                                 privacy_password);
+
+  memset(password, 0, strlen (password));
+  memset(privacy_password, 0, strlen (privacy_password));
 
   g_free (login);
   g_free (password);


### PR DESCRIPTION
## What
Before the memory related to a password (and other private values) is freed, we will now clear them from memory.

## Why
This will ensure that auth/credential related values are available in memory for as short as absolutely necessary. This will prevent potential that an attacker could get access to the auth/credential values.

## References
https://jira.greenbone.net/browse/GEA-1158