### PR TITLE
Fix: remove old transaction functions

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -30354,9 +30354,6 @@ process_gmp_client_input ()
   gboolean success;
   GError* error = NULL;
 
-  /* Terminate any pending transaction. (force close = TRUE). */
-  manage_transaction_stop (TRUE);
-
   if (xml_context == NULL) return -1;
 
   success = g_markup_parse_context_parse (xml_context,
@@ -30447,9 +30444,6 @@ process_gmp (gmp_parser_t *parser, const gchar *command, gchar **response)
   GMarkupParseContext *old_xml_context;
   client_state_t old_client_state;
   command_data_t old_command_data;
-
-  /* Terminate any pending transaction. (force close = TRUE). */
-  manage_transaction_stop (TRUE);
 
   if (response) *response = NULL;
 

--- a/src/manage.h
+++ b/src/manage.h
@@ -262,9 +262,6 @@ validate_sort_field (const gchar*, const gchar*);
 void
 manage_session_set_timezone (const char *);
 
-void
-manage_transaction_stop (gboolean);
-
 
 /* Task macros and structures. */
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -298,16 +298,6 @@ static nvtis_t* nvti_cache = NULL;
 db_conn_info_t gvmd_db_conn_info = { NULL, NULL, NULL, NULL, 60 };
 
 /**
- * @brief Whether a transaction has been opened and not committed yet.
- */
-static gboolean in_transaction;
-
-/**
- * @brief Time of reception of the currently processed message.
- */
-static struct timeval last_msg;
-
-/**
  * @brief The VT verification collation override
  */
 static gchar *vt_verification_collation = NULL;
@@ -20504,31 +20494,6 @@ clean_hosts (const char *given_hosts, int *max)
     }
 
   return g_string_free (clean, FALSE);
-}
-
-/**
- * @brief Commit the current transaction, if any.
- *
- * The algorithm is extremely naive (time elapsed since the last message
- * was received) but delivers good enough performances when facing
- * bursts of messages.
- *
- * @param[in] force_commit  Force committing the pending transaction.
- */
-void
-manage_transaction_stop (gboolean force_commit)
-{
-  struct timeval now;
-
-  if (!in_transaction)
-    return;
-
-  gettimeofday (&now, NULL);
-  if (force_commit || TIMEVAL_SUBTRACT_MS (now, last_msg) >= 500)
-    {
-      sql_commit ();
-      in_transaction = FALSE;
-    }
 }
 
 /**


### PR DESCRIPTION
## What

Remove `manage_transaction_start` and `manage_transaction_stop`.

## Why

These transaction functions were last used by the OTP handling, which was removed in 558e957ecef57f9fb3786b5d2fefbc1078add4e8.

This is part of reducing the size of `manage_sql.c`.

## References

Follows /pull/2759.

## Testing

Compiles, tests pass, modifying target works.

