### PR TITLE
Add/gmp get report errors

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -248,6 +248,7 @@ set(
   manage_sql_port_lists.c
   manage_sql_configs.c
   manage_sql_report_configs.c
+  manage_sql_report_errors.c
   manage_sql_report_formats.c
   manage_sql_resources.c
   manage_sql_report_hosts.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -296,6 +296,7 @@ set(
   gmp_oci_image_targets.c
   gmp_port_lists.c
   gmp_report_configs.c
+  gmp_report_errors.c
   gmp_report_formats.c
   gmp_report_hosts.c
   gmp_report_ports.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -188,6 +188,7 @@ set(
   manage_preferences.c
   manage_resources.c
   manage_report_configs.c
+  manage_report_errors.c
   manage_report_formats.c
   manage_report_hosts.c
   manage_report_ports.c

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -90,6 +90,7 @@
 #include "gmp_oci_image_targets.h"
 #include "gmp_port_lists.h"
 #include "gmp_report_configs.h"
+#include "gmp_report_errors.h"
 #include "gmp_report_formats.h"
 #include "gmp_report_hosts.h"
 #include "gmp_report_ports.h"
@@ -4552,6 +4553,7 @@ typedef enum
   CLIENT_GET_PREFERENCES,
   CLIENT_GET_REPORTS,
   CLIENT_GET_REPORT_CONFIGS,
+  CLIENT_GET_REPORT_ERRORS,
   CLIENT_GET_REPORT_FORMATS,
   CLIENT_GET_REPORT_HOSTS,
   CLIENT_GET_REPORT_PORTS,
@@ -5883,6 +5885,8 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
 
             set_client_state (CLIENT_GET_REPORT_FORMATS);
           }
+
+        ELSE_GET_START (report_errors, REPORT_ERRORS)
 
         ELSE_GET_START (report_hosts, REPORT_HOSTS)
 
@@ -22124,6 +22128,8 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
       case CLIENT_GET_REPORT_FORMATS:
         handle_get_report_formats (gmp_parser, error);
         break;
+
+      CASE_GET_END (REPORT_ERRORS, report_errors);
 
       CASE_GET_END (REPORT_HOSTS, report_hosts);
 

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -5857,6 +5857,9 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
 
             set_client_state (CLIENT_GET_REPORT_CONFIGS);
           }
+
+        ELSE_GET_START (report_errors, REPORT_ERRORS)
+
         else if (strcasecmp ("GET_REPORT_FORMATS", element_name) == 0)
           {
             const gchar* attribute;
@@ -5885,8 +5888,6 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
 
             set_client_state (CLIENT_GET_REPORT_FORMATS);
           }
-
-        ELSE_GET_START (report_errors, REPORT_ERRORS)
 
         ELSE_GET_START (report_hosts, REPORT_HOSTS)
 
@@ -22125,11 +22126,11 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
         handle_get_report_configs (gmp_parser, error);
         break;
 
+      CASE_GET_END (REPORT_ERRORS, report_errors);
+
       case CLIENT_GET_REPORT_FORMATS:
         handle_get_report_formats (gmp_parser, error);
         break;
-
-      CASE_GET_END (REPORT_ERRORS, report_errors);
 
       CASE_GET_END (REPORT_HOSTS, report_hosts);
 

--- a/src/gmp_get.c
+++ b/src/gmp_get.c
@@ -600,6 +600,7 @@ send_get_end_internal (const char *type, get_data_t *get, int get_counts,
       g_free (filter);
       if ((strcmp (type, "task") == 0)
           || (strcmp (type, "report") == 0)
+          || (strcmp (type, "report_error") == 0)
           || (strcmp (type, "report_host") == 0)
           || (strcmp (type, "report_port") == 0)
           || (strcmp (type, "report_tls_certificate") == 0)
@@ -621,6 +622,7 @@ send_get_end_internal (const char *type, get_data_t *get, int get_counts,
 
           if ((strcmp (type, "task") == 0)
               || (strcmp (type, "report") == 0)
+              || (strcmp (type, "report_error") == 0)
               || (strcmp (type, "report_host") == 0)
               || (strcmp (type, "report_port") == 0)
               || (strcmp (type, "report_tls_certificate") == 0)
@@ -644,6 +646,7 @@ send_get_end_internal (const char *type, get_data_t *get, int get_counts,
     {
       if ((strcmp (type, "task") == 0)
           || (strcmp (type, "report") == 0)
+          || (strcmp (type, "report_error") == 0)
           || (strcmp (type, "report_host") == 0)
           || (strcmp (type, "report_port") == 0)
           || (strcmp (type, "report_tls_certificate") == 0)

--- a/src/gmp_report_errors.c
+++ b/src/gmp_report_errors.c
@@ -1,0 +1,176 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "gmp_report_errors.h"
+
+#include "gmp_get.h"
+#include "manage.h"
+#include "manage_report_errors.h"
+
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md    gmp"
+
+/**
+ * @brief Command data for the get_report_errors command.
+ */
+typedef struct
+{
+  get_data_t get;  ///< Get args with filtering.
+  char *report_id; ///< ID of single report to get.
+} get_report_errors_data_t;
+
+/**
+ * @brief Parser callback data.
+ */
+static get_report_errors_data_t get_report_errors_data;
+
+/**
+ * @brief Reset the internal state of the <get_report_errors> command.
+ */
+static void
+get_report_errors_reset ()
+{
+  get_data_reset (&get_report_errors_data.get);
+  g_free (get_report_errors_data.report_id);
+  memset (&get_report_errors_data, 0, sizeof (get_report_errors_data));
+}
+
+/**
+ * @brief Initialize the <get_report_errors> GMP command by parsing
+ *        attributes.
+ *
+ * @param[in] attribute_names   Null-terminated array of attribute names.
+ * @param[in] attribute_values  Null-terminated array of corresponding
+ *                              attribute values.
+ */
+void
+get_report_errors_start (const gchar **attribute_names,
+                         const gchar **attribute_values)
+{
+  const gchar *attribute;
+
+  get_data_parse_attributes (&get_report_errors_data.get,
+                             "error",
+                             attribute_names,
+                             attribute_values);
+
+  if (find_attribute (attribute_names, attribute_values,
+                      "report_id", &attribute))
+    {
+      get_report_errors_data.report_id = g_strdup (attribute);
+
+      get_data_set_extra (&get_report_errors_data.get,
+                          "report_id",
+                          g_strdup (attribute));
+    }
+}
+
+/**
+ * @brief Execute the <get_report_errors> GMP command.
+ *
+ * @param[in] gmp_parser  Pointer to the GMP parser handling the current
+ *                        session.
+ * @param[in] error       Location to store error information, if any occurs.
+ */
+void
+get_report_errors_run (gmp_parser_t *gmp_parser, GError **error)
+{
+  report_t report;
+  int ret, filtered, count;
+
+  count = 0;
+
+  if (get_report_errors_data.report_id == NULL)
+    {
+      SEND_TO_CLIENT_OR_FAIL
+        (XML_ERROR_SYNTAX ("get_report_errors",
+                           "Missing report_id attribute"));
+      get_report_errors_reset ();
+      return;
+    }
+
+  ret = init_get ("get_report_errors",
+                  &get_report_errors_data.get,
+                  "Report Errors",
+                  NULL);
+  if (ret)
+    {
+      switch (ret)
+        {
+        case 99:
+          SEND_TO_CLIENT_OR_FAIL
+            (XML_ERROR_SYNTAX ("get_report_errors",
+                               "Permission denied"));
+          break;
+        default:
+          internal_error_send_to_client (error);
+          get_report_errors_reset ();
+          return;
+        }
+      get_report_errors_reset ();
+      return;
+    }
+
+  if (find_report_with_permission (get_report_errors_data.report_id,
+                                   &report,
+                                   "get_reports"))
+    {
+      internal_error_send_to_client (error);
+      get_report_errors_reset ();
+      return;
+    }
+
+  if (report == 0)
+    {
+      if (send_find_error_to_client ("get_report_errors",
+                                     "report",
+                                     get_report_errors_data.report_id,
+                                     gmp_parser))
+        error_send_to_client (error);
+      get_report_errors_reset ();
+      return;
+    }
+
+  SEND_GET_START ("report_error");
+
+  ret = manage_send_report_errors (
+    report,
+    &get_report_errors_data.get,
+    send_to_client,
+    gmp_parser->client_writer,
+    gmp_parser->client_writer_data);
+
+  if (ret)
+    {
+      switch (ret)
+        {
+        case 2:
+          if (send_find_error_to_client ("get_report_errors",
+                                         "filter",
+                                         get_report_errors_data.get.filt_id,
+                                         gmp_parser))
+            error_send_to_client (error);
+          break;
+        default:
+          internal_error_send_to_client (error);
+          break;
+        }
+      get_report_errors_reset ();
+      return;
+    }
+
+  filtered = get_report_errors_data.get.id
+               ? 1
+               : report_error_count (report);
+  SEND_GET_END ("report_error",
+                &get_report_errors_data.get,
+                count,
+                filtered);
+
+  get_report_errors_reset ();
+}

--- a/src/gmp_report_errors.h
+++ b/src/gmp_report_errors.h
@@ -1,0 +1,19 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef _GVM_GMP_REPORT_ERRORS_H
+#define _GVM_GMP_REPORT_ERRORS_H
+
+#include "gmp_base.h"
+
+/* GET_REPORT_ERRORS. */
+
+void
+get_report_errors_start (const gchar **, const gchar **);
+
+void
+get_report_errors_run (gmp_parser_t *, GError **);
+
+#endif //_GVM_GMP_REPORT_ERRORS_H

--- a/src/manage.h
+++ b/src/manage.h
@@ -21,6 +21,7 @@
 #include "manage_events.h"
 #include "manage_get.h"
 #include "manage_integration_configs.h"
+#include "manage_report_errors.h"
 #include "manage_report_hosts.h"
 #include "manage_report_ports.h"
 #include "manage_report_tls_certificates.h"

--- a/src/manage.h
+++ b/src/manage.h
@@ -1198,9 +1198,6 @@ void
 init_report_iterator_task (iterator_t*, task_t);
 
 void
-init_report_errors_iterator (iterator_t*, report_t);
-
-void
 init_report_awaiting_processing_iterator (iterator_t*, int);
 
 const char*

--- a/src/manage_commands.c
+++ b/src/manage_commands.c
@@ -124,6 +124,7 @@ command_t gmp_commands[]
     {"GET_PREFERENCES", "Get preferences for all available NVTs."},
     {"GET_REPORTS", "Get all reports."},
     {"GET_REPORT_CONFIGS", "Get all report configs."},
+    {"GET_REPORT_ERRORS", "Get all report errors for specific report."},
     {"GET_REPORT_FORMATS", "Get all report formats."},
     {"GET_REPORT_HOSTS", "Get all report hosts for specific report."},
     {"GET_REPORT_PORTS", "Get all report ports for specific report."},

--- a/src/manage_report_errors.c
+++ b/src/manage_report_errors.c
@@ -1,0 +1,163 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file
+ * @brief GVM management layer: Report errors.
+ *
+ * Non-SQL report errors code for the GVM management layer.
+ */
+
+#include "manage_report_errors.h"
+#include "manage_filters.h"
+#include "manage_settings.h"
+#include "manage_sql_report_hosts.h"
+#include "manage_sql_report_errors.h"
+
+#include <gvm/util/fileutils.h>
+
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md manage"
+
+/**
+ * @brief Send report Errors XML to the client.
+ *
+ * @param[in]  report                        Report.
+ * @param[in]  get                           GET command data.
+ * @param[in]  send                          Function to write to client.
+ * @param[in]  send_data_1                   Second argument to @p send.
+ * @param[in]  send_data_2                   Third argument to @p send.
+ *
+ * @return 0 on success, -1 on error, 2 if filter was not found.
+ */
+int
+manage_send_report_errors (report_t report,
+                           const get_data_t *get,
+                           gboolean (*send) (const char *,
+                                             int (*) (const char *,
+                                               void *),
+                                             void *),
+                           int (*send_data_1) (const char *, void *),
+                           void *send_data_2)
+{
+  gchar *xml_file;
+  gchar *term;
+  char xml_dir[] = "/tmp/gvmd_XXXXXX";
+  gboolean xml_dir_created = FALSE;
+  char chunk[MANAGE_SEND_REPORT_CHUNK_SIZE + 1];
+  FILE *stream;
+  int ret;
+
+  term = NULL;
+  xml_file = NULL;
+  stream = NULL;
+
+  if (get == NULL)
+    {
+      g_warning ("%s: get is NULL", __func__);
+      return -1;
+    }
+
+  if (mkdtemp (xml_dir) == NULL)
+    {
+      g_warning ("%s: mkdtemp failed", __func__);
+      ret = -1;
+      goto cleanup;
+    }
+
+  xml_dir_created = TRUE;
+
+  xml_file = g_strdup_printf ("%s/report-errors.xml", xml_dir);
+  stream = fopen (xml_file, "w");
+  if (stream == NULL)
+    {
+      g_warning ("%s: %s", __func__, strerror (errno));
+      ret = -1;
+      goto cleanup;
+    }
+
+  ret = print_report_errors_xml_summary_or_details (
+    report,
+    stream,
+    get->details);
+
+  if (fclose (stream))
+    {
+      stream = NULL;
+      ret = -1;
+      goto cleanup;
+    }
+  stream = NULL;
+
+  if (ret)
+    {
+      ret = -1;
+      goto cleanup;
+    }
+
+  stream = fopen (xml_file, "r");
+  if (stream == NULL)
+    {
+      g_warning ("%s: %s", __func__, strerror (errno));
+      ret = -1;
+      goto cleanup;
+    }
+
+  while (1)
+    {
+      int left;
+      char *dest;
+
+      left = MANAGE_SEND_REPORT_CHUNK_SIZE;
+      dest = chunk;
+
+      while (1)
+        {
+          ret = fread (dest, 1, left, stream);
+          if (ferror (stream))
+            {
+              g_warning ("%s: error after fread", __func__);
+              ret = -1;
+              goto cleanup;
+            }
+
+          left -= ret;
+          if (left == 0 || feof (stream))
+            break;
+          dest += ret;
+        }
+
+      if (left < MANAGE_SEND_REPORT_CHUNK_SIZE)
+        {
+          chunk[MANAGE_SEND_REPORT_CHUNK_SIZE - left] = '\0';
+          if (send (chunk, send_data_1, send_data_2))
+            {
+              g_warning ("%s: send error", __func__);
+              ret = -1;
+              goto cleanup;
+            }
+        }
+
+      if (feof (stream))
+        break;
+    }
+
+  ret = 0;
+
+cleanup:
+  if (stream)
+    fclose (stream);
+
+  g_free (xml_file);
+  g_free (term);
+
+  if (xml_dir_created)
+    gvm_file_remove_recurse (xml_dir);
+
+  return ret;
+}

--- a/src/manage_report_errors.h
+++ b/src/manage_report_errors.h
@@ -51,12 +51,6 @@ report_errors_iterator_nvt_name (iterator_t *);
 const char *
 report_errors_iterator_nvt_cvss (iterator_t *);
 
-const char *
-report_errors_iterator_scan_nvt_version (iterator_t *);
-
-const char *
-report_errors_iterator_severity (iterator_t *);
-
 int
 report_error_count (report_t);
 

--- a/src/manage_report_errors.h
+++ b/src/manage_report_errors.h
@@ -24,4 +24,40 @@ manage_send_report_errors (report_t ,
                            int (*) (const char *, void *),
                            void *);
 
+void
+init_report_errors_iterator (iterator_t *, report_t);
+
+const char *
+report_errors_iterator_host (iterator_t *);
+
+const char *
+report_errors_iterator_severity (iterator_t *);
+
+const char *
+report_errors_iterator_scan_nvt_version (iterator_t *);
+
+const char *
+report_errors_iterator_port (iterator_t *);
+
+const char *
+report_errors_iterator_nvt_oid (iterator_t *);
+
+const char *
+report_errors_iterator_desc (iterator_t *);
+
+const char *
+report_errors_iterator_nvt_name (iterator_t *);
+
+const char *
+report_errors_iterator_nvt_cvss (iterator_t *);
+
+const char *
+report_errors_iterator_scan_nvt_version (iterator_t *);
+
+const char *
+report_errors_iterator_severity (iterator_t *);
+
+int
+report_error_count (report_t);
+
 #endif //_GVM_MANAGE_REPORT_ERRORS_H

--- a/src/manage_report_errors.h
+++ b/src/manage_report_errors.h
@@ -1,0 +1,27 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file
+ * @brief GVM management layer: Report errors.
+ *
+ * Non-SQL report errors code for the GVM management layer.
+ */
+
+#ifndef _GVM_MANAGE_REPORT_ERRORS_H
+#define _GVM_MANAGE_REPORT_ERRORS_H
+
+#include "manage_get.h"
+
+int
+manage_send_report_errors (report_t ,
+                           const get_data_t *,
+                           gboolean (*)(const char*,
+                                        int (*)(const char*, void*),
+                                        void*),
+                           int (*) (const char *, void *),
+                           void *);
+
+#endif //_GVM_MANAGE_REPORT_ERRORS_H

--- a/src/manage_resources.c
+++ b/src/manage_resources.c
@@ -312,6 +312,7 @@ type_owned (const char* type)
   return strcasecmp (type, "info")
          && type_is_info_subtype (type) == 0
          && strcasecmp (type, "vuln")
+         && strcasecmp (type, "report_error")
          && strcasecmp (type, "report_host")
          && strcasecmp (type, "report_port")
          && strcasecmp (type, "report_tls_certificate");

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -52,6 +52,7 @@
 #include "manage_sql_permissions_cache.h"
 #include "manage_sql_port_lists.h"
 #include "manage_sql_report_configs.h"
+#include "manage_sql_report_errors.h"
 #include "manage_sql_report_formats.h"
 #include "manage_sql_resources.h"
 #include "manage_sql_roles.h"
@@ -12992,133 +12993,6 @@ cleanup_result_nvts ()
 }
 
 /**
- * @brief Initialise a report errors iterator.
- *
- * @param[in]  iterator  Iterator.
- * @param[in]  report   The report.
- */
-void
-init_report_errors_iterator (iterator_t* iterator, report_t report)
-{
-  if (report)
-    init_iterator (iterator,
-                   "SELECT results.host, results.port, results.nvt,"
-                   " results.description,"
-                   " coalesce((SELECT name FROM nvts"
-                   "           WHERE nvts.oid = results.nvt), ''),"
-                   " coalesce((SELECT cvss_base FROM nvts"
-                   "           WHERE nvts.oid = results.nvt), ''),"
-                   " results.nvt_version, results.severity,"
-                   " results.id"
-                   " FROM results"
-                   " WHERE results.severity = %0.1f"
-                   "  AND results.report = %llu",
-                   SEVERITY_ERROR, report);
-}
-
-/**
- * @brief Get the host from a report error messages iterator.
- *
- * @param[in]  iterator  Iterator.
- *
- * @return The host of the report error message.  Caller must use only before
- *         calling cleanup_iterator.
- */
-static
-DEF_ACCESS (report_errors_iterator_host, 0);
-
-/**
- * @brief Get the port from a report error messages iterator.
- *
- * @param[in]  iterator  Iterator.
- *
- * @return The port of the report error message.  Caller must use only before
- *         calling cleanup_iterator.
- */
-static
-DEF_ACCESS (report_errors_iterator_port, 1);
-
-/**
- * @brief Get the nvt oid from a report error messages iterator.
- *
- * @param[in]  iterator  Iterator.
- *
- * @return The nvt of the report error message.  Caller must use only before
- *         calling cleanup_iterator.
- */
-static
-DEF_ACCESS (report_errors_iterator_nvt_oid, 2);
-
-/**
- * @brief Get the description from a report error messages iterator.
- *
- * @param[in]  iterator  Iterator.
- *
- * @return The description of the report error message.  Caller must use only
- * before calling cleanup_iterator.
- */
-static
-DEF_ACCESS (report_errors_iterator_desc, 3);
-
-/**
- * @brief Get the nvt name from a report error messages iterator.
- *
- * @param[in]  iterator  Iterator.
- *
- * @return The nvt of the report error message.  Caller must use only before
- *         calling cleanup_iterator.
- */
-static
-DEF_ACCESS (report_errors_iterator_nvt_name, 4);
-
-/**
- * @brief Get the nvt cvss base from a report error messages iterator.
- *
- * @param[in]  iterator  Iterator.
- *
- * @return The nvt cvss base of the report error message.  Caller must use only
- *         before calling cleanup_iterator.
- */
-static
-DEF_ACCESS (report_errors_iterator_nvt_cvss, 5);
-
-/**
- * @brief Get the nvt cvss base from a report error messages iterator.
- *
- * @param[in]  iterator  Iterator.
- *
- * @return The nvt version at scan time of the report error message.
- *         Caller must use only before calling cleanup_iterator.
- */
-static
-DEF_ACCESS (report_errors_iterator_scan_nvt_version, 6);
-
-/**
- * @brief Get the nvt cvss base from a report error messages iterator.
- *
- * @param[in]  iterator  Iterator.
- *
- * @return The severity at scan time of the report error message.
- *         Caller must use only before calling cleanup_iterator.
- */
-static
-DEF_ACCESS (report_errors_iterator_severity, 7);
-
-/**
- * @brief Get the result from a report error messages iterator.
- *
- * @param[in]  iterator  Iterator.
- *
- * @return Result.
- */
-static result_t
-report_errors_iterator_result (iterator_t* iterator)
-{
-  if (iterator->done) return 0;
-  return iterator_int64 (iterator, 8);
-}
-
-/**
  * @brief Initialise a report host details iterator.
  *
  * @param[in]  iterator     Iterator.
@@ -14967,21 +14841,6 @@ report_app_count (report_t report)
 }
 
 /**
- * @brief Count a report's total number of error messages.
- *
- * @param[in]  report  Report.
- *
- * @return Error Messages count.
- */
-static int
-report_error_count (report_t report)
-{
-  return sql_int ("SELECT count (id) FROM results"
-                  " WHERE report = %llu and type = 'Error Message';",
-                  report);
-}
-
-/**
  * @brief Get a list string of finished hosts in a report.
  *
  * @param[in]  report  The report to get the finished hosts from.
@@ -15034,75 +14893,6 @@ free_f_host (GHashTable *table)
 {
   if (table)
     g_hash_table_destroy (table);
-}
-
-/**
- * @brief Write report error message to file stream.
- *
- * @param[in]   stream      Stream to write to.
- * @param[in]   errors      Pointer to report error messages iterator.
- * @param[in]   asset_id    Asset ID.
- */
-#define PRINT_REPORT_ERROR(stream, errors, asset_id)                       \
-  do                                                                       \
-    {                                                                      \
-      PRINT (stream,                                                       \
-             "<error>"                                                     \
-             "<host>"                                                      \
-             "%s"                                                          \
-             "<asset asset_id=\"%s\"/>"                                    \
-             "</host>"                                                     \
-             "<port>%s</port>"                                             \
-             "<description>%s</description>"                               \
-             "<nvt oid=\"%s\">"                                            \
-             "<type>nvt</type>"                                            \
-             "<name>%s</name>"                                             \
-             "<cvss_base>%s</cvss_base>"                                   \
-             "</nvt>"                                                      \
-             "<scan_nvt_version>%s</scan_nvt_version>"                     \
-             "<severity>%s</severity>"                                     \
-             "</error>",                                                   \
-             report_errors_iterator_host (errors) ?: "",                   \
-             asset_id ? asset_id : "",                                     \
-             report_errors_iterator_port (errors),                         \
-             report_errors_iterator_desc (errors),                         \
-             report_errors_iterator_nvt_oid (errors),                      \
-             report_errors_iterator_nvt_name (errors),                     \
-             report_errors_iterator_nvt_cvss (errors),                     \
-             report_errors_iterator_scan_nvt_version (errors),             \
-             report_errors_iterator_severity (errors));                    \
-    }                                                                      \
-  while (0)
-
-/**
- * @brief Print the XML for a report's error messages to a file stream.
- * @param[in]  report   The report.
- * @param[in]  stream   File stream to write to.
- *
- * @return 0 on success, -1 error.
- */
-static int
-print_report_errors_xml (report_t report, FILE *stream)
-{
-  iterator_t errors;
-
-  init_report_errors_iterator
-   (&errors, report);
-
-  PRINT (stream, "<errors><count>%i</count>", report_error_count (report));
-  while (next (&errors))
-    {
-      char *asset_id;
-
-      asset_id = result_host_asset_id (report_errors_iterator_host (&errors),
-                                       report_errors_iterator_result (&errors));
-      PRINT_REPORT_ERROR (stream, &errors, asset_id);
-      free (asset_id);
-    }
-  cleanup_iterator (&errors);
-  PRINT (stream, "</errors>");
-
-  return 0;
 }
 
 /**

--- a/src/manage_sql_report_errors.c
+++ b/src/manage_sql_report_errors.c
@@ -189,6 +189,7 @@ report_error_count (report_t report)
 
 /**
  * @brief Print the XML for a report's error messages to a file stream.
+ *
  * @param[in]  report   The report.
  * @param[in]  stream   File stream to write to.
  *
@@ -216,4 +217,27 @@ print_report_errors_xml (report_t report, FILE *stream)
   PRINT (stream, "</errors>");
 
   return 0;
+}
+
+/**
+ * @brief Print report error XML, returning either full details or only the count.
+ *
+ * @param[in]  report   The report.
+ * @param[in]  stream   File stream to write to.
+ * @param[in]  details  Boolean flag whether to include full details
+ *
+ * @return 0 on success, -1 error.
+ */
+int
+print_report_errors_xml_summary_or_details (report_t report, FILE *stream,
+                                            int details)
+{
+  if (details == 0)
+    {
+      PRINT (stream, "<errors><count>%i</count></errors>",
+             report_error_count (report));
+      return 0;
+    }
+
+  return print_report_errors_xml (report, stream);
 }

--- a/src/manage_sql_report_errors.c
+++ b/src/manage_sql_report_errors.c
@@ -1,0 +1,219 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file
+ * @brief GVM SQL layer: Report errors.
+ *
+ * SQL handlers for report error XML.
+ */
+
+#include "manage_sql_report_errors.h"
+
+#include "manage_sql_assets.h"
+
+/**
+ * @brief Initialise a report errors iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ * @param[in]  report   The report.
+ */
+void
+init_report_errors_iterator (iterator_t *iterator, report_t report)
+{
+  if (report)
+    init_iterator (iterator,
+                   "SELECT results.host, results.port, results.nvt,"
+                   " results.description,"
+                   " coalesce((SELECT name FROM nvts"
+                   "           WHERE nvts.oid = results.nvt), ''),"
+                   " coalesce((SELECT cvss_base FROM nvts"
+                   "           WHERE nvts.oid = results.nvt), ''),"
+                   " results.nvt_version, results.severity,"
+                   " results.id"
+                   " FROM results"
+                   " WHERE results.severity = %0.1f"
+                   "  AND results.report = %llu",
+                   SEVERITY_ERROR, report);
+}
+
+/**
+ * @brief Get the host from a report error messages iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The host of the report error message.  Caller must use only before
+ *         calling cleanup_iterator.
+ */
+DEF_ACCESS (report_errors_iterator_host, 0);
+
+/**
+ * @brief Get the port from a report error messages iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The port of the report error message.  Caller must use only before
+ *         calling cleanup_iterator.
+ */
+DEF_ACCESS (report_errors_iterator_port, 1);
+
+/**
+ * @brief Get the nvt oid from a report error messages iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The nvt of the report error message.  Caller must use only before
+ *         calling cleanup_iterator.
+ */
+DEF_ACCESS (report_errors_iterator_nvt_oid, 2);
+
+/**
+ * @brief Get the description from a report error messages iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The description of the report error message.  Caller must use only
+ * before calling cleanup_iterator.
+ */
+DEF_ACCESS (report_errors_iterator_desc, 3);
+
+/**
+ * @brief Get the nvt name from a report error messages iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The nvt of the report error message.  Caller must use only before
+ *         calling cleanup_iterator.
+ */
+DEF_ACCESS (report_errors_iterator_nvt_name, 4);
+
+/**
+ * @brief Get the nvt cvss base from a report error messages iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The nvt cvss base of the report error message.  Caller must use only
+ *         before calling cleanup_iterator.
+ */
+DEF_ACCESS (report_errors_iterator_nvt_cvss, 5);
+
+/**
+ * @brief Get the nvt cvss base from a report error messages iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The nvt version at scan time of the report error message.
+ *         Caller must use only before calling cleanup_iterator.
+ */
+DEF_ACCESS (report_errors_iterator_scan_nvt_version, 6);
+
+/**
+ * @brief Get the nvt cvss base from a report error messages iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The severity at scan time of the report error message.
+ *         Caller must use only before calling cleanup_iterator.
+ */
+DEF_ACCESS (report_errors_iterator_severity, 7);
+
+/**
+ * @brief Write report error message to file stream.
+ *
+ * @param[in]   stream      Stream to write to.
+ * @param[in]   errors      Pointer to report error messages iterator.
+ * @param[in]   asset_id    Asset ID.
+ */
+#define PRINT_REPORT_ERROR(stream, errors, asset_id)                       \
+  do                                                                       \
+    {                                                                      \
+      PRINT (stream,                                                       \
+             "<error>"                                                     \
+             "<host>"                                                      \
+             "%s"                                                          \
+             "<asset asset_id=\"%s\"/>"                                    \
+             "</host>"                                                     \
+             "<port>%s</port>"                                             \
+             "<description>%s</description>"                               \
+             "<nvt oid=\"%s\">"                                            \
+             "<type>nvt</type>"                                            \
+             "<name>%s</name>"                                             \
+             "<cvss_base>%s</cvss_base>"                                   \
+             "</nvt>"                                                      \
+             "<scan_nvt_version>%s</scan_nvt_version>"                     \
+             "<severity>%s</severity>"                                     \
+             "</error>",                                                   \
+             report_errors_iterator_host (errors) ?: "",                   \
+             asset_id ? asset_id : "",                                     \
+             report_errors_iterator_port (errors),                         \
+             report_errors_iterator_desc (errors),                         \
+             report_errors_iterator_nvt_oid (errors),                      \
+             report_errors_iterator_nvt_name (errors),                     \
+             report_errors_iterator_nvt_cvss (errors),                     \
+             report_errors_iterator_scan_nvt_version (errors),             \
+             report_errors_iterator_severity (errors));                    \
+    }                                                                      \
+  while (0)
+
+/**
+ * @brief Get the result from a report error messages iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return Result.
+ */
+static result_t
+report_errors_iterator_result (iterator_t *iterator)
+{
+  if (iterator->done)
+    return 0;
+  return iterator_int64 (iterator, 8);
+}
+
+/**
+ * @brief Count a report's total number of error messages.
+ *
+ * @param[in]  report  Report.
+ *
+ * @return Error Messages count.
+ */
+int
+report_error_count (report_t report)
+{
+  return sql_int ("SELECT count (id) FROM results"
+                  " WHERE report = %llu and type = 'Error Message';",
+                  report);
+}
+
+/**
+ * @brief Print the XML for a report's error messages to a file stream.
+ * @param[in]  report   The report.
+ * @param[in]  stream   File stream to write to.
+ *
+ * @return 0 on success, -1 error.
+ */
+int
+print_report_errors_xml (report_t report, FILE *stream)
+{
+  iterator_t errors;
+
+  init_report_errors_iterator
+    (&errors, report);
+
+  PRINT (stream, "<errors><count>%i</count>", report_error_count (report));
+  while (next (&errors))
+    {
+      char *asset_id;
+
+      asset_id = result_host_asset_id (report_errors_iterator_host (&errors),
+                                       report_errors_iterator_result (&errors));
+      PRINT_REPORT_ERROR (stream, &errors, asset_id);
+      free (asset_id);
+    }
+  cleanup_iterator (&errors);
+  PRINT (stream, "</errors>");
+
+  return 0;
+}

--- a/src/manage_sql_report_errors.h
+++ b/src/manage_sql_report_errors.h
@@ -54,4 +54,7 @@ report_error_count (report_t);
 int
 print_report_errors_xml (report_t, FILE *);
 
+int
+print_report_errors_xml_summary_or_details (report_t, FILE *, int);
+
 #endif //_GVM_MANAGE_SQL_REPORT_ERRORS_H

--- a/src/manage_sql_report_errors.h
+++ b/src/manage_sql_report_errors.h
@@ -15,42 +15,6 @@
 
 #include "manage_sql.h"
 
-void
-init_report_errors_iterator (iterator_t *, report_t);
-
-const char *
-report_errors_iterator_host (iterator_t *);
-
-const char *
-report_errors_iterator_severity (iterator_t *);
-
-const char *
-report_errors_iterator_scan_nvt_version (iterator_t *);
-
-const char *
-report_errors_iterator_port (iterator_t *);
-
-const char *
-report_errors_iterator_nvt_oid (iterator_t *);
-
-const char *
-report_errors_iterator_desc (iterator_t *);
-
-const char *
-report_errors_iterator_nvt_name (iterator_t *);
-
-const char *
-report_errors_iterator_nvt_cvss (iterator_t *);
-
-const char *
-report_errors_iterator_scan_nvt_version (iterator_t *);
-
-const char *
-report_errors_iterator_severity (iterator_t *);
-
-int
-report_error_count (report_t);
-
 int
 print_report_errors_xml (report_t, FILE *);
 

--- a/src/manage_sql_report_errors.h
+++ b/src/manage_sql_report_errors.h
@@ -1,0 +1,57 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file
+ * @brief GVM SQL layer: Report errors.
+ *
+ * Headers for SQL handlers for report error XML.
+ */
+
+#ifndef _GVM_MANAGE_SQL_REPORT_ERRORS_H
+#define _GVM_MANAGE_SQL_REPORT_ERRORS_H
+
+#include "manage_sql.h"
+
+void
+init_report_errors_iterator (iterator_t *, report_t);
+
+const char *
+report_errors_iterator_host (iterator_t *);
+
+const char *
+report_errors_iterator_severity (iterator_t *);
+
+const char *
+report_errors_iterator_scan_nvt_version (iterator_t *);
+
+const char *
+report_errors_iterator_port (iterator_t *);
+
+const char *
+report_errors_iterator_nvt_oid (iterator_t *);
+
+const char *
+report_errors_iterator_desc (iterator_t *);
+
+const char *
+report_errors_iterator_nvt_name (iterator_t *);
+
+const char *
+report_errors_iterator_nvt_cvss (iterator_t *);
+
+const char *
+report_errors_iterator_scan_nvt_version (iterator_t *);
+
+const char *
+report_errors_iterator_severity (iterator_t *);
+
+int
+report_error_count (report_t);
+
+int
+print_report_errors_xml (report_t, FILE *);
+
+#endif //_GVM_MANAGE_SQL_REPORT_ERRORS_H

--- a/src/manage_sql_resources.c
+++ b/src/manage_sql_resources.c
@@ -771,6 +771,20 @@ resource_count (const char *type, const get_data_t *get)
       const gchar *usage_type = get_data_get_extra (get, "usage_type");
       extra_where = reports_extra_where (0, NULL, usage_type);
     }
+  else if (strcmp (type, "report_error") == 0)
+    {
+      report_t report;
+      const gchar *report_uuid = get_data_get_extra (get, "report_id");
+      if (!str_blank (report_uuid))
+        {
+          find_report_with_permission (report_uuid, &report, "get_reports");
+          if (report != 0)
+            {
+              return report_error_count (report);
+            }
+        }
+      return 0;
+    }
   else if (strcmp (type, "report_host") == 0)
     {
       const gchar *report_uuid = get_data_get_extra (get, "report_id");

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -20751,6 +20751,468 @@ END:VCALENDAR
     </example>
   </command>
   <command>
+    <name>get_report_errors</name>
+    <summary>Get error messages from a report</summary>
+    <description>
+      <p>
+        The client uses the get_report_errors command to get error message
+        information from a single report.
+      </p>
+      <p>
+        This command is an error-focused subset of get_reports intended to support
+        pagination and reduced response sizes when only report error data is
+        needed.
+      </p>
+      <p>
+        If the "details" attribute is set, the response includes error entries.
+        Otherwise only the total error count together with filter, sort and count
+        information is returned.
+      </p>
+      <p>
+        The filter affects the selection of matching results and the derived error
+        information returned by the command.
+      </p>
+    </description>
+    <pattern>
+      <attrib>
+        <name>report_id</name>
+        <summary>ID of the report to get errors from</summary>
+        <type>uuid</type>
+        <required>1</required>
+      </attrib>
+      <attrib>
+        <name>filter</name>
+        <summary>Filter term to use for report error retrieval</summary>
+        <type>text</type>
+        <filter_keywords>
+          <option>
+            <name>first</name>
+            <type>integer</type>
+            <summary>
+              Index of the first item returned, starting at 1 (e.g. first=5
+              starts at the 5th item)
+            </summary>
+          </option>
+          <option>
+            <name>sort</name>
+            <type>text</type>
+            <summary>Column to sort by in ascending order</summary>
+          </option>
+          <option>
+            <name>sort-reverse</name>
+            <type>text</type>
+            <summary>Column to sort by in descending order</summary>
+          </option>
+          <option>
+            <name>levels</name>
+            <type>levels</type>
+            <summary>Severity levels to select</summary>
+          </option>
+          <column>
+            <name>uuid</name>
+            <type>uuid</type>
+            <summary>Unique ID</summary>
+          </column>
+          <column>
+            <name>host</name>
+            <type>text</type>
+            <summary>IP address of the host</summary>
+          </column>
+          <column>
+            <name>port</name>
+            <type>text</type>
+            <summary>Port of the result</summary>
+          </column>
+          <column>
+            <name>severity</name>
+            <type>severity</type>
+            <summary>Severity of the error result</summary>
+          </column>
+        </filter_keywords>
+      </attrib>
+      <attrib>
+        <name>filt_id</name>
+        <summary>ID of filter to use to filter report errors</summary>
+        <type>uuid</type>
+      </attrib>
+      <attrib>
+        <name>details</name>
+        <summary>Whether to include error details</summary>
+        <type>boolean</type>
+      </attrib>
+    </pattern>
+    <response>
+      <pattern>
+        <attrib>
+          <name>status</name>
+          <type>status</type>
+          <required>1</required>
+        </attrib>
+        <attrib>
+          <name>status_text</name>
+          <type>text</type>
+          <required>1</required>
+        </attrib>
+        <o><e>errors</e></o>
+        <o><e>filters</e></o>
+        <o><e>sort</e></o>
+        <o><e>report_errors</e></o>
+        <o><e>report_error_count</e></o>
+      </pattern>
+      <ele>
+        <name>errors</name>
+        <summary>Error information from the selected report</summary>
+        <pattern>
+          <attrib>
+            <name>start</name>
+            <summary>First report error</summary>
+            <type>integer</type>
+            <required>1</required>
+          </attrib>
+          <attrib>
+            <name>max</name>
+            <summary>Maximum number of report errors</summary>
+            <type>integer</type>
+            <required>1</required>
+          </attrib>
+          <e>count</e>
+          <any><e>error</e></any>
+        </pattern>
+        <ele>
+          <name>count</name>
+          <summary>Total number of report errors</summary>
+          <pattern><t>integer</t></pattern>
+        </ele>
+        <ele>
+          <name>error</name>
+          <summary>An error from the selected report</summary>
+          <pattern>
+            <e>host</e>
+            <e>port</e>
+            <e>description</e>
+            <e>nvt</e>
+            <e>scan_nvt_version</e>
+            <e>severity</e>
+          </pattern>
+          <ele>
+            <name>host</name>
+            <summary>IP address of the host</summary>
+            <pattern>
+              text
+              <o><e>asset</e></o>
+            </pattern>
+            <ele>
+              <name>asset</name>
+              <summary>Asset linked to the host</summary>
+              <pattern>
+                <attrib>
+                  <name>asset_id</name>
+                  <summary>ID of the asset</summary>
+                  <type>uuid</type>
+                  <required>1</required>
+                </attrib>
+              </pattern>
+            </ele>
+          </ele>
+          <ele>
+            <name>port</name>
+            <summary>Port of the error result</summary>
+            <pattern>text</pattern>
+          </ele>
+          <ele>
+            <name>description</name>
+            <summary>Description of the error</summary>
+            <pattern>text</pattern>
+          </ele>
+          <ele>
+            <name>nvt</name>
+            <summary>NVT associated with the error</summary>
+            <pattern>
+              <attrib>
+                <name>oid</name>
+                <summary>OID of the NVT</summary>
+                <type>text</type>
+                <required>1</required>
+              </attrib>
+              <e>type</e>
+              <e>name</e>
+              <e>cvss_base</e>
+            </pattern>
+            <ele>
+              <name>type</name>
+              <summary>Type of the NVT</summary>
+              <pattern>text</pattern>
+            </ele>
+            <ele>
+              <name>name</name>
+              <summary>Name of the NVT</summary>
+              <pattern>text</pattern>
+            </ele>
+            <ele>
+              <name>cvss_base</name>
+              <summary>CVSS base score of the NVT</summary>
+              <pattern>real</pattern>
+            </ele>
+          </ele>
+          <ele>
+            <name>scan_nvt_version</name>
+            <summary>NVT version at scan time</summary>
+            <pattern>text</pattern>
+          </ele>
+          <ele>
+            <name>severity</name>
+            <summary>Severity at scan time of the error</summary>
+            <pattern>real</pattern>
+          </ele>
+        </ele>
+      </ele>
+      <ele>
+        <name>filters</name>
+        <pattern>
+          <attrib>
+            <name>id</name>
+            <summary>UUID of filter if any, else empty or 0</summary>
+            <type>uuid</type>
+          </attrib>
+          <e>term</e>
+          <e>keywords</e>
+        </pattern>
+        <ele>
+          <name>term</name>
+          <summary>Filter term</summary>
+          <pattern>text</pattern>
+        </ele>
+        <ele>
+          <name>keywords</name>
+          <summary>Filter broken down into keywords</summary>
+          <pattern><any><e>keyword</e></any></pattern>
+          <ele>
+            <name>keyword</name>
+            <pattern>
+              <e>column</e>
+              <e>relation</e>
+              <e>value</e>
+            </pattern>
+            <ele>
+              <name>column</name>
+              <summary>Column prefix</summary>
+              <pattern>text</pattern>
+            </ele>
+            <ele>
+              <name>relation</name>
+              <summary>Relation operator</summary>
+              <pattern>
+                <alts>
+                  <alt>=</alt>
+                  <alt>:</alt>
+                  <alt>~</alt>
+                  <alt>&gt;</alt>
+                  <alt>&lt;</alt>
+                </alts>
+              </pattern>
+            </ele>
+            <ele>
+              <name>value</name>
+              <summary>The filter text</summary>
+              <pattern>text</pattern>
+            </ele>
+          </ele>
+        </ele>
+      </ele>
+      <ele>
+        <name>sort</name>
+        <pattern>
+          text
+          <e>field</e>
+        </pattern>
+        <ele>
+          <name>field</name>
+          <pattern>
+            text
+            <e>order</e>
+          </pattern>
+          <ele>
+            <name>order</name>
+            <pattern>
+              <alts>
+                <alt>ascending</alt>
+                <alt>descending</alt>
+              </alts>
+            </pattern>
+          </ele>
+        </ele>
+      </ele>
+      <ele>
+        <name>report_errors</name>
+        <pattern>
+          <attrib>
+            <name>start</name>
+            <summary>First report error</summary>
+            <type>integer</type>
+            <required>1</required>
+          </attrib>
+          <attrib>
+            <name>max</name>
+            <summary>Maximum number of report errors</summary>
+            <type>integer</type>
+            <required>1</required>
+          </attrib>
+        </pattern>
+      </ele>
+      <ele>
+        <name>report_error_count</name>
+        <pattern>
+          text
+          <e>filtered</e>
+          <e>page</e>
+        </pattern>
+        <ele>
+          <name>filtered</name>
+          <summary>Number of report errors after filtering</summary>
+          <pattern><t>integer</t></pattern>
+        </ele>
+        <ele>
+          <name>page</name>
+          <summary>Number of report errors on current page</summary>
+          <pattern><t>integer</t></pattern>
+        </ele>
+      </ele>
+    </response>
+    <example>
+      <summary>Get errors of a report with details</summary>
+      <request>
+        <get_report_errors report_id="2f628a42-13f3-4420-9f2b-5754aa1aafe9"
+                           details="1"
+                           filter="levels=chml rows=100 min_qod=70 first=1 sort-reverse=severity result_hosts_only=0">
+        </get_report_errors>
+      </request>
+      <response>
+        <get_report_errors_response status="200" status_text="OK">
+          <errors start="1" max="100">
+            <count>1</count>
+            <error>
+              <host>127.0.0.1<asset asset_id="9fd3aff1-4550-42cb-8339-1b6776f555d0"/></host>
+              <port>general/tcp</port>
+              <description>NVT timed out after 320 seconds.</description>
+              <nvt oid="1.3.6.1.4.1.25623.1.0.12241">
+                <type>nvt</type>
+                <name>Do not print on AppSocket and socketAPI printers</name>
+                <cvss_base>0.0</cvss_base>
+              </nvt>
+              <scan_nvt_version>2025-01-22T08:32:30Z</scan_nvt_version>
+              <severity>-3</severity>
+            </error>
+          </errors>
+          <filters id="">
+            <term>apply_overrides=0 levels=chml rows=100 min_qod=70 first=1 sort-reverse=severity result_hosts_only=0</term>
+            <keywords>
+              <keyword>
+                <column>apply_overrides</column>
+                <relation>=</relation>
+                <value>0</value>
+              </keyword>
+              <keyword>
+                <column>levels</column>
+                <relation>=</relation>
+                <value>chml</value>
+              </keyword>
+              <keyword>
+                <column>rows</column>
+                <relation>=</relation>
+                <value>100</value>
+              </keyword>
+              <keyword>
+                <column>min_qod</column>
+                <relation>=</relation>
+                <value>70</value>
+              </keyword>
+              <keyword>
+                <column>first</column>
+                <relation>=</relation>
+                <value>1</value>
+              </keyword>
+              <keyword>
+                <column>sort-reverse</column>
+                <relation>=</relation>
+                <value>severity</value>
+              </keyword>
+              <keyword>
+                <column>result_hosts_only</column>
+                <relation>=</relation>
+                <value>0</value>
+              </keyword>
+            </keywords>
+          </filters>
+          <sort>
+            <field>severity<order>descending</order></field>
+          </sort>
+          <report_errors start="1" max="100"/>
+          <report_error_count>1<filtered>1</filtered><page>0</page></report_error_count>
+        </get_report_errors_response>
+      </response>
+    </example>
+    <example>
+      <summary>Get only report error count information</summary>
+      <request>
+        <get_report_errors report_id="2f628a42-13f3-4420-9f2b-5754aa1aafe9"
+                           details="0">
+        </get_report_errors>
+      </request>
+      <response>
+        <get_report_errors_response status="200" status_text="OK">
+          <errors start="1" max="100">
+            <count>1</count>
+          </errors>
+          <filters id="">
+            <term>apply_overrides=0 levels=chml rows=100 min_qod=70 first=1 sort-reverse=severity result_hosts_only=0</term>
+            <keywords>
+              <keyword>
+                <column>apply_overrides</column>
+                <relation>=</relation>
+                <value>0</value>
+              </keyword>
+              <keyword>
+                <column>levels</column>
+                <relation>=</relation>
+                <value>chml</value>
+              </keyword>
+              <keyword>
+                <column>rows</column>
+                <relation>=</relation>
+                <value>100</value>
+              </keyword>
+              <keyword>
+                <column>min_qod</column>
+                <relation>=</relation>
+                <value>70</value>
+              </keyword>
+              <keyword>
+                <column>first</column>
+                <relation>=</relation>
+                <value>1</value>
+              </keyword>
+              <keyword>
+                <column>sort-reverse</column>
+                <relation>=</relation>
+                <value>severity</value>
+              </keyword>
+              <keyword>
+                <column>result_hosts_only</column>
+                <relation>=</relation>
+                <value>0</value>
+              </keyword>
+            </keywords>
+          </filters>
+          <sort>
+            <field>severity<order>descending</order></field>
+          </sort>
+          <report_errors start="1" max="100"/>
+          <report_error_count>1<filtered>1</filtered><page>0</page></report_error_count>
+        </get_report_errors_response>
+      </response>
+    </example>
+  </command>
+  <command>
     <name>get_report_formats</name>
     <summary>Get one or many report formats</summary>
     <description>


### PR DESCRIPTION
## What

- Added new GMP command `get_report_errors`
- Implemented SQL layer for report errors (iterator, count, XML printing)
- Added management layer helper to generate and stream report error XML
- Added support for summary (`details=0`) and detailed (`details=1`) responses
- Implemented GMP parsing, validation, and execution logic
- Registered the command in `gmp.c` and related files
- Added XML specification including request/response and examples

## Why

- Reduce response size by allowing error-specific queries instead of full report
- Support pagination and filtering for report error data
- Align with existing split commands like `get_report_ports` and `get_report_hosts`
- Improve modularity and reuse of report-related logic
- Prepare backend for GSA/report details page optimizations

## References

GEA-1692

