### PR TITLE
Fix: prevent build warnings from Postgres includes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -153,6 +153,12 @@ include_directories(
   ${PostgreSQL_SERVER_INCLUDE_DIRS}
 )
 
+# PostgreSQL headers and macros trigger -Wredundant-decls in this file.
+set_source_files_properties(
+  manage_pg_server.c
+  PROPERTIES COMPILE_OPTIONS "-Wno-redundant-decls"
+)
+
 # Source lists
 set(
   ALL_MANAGE_SRC


### PR DESCRIPTION
## What

Turn off `-Wno-redundant-decl` for `manage_pg_server.c`.

## Why

Postgres headers and macros like PG_FUNCTION_INFO_V1 are including code into the file that trigger the redundant declaration warning.

Because they're used all over the file it's cleanest to just disable the warning.

A bit unsure why I'm suddenly seeing this. Perhaps due to a GCC/Postgres upgrade.

## Testing

Compiles.


