### PR TITLE
Fix NVT iterator sorting, simplify iterator columns

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -3266,11 +3266,14 @@ xml_escape_text_truncated (const char *, size_t, const char *);
 int
 column_is_timestamp (const char*);
 
-char*
-type_columns (const char *);
+column_t*
+type_select_columns (const char *);
 
-char*
-type_trash_columns (const char *);
+column_t*
+type_where_columns (const char *);
+
+const char**
+type_filter_columns (const char *);
 
 gboolean
 manage_migrate_needs_timezone (GSList *, const db_conn_info_t *);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -247,15 +247,6 @@ set_credential_snmp_secret (credential_t, const char *, const char *,
 static char *
 setting_timezone ();
 
-static column_t *
-type_select_columns (const char *type);
-
-static column_t *
-type_where_columns (const char *type);
-
-static const char**
-type_filter_columns (const char *);
-
 static int
 type_build_select (const char *, const char *, const get_data_t *,
                    gboolean, gboolean, const char *, const char *,
@@ -34559,7 +34550,7 @@ column_is_timestamp (const char* column)
  *
  * @return The columns.
  */
-static column_t *
+column_t *
 type_select_columns (const char *type)
 {
 #if ENABLE_AGENTS
@@ -34678,7 +34669,7 @@ type_select_columns (const char *type)
  *
  * @return The columns.
  */
-static column_t *
+column_t *
 type_where_columns (const char *type)
 {
   static column_t task_columns[] = TASK_ITERATOR_WHERE_COLUMNS;
@@ -34706,7 +34697,7 @@ type_where_columns (const char *type)
  *
  * @return The filter columns.
  */
-static const char**
+const char**
 type_filter_columns (const char *type)
 {
   if (type == NULL)

--- a/src/manage_sql_nvts.h
+++ b/src/manage_sql_nvts.h
@@ -31,61 +31,16 @@
  */
 #define NVT_ITERATOR_COLUMNS                                                \
  {                                                                          \
-   GET_ITERATOR_COLUMNS_PREFIX (""),                                        \
-   { "''", "_owner", KEYWORD_TYPE_STRING },                                 \
-   { "0", NULL, KEYWORD_TYPE_INTEGER },                                     \
-   { "oid", NULL, KEYWORD_TYPE_STRING },                                    \
-   { "modification_time", "version", KEYWORD_TYPE_INTEGER },                \
-   { "name", NULL, KEYWORD_TYPE_STRING },                                   \
-   { "cve", NULL, KEYWORD_TYPE_STRING },                                    \
-   { "tag", NULL, KEYWORD_TYPE_STRING },                                    \
-   { "category", NULL, KEYWORD_TYPE_STRING },                               \
-   { "family", NULL, KEYWORD_TYPE_STRING },                                 \
-   { "cvss_base", NULL, KEYWORD_TYPE_DOUBLE },                              \
-   { "cvss_base", "severity", KEYWORD_TYPE_DOUBLE },                        \
-   { "cvss_base", "cvss", KEYWORD_TYPE_DOUBLE },                            \
-   { "qod", NULL, KEYWORD_TYPE_INTEGER },                                   \
-   { "qod_type", NULL, KEYWORD_TYPE_STRING },                               \
-   { "solution_type", NULL, KEYWORD_TYPE_STRING },                          \
-   { "tag", "script_tags", KEYWORD_TYPE_STRING},                            \
-   { "solution", NULL, KEYWORD_TYPE_STRING},                                \
-   { "summary", NULL, KEYWORD_TYPE_STRING },                                \
-   { "insight", NULL, KEYWORD_TYPE_STRING },                                \
-   { "affected", NULL, KEYWORD_TYPE_STRING },                               \
-   { "impact", NULL, KEYWORD_TYPE_STRING },                                 \
-   { "detection", NULL, KEYWORD_TYPE_STRING },                              \
-   { "solution_method", NULL, KEYWORD_TYPE_STRING },                        \
-   { "coalesce (epss_score, 0.0)", "epss_score",                            \
-     KEYWORD_TYPE_DOUBLE },                                                 \
-   { "coalesce (epss_percentile, 0.0)", "epss_percentile",                  \
-     KEYWORD_TYPE_DOUBLE },                                                 \
-   { "epss_cve", NULL, KEYWORD_TYPE_STRING },                               \
-   { "epss_severity", NULL, KEYWORD_TYPE_DOUBLE },                          \
-   { "coalesce (max_epss_score, 0.0)", "max_epss_score",                    \
-     KEYWORD_TYPE_DOUBLE },                                                 \
-   { "coalesce (max_epss_percentile, 0.0)", "max_epss_percentile",          \
-     KEYWORD_TYPE_DOUBLE },                                                 \
-   { "max_epss_cve", NULL, KEYWORD_TYPE_STRING },                           \
-   { "max_epss_severity", NULL, KEYWORD_TYPE_DOUBLE },                      \
-   { "discovery", NULL, KEYWORD_TYPE_INTEGER },                             \
-   { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                                     \
- }
-
-/**
- * @brief NVT iterator columns.
- */
-#define NVT_ITERATOR_COLUMNS_NVTS                                           \
- {                                                                          \
    GET_ITERATOR_COLUMNS_PREFIX ("nvts."),                                   \
    { "''", "_owner", KEYWORD_TYPE_STRING },                                 \
    { "0", NULL, KEYWORD_TYPE_STRING },                                      \
    { "oid", NULL, KEYWORD_TYPE_STRING },                                    \
    { "modification_time", "version", KEYWORD_TYPE_INTEGER },                \
-   { "nvts.name", NULL, KEYWORD_TYPE_STRING },                              \
+   { "nvts.name", "name", KEYWORD_TYPE_STRING },                            \
    { "cve", NULL, KEYWORD_TYPE_STRING },                                    \
    { "tag", NULL, KEYWORD_TYPE_STRING },                                    \
    { "category", NULL, KEYWORD_TYPE_STRING },                               \
-   { "nvts.family", NULL, KEYWORD_TYPE_STRING },                            \
+   { "nvts.family", "family", KEYWORD_TYPE_STRING },                        \
    { "cvss_base", NULL, KEYWORD_TYPE_DOUBLE },                              \
    { "cvss_base", "severity", KEYWORD_TYPE_DOUBLE },                        \
    { "cvss_base", "cvss", KEYWORD_TYPE_DOUBLE },                            \


### PR DESCRIPTION
## What
The sorting in get_nvts iterators is now more consistent with the iterator columns, which have been simplified to only one set of columns.

## Why
This fixes the sorting not working for columns like the name.

## References
Closes #2790
GEA-1626

