### PR TITLE
Fix: Fix excluding general ports in report ports summary.

### DIFF
--- a/src/manage_sql_report_ports.c
+++ b/src/manage_sql_report_ports.c
@@ -250,7 +250,7 @@ print_report_port_xml (print_report_context_t *ctx, report_t report, FILE *out,
       const char *host = result_iterator_host (results);
       double cvss_double;
 
-      if (port == NULL || g_str_has_prefix (port, "general/"))
+      if (port == NULL)
         continue;
 
       cvss_double = result_iterator_severity_double (results);


### PR DESCRIPTION
## What
Fix excluding general ports in report ports summary

## Why
Skipping "general" ports was breaking PDF report generation

## References
GEA-1720

