### PR TITLE
Add: Option to auto-update relays from file

### DIFF
--- a/docs/gvmd.8
+++ b/docs/gvmd.8
@@ -180,6 +180,9 @@ Rebuild all SCAP data.
 \fB--relay-mapper=\fIFILE\fB\f1
 Executable for automatically mapping scanner hosts to relays. If the option is empty or not given, automatic mapping is disabled. This option is deprecated and relays should be set explictly in the relay_... fields of scanners. 
 .TP
+\fB--relays-path=\fIFILE\fB\f1
+Path to an externally managed JSON file used to automatically update the relays of scanners. These will overwrite any relays set manually. 
+.TP
 \fB--role=\fIROLE\fB\f1
 Role for --create-user and --get-users.
 .TP

--- a/docs/gvmd.8
+++ b/docs/gvmd.8
@@ -181,7 +181,7 @@ Rebuild all SCAP data.
 Executable for automatically mapping scanner hosts to relays. If the option is empty or not given, automatic mapping is disabled. This option is deprecated and relays should be set explictly in the relay_... fields of scanners. 
 .TP
 \fB--relays-path=\fIFILE\fB\f1
-Path to an externally managed JSON file used to automatically update the relays of scanners. These will overwrite any relays set manually. 
+Path to an externally managed JSON file used to automatically update the relays of scanners. These will overwrite any relays set manually and remove the relays for scanners not listed in the file. 
 .TP
 \fB--role=\fIROLE\fB\f1
 Role for --create-user and --get-users.

--- a/docs/gvmd.8.xml
+++ b/docs/gvmd.8.xml
@@ -428,7 +428,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         <p>
           Path to an externally managed JSON file used to automatically
           update the relays of scanners. These will overwrite any relays
-          set manually.
+          set manually and remove the relays for scanners not listed
+          in the file.
         </p>
       </optdesc>
     </option>

--- a/docs/gvmd.8.xml
+++ b/docs/gvmd.8.xml
@@ -423,6 +423,16 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       </optdesc>
     </option>
     <option>
+      <p><opt>--relays-path=<arg>FILE</arg></opt></p>
+      <optdesc>
+        <p>
+          Path to an externally managed JSON file used to automatically
+          update the relays of scanners. These will overwrite any relays
+          set manually.
+        </p>
+      </optdesc>
+    </option>
+    <option>
       <p><opt>--role=<arg>ROLE</arg></opt></p>
       <optdesc>
         <p>Role for --create-user and --get-users.</p>

--- a/docs/gvmd.html
+++ b/docs/gvmd.html
@@ -388,7 +388,8 @@
       
         <p>Path to an externally managed JSON file used to automatically
           update the relays of scanners. These will overwrite any relays
-          set manually.
+          set manually and remove the relays for scanners not listed
+          in the file.
         </p>
       
     

--- a/docs/gvmd.html
+++ b/docs/gvmd.html
@@ -384,6 +384,15 @@
       
     
     
