### PR TITLE
change: bump LIBGVM_HTTP_SCANNER to 22.35

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,7 +14,7 @@ Prerequisites:
 * glib-2.0 >= 2.42
 * gnutls >= 3.2.15
 * gpgme
-* [gvm-libs](https://github.com/greenbone/gvm-libs/) >= 22.34 (or 22.35 if you ENABLE_AGENTS or ENABLE_CONTAINER_SCANNING)
+* [gvm-libs](https://github.com/greenbone/gvm-libs/) >= 22.34 (or 22.35 if you ENABLE_AGENTS, ENABLE_CONTAINER_SCANNING or ENABLE_OPENVASD)
 * libical >= 1.0.0
 * libbsd
 * pkg-config

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,7 +21,7 @@ pkg_check_modules(LIBGVM_GMP REQUIRED libgvm_gmp>=22.30)
 
 if(ENABLE_HTTP_SCANNER)
   pkg_check_modules(LIBGVM_HTTP REQUIRED libgvm_http>=22.30)
-  pkg_check_modules(LIBGVM_HTTP_SCANNER REQUIRED libgvm_http_scanner>=22.30)
+  pkg_check_modules(LIBGVM_HTTP_SCANNER REQUIRED libgvm_http_scanner>=22.35)
 endif(ENABLE_HTTP_SCANNER)
 if(ENABLE_OPENVASD)
   pkg_check_modules(LIBGVM_OPENVASD REQUIRED libgvm_openvasd>=22.30)


### PR DESCRIPTION
## What

Update `LIBGVM_HTTP_SCANNER` from 22.30 to 22.35 in order to use the latest `parse_result` changes from `gvm-libs`.

## Why

The newer version of `gvm-libs` includes improvements in `parse_result`, which is needed for agent integration.

## References

GEA-1585


