### PR TITLE
fix: add missing default for security_intelligence_export retries

### DIFF
--- a/config/gvmd.conf.in
+++ b/config/gvmd.conf.in
@@ -14,3 +14,6 @@ enable_openvasd = false
 enable_vt_metadata = false
 enable_security_intelligence_export = false
 enable_jwt_auth = false
+
+[security_intelligence_export]
+max_retries = 10


### PR DESCRIPTION
## What
- Add missing `[security_intelligence_export]` default config
- Set `max_retries = 10` in `gvmd.conf.in`

## Why
- Complete the previous config change
- Ensure the retry setting is available by default

## References

GEA-1613, https://github.com/greenbone/gvmd#security-intelligence-export 


