### PR TITLE
Fix: remove hosts_str_contains

### DIFF
--- a/src/manage_utils.c
+++ b/src/manage_utils.c
@@ -233,40 +233,6 @@ level_max_severity (const char *level)
 }
 
 /**
- * @brief Returns whether a host has an equal host in a hosts string.
- *
- * For example, 192.168.10.1 has an equal in a hosts string
- * "192.168.10.1-5, 192.168.10.10-20" string while 192.168.10.7 doesn't.
- *
- * @param[in] hosts_str      Hosts string to check.
- * @param[in] find_host_str  The host to find.
- * @param[in] max_hosts      Maximum number of hosts allowed in hosts_str.
- *
- * @return 1 if host has equal in hosts_str, 0 otherwise.
- */
-int
-hosts_str_contains (const char *hosts_str, const char *find_host_str,
-                    int max_hosts)
-{
-  gvm_hosts_t *hosts, *find_hosts;
-
-  hosts = gvm_hosts_new_with_max (hosts_str, max_hosts);
-  find_hosts = gvm_hosts_new_with_max (find_host_str, 1);
-
-  if (hosts == NULL || find_hosts == NULL || find_hosts->count != 1)
-    {
-      gvm_hosts_free (hosts);
-      gvm_hosts_free (find_hosts);
-      return 0;
-    }
-
-  int ret = gvm_host_in_hosts (find_hosts->hosts[0], NULL, hosts);
-  gvm_hosts_free (hosts);
-  gvm_hosts_free (find_hosts);
-  return ret;
-}
-
-/**
  * @brief Check whether a resource type table name is valid.
  *
  * @param[in]  type  Type of resource.

--- a/src/manage_utils.h
+++ b/src/manage_utils.h
@@ -54,9 +54,6 @@ level_max_severity (const char *);
 int
 valid_db_resource_type (const char *);
 
-int
-hosts_str_contains (const char *, const char *, int);
-
 void
 blank_control_chars (char *);
 


### PR DESCRIPTION
## What

Remove old function `hosts_str_contains`.

## Why

This was used in the SQL backend implementations of hosts_contains. The Postgres one was moved out in 5d48d2f163316a4b8fd86ddd6bcd00d70b839494. Sqlite was removed entirely in 8b46f655bbaaf8c2cca1f4103545afa2c0609224.

## Testing

Compiles fine.

