### PR TITLE
Fix: Check if pg-gvm version is newer instead of equal

### DIFF
--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -3631,8 +3631,10 @@ check_db_extensions ()
       sql ("CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\"");
       sql ("CREATE EXTENSION IF NOT EXISTS \"pgcrypto\"");
       sql ("CREATE EXTENSION IF NOT EXISTS \"pg-gvm\"");
-      if (sql_int ("SELECT extversion != '1.1' FROM pg_extension"
-                   " WHERE extname='pg-gvm';"))
+      if (sql_int ("SELECT string_to_array(extversion, '.')::int[] "
+                   "       < string_to_array('1.1', '.')::int[] "
+                   "FROM pg_extension "
+                   "WHERE extname='pg-gvm';"))
         sql ("ALTER EXTENSION \"pg-gvm\" UPDATE;");
 
       sql ("RESET ROLE;");


### PR DESCRIPTION
## What

Change the condition to check if the extension is older than 1.1 rather than not equal to 1.1.

## Why

This avoid upgrading the extension when not required.

## References

Bug: https://github.com/greenbone/gvmd/issues/2770  
Forum thread: https://forum.greenbone.net/t/is-superuser-required-on-the-postgresql-user/22075/4

## Checklist

- [x] Tests
