### PR TITLE
Add: Add a flag to indicate if a scanner is used by a disabled feature.

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -17894,12 +17894,6 @@ handle_get_scanners (gmp_parser_t *gmp_parser, GError **error)
           break;
         }
 
-      if (! feature_enabled (FEATURE_ID_CONTAINER_SCANNING)
-          && (scanner_iterator_type (&scanners) == SCANNER_TYPE_CONTAINER_IMAGE))
-        {
-          continue;
-        }
-
       SEND_GET_COMMON (scanner, &get_scanners_data->get, &scanners);
 
       SENDF_TO_CLIENT_OR_FAIL
@@ -17915,6 +17909,12 @@ handle_get_scanners (gmp_parser_t *gmp_parser, GError **error)
         scanner_iterator_ca_pub (&scanners) ?: "",
         scanner_iterator_relay_host (&scanners) ?: "",
         scanner_iterator_relay_port (&scanners) ?: 0);
+
+      if (check_scanner_feature (scanner_iterator_type (&scanners))
+           != SCANNER_FEATURE_OK)
+        {
+          SENDF_TO_CLIENT_OR_FAIL ("<disabled>1</disabled>");
+        }
 
       if (get_scanners_data->get.details)
         {

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -25950,6 +25950,7 @@ END:VCALENDAR
           <e>credential</e>
           <e>relay_host</e>
           <e>relay_port</e>
+          <o><e>disabled</e></o>
           <o><e>configs</e></o>
           <o><e>tasks</e></o>
           <o><e>info</e></o>
@@ -26147,6 +26148,11 @@ END:VCALENDAR
           <name>relay_port</name>
           <summary>Optional relay port of the scanner</summary>
           <pattern>text</pattern>
+        </ele>
+        <ele>
+          <name>disabled</name>
+          <summary>Optional Whether the scanner is used by a disabled feature</summary>
+          <pattern><t>boolean</t></pattern>
         </ele>
         <ele>
           <name>configs</name>


### PR DESCRIPTION
## What
Added a flag to indicate if a scanner is used by a disabled feature.

## Why
To highlight unusable scanners in GSA list page instead of hiding ones that are already created in `get_scanners` response.

## References
GEA-1722
