### PR TITLE
Made number of database table lock retries parametrizeable.

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -15974,6 +15974,28 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
     {
       gchar *extension, *content_type;
       GString *prefix;
+      int lock_ret, lock_retries;
+
+      sql_begin_immediate ();
+
+      lock_retries = get_max_table_lock_retries ();
+      lock_ret = sql_table_shared_lock_wait ("reports", LOCK_TIMEOUT);
+      while ((lock_ret == 0) && (lock_retries > 0))
+        {
+          lock_ret = sql_table_shared_lock_wait ("reports", LOCK_TIMEOUT);
+          lock_retries--;
+        }
+      if (lock_ret == 0)
+        {
+          sql_rollback ();
+          break;
+        }
+
+      if (!resource_with_id_exists ("report", report))
+        {
+          sql_rollback ();
+          continue;
+        }
 
       prefix = g_string_new ("");
       content_type = no_report_format
@@ -16137,6 +16159,7 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
             switch (ret)
               {
                 case 0:
+                  sql_rollback ();
                   break;
                 case 1:
                   if (send_find_error_to_client
@@ -16144,6 +16167,7 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
                         get_reports_data->alert_id, gmp_parser))
                     {
                       error_send_to_client (error);
+                      sql_rollback ();
                       return;
                     }
                   /* Close the connection with the client, as part of the
@@ -16154,6 +16178,7 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
                     cleanup_iterator (&reports);
                   get_reports_data_reset (get_reports_data);
                   set_client_state (CLIENT_AUTHENTIC);
+                  sql_rollback ();
                   return;
                   break;
                 case 2:
@@ -16162,6 +16187,7 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
                         get_reports_data->get.filt_id, gmp_parser))
                     {
                       error_send_to_client (error);
+                      sql_rollback ();
                       return;
                     }
                   /* This error always occurs before anything is sent
@@ -16170,6 +16196,7 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
                     cleanup_iterator (&reports);
                   get_reports_data_reset (get_reports_data);
                   set_client_state (CLIENT_AUTHENTIC);
+                  sql_rollback ();
                   return;
                   break;
                 case -2:
@@ -16181,6 +16208,7 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
                     cleanup_iterator (&reports);
                   get_reports_data_reset (get_reports_data);
                   set_client_state (CLIENT_AUTHENTIC);
+                  sql_rollback ();
                   return;
                   break;
                 case -3:
@@ -16190,6 +16218,7 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
                     cleanup_iterator (&reports);
                   get_reports_data_reset (get_reports_data);
                   set_client_state (CLIENT_AUTHENTIC);
+                  sql_rollback ();
                   return;
                   break;
                 case -4:
@@ -16201,6 +16230,7 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
                     cleanup_iterator (&reports);
                   get_reports_data_reset (get_reports_data);
                   set_client_state (CLIENT_AUTHENTIC);
+                  sql_rollback ();
                   return;
                   break;
                 default:
@@ -16215,6 +16245,7 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
                     cleanup_iterator (&reports);
                   get_reports_data_reset (get_reports_data);
                   set_client_state (CLIENT_AUTHENTIC);
+                  sql_rollback ();
                   return;
                   break;
               }
@@ -16225,6 +16256,7 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
                      get_reports_data->get.filt_id, gmp_parser))
                 {
                   error_send_to_client (error);
+                  sql_rollback ();
                   return;
                 }
               /* This error always occurs before anything is sent
@@ -16233,6 +16265,7 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
                 cleanup_iterator (&reports);
               get_reports_data_reset (get_reports_data);
               set_client_state (CLIENT_AUTHENTIC);
+              sql_rollback ();
               return;
             }
           else
@@ -16245,6 +16278,7 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
                 cleanup_iterator (&reports);
               get_reports_data_reset (get_reports_data);
               set_client_state (CLIENT_AUTHENTIC);
+              sql_rollback ();
               return;
             }
         }
@@ -16254,8 +16288,13 @@ handle_get_reports (gmp_parser_t *gmp_parser, GError **error)
       count++;
 
       if (request_report)
-        /* Just to be safe, because iterator has been freed. */
-        break;
+        {
+          /* Just to be safe, because iterator has been freed. */
+          sql_commit ();
+          break;
+        }
+
+      sql_commit ();
     }
   if (request_report == 0)
     cleanup_iterator (&reports);

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -2401,6 +2401,7 @@ gvmd (int argc, char** argv, char *env[])
   static int max_active_scan_handlers = DEFAULT_MAX_ACTIVE_SCAN_HANDLERS;
   static int max_concurrent_scan_updates = 0;
   static int max_database_connections = MAX_DATABASE_CONNECTIONS_DEFAULT;
+  static int max_table_lock_retries = MAX_TABLE_LOCK_RETRIES_DEFAULT;
   static int max_concurrent_report_processing = MAX_REPORT_PROCESSING_DEFAULT;
   static int mem_wait_retries = 30;
   static int min_mem_feed_update = 0;