+      <p><b>--relays-path=<em>FILE</em></b></p>
+      
+        <p>Path to an externally managed JSON file used to automatically
+          update the relays of scanners. These will overwrite any relays
+          set manually.
+        </p>
+      
+    
+    
       <p><b>--role=<em>ROLE</em></b></p>
       
         <p>Role for --create-user and --get-users.</p>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -199,6 +199,7 @@ set(
   manage_pg.c
   manage_scan_handler.c
   manage_scan_queue.c
+  manage_scanner_relays.c
   manage_oci_image_targets.c
   manage_container_image_scanner.c
   manage_tags.c
@@ -245,6 +246,7 @@ set(
   manage_sql_report_formats.c
   manage_sql_resources.c
   manage_sql_roles.c
+  manage_sql_scanner_relays.c
   manage_sql_settings.c
   manage_sql_tags.c
   manage_sql_targets.c

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -2696,7 +2696,8 @@ gvmd (int argc, char** argv, char *env[])
           &relays_path,
           "Path to an externally managed JSON file used to automatically"
           " update the relays of scanners. These will overwrite any relays"
-          " set manually.",
+          " set manually and remove the relays for scanners not listed"
+          " in the file.",
           "<file>" },
         { "role", '\0', 0, G_OPTION_ARG_STRING,
           &role,

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -97,6 +97,7 @@
 #include "manage_runtime_flags.h"
 #include "manage_roles.h"
 #include "manage_scan_queue.h"
+#include "manage_scanner_relays.h"
 #include "manage_settings.h"
 #include "manage_targets.h"
 #include "manage_users.h"
@@ -2357,6 +2358,7 @@ gvmd (int argc, char** argv, char *env[])
   static gchar *scanner_name = NULL;
   static gchar *rc_name = NULL;
   static gchar *relay_mapper = NULL;
+  static gchar *relays_path = NULL;
   static gboolean rebuild = FALSE;
   static gchar *rebuild_gvmd_data = NULL;
   static gboolean rebuild_scap = FALSE;
@@ -2689,6 +2691,12 @@ gvmd (int argc, char** argv, char *env[])
           " If the option is empty or not given, automatic mapping"
           " is disabled. This option is deprecated and relays should be"
           " set explictly in the relay_... fields of scanners.",
+          "<file>" },
+        { "relays-path", '\0', 0, G_OPTION_ARG_FILENAME,
+          &relays_path,
+          "Path to an externally managed JSON file used to automatically"
+          " update the relays of scanners. These will overwrite any relays"
+          " set manually.",
           "<file>" },
         { "role", '\0', 0, G_OPTION_ARG_STRING,
           &role,
@@ -3093,6 +3101,12 @@ gvmd (int argc, char** argv, char *env[])
     }
   else
     g_debug ("Relay mapper disabled.");
+
+  /* Set relays file path */
+  if (relays_path && strcmp (relays_path, ""))
+    {
+      set_relays_path (relays_path);
+    }
 
   /*
    * Set up scan queue

--- a/src/manage.c
+++ b/src/manage.c
@@ -50,6 +50,7 @@
 #include "manage_oci_image_targets.h"
 #include "manage_http_scanner.h"
 #include "manage_runtime_flags.h"
+#include "manage_scanner_relays.h"
 #include "manage_sql.h"
 #include "manage_sql_assets.h"
 #include "manage_sql_resources.h"
@@ -91,6 +92,7 @@
 #include <gvm/util/uuidutils.h>
 #include <gvm/util/versionutils.h>
 #include <gvm/gmp/gmp.h>
+
 
 #undef G_LOG_DOMAIN
 /**
@@ -4218,6 +4220,8 @@ manage_sync (sigset_t *sigmask_current,
 
   reinit_manage_process ();
   manage_session_init (current_credentials.uuid);
+
+  sync_scanner_relays ();
 
   if (feed_sync_required ())
     {

--- a/src/manage.c
+++ b/src/manage.c
@@ -93,7 +93,6 @@
 #include <gvm/util/versionutils.h>
 #include <gvm/gmp/gmp.h>
 
-
 #undef G_LOG_DOMAIN
 /**
  * @brief GLib log domain.

--- a/src/manage_scanner_relays.c
+++ b/src/manage_scanner_relays.c
@@ -129,7 +129,7 @@ extract_relay_fields_from_json_item (cJSON *json_item,
   item_out->original_port = 0;
   item_out->relay_host = NULL;
   item_out->relay_port = 0;
-  item_out->protocol = NULL;
+  item_out->scanner_type = NULL;
 
   if (json_item == NULL)
     {
@@ -145,12 +145,26 @@ extract_relay_fields_from_json_item (cJSON *json_item,
                           &item_out->relay_host);
   gvm_json_obj_check_int (json_item, "relay_port",
                           &item_out->relay_port);
-  gvm_json_obj_check_str (json_item, "protocol",
-                          &item_out->protocol);
+  gvm_json_obj_check_str (json_item, "scanner_type",
+                          &item_out->scanner_type);
 
   if (item_out->original_host == NULL)
     {
       g_debug ("%s: mandatory original_host field missing or not a string",
+               __func__);
+      return -1;
+    }
+
+  if (item_out->relay_host == NULL)
+    {
+      g_debug ("%s: mandatory relay_host field missing or not a string",
+               __func__);
+      return -1;
+    }
+
+  if (item_out->scanner_type == NULL)
+    {
+      g_debug ("%s: mandatory scanner_type field missing or not a string",
                __func__);
       return -1;
     }
@@ -182,6 +196,7 @@ update_all_scanner_relays_from_json (cJSON *parsed_file,
   updated_scanners
     = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
 
+  sql_begin_immediate ();
   update_all_scanner_relays_start ();
 
   cJSON_ArrayForEach (json_item, relays)
@@ -193,6 +208,7 @@ update_all_scanner_relays_from_json (cJSON *parsed_file,
       if (update_all_scanner_relays_from_item (&parsed_item, updated_scanners))
         {
           g_hash_table_destroy (updated_scanners);
+          sql_rollback ();
           return -1;
         }
     }
@@ -207,6 +223,7 @@ update_all_scanner_relays_from_json (cJSON *parsed_file,
                  "updated according to relays file");
     }
   g_hash_table_destroy (updated_scanners);
+  sql_commit ();
   return 0;
 }
 
@@ -243,7 +260,7 @@ sync_scanner_relays ()
   if (stat_buffer.st_mtime <= db_mod_time)
     {
       g_debug ("%s: relays file not modified since last sync", __func__);
-      return -1;
+      return 0;
     }
 
   if (! g_file_get_contents (relays_path, &file_contents, &file_size, &error))
@@ -254,6 +271,7 @@ sync_scanner_relays ()
     }
 
   parsed_file = cJSON_ParseWithLength (file_contents, file_size);
+  g_free (file_contents);
   if (parsed_file == NULL)
     {
       g_warning ("%s: could not parse JSON", __func__);
@@ -272,28 +290,28 @@ sync_scanner_relays ()
 }
 
 /**
- * @brief Check if a scanner type matches a relays file "protocol" string.
+ * @brief Check if a scanner type matches a relays file type string.
  *
- * @param[in]  scanner_type  The scanner type to check
- * @param[in]  protocol      The protocol string from the relays file to check
+ * @param[in]  scanner_type       The scanner type to check
+ * @param[in]  relay_scanner_type The relay scanner type from the relays file
  *
  * @return TRUE if the two match, FALSE otherwise
  */
 static gboolean
-scanner_type_matches_relay_protocol (int scanner_type,
-                                     const char *protocol)
+scanner_type_matches_relay (int scanner_type,
+                            const char *relay_scanner_type)
 {
   switch (scanner_type)
   {
     case SCANNER_TYPE_AGENT_CONTROLLER_SENSOR:
-      return protocol == NULL
-             || strcasecmp (protocol, "agent-control") == 0;
+      return relay_scanner_type == NULL
+             || strcasecmp (relay_scanner_type, "agent-control") == 0;
     case SCANNER_TYPE_OPENVASD_SENSOR:
-      return protocol == NULL
-             || strcasecmp (protocol, "openvasd") == 0;
+      return relay_scanner_type == NULL
+             || strcasecmp (relay_scanner_type, "openvasd") == 0;
     case SCANNER_TYPE_OSP_SENSOR:
-      return protocol == NULL
-             || strcasecmp (protocol, "osp") == 0;
+      return relay_scanner_type == NULL
+             || strcasecmp (relay_scanner_type, "osp") == 0;
     default:
       return FALSE;
   }
@@ -339,6 +357,7 @@ get_single_relay_from_file (int scanner_type,
     }
 
   parsed_file = cJSON_ParseWithLength (file_contents, file_size);
+  g_free (file_contents);
   if (parsed_file == NULL)
     {
       g_warning ("%s: could not parse JSON", __func__);
@@ -356,8 +375,8 @@ get_single_relay_from_file (int scanner_type,
       relays_list_item_t parsed_item;
       if (extract_relay_fields_from_json_item (json_item, &parsed_item))
         continue;
-      if (scanner_type_matches_relay_protocol (scanner_type,
-                                               parsed_item.protocol)
+      if (scanner_type_matches_relay (scanner_type,
+                                      parsed_item.scanner_type)
           && (parsed_item.original_port == 0
               || parsed_item.original_port == original_port)
           && (strcmp (original_host, parsed_item.original_host) == 0))
@@ -367,5 +386,6 @@ get_single_relay_from_file (int scanner_type,
           *relay_port = parsed_item.relay_port;
         }
     }
+  cJSON_Delete (parsed_file);
   return 0;
 }

--- a/src/manage_scanner_relays.c
+++ b/src/manage_scanner_relays.c
@@ -1,0 +1,371 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file
+ * @brief Greenbone Vulnerability Manager scanner relays.
+ */
+
+#include "gmp_base.h"
+#include "manage_scanner_relays.h"
+#include "manage_sql_scanner_relays.h"
+#include "manage_sql.h"
+
+#include <glib/gstdio.h>
+#include <gvm/util/json.h>
+
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain used for messages from this module.
+ */
+#define G_LOG_DOMAIN "md   manage"
+
+/**
+ * @brief Path to the relay mappings JSON file, NULL to disable relays.
+ */
+static gchar *relays_path = NULL;
+
+/**
+ * @brief Gets the current path of the relay mappings data file.
+ *
+ * @return The current relay mappings path.
+ */
+const char *
+get_relays_path ()
+{
+  return relays_path;
+}
+
+/**
+ * @brief Sets a new path for the relay mappings data file.
+ *
+ * @param[in]  new_path  The new relay mappings path.
+ */
+void
+set_relays_path (const char *new_path)
+{
+  g_free (relays_path);
+  relays_path = (new_path && strcmp (new_path, ""))
+                  ? g_strdup (new_path) : NULL;
+}
+
+/**
+ * @brief Checks if relays are managed externally.
+ *
+ * @return TRUE if relays are managed externally, FALSE if not.
+ */
+gboolean
+relays_managed_externally ()
+{
+  return relays_path ? TRUE : FALSE;
+}
+
+/**
+ * @brief Extract the fields from the root object of a relays JSON file.
+ *
+ * @param[in]  parsed_file  Root object of the file to get fields from.
+ * @param[out] relays_out   Output of the relays array.
+ *
+ * @return 0 success, -1 error
+ */
+static int
+extract_relays_fields_from_root_cjson (cJSON *parsed_file,
+                                       cJSON **relays_out)
+{
+  cJSON *relays;
+
+  if (! parsed_file)
+    return -1;
+
+  if (relays_out)
+    *relays_out = NULL;
+
+  if (! cJSON_IsObject (parsed_file))
+    {
+      g_warning ("%s: root element must be an object", __func__);
+      return -1;
+    }
+
+  relays = cJSON_GetObjectItem (parsed_file, "relays");
+  if (relays == NULL)
+    {
+      g_warning ("%s: missing 'relays' array", __func__);
+      return -1;
+    }
+  if (! cJSON_IsArray (relays))
+    {
+      g_warning ("%s: 'relays' field is not an array", __func__);
+      return -1;
+    }
+
+  if (relays_out)
+    *relays_out = relays;
+  return 0;
+}
+
+/**
+ * @brief Extract the fields from a cJSON item from a relays array.
+ *
+ * Strings are freed when the cJSON item is destroyed.
+ *
+ * @param[in]  json_item  The list item as a cJSON object.
+ * @param[out] item_out   Pointer to structure holding the field values.
+ *
+ * @return 0 success, -1 error
+ */
+static int
+extract_relay_fields_from_json_item (cJSON *json_item,
+                                     relays_list_item_t *item_out)
+{
+  if (item_out == NULL)
+    {
+      g_warning ("%s: no output item given", __func__);
+      return -1;
+    }
+
+  item_out->original_host = NULL;
+  item_out->original_port = 0;
+  item_out->relay_host = NULL;
+  item_out->relay_port = 0;
+  item_out->protocol = NULL;
+
+  if (json_item == NULL)
+    {
+      g_warning ("%s: no input JSON object given", __func__);
+      return -1;
+    }
+
+  gvm_json_obj_check_str (json_item, "original_host",
+                          &item_out->original_host);
+  gvm_json_obj_check_int (json_item, "original_port",
+                          &item_out->original_port);
+  gvm_json_obj_check_str (json_item, "relay_host",
+                          &item_out->relay_host);
+  gvm_json_obj_check_int (json_item, "relay_port",
+                          &item_out->relay_port);
+  gvm_json_obj_check_str (json_item, "protocol",
+                          &item_out->protocol);
+
+  if (item_out->original_host == NULL)
+    {
+      g_debug ("%s: mandatory original_host field missing or not a string",
+               __func__);
+      return -1;
+    }
+
+  return 0;
+}
+
+/**
+ * @brief Update all scanner relays using a parsed JSON file.
+ *
+ * If the update is successful, the scanner_relays_update_time entry in the
+ * meta table is updated and events are logged for the updated scanners.
+ *
+ * @param[in]  parsed_file    The root cJSON object of the parsed file.
+ * @param[in]  file_mod_time  Modification time of the file.
+ */
+static int
+update_all_scanner_relays_from_json (cJSON *parsed_file,
+                                     time_t file_mod_time)
+{
+  cJSON *relays, *json_item;
+  GHashTable *updated_scanners;
+  GHashTableIter scanners_iter;
+  gchar *scanner_id;
+
+  if (extract_relays_fields_from_root_cjson (parsed_file, &relays))
+    return -1;
+
+  updated_scanners
+    = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+
+  update_all_scanner_relays_start ();
+
+  cJSON_ArrayForEach (json_item, relays)
+    {
+      relays_list_item_t parsed_item;
+      if (extract_relay_fields_from_json_item (json_item, &parsed_item))
+        continue;
+
+      if (update_all_scanner_relays_from_item (&parsed_item, updated_scanners))
+        {
+          g_hash_table_destroy (updated_scanners);
+          return -1;
+        }
+    }
+
+  update_all_scanner_relays_end (file_mod_time);
+
+  g_hash_table_iter_init (&scanners_iter, updated_scanners);
+  while (g_hash_table_iter_next (&scanners_iter,
+                                 (gpointer*)(&scanner_id), NULL))
+    {
+      log_event ("scanner", "Scanner", scanner_id,
+                 "updated according to relays file");
+    }
+  g_hash_table_destroy (updated_scanners);
+  return 0;
+}
+
+/**
+ * @brief Update the scanner relays from a file if neeeded.
+ *
+ * The scanners are updated if a path is set for the relays file and if the
+ * file is updated more recently than the scanner_relays_update_time entry
+ * in the meta table.
+ *
+ * @return 0 success, -1 error.
+ */
+int
+sync_scanner_relays ()
+{
+  time_t db_mod_time;
+  GStatBuf stat_buffer;
+  GError *error = NULL;
+  gchar *file_contents = NULL;
+  size_t file_size = 0;
+  cJSON *parsed_file;
+
+  if (relays_path == NULL || strcmp (relays_path, "") == 0)
+    return 0;
+
+  if (g_stat (relays_path, &stat_buffer))
+    {
+      g_warning ("%s: Failed to stat scanner relays file: %s",
+                 __func__, strerror (errno));
+      return -1;
+    }
+
+  db_mod_time = get_scanner_relays_db_update_time ();
+  if (stat_buffer.st_mtime <= db_mod_time)
+    {
+      g_debug ("%s: relays file not modified since last sync", __func__);
+      return -1;
+    }
+
+  if (! g_file_get_contents (relays_path, &file_contents, &file_size, &error))
+    {
+      g_warning ("%s: could not read file: %s", __func__, error->message);
+      g_error_free (error);
+      return -1;
+    }
+
+  parsed_file = cJSON_ParseWithLength (file_contents, file_size);
+  if (parsed_file == NULL)
+    {
+      g_warning ("%s: could not parse JSON", __func__);
+      return -1;
+    }
+
+  if (update_all_scanner_relays_from_json (parsed_file, stat_buffer.st_mtime))
+    {
+      g_warning ("%s: could not update relays", __func__);
+      cJSON_Delete (parsed_file);
+      return -1;
+    }
+
+  cJSON_Delete (parsed_file);
+  return 0;
+}
+
+/**
+ * @brief Check if a scanner type matches a relays file "protocol" string.
+ *
+ * @param[in]  scanner_type  The scanner type to check
+ * @param[in]  protocol      The protocol string from the relays file to check
+ *
+ * @return TRUE if the two match, FALSE otherwise
+ */
+static gboolean
+scanner_type_matches_relay_protocol (int scanner_type,
+                                     const char *protocol)
+{
+  switch (scanner_type)
+  {
+    case SCANNER_TYPE_AGENT_CONTROLLER_SENSOR:
+      return protocol == NULL
+             || strcasecmp (protocol, "agent-control") == 0;
+    case SCANNER_TYPE_OPENVASD_SENSOR:
+      return protocol == NULL
+             || strcasecmp (protocol, "openvasd") == 0;
+    case SCANNER_TYPE_OSP_SENSOR:
+      return protocol == NULL
+             || strcasecmp (protocol, "osp") == 0;
+    default:
+      return FALSE;
+  }
+}
+
+/**
+ * @brief Get the relays host and port matching the data of a single scanner.
+ *
+ * @param[in]  scanner_type   The type of scanner to match
+ * @param[in]  original_host  Original host of the scanner to match
+ * @param[in]  original_port  Original port of the scanner to match, 0 for any
+ * @param[out] relay_host     Output of the relay host
+ * @param[out] relay_port     Output of the relay port
+ *
+ * @return 0 success, -1 error
+ */
+int
+get_single_relay_from_file (int scanner_type,
+                            const char *original_host,
+                            int original_port,
+                            char **relay_host,
+                            int *relay_port)
+{
+  GError *error = NULL;
+  gchar *file_contents = NULL;
+  size_t file_size = 0;
+  cJSON *parsed_file, *relays, *json_item;
+
+  if (relay_host == NULL || relay_port == NULL)
+    {
+      g_warning ("%s: output parameters must not be NULL", __func__);
+      return -1;
+    }
+
+  *relay_host = NULL;
+  *relay_port = 0;
+
+  if (! g_file_get_contents (relays_path, &file_contents, &file_size, &error))
+    {
+      g_warning ("%s: could not read file: %s", __func__, error->message);
+      g_error_free (error);
+      return -1;
+    }
+
+  parsed_file = cJSON_ParseWithLength (file_contents, file_size);
+  if (parsed_file == NULL)
+    {
+      g_warning ("%s: could not parse JSON", __func__);
+      return -1;
+    }
+
+  if (extract_relays_fields_from_root_cjson (parsed_file, &relays))
+    {
+      cJSON_Delete (parsed_file);
+      return -1;
+    }
+
+  cJSON_ArrayForEach (json_item, relays)
+    {
+      relays_list_item_t parsed_item;
+      if (extract_relay_fields_from_json_item (json_item, &parsed_item))
+        continue;
+      if (scanner_type_matches_relay_protocol (scanner_type,
+                                               parsed_item.protocol)
+          && (parsed_item.original_port == 0
+              || parsed_item.original_port == original_port)
+          && (strcmp (original_host, parsed_item.original_host) == 0))
+        {
+          g_free (*relay_host);
+          *relay_host = g_strdup (parsed_item.relay_host);
+          *relay_port = parsed_item.relay_port;
+        }
+    }
+  return 0;
+}

--- a/src/manage_scanner_relays.h
+++ b/src/manage_scanner_relays.h
@@ -21,7 +21,7 @@ typedef struct {
   int original_port;    ///< Original port of the scanner
   char *relay_host;     ///< Host or socket path of the relay
   int relay_port;       ///< Port of the relay
-  char *protocol;       ///< Protocol string defining the scanner type.
+  char *scanner_type;   ///< Scanner type string defining the scanner type.
 } relays_list_item_t;
 
 const char *

--- a/src/manage_scanner_relays.h
+++ b/src/manage_scanner_relays.h
@@ -1,0 +1,42 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file
+ * @brief Greenbone Vulnerability Manager scanner relays headers.
+ */
+
+#ifndef _GVMD_MANAGE_SCANNER_RELAYS
+#define _GVMD_MANAGE_SCANNER_RELAYS
+
+#include <glib.h>
+
+/**
+ * @brief  Data structure describing an item from a scanner relays list.
+ */
+typedef struct {
+  char *original_host;  ///< The original host / socket path of the scanner
+  int original_port;    ///< Original port of the scanner
+  char *relay_host;     ///< Host or socket path of the relay
+  int relay_port;       ///< Port of the relay
+  char *protocol;       ///< Protocol string defining the scanner type.
+} relays_list_item_t;
+
+const char *
+get_relays_path ();
+
+void
+set_relays_path (const char *);
+
+gboolean
+relays_managed_externally ();
+
+int
+sync_scanner_relays ();
+
+int
+get_single_relay_from_file (int, const char *, int, char **, int *);
+
+#endif /* _GVMD_MANAGE_SCANNER_RELAYS */

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -34,6 +34,7 @@
 #include "manage_report_formats.h"
 #include "manage_roles.h"
 #include "manage_runtime_flags.h"
+#include "manage_scanner_relays.h"
 #include "manage_sql_credential_stores.h"
 #include "manage_sql_copy.h"
 #include "manage_sql_secinfo.h"
@@ -54,6 +55,7 @@
 #include "manage_sql_report_formats.h"
 #include "manage_sql_resources.h"
 #include "manage_sql_roles.h"
+#include "manage_sql_scanner_relays.h"
 #include "manage_sql_settings.h"
 #include "manage_sql_tags.h"
 #include "manage_sql_targets.h"
@@ -26842,6 +26844,10 @@ create_scanner (const char* name, const char *comment, const char *host,
 {
   int iport, itype, irelay_port, unix_socket, relay_unix_socket = 0;
   credential_t credential;
+  gboolean use_relay_from_file = FALSE;
+  const char *used_relay_host;
+  char *file_relay_host = NULL;
+  int ifile_relay_port = 0;
 
   assert (name);
 
@@ -26927,37 +26933,58 @@ create_scanner (const char* name, const char *comment, const char *host,
         }
     }
 
-  if (relay_host == NULL || strcmp (relay_host, "") == 0)
+  if (relays_managed_externally ())
     {
-      irelay_port = 0;
+      int ret = get_single_relay_from_file (itype,
+                                            host,
+                                            iport,
+                                            &file_relay_host,
+                                            &ifile_relay_port);
+      use_relay_from_file = (ret == 0);
     }
-  else if (relay_unix_socket)
+
+  if (use_relay_from_file)
     {
-      if (! scanner_type_supports_unix_sockets (itype))
-        {
-          sql_rollback ();
-          return CREATE_SCANNER_UNIX_SOCKET_UNSUPPORTED;
-        }
-      irelay_port = 0;
+      irelay_port = ifile_relay_port;
+      used_relay_host = file_relay_host;
     }
   else
     {
-      irelay_port = atoi (relay_port ?: "0");
-      if (irelay_port <= 0 || irelay_port > 65535)
+      if (relay_host == NULL || strcmp (relay_host, "") == 0)
         {
-          sql_rollback ();
-          return CREATE_SCANNER_INVALID_RELAY_PORT;
+          used_relay_host = NULL;
+          irelay_port = 0;
         }
-      if (gvm_get_host_type (host) == -1)
+      else if (relay_unix_socket)
         {
-          sql_rollback ();
-          return CREATE_SCANNER_INVALID_RELAY_HOST;
+          if (! scanner_type_supports_unix_sockets (itype))
+            {
+              sql_rollback ();
+              return CREATE_SCANNER_UNIX_SOCKET_UNSUPPORTED;
+            }
+          used_relay_host = relay_host;
+          irelay_port = 0;
+        }
+      else
+        {
+          irelay_port = atoi (relay_port ?: "0");
+          used_relay_host = relay_host;
+          if (irelay_port <= 0 || irelay_port > 65535)
+            {
+              sql_rollback ();
+              return CREATE_SCANNER_INVALID_RELAY_PORT;
+            }
+          if (gvm_get_host_type (host) == -1)
+            {
+              sql_rollback ();
+              return CREATE_SCANNER_INVALID_RELAY_HOST;
+            }
         }
     }
 
   if (unix_socket)
     insert_scanner (name, comment, host, ca_pub, iport, itype,
-                    relay_host, irelay_port, new_scanner);
+                    used_relay_host, irelay_port, new_scanner);
   else
     {
       credential = 0;
@@ -26968,11 +26995,13 @@ create_scanner (const char* name, const char *comment, const char *host,
           if (find_credential_with_permission
               (credential_id, &credential, "get_credentials"))
             {
+              g_free (file_relay_host);
               sql_rollback ();
               return CREATE_SCANNER_INTERNAL_ERROR;
             }
           if (credential == 0)
             {
+              g_free (file_relay_host);
               sql_rollback ();
               return CREATE_SCANNER_CREDENTIAL_NOT_FOUND;
             }
@@ -26980,6 +27009,7 @@ create_scanner (const char* name, const char *comment, const char *host,
                        " WHERE id = %llu;",
                        credential))
             {
+              g_free (file_relay_host);
               sql_rollback ();
               return CREATE_SCANNER_CREDENTIAL_NOT_CC;
             }
@@ -26987,6 +27017,7 @@ create_scanner (const char* name, const char *comment, const char *host,
 
       insert_scanner (name, comment, host, ca_pub, iport, itype,
                       relay_host, irelay_port, new_scanner);
+      g_free (file_relay_host);
 
       if (credential)
         {
@@ -27048,11 +27079,12 @@ modify_scanner (const char *scanner_id, const char *name, const char *comment,
                 const char *ca_pub, const char *credential_id,
                 const char *relay_host, const char *relay_port)
 {
-  gchar *used_host, *used_relay_host;
+  gboolean use_relay_from_file = FALSE;
+  gchar *used_host, *file_relay_host = NULL, *used_relay_host;
   gchar *quoted_name, *quoted_comment, *quoted_host, *quoted_relay_host;
   scanner_t scanner = 0;
   credential_t credential = 0;
-  int itype, iport, irelay_port;
+  int itype, iport, ifile_relay_port = 0, irelay_port;
   int unix_socket, relay_unix_socket, credential_given;
 
   assert (current_credentials.uuid);
@@ -27118,12 +27150,6 @@ modify_scanner (const char *scanner_id, const char *name, const char *comment,
     iport = sql_int ("SELECT port FROM scanners WHERE id = %llu;",
                      scanner);
 
-  if (relay_port)
-    irelay_port = atoi (relay_port);
-  else
-    irelay_port = sql_int ("SELECT relay_port FROM scanners WHERE id = %llu;",
-                           scanner);
-
   if (host)
     used_host = g_strdup (host);
   else
@@ -27131,12 +27157,36 @@ modify_scanner (const char *scanner_id, const char *name, const char *comment,
                             " WHERE id = %llu;",
                             scanner);
 
-  if (relay_host)
-    used_relay_host = g_strdup (relay_host);
+  if (relays_managed_externally ())
+    {
+      int ret = get_single_relay_from_file (itype,
+                                            used_host,
+                                            iport,
+                                            &file_relay_host,
+                                            &ifile_relay_port);
+      use_relay_from_file = (ret == 0);
+    }
+
+  if (use_relay_from_file)
+    {
+      irelay_port = ifile_relay_port;
+      used_relay_host = file_relay_host;
+    }
   else
-    used_relay_host = sql_string ("SELECT relay_host FROM scanners"
-                                  " WHERE id = %llu;",
-                                  scanner);
+    {
+      if (relay_port)
+        irelay_port = atoi (relay_port);
+      else
+        irelay_port = sql_int ("SELECT relay_port FROM scanners WHERE id = %llu;",
+                              scanner);
+
+      if (relay_host)
+        used_relay_host = g_strdup (relay_host);
+      else
+        used_relay_host = sql_string ("SELECT relay_host FROM scanners"
+                                      " WHERE id = %llu;",
+                                      scanner);
+    }
 
   unix_socket = used_host && (*used_host == '/');
   relay_unix_socket = used_relay_host && (*used_relay_host == '/');
@@ -27320,8 +27370,9 @@ modify_scanner (const char *scanner_id, const char *name, const char *comment,
         sql ("UPDATE scanners SET credential = NULL WHERE id = %llu;",
              scanner);
     }
+
   sql_commit ();
-  return 0;
+  return MODIFY_SCANNER_SUCCESS;
 }
 
 /**

--- a/src/manage_sql_scanner_relays.c
+++ b/src/manage_sql_scanner_relays.c
@@ -1,0 +1,144 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file
+ * @brief Greenbone Vulnerability Manager scanner relays SQL.
+ */
+
+#include "manage_scanner_relays.h"
+#include "manage_sql.h"
+
+#include <glib/gstdio.h>
+#include <gvm/util/json.h>
+
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain used for messages from this module.
+ */
+#define G_LOG_DOMAIN "md   manage"
+
+/**
+ * @brief Get the time the scanner relays were last updated in the database.
+ *
+ * @return The time in the "scanner_relays_update_time" meta table entry.
+ */
+time_t
+get_scanner_relays_db_update_time ()
+{
+  long long db_update_time = 0;
+  sql_int64_ps (&db_update_time,
+                "SELECT value FROM meta"
+                " WHERE name = 'scanner_relays_update_time'",
+                NULL);
+  return db_update_time;
+}
+
+/**
+ * @brief Sets a scanner relays update time in the meta table.
+ *
+ * @param[in]  new_time  The new time to set.
+ */
+void
+set_scanner_relays_update_time (time_t new_time)
+{
+  sql_ps ("INSERT INTO meta (name, value)"
+          " VALUES ('scanner_relays_update_time', $1)"
+          " ON CONFLICT (name) DO UPDATE SET value = EXCLUDED.value;",
+          SQL_RESOURCE_PARAM (new_time),
+          NULL);
+}
+
+/**
+ * @brief Perform actions at the start of updating all scanner relays.
+ *
+ * The relay hosts and ports for all scanners are reset.
+ */
+void
+update_all_scanner_relays_start ()
+{
+  sql_ps ("UPDATE scanners SET relay_host = NULL, relay_port = NULL", NULL);
+}
+
+/**
+ * @brief Update all affected scanners according a relays list item
+ *
+ * @param[in]  item  Relays list item describing the scanner(s) and relay
+ * @param[out] updated_scanner_uuids  Hashtable insert updated scanners into
+ *
+ * @return 0 success, -1 error
+ */
+int
+update_all_scanner_relays_from_item (relays_list_item_t *item,
+                                     GHashTable *updated_scanner_uuids)
+{
+  iterator_t iterator;
+
+  if (item->protocol && strcmp (item->protocol, ""))
+    {
+      scanner_type_t sc_type;
+      if (strcasecmp (item->protocol, "agent-control") == 0)
+        sc_type = SCANNER_TYPE_AGENT_CONTROLLER_SENSOR;
+      else if (strcasecmp (item->protocol, "openvasd") == 0)
+        sc_type = SCANNER_TYPE_OPENVASD_SENSOR;
+      else if (strcasecmp (item->protocol, "osp") == 0)
+        sc_type = SCANNER_TYPE_OSP_SENSOR;
+      else
+        {
+          g_warning ("%s: relay with unknown protocol '%s'",
+                     __func__, item->protocol);
+          return 0;
+        }
+
+      init_ps_iterator (&iterator,
+                        "UPDATE scanners SET relay_host = $1, relay_port = $2"
+                        " WHERE type = $3 AND host = $4 AND ($5 = 0 OR port = $5)"
+                        " RETURNING uuid",
+                        SQL_STR_PARAM (item->relay_host),
+                        SQL_INT_PARAM (item->relay_port),
+                        SQL_INT_PARAM (sc_type),
+                        SQL_STR_PARAM (item->original_host),
+                        SQL_INT_PARAM (item->original_port),
+                        NULL);
+    }
+  else
+    {
+      init_ps_iterator (&iterator,
+                        "UPDATE scanners SET relay_host = $1, relay_port = $2"
+                        " WHERE host = $3 AND ($4 = 0 OR port = $4)"
+                        " RETURNING uuid",
+                        SQL_STR_PARAM (item->relay_host),
+                        SQL_INT_PARAM (item->relay_port),
+                        SQL_STR_PARAM (item->original_host),
+                        SQL_INT_PARAM (item->original_port),
+                        NULL);
+    }
+
+  if (updated_scanner_uuids)
+    {
+      while (next (&iterator))
+        {
+          gchar *updated_uuid = g_strdup (iterator_string (&iterator, 0));
+          g_hash_table_add (updated_scanner_uuids, updated_uuid);
+        }
+    }
+
+  cleanup_iterator (&iterator);
+
+  return 0;
+}
+
+/**
+ * @brief Perform actions at the end of updating all scanner relays
+ *
+ * The scanner relays update time in the DB is set to the file timestamp
+ *
+ * @param[in]  file_mod_time  File modification time to set in the DB
+ */
+void
+update_all_scanner_relays_end (time_t file_mod_time)
+{
+  set_scanner_relays_update_time (file_mod_time);
+}

--- a/src/manage_sql_scanner_relays.c
+++ b/src/manage_sql_scanner_relays.c
@@ -76,19 +76,19 @@ update_all_scanner_relays_from_item (relays_list_item_t *item,
 {
   iterator_t iterator;
 
-  if (item->protocol && strcmp (item->protocol, ""))
+  if (item->scanner_type && strcmp (item->scanner_type, ""))
     {
       scanner_type_t sc_type;
-      if (strcasecmp (item->protocol, "agent-control") == 0)
+      if (strcasecmp (item->scanner_type, "agent-control") == 0)
         sc_type = SCANNER_TYPE_AGENT_CONTROLLER_SENSOR;
-      else if (strcasecmp (item->protocol, "openvasd") == 0)
+      else if (strcasecmp (item->scanner_type, "openvasd") == 0)
         sc_type = SCANNER_TYPE_OPENVASD_SENSOR;
-      else if (strcasecmp (item->protocol, "osp") == 0)
+      else if (strcasecmp (item->scanner_type, "osp") == 0)
         sc_type = SCANNER_TYPE_OSP_SENSOR;
       else
         {
-          g_warning ("%s: relay with unknown protocol '%s'",
-                     __func__, item->protocol);
+          g_warning ("%s: relay with unknown scanner type '%s'",
+                     __func__, item->scanner_type);
           return 0;
         }
 

--- a/src/manage_sql_scanner_relays.h
+++ b/src/manage_sql_scanner_relays.h
@@ -1,0 +1,31 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file
+ * @brief Greenbone Vulnerability Manager scanner relays headers.
+ */
+
+#ifndef _GVMD_MANAGE_SQL_SCANNER_RELAYS
+#define _GVMD_MANAGE_SQL_SCANNER_RELAYS
+
+#include "manage_scanner_relays.h"
+
+time_t
+get_scanner_relays_db_update_time ();
+
+void
+set_scanner_relays_update_time (time_t);
+
+int
+update_all_scanner_relays_start ();
+
+int
+update_all_scanner_relays_from_item (relays_list_item_t *, GHashTable *);
+
+int
+update_all_scanner_relays_end (time_t);
+
+#endif /* _GVMD_MANAGE_SQL_SCANNER_RELAYS */


### PR DESCRIPTION
## What
The command llne option --relays-path is added which makes gvmd update the relay_host and relay_port fields of scanners automatically from a JSON file with the given path.

## Why
This is meant as a replacement for the deprecated --relay-mapper option.

## References
GEA-1685