### PR TITLE
fix: ignore default row limit (10) in init_agent_uuid_list_iterator with filter

### DIFF
--- a/src/manage_agents.c
+++ b/src/manage_agents.c
@@ -648,6 +648,8 @@ get_agents_by_scanner_and_uuids (scanner_t scanner, agent_uuid_list_t uuid_list,
     }
   if (count != uuid_list->count)
     {
+      g_debug ("%s: agent iterator agent count: %d, user agent list count: %d",
+               __func__, count, uuid_list->count);
       cleanup_iterator (&iterator);
       return AGENT_RESPONSE_AGENT_NOT_FOUND;
     }

--- a/src/manage_sql_agents.c
+++ b/src/manage_sql_agents.c
@@ -439,6 +439,7 @@ init_agent_uuid_list_iterator (iterator_t *iterator,
   get.type = "agent";
   get.ignore_pagination = 1;
   get.ignore_max_rows_per_page = 1;
+  get.filter = "rows=-1";
 
   GString *where_clause = g_string_new (NULL);
 


### PR DESCRIPTION
## What

Remove the implicit default limit of 10 in `init_agent_uuid_list_iterator` by using filter so all agent UUIDs are returned.

## Why

Remove the implicit default limit of 10 in `init_agent_uuid_list_iterator` so all agent UUIDs are returned.

## References

GEA-1581