@@ -2611,6 +2612,11 @@ gvmd (int argc, char** argv, char *env[])
           &max_database_connections,
           "Maximum number of database connections at the same time."
           " Default: 50",
+          "<number>" },
+        { "max-table-lock-retries", '\0', 0, G_OPTION_ARG_INT,
+          &max_table_lock_retries,
+          "Maximum number of retries for a table lock."
+          " Default: "G_STRINGIFY (MAX_TABLE_LOCK_RETRIES_DEFAULT),
           "<number>" },
         { "max-concurrent-report-processing", '\0', 0, G_OPTION_ARG_INT,
           &max_concurrent_report_processing,
@@ -3030,6 +3036,11 @@ gvmd (int argc, char** argv, char *env[])
 
   /* Set maximum number of database connections */
   set_max_database_connections (max_database_connections);
+
+  /* Set maximum number of table lock retries */
+  set_max_table_lock_retries (max_table_lock_retries
+                             ? max_table_lock_retries
+                             : MAX_TABLE_LOCK_RETRIES_DEFAULT);
 
   /* Set maximum number of concurrent report processing */
   set_max_concurrent_report_processing (max_concurrent_report_processing);

--- a/src/manage.c
+++ b/src/manage.c
@@ -190,6 +190,11 @@ static int max_concurrent_scan_updates = 0;
 static int max_database_connections = MAX_DATABASE_CONNECTIONS_DEFAULT;
 
 /**
+ * @brief Maximum number of table lock retries.
+ */
+static int max_table_lock_retries = MAX_TABLE_LOCK_RETRIES_DEFAULT;
+
+/**
  * @brief Maximum number of imported reports processed concurrently.
  */
 static int max_concurrent_report_processing = MAX_REPORT_PROCESSING_DEFAULT;
@@ -5759,6 +5764,17 @@ get_max_database_connections ()
 }
 
 /**
+ * @brief Get the maximum number of table lock retries.
+ *
+ * @return The current maximum number of table lock retries.
+ */
+int
+get_max_table_lock_retries ()
+{
+  return max_table_lock_retries;
+}
+
+/**
  * @brief Get the maximum number of reports to be processed concurrently.
  *
  * @return The current maximum number of reports to be processed concurrently.
@@ -5795,6 +5811,20 @@ set_max_database_connections (int new_max)
     max_database_connections = MAX_DATABASE_CONNECTIONS_DEFAULT;
   else
     max_database_connections = new_max;
+}
+
+/**
+ * @brief Set the maximum number of table lock retries.
+ *
+ * @param new_max The current maximum number of table lock retries.
+ */
+void
+set_max_table_lock_retries (int new_max)
+{
+  if (new_max <= 0)
+    max_table_lock_retries = MAX_TABLE_LOCK_RETRIES_DEFAULT;
+  else
+    max_table_lock_retries = new_max;
 }
 
 /**

--- a/src/manage.h
+++ b/src/manage.h
@@ -162,6 +162,16 @@ manage_session_init (const char *);
 
 #define MAX_DATABASE_CONNECTIONS_DEFAULT 50
 
+/**
+ * @brief Maximum number of retries to lock a table.
+ */
+#define MAX_TABLE_LOCK_RETRIES_DEFAULT 128
+
+/**
+ * @brief Timeout for trying to acquire a table lock in milliseconds.
+ */
+#define LOCK_TIMEOUT 500
+
 #define MAX_REPORT_PROCESSING_DEFAULT 30
 
 /* Certificate and key management. */
@@ -3239,8 +3249,14 @@ set_max_concurrent_scan_updates (int);
 int
 get_max_database_connections ();
 
+int
+get_max_table_lock_retries ();
+
 void
 set_max_database_connections (int);
+
+void
+set_max_table_lock_retries (int);
 
 int
 get_max_concurrent_report_processing ();

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -337,6 +337,18 @@ manage_create_sql_functions ()
        " END;"
        "$$ language 'plpgsql';");
 
