### PR TITLE
Fix: quote "end" in port range SQL

### DIFF
--- a/src/manage_sql_port_lists.c
+++ b/src/manage_sql_port_lists.c
@@ -2165,7 +2165,7 @@ init_port_range_iterator (iterator_t* iterator, port_list_t port_list,
     }
   else
     init_iterator (iterator,
-                   "SELECT uuid, comment, start, end, type, exclude"
+                   "SELECT uuid, comment, start, \"end\", type, exclude"
                    " FROM port_ranges%s"
                    " WHERE"
                    " (((SELECT owner FROM port_lists%s WHERE id = port_list)"


### PR DESCRIPTION
## What

Quote the keyword `end` in the SQL in `init_port_range_iterator`.

See L2166 and L2176 above where the exact same quoting is already done. 

## Why

This was causing a segfault when getting trash targets with details.

I think nobody uses this case (trash targets with details), because the quoting has been missing since 2012.

## Testing

```
o m m '<get_targets details="1" trash="1"/>'
```
Before this would have an empty response, with a segv showing in the logs.