### PR TITLE
Change: free the report counts with the rest of the report context

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -16682,6 +16682,7 @@ struct print_report_context
   int false_positives;        ///< Number of false positives.
   int total_result_count;     ///< Total number of results.
   // Filtered counts.
+  GHashTable *f_host_criticals;       ///< Criticals per host.
   GHashTable *f_host_false_positives; ///< False positives per host.
   GHashTable *f_host_holes;           ///< Holes per host.
   GHashTable *f_host_infos;           ///< Infos per host.
@@ -16689,7 +16690,6 @@ struct print_report_context
   GHashTable *f_host_ports;           ///< Ports per host.
   GHashTable *f_host_warnings;        ///< Warnings per hosts.
   // Filtered counts: audit.
-  GHashTable *f_host_criticals;       ///< Criticals per host.
   GHashTable *f_host_compliant;       ///< Compliants per host.
   GHashTable *f_host_incomplete;      ///< Incompletes per host.
   GHashTable *f_host_notcompliant;    ///< Notcompliants per host.


### PR DESCRIPTION
## What

Move the freeing of the  report count hasthables from `print_report_xml_start` to `print_report_context_cleanup`.

Note that
 - we always call `print_report_context_cleanup` before exiting `print_report_xml_start`
 - it's safe to call `print_report_context_cleanup` even before the hashtables are created, because the context is initialised to 0, and we check if the hashtables exist before trying to free them.

## Why

The other context fields are all freed in print_report_context_cleanup, so the count hashtables must also be.

This is the next small step in reducing the size of the `print_report_xml_start` function, to make it easier to understand and maintain.

## References

Follows /pull/2781.

## Testing

I got a report with main and with the PR, and compared them.
```sh
o m m '<get_reports report_id="82f3531c-43cd-4453-8300-990dc423d96b" filter="apache levels=hm" details="1"/>' > /tmp/r-pr
o m m '<get_reports report_id="82f3531c-43cd-4453-8300-990dc423d96b" filter="apache levels=hm" details="1"/>' > /tmp/r-main
o m m '<get_reports details="1"/>' > /tmp/r2-pr
o m m '<get_reports details="1"/>' > /tmp/r2-main
diff -u /tmp/r-pr /tmp/r-main
diff -u /tmp/r2-pr /tmp/r2-main
```