+  sql ("CREATE OR REPLACE FUNCTION try_shared_lock_wait (regclass)"
+       " RETURNS integer AS $$"
+       " BEGIN"
+       "   EXECUTE 'LOCK TABLE '"
+       "           || quote_ident_split($1::text)"
+       "           || ' IN ACCESS SHARE MODE;';"
+       "   RETURN 1;"
+       " EXCEPTION WHEN lock_not_available THEN"
+       "   RETURN 0;"
+       " END;"
+       "$$ language 'plpgsql';");
+
   if (sql_int ("SELECT EXISTS (SELECT * FROM information_schema.tables"
                "               WHERE table_catalog = '%s'"
                "               AND table_schema = 'public'"

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -113,18 +113,6 @@
  */
 #define G_LOG_DOMAIN "md manage"
 
-/**
- * @brief Number of retries for
- *        LOCK TABLE .. IN ACCESS EXLUSIVE MODE NOWAIT
- *        statements.
- */
-#define LOCK_RETRIES 64
-
-/**
- * @brief Timeout for trying to acquire a lock in milliseconds.
- */
-#define LOCK_TIMEOUT 500
-
 #ifdef DEBUG_FUNCTION_NAMES
 #include <dlfcn.h>
 
@@ -298,6 +286,32 @@ static gchar *vt_verification_collation = NULL;
 
 
 /* General helpers. */
+
+/**
+ * @brief Check if a resource with a given id still exists.
+ *
+ * @param[in]   type      Type of resource.
+ * @param[in]   resource  Resource to check.
+ *
+ * @return Whether resource with id exists.
+ */
+gboolean
+resource_with_id_exists (const char *type, resource_t resource)
+{
+  int ret;
+  char *quoted_type;
+
+  assert (type);
+  quoted_type = sql_quote (type);
+
+  if (resource)
+    ret = sql_int ("SELECT COUNT(*) FROM %ss"
+                   " WHERE id = %llu;",
+                   quoted_type, resource);
+
+  g_free (quoted_type);
+  return !!ret;
+}
 
 /**
  * @brief Check if a resource with a certain name exists already.
@@ -14400,7 +14414,7 @@ delete_report (const char *report_id, int dummy)
    *
    * If the report is running already then delete_report_internal will
    * ROLLBACK. */
-  lock_retries = LOCK_RETRIES;
+  lock_retries = get_max_table_lock_retries ();
   lock_ret = sql_table_lock_wait ("reports", LOCK_TIMEOUT);
   while ((lock_ret == 0) && (lock_retries > 0))
     {
@@ -19248,7 +19262,7 @@ delete_task_lock (task_t task, int ultimate)
    *
    * If the task is already active then delete_report (via delete_task)
    * will fail and rollback. */
-  lock_retries = LOCK_RETRIES;
+  lock_retries = get_max_table_lock_retries ();
   lock_ret = sql_table_lock_wait ("reports", LOCK_TIMEOUT);
   while ((lock_ret == 0) && (lock_retries > 0))
     {
@@ -19428,7 +19442,7 @@ request_delete_task_uuid (const char *task_id, int ultimate)
                *
                * If the task is running already then delete_task will lead to
                * ROLLBACK. */
-              lock_retries = LOCK_RETRIES;
+              lock_retries = get_max_table_lock_retries ();
               lock_ret = sql_table_lock_wait ("reports", LOCK_TIMEOUT);
               while ((lock_ret == 0) && (lock_retries > 0))
                 {

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -437,6 +437,9 @@ void
 init_user_task_iterator (iterator_t *, int, int);
 
 gboolean
+resource_with_id_exists (const char *, resource_t);
+
+gboolean
 resource_with_name_exists (const char *, const char *, resource_t);
 
 gboolean

--- a/src/sql.h
+++ b/src/sql.h
@@ -233,6 +233,9 @@ sql_rollback ();
 int
 sql_table_lock_wait (const char *, int);
 
+int
+sql_table_shared_lock_wait (const char *, int);
+
 /* Iterators. */
 
 /* These functions are for "internal" use.  They may only be accessed by code

--- a/src/sql_pg.c
+++ b/src/sql_pg.c
@@ -656,7 +656,7 @@ sql_rollback ()
 }
 
 /**
- * Try to lock a table, timing out after a given time.
+ * Try to lock a table in exclusive mode, timing out after a given time.
  *
  * @param[in]  table         The table to lock.
  * @param[in]  lock_timeout  The lock timeout in milliseconds, 0 for unlimited.
@@ -671,6 +671,27 @@ sql_table_lock_wait (const char *table, int lock_timeout)
 
   // This requires the gvmd functions to be defined first.
   int ret = sql_int ("SELECT try_exclusive_lock_wait ('%s');", table);
+
+  sql ("SET LOCAL lock_timeout = %d;", old_lock_timeout);
+  return ret;
+}
+
+/**
+ * Try to lock a table in shared mode, timing out after a given time.
+ *
+ * @param[in]  table         The table to lock.
+ * @param[in]  lock_timeout  The lock timeout in milliseconds, 0 for unlimited.
+ *
+ * @return 1 if locked, 0 if failed / timed out.
+ */
+int
+sql_table_shared_lock_wait (const char *table, int lock_timeout)
+{
+  int old_lock_timeout = sql_int ("SHOW lock_timeout;");
+  sql ("SET LOCAL lock_timeout = %d;", lock_timeout);
+
+  // This requires the gvmd functions to be defined first.
+  int ret = sql_int ("SELECT try_shared_lock_wait ('%s');", table);
 
   sql ("SET LOCAL lock_timeout = %d;", old_lock_timeout);
   return ret;


### PR DESCRIPTION
Made the number of database table lock retries parametrizable.

## What

- Made the number of database table lock retries parametrizeable.
- Added a shared lock of the table reports around the code for getting a single report to avoid signals.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This eliminates two bugs.
<!-- Describe why are these changes necessary? -->

## References
GEA-1552
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist
Tested manually on my local development system.
<!-- Remove this section if not applicable to your changes -->



