### PR TITLE
Fix: Ignore unknown elements in GMP `create_tasks`

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -8310,7 +8310,7 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
           }
         else if (strcasecmp ("USAGE_TYPE", element_name) == 0)
           set_client_state (CLIENT_CREATE_TASK_USAGE_TYPE);
-        ELSE_READ_OVER_CREATE_TASK;
+        ELSE_READ_OVER;
 
       case CLIENT_CREATE_TASK_OBSERVERS:
         if (strcasecmp ("GROUP", element_name) == 0)
@@ -8321,7 +8321,7 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
               array_add (create_task_data->groups, g_strdup (attribute));
             set_client_state (CLIENT_CREATE_TASK_OBSERVERS_GROUP);
           }
-        ELSE_READ_OVER_CREATE_TASK;
+        ELSE_READ_OVER;
 
       case CLIENT_CREATE_TASK_PREFERENCES:
         if (strcasecmp ("PREFERENCE", element_name) == 0)
@@ -8332,14 +8332,14 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
             create_task_data->preference->value = NULL;
             set_client_state (CLIENT_CREATE_TASK_PREFERENCES_PREFERENCE);
           }
-        ELSE_READ_OVER_CREATE_TASK;
+        ELSE_READ_OVER;
 
       case CLIENT_CREATE_TASK_PREFERENCES_PREFERENCE:
         if (strcasecmp ("SCANNER_NAME", element_name) == 0)
           set_client_state (CLIENT_CREATE_TASK_PREFERENCES_PREFERENCE_NAME);
         else if (strcasecmp ("VALUE", element_name) == 0)
           set_client_state (CLIENT_CREATE_TASK_PREFERENCES_PREFERENCE_VALUE);
-        ELSE_READ_OVER_CREATE_TASK;
+        ELSE_READ_OVER;
 
       case CLIENT_CREATE_TICKET:
         create_ticket_element_start (gmp_parser, element_name,


### PR DESCRIPTION
## What
Unknown elements in the `create_tasks` GMP command are now ignored and will no longer cause the new task to be deleted.

## Why
This makes the command more consistent with others and prevents errors caused by the task creation not being aborted cleanly when unknown elements like the now removed `hosts_ordering` appear in the XML.

## References
GEA-1669
