### PR TITLE
Docs: add port list to CREATE_TARGET GMP example

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -6377,6 +6377,7 @@ END:VCALENDAR
         <create_target>
           <name>All GNU/Linux machines</name>
           <hosts>192.168.1.0/24</hosts>
+          <port_list id="33d0cd82-57c6-11e1-8ed1-406186ea4fc5"/>
         </create_target>
       </request>
       <response>


### PR DESCRIPTION
## What

Add PORT_LIST to the CREATE_TARGET GMP doc eg.

## Why

A port list or port range is required.