### PR TITLE
Change: output full path from cmake trailing space check

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -348,12 +348,7 @@ if(NOT CMAKE_BUILD_TYPE MATCHES "Release")
   add_custom_target(
     check-trailing-space
     ALL
-    # once for output
-    COMMAND
-      grep -Hn "[ ]$$" *.c *.h | sed
-      "'s/^\\(.\\+:.\\+:\\)/\\1 error: trailing space: /'"
-    # again for exit code
-    COMMAND ! grep --quiet "[ ]$$" *.c *.h
+    COMMAND ${CMAKE_SOURCE_DIR}/tools/check-trailing-space
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "Checking for trailing space..."
   )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -346,7 +346,7 @@ add_library(all-misc-obj OBJECT ${ALL_MISC_SRC})
 
 if(NOT CMAKE_BUILD_TYPE MATCHES "Release")
   add_custom_target(
-    check-whitespace
+    check-trailing-space
     ALL
     # once for output
     COMMAND
@@ -355,7 +355,7 @@ if(NOT CMAKE_BUILD_TYPE MATCHES "Release")
     # again for exit code
     COMMAND ! grep --quiet "[ ]$$" *.c *.h
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    COMMENT "Checking whitespace..."
+    COMMENT "Checking for trailing space..."
   )
 
   add_custom_target(

--- a/tools/check-trailing-space
+++ b/tools/check-trailing-space
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+FOUND=0
+for FILE in *.c *.h; do
+  grep -qn "[ ]$" "$FILE" && FOUND=1
+  grep -Hn "[ ]$" "$FILE" | sed "s/^\(.\+:.\:.\+\)/\1 error: trailing space/"
+done
+
+exit $FOUND

--- a/tools/check-trailing-space
+++ b/tools/check-trailing-space
@@ -3,7 +3,7 @@
 FOUND=0
 for FILE in *.c *.h; do
   grep -qn "[ ]$" "$FILE" && FOUND=1
-  grep -Hn "[ ]$" "$FILE" | sed "s/^\(.\+:.\:.\+\)/\1 error: trailing space/"
+  grep -Hn "[ ]$" "$FILE" | sed "s%^\(.\+:.\:.\+\)%$(pwd)/\1 error: trailing space%"
 done
 
 exit $FOUND


### PR DESCRIPTION
## What

Include full path in error messages from the trailing space check.

## Why

Makes it easier for editors/IDEs to jump to the error.
