### PR TITLE
Require CMake >= 3.18 and update copyright year in README

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 
 message("-- Configuring Greenbone Vulnerability Manager...")
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,7 +9,7 @@ install dependent development packages.
 Prerequisites:
 
 * cJSON >= 1.7.14
-* cmake >= 3.5
+* cmake >= 3.18
 * GCC
 * glib-2.0 >= 2.42
 * gnutls >= 3.2.15

--- a/README.md
+++ b/README.md
@@ -110,6 +110,6 @@ gersemi -i cmake .
 
 ## License
 
-Copyright (C) 2009-2025 [Greenbone AG](https://www.greenbone.net/)
+Copyright (C) 2009-2026 [Greenbone AG](https://www.greenbone.net/)
 
 Licensed under the [GNU Affero General Public License v3.0 or later](COPYING).


### PR DESCRIPTION



## What

Require CMake >= 3.18 and update copyright year in README

## Why

CMake 3.18 is the version in Debian Bullseye. This this should be the minimum version we support.

## References

Closes #2749