### PR TITLE
Change: remove redundant inits in print_report_xml_start

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -16923,17 +16923,6 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
   orig_f_false_positives = orig_f_warnings = orig_f_logs = orig_f_infos = 0;
   orig_f_holes = orig_f_criticals = 0;
   host_summary_buffer = NULL;
-  ctx.f_host_criticals = NULL;
-  ctx.f_host_ports = NULL;
-  ctx.f_host_holes = NULL;
-  ctx.f_host_warnings = NULL;
-  ctx.f_host_infos = NULL;
-  ctx.f_host_logs = NULL;
-  ctx.f_host_false_positives = NULL;
-  ctx.f_host_compliant = NULL;
-  ctx.f_host_notcompliant = NULL;
-  ctx.f_host_incomplete = NULL;
-  ctx.f_host_undefined = NULL;
 
   ctx.delta = delta;
   ctx.get = get;


### PR DESCRIPTION
## What

Remove inits of `ctx.f_host_*` in `print_report_xml_start`.

I'm making this a very small change, to keep review easier. This function is big and messy. 

## Why

They are redundant.

ctx is initialized with `print_report_context_t ctx = {0};`, which ensures that all fields are 0 (which is NULL for pointers).


## References

Follows /pull/2776.

Breakdown of /pull/2712.

## Testing

I ran GET_REPORTS on branch and main, and compared the output.
```sh
o m m '<get_reports report_id="82f3531c-43cd-4453-8300-990dc423d96b" filter="apache levels=hm" details="1"/>' > /tmp/r-pr
o m m '<get_reports report_id="82f3531c-43cd-4453-8300-990dc423d96b" filter="apache levels=hm" details="1"/>' > /tmp/r-main
o m m '<get_reports details="1"/>' > /tmp/r2-pr
o m m '<get_reports details="1"/>' > /tmp/r2-main
diff -u /tmp/r-pr /tmp/r-main
diff -u /tmp/r2-pr /tmp/r2-main
```
