### PR TITLE
Docs: fix: a couple CREATE_OVERRIDES issues

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -5167,7 +5167,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
           <text>This is actually of little concern.</text>
           <nvt oid="1.3.6.1.4.1.25623.1.0.10330"></nvt>
           <new_threat>Low</new_threat>
-          <result>254cd3ef-bbe1-4d58-859d-21b8d0c046c6</result>
+          <result id="254cd3ef-bbe1-4d58-859d-21b8d0c046c6"/>
         </create_override>
       </request>
       <response>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -5030,11 +5030,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     <pattern>
       <e>text</e>
       <e>nvt</e>
+      <or>
+        <e>new_severity</e>
+        <e>new_threat</e>
+      </or>
       <o><e>active</e></o>
       <o><e>copy</e></o>
       <o><e>hosts</e></o>
-      <o><e>new_severity</e></o>
-      <o><e>new_threat</e></o>
       <o><e>port</e></o>
       <o><e>result</e></o>
       <o><e>severity</e></o>


### PR DESCRIPTION
## What

1. Make threat/severity element required
2. In the example use an attribute for the RESULT id.

## Why

Correct.

1. CREATE_OVERRIDE will respond with error if threat and severity are missing:
```
$ o m m '<create_override><text>OV TEST 1</text><nvt oid="1.3.6.1.4.1.25623.1.0.80091"/></create_override>'
<create_override_response status="400" status_text="A NEW_THREAT or NEW_SEVERITY entity is required" />
$ o m m '<create_override><text>OV TEST 1</text><nvt oid="1.3.6.1.4.1.25623.1.0.80091"/><new_severity>10.0</new_severity></create_override>'
<create_override_response status="201" status_text="OK, resource created" id="fdce3aee-acdd-4b93-8848-e0a4a494c8f3" />
```

2. The RESULT id must be an attribute. It already correctly says this in the command section of the doc.

## Testing

1. Ran the commands above.
2. Ran CREATE_OVERRIDE with id in both places. Both rightly succeed, but I checked with GET_OVERRIDES and only the attribute version had a result.