### PR TITLE
fix: Use ALTER TABLE IF EXISTS for asset_snapshots

### DIFF
--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -3547,7 +3547,7 @@ migrate_266_to_267 ()
   // Add scanner field to asset_snapshots
 
   sql (
-    "ALTER TABLE asset_snapshots ADD COLUMN scanner INTEGER;"
+    "ALTER TABLE IF EXISTS asset_snapshots ADD COLUMN scanner INTEGER;"
     );
 
   /* Set the database version to 267. */


### PR DESCRIPTION
## What

Fix the SQL syntax in the migration by using the correct ALTER TABLE IF EXISTS order.


## Why

The previous order was invalid in Postgres and caused the migration to fail.


## References

https://github.com/greenbone/gvmd/issues/2787

