### PR TITLE
fix: Add connection_status to agent filter columns macro

### DIFF
--- a/src/manage_sql_agents.h
+++ b/src/manage_sql_agents.h
@@ -57,7 +57,7 @@
       "creation_time", "modification_time", "owner", "id", "updater_version",  \
       "agent_version", "operating_system", "architecture", "update_to_latest", \
       "agent_update_available", "updater_update_available",                    \
-      "latest_agent_version", "latest_updater_version",                        \
+      "latest_agent_version", "latest_updater_version", "connection_status",   \
       NULL                                                                     \
   }
 


### PR DESCRIPTION
## What

This PR adds connection_status to the agent filter columns macro.

## Why

`connection_status` was missing from the agent filter columns macro, which caused it to be unsorted for filtering logic.

## References

GEA-1547


