### PR TITLE
Add/report hosts severity

### DIFF
--- a/src/manage_report_hosts.c
+++ b/src/manage_report_hosts.c
@@ -133,7 +133,8 @@ manage_send_report_hosts (report_t report,
                                         report,
                                         &results,
                                         is_container_scanning_report,
-                                        &ctx);
+                                        &ctx,
+                                        TRUE);
       if (ret)
         {
           ret = -1;
@@ -161,7 +162,8 @@ manage_send_report_hosts (report_t report,
                                 is_container_scanning_report,
                                 result_hosts_only,
                                 result_hosts,
-                                NULL);
+                                NULL,
+                                TRUE);
 
 
   if (fclose (stream))

--- a/src/manage_report_tls_certificates.c
+++ b/src/manage_report_tls_certificates.c
@@ -112,7 +112,8 @@ manage_send_report_tls_certificates (report_t report,
                                         report,
                                         &results,
                                         is_container_scanning_report,
-                                        NULL);
+                                        NULL,
+                                        FALSE);
       if (ret)
         {
           ret = -1;

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -14965,7 +14965,7 @@ print_report_init_f_hosts (print_report_context_t *ctx)
   ctx->f_host_max_severity = g_hash_table_new_full (g_str_hash,
                                                     g_str_equal,
                                                     g_free,
-                                                    host_max_severity_free);
+                                                    g_free);
 }
 
 /**

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -14917,6 +14917,7 @@ print_report_context_cleanup (print_report_context_t *ctx)
   free_f_host (ctx->f_host_logs);
   free_f_host (ctx->f_host_ports);
   free_f_host (ctx->f_host_warnings);
+  free_f_host (ctx->f_host_max_severity);
   // Filtered counts: audit.
   free_f_host (ctx->f_host_compliant);
   free_f_host (ctx->f_host_criticals);
@@ -14960,6 +14961,11 @@ print_report_init_f_hosts (print_report_context_t *ctx)
                                                            g_str_equal,
                                                            g_free, NULL);
     }
+
+  ctx->f_host_max_severity = g_hash_table_new_full (g_str_hash,
+                                                    g_str_equal,
+                                                    g_free,
+                                                    host_max_severity_free);
 }
 
 /**
@@ -16653,7 +16659,8 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
                                   is_container_scanning_report,
                                   result_hosts_only,
                                   result_hosts,
-                                  host_summary_buffer))
+                                  host_summary_buffer,
+                                  FALSE))
         {
           goto failed_print_report_host;
         }

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -208,6 +208,7 @@ struct print_report_context
  GHashTable *f_host_logs;            ///< Logs per hosts.
  GHashTable *f_host_ports;           ///< Ports per host.
  GHashTable *f_host_warnings;        ///< Warnings per hosts.
+ GHashTable *f_host_max_severity;    ///< Max severity per host.
  // Filtered counts: audit.
  GHashTable *f_host_compliant;       ///< Compliants per host.
  GHashTable *f_host_incomplete;      ///< Incompletes per host.

--- a/src/manage_sql_report_hosts.c
+++ b/src/manage_sql_report_hosts.c
@@ -844,17 +844,14 @@ print_container_scan_report_host_xml (print_report_context_t *ctx,
         }
     }
 
+  g_free (host_key);
+
   if (print_report_host_details_xml (host_iterator_report_host (hosts),
                                      stream,
                                      lean))
-    {
-      g_free (host_key);
-      return -1;
-    }
+    return -1;
 
   PRINT (stream, "</host>");
-
-  g_free (host_key);
 
   return 0;
 }

--- a/src/manage_sql_report_hosts.c
+++ b/src/manage_sql_report_hosts.c
@@ -110,6 +110,29 @@ static
 DEF_ACCESS (host_iterator_asset_uuid, 9);
 
 /**
+ * @brief Get the cpe from a host detail iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The cpe of the host. Caller must use
+ *         only before calling cleanup_iterator.
+ */
+static
+DEF_ACCESS (report_host_os_iterator_cpe, 0);
+
+/**
+ * @brief Get the best_os_txt from a host detail iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The best_os_txt of the host. Caller must use
+ *         only before calling cleanup_iterator.
+ */
+static
+DEF_ACCESS (report_host_os_iterator_name, 1);
+
+
+/**
  * @brief Maximum severity information for a host.
  */
 typedef struct
@@ -210,6 +233,131 @@ report_host_app_count (report_host_t report_host)
                      "   AND name = 'App';",
                      SQL_RESOURCE_PARAM (report_host),
                      NULL);
+}
+
+/**
+ * @brief Initialise an operating system iterator for a report host.
+ *
+ * @param[in]  iterator     Iterator.
+ * @param[in]  report_host  Report host whose OS information is retrieved.
+ */
+void
+init_report_host_os_iterator (iterator_t *iterator, report_host_t report_host)
+{
+  init_ps_iterator (iterator,
+                    "SELECT"
+                    " (SELECT value FROM report_host_details"
+                    "   WHERE report_host = $1 AND name = 'best_os_cpe'"
+                    "   LIMIT 1) AS cpe,"
+                    " (SELECT value FROM report_host_details"
+                    "   WHERE report_host = $1 AND name = 'best_os_txt'"
+                    "   LIMIT 1) AS os_name;",
+                    SQL_RESOURCE_PARAM (report_host),
+                    NULL);
+}
+
+/**
+ * @brief Get the hostname  for a report host.
+ *
+ * @param[in]  report_host  Report host whose OS information is retrieved.
+ *
+ * @return hostname of the report host
+ */
+static char *
+get_report_host_hostname (report_host_t report_host)
+{
+  return sql_string_ps ("SELECT value FROM report_host_details"
+                        "   WHERE report_host = $1 AND name = 'hostname'"
+                        "   LIMIT 1 ;",
+                        SQL_RESOURCE_PARAM (report_host),
+                        NULL);
+}
+
+/**
+ * @brief Print get_report_hosts summary XML for a host.
+ *
+ * Prints application count, OS information, hostname
+ * and maximum severity for the given host.
+ *
+ * @param[in]  ctx          Report print context.
+ * @param[in]  stream       File stream to write to.
+ * @param[in]  report_host  Report host.
+ * @param[in]  host_key     Host key used for per-host aggregations.
+ * @param[in]  lean         Whether to return lean report.
+ *
+ * @return 0 on success, -1 on error.
+ */
+static int
+print_report_host_summary_xml (print_report_context_t *ctx,
+                               FILE *stream,
+                               report_host_t report_host,
+                               const char *host_key,
+                               int lean)
+{
+  iterator_t os_iterator;
+  host_max_severity_t *max_severity;
+  int apps_count;
+  const char *os_cpe = NULL;
+  const char *os_name = NULL;
+  const char *hostname = NULL;
+
+  if (ctx == NULL || stream == NULL || host_key == NULL)
+    return -1;
+
+  apps_count = report_host_app_count (report_host);
+
+  init_report_host_os_iterator (&os_iterator, report_host);
+  if (next (&os_iterator))
+    {
+      os_cpe = report_host_os_iterator_cpe (&os_iterator);
+      os_name = report_host_os_iterator_name (&os_iterator);
+    }
+
+  hostname = get_report_host_hostname (report_host);
+
+  PRINT (stream,
+         "<app_count><page>%d</page></app_count>",
+         apps_count);
+
+  if (os_cpe && strlen (os_cpe))
+    PRINT (stream,
+         "<best_os_cpe>%s</best_os_cpe>",
+         os_cpe);
+  else if (lean == 0)
+    PRINT (stream,
+         "<best_os_cpe></best_os_cpe>");
+
+  if (os_name && strlen (os_name))
+    PRINT (stream,
+         "<best_os_txt>%s</best_os_txt>",
+         os_name);
+  else if (lean == 0)
+    PRINT (stream,
+         "<best_os_txt></best_os_txt>");
+
+  if (hostname && strlen (hostname))
+    PRINT (stream,
+         "<hostname>%s</hostname>",
+         hostname);
+  else if (lean == 0)
+    PRINT (stream,
+         "<hostname></hostname>");
+
+  max_severity = g_hash_table_lookup (ctx->f_host_max_severity, host_key);
+  if (max_severity)
+    PRINT (stream,
+         "<severity>%1.1f</severity>"
+         "<threat>%s</threat>",
+         max_severity->severity_double,
+         severity_to_level (max_severity->severity_double, 0));
+  else if (lean == 0)
+    PRINT (stream,
+         "<severity>0.0</severity>"
+         "<threat>Log</threat>");
+
+  cleanup_iterator (&os_iterator);
+
+  return 0;
 }
 
 /**
@@ -421,7 +569,6 @@ print_report_host_xml (print_report_context_t *ctx,
 {
   const char *current_host;
   int ports_count;
-  host_max_severity_t *max_severity = NULL;
 
   current_host = host_iterator_host (hosts);
 
@@ -554,27 +701,18 @@ print_report_host_xml (print_report_context_t *ctx,
 
   if (is_get_report_hosts)
     {
-      /* get_report_hosts: print severity/threat instead of host details */
-      max_severity = g_hash_table_lookup (ctx->f_host_max_severity,
-                                          current_host);
-      int apps_count =
-        report_host_app_count (host_iterator_report_host (hosts));
-      if (max_severity)
-        PRINT (stream,
-             "<app_count><page>%d</page></app_count>"
-             "<severity>%1.1f</severity>"
-             "<threat>%s</threat>",
-             apps_count,
-             max_severity->severity_double,
-             severity_to_level (g_strtod (max_severity->severity, NULL), 0));
-    }
-  else
-    {
-      if (print_report_host_details_xml (host_iterator_report_host (hosts),
+      if (print_report_host_summary_xml (ctx,
                                          stream,
+                                         host_iterator_report_host (hosts),
+                                         current_host,
                                          lean))
         return -1;
     }
+
+  if (print_report_host_details_xml (host_iterator_report_host (hosts),
+                                     stream,
+                                     lean))
+    return -1;
 
   PRINT (stream, "</host>");
 
@@ -606,7 +744,6 @@ print_container_scan_report_host_xml (print_report_context_t *ctx,
   const char *host;
   const char *hostname;
   gchar *host_key;
-  host_max_severity_t *max_severity = NULL;
 
   int holes_count, warnings_count, infos_count;
   int logs_count, false_positives_count;
@@ -696,29 +833,23 @@ print_container_scan_report_host_xml (print_report_context_t *ctx,
 
   if (is_get_report_hosts)
     {
-      /* get_report_hosts: print severity/threat instead of host details */
-      max_severity = g_hash_table_lookup (ctx->f_host_max_severity,
-                                          host_key);
-      /* application info is not included in container scanning host details
-       * for consistency always returns 0.
-       */
-      if (max_severity)
-        PRINT (stream,
-             "<app_count><page>0</page></app_count>"
-             "<severity>%1.1f</severity>"
-             "<threat>%s</threat>",
-             max_severity->severity_double,
-             severity_to_level (g_strtod (max_severity->severity, NULL), 0));
-    }
-  else
-    {
-      if (print_report_host_details_xml (host_iterator_report_host (hosts),
+      if (print_report_host_summary_xml (ctx,
                                          stream,
+                                         host_iterator_report_host (hosts),
+                                         host_key,
                                          lean))
         {
           g_free (host_key);
           return -1;
         }
+    }
+
+  if (print_report_host_details_xml (host_iterator_report_host (hosts),
+                                     stream,
+                                     lean))
+    {
+      g_free (host_key);
+      return -1;
     }
 
   PRINT (stream, "</host>");

--- a/src/manage_sql_report_hosts.c
+++ b/src/manage_sql_report_hosts.c
@@ -590,6 +590,7 @@ print_report_host_xml (print_report_context_t *ctx,
  * @param[in]  hosts                Host iterator.
  * @param[in]  lean                 Whether to return lean report.
  * @param[in]  host_summary_buffer  Host summary buffer.
+ * @param[in]  is_get_report_hosts  Whether called from get_report_hosts.
  *
  * @return 0 on success, -1 error.
  */
@@ -598,12 +599,14 @@ print_container_scan_report_host_xml (print_report_context_t *ctx,
                                       FILE *stream,
                                       iterator_t *hosts,
                                       int lean,
-                                      GString *host_summary_buffer)
+                                      GString *host_summary_buffer,
+                                      gboolean is_get_report_hosts)
 {
   int ports_count;
   const char *host;
   const char *hostname;
   gchar *host_key;
+  host_max_severity_t *max_severity = NULL;
 
   int holes_count, warnings_count, infos_count;
   int logs_count, false_positives_count;
@@ -691,14 +694,36 @@ print_container_scan_report_host_xml (print_report_context_t *ctx,
          logs_count,
          false_positives_count);
 
-  g_free (host_key);
-
-  if (print_report_host_details_xml (host_iterator_report_host (hosts),
-                                     stream,
-                                     lean))
-    return -1;
+  if (is_get_report_hosts)
+    {
+      /* get_report_hosts: print severity/threat instead of host details */
+      max_severity = g_hash_table_lookup (ctx->f_host_max_severity,
+                                          host_key);
+      /* application info is not included in container scanning host details
+       * for consistency always returns 0.
+       */
+      if (max_severity)
+        PRINT (stream,
+             "<app_count><page>0</page></app_count>"
+             "<severity>%1.1f</severity>"
+             "<threat>%s</threat>",
+             max_severity->severity_double,
+             severity_to_level (g_strtod (max_severity->severity, NULL), 0));
+    }
+  else
+    {
+      if (print_report_host_details_xml (host_iterator_report_host (hosts),
+                                         stream,
+                                         lean))
+        {
+          g_free (host_key);
+          return -1;
+        }
+    }
 
   PRINT (stream, "</host>");
+
+  g_free (host_key);
 
   return 0;
 }
@@ -711,6 +736,7 @@ print_container_scan_report_host_xml (print_report_context_t *ctx,
  * @param[in]  hosts                Host iterator.
  * @param[in]  lean                 Whether to return lean report.
  * @param[in]  host_summary_buffer  Host summary buffer.
+ * @param[in]  is_get_report_hosts  Whether called from get_report_hosts.
  *
  * @return 0 on success, -1 error.
  */
@@ -719,7 +745,8 @@ print_container_scan_report_hosts_xml (print_report_context_t *ctx,
                                        FILE *stream,
                                        iterator_t *hosts,
                                        int lean,
-                                       GString *host_summary_buffer)
+                                       GString *host_summary_buffer,
+                                       gboolean is_get_report_hosts)
 {
   while (next (hosts))
     {
@@ -727,7 +754,8 @@ print_container_scan_report_hosts_xml (print_report_context_t *ctx,
                                                 stream,
                                                 hosts,
                                                 lean,
-                                                host_summary_buffer))
+                                                host_summary_buffer,
+                                                is_get_report_hosts))
         {
           g_warning ("%s: Failed to print host XML", __func__);
           return -1;
@@ -824,7 +852,8 @@ print_report_hosts_xml (print_report_context_t *ctx,
                 stream,
                 &hosts,
                 lean,
-                host_summary_buffer))
+                host_summary_buffer,
+                is_get_report_hosts))
                 {
                   cleanup_iterator (&hosts);
                   return -1;
@@ -845,7 +874,8 @@ print_report_hosts_xml (print_report_context_t *ctx,
             stream,
             &hosts,
             lean,
-            host_summary_buffer))
+            host_summary_buffer,
+            is_get_report_hosts))
             {
               cleanup_iterator (&hosts);
               return -1;

--- a/src/manage_sql_report_hosts.c
+++ b/src/manage_sql_report_hosts.c
@@ -110,6 +110,92 @@ static
 DEF_ACCESS (host_iterator_asset_uuid, 9);
 
 /**
+ * @brief Maximum severity information for a host.
+ */
+typedef struct
+{
+  double severity_double; ///< Numeric severity value.
+  gchar *severity;        ///< Severity string representation.
+} host_max_severity_t;
+
+/**
+ * @brief Free a host maximum severity entry.
+ *
+ * @param[in]  data  Host maximum severity entry.
+ */
+void
+host_max_severity_free (gpointer data)
+{
+  host_max_severity_t *item = data;
+
+  if (item == NULL)
+    return;
+
+  g_free (item->severity);
+  g_free (item);
+}
+
+/**
+ * @brief Create a new host maximum severity entry.
+ *
+ * @param[in]  severity_double  Numeric severity value.
+ * @param[in]  severity         Severity string representation.
+ *
+ * @return Newly allocated host maximum severity entry.
+ */
+static host_max_severity_t *
+host_max_severity_new (double severity_double, const char *severity)
+{
+  host_max_severity_t *item;
+
+  item = g_malloc0 (sizeof (*item));
+  item->severity_double = severity_double;
+  item->severity = g_strdup (severity ? severity : "");
+
+  return item;
+}
+
+/**
+ * @brief Update maximum severity information for a host.
+ *
+ * @param[in,out]  ctx       Report print context holding per-host severity data.
+ * @param[in]      results   Result iterator positioned at the current result.
+ * @param[in]      host_key  Key identifying the host for aggregation.
+ */
+static void
+update_filtered_host_max_severity (print_report_context_t *ctx,
+                                   iterator_t *results,
+                                   const gchar *host_key)
+{
+  host_max_severity_t *item;
+  double cvss_double;
+  const char *severity;
+
+  if (ctx == NULL || results == NULL || host_key == NULL)
+    return;
+
+  cvss_double = result_iterator_severity_double (results);
+  severity = result_iterator_severity (results);
+
+  item = g_hash_table_lookup (ctx->f_host_max_severity, host_key);
+
+  if (item == NULL)
+    {
+      item = host_max_severity_new (cvss_double, severity);
+
+      g_hash_table_replace (ctx->f_host_max_severity,
+                            g_strdup (host_key),
+                            item);
+    }
+  else if (item->severity_double <= cvss_double)
+    {
+      item->severity_double = cvss_double;
+      g_free (item->severity);
+      item->severity = g_strdup (severity ? severity : "");
+    }
+}
+
+/**
  * @brief Write report host detail to file stream.
  *
  * @param[in]  stream   Stream to write to.
@@ -302,6 +388,7 @@ host_summary_append (GString *host_summary_buffer, const char *host,
  * @param[in]  usage_type           Report usage type.
  * @param[in]  lean                 Whether to return lean report.
  * @param[in]  host_summary_buffer  Host summary buffer.
+ * @param[in]  is_get_report_hosts  Whether called from get_report_hosts.
  *
  * @return 0 on success, -1 error.
  */
@@ -312,10 +399,12 @@ print_report_host_xml (print_report_context_t *ctx,
                        const char *host,
                        gchar *usage_type,
                        int lean,
-                       GString *host_summary_buffer)
+                       GString *host_summary_buffer,
+                       gboolean is_get_report_hosts)
 {
   const char *current_host;
   int ports_count;
+  host_max_severity_t *max_severity = NULL;
 
   current_host = host_iterator_host (hosts);
 
@@ -446,10 +535,25 @@ print_report_host_xml (print_report_context_t *ctx,
              false_positives_count);
     }
 
-  if (print_report_host_details_xml (host_iterator_report_host (hosts),
-                                     stream,
-                                     lean))
-    return -1;
+  if (is_get_report_hosts)
+    {
+      /* get_report_hosts: print severity/threat instead of host details */
+      max_severity = g_hash_table_lookup (ctx->f_host_max_severity,
+                                          current_host);
+      if (max_severity)
+        PRINT (stream,
+             "<severity>%1.1f</severity>"
+             "<threat>%s</threat>",
+             max_severity->severity_double,
+             severity_to_level (g_strtod (max_severity->severity, NULL), 0));
+    }
+  else
+    {
+      if (print_report_host_details_xml (host_iterator_report_host (hosts),
+                                         stream,
+                                         lean))
+        return -1;
+    }
 
   PRINT (stream, "</host>");
 
@@ -626,6 +730,7 @@ print_container_scan_report_hosts_xml (print_report_context_t *ctx,
  * @param[in]  result_hosts_only    Whether to print only hosts with results.
  * @param[in]  result_hosts         Result hosts array, used when result_hosts_only is set.
  * @param[in]  host_summary_buffer  Host summary buffer.
+ * @param[in]  is_get_report_hosts  Whether called from get_report_hosts.
  *
  * @return 0 on success, -1 error.
  */
@@ -639,7 +744,8 @@ print_report_hosts_xml (print_report_context_t *ctx,
                         gboolean is_container_scan,
                         gboolean result_hosts_only,
                         array_t *result_hosts,
-                        GString *host_summary_buffer)
+                        GString *host_summary_buffer,
+                        gboolean is_get_report_hosts)
 {
   if (get == NULL)
     {
@@ -760,7 +866,8 @@ print_report_hosts_xml (print_report_context_t *ctx,
                                          result_host,
                                          (gchar *) usage_type,
                                          lean,
-                                         host_summary_buffer))
+                                         host_summary_buffer,
+                                         is_get_report_hosts))
                 {
                   cleanup_iterator (&hosts);
                   return -1;
@@ -786,7 +893,8 @@ print_report_hosts_xml (print_report_context_t *ctx,
                                      NULL,
                                      (gchar *) usage_type,
                                      lean,
-                                     host_summary_buffer))
+                                     host_summary_buffer,
+                                     is_get_report_hosts))
             {
               cleanup_iterator (&hosts);
               return -1;
@@ -801,9 +909,9 @@ print_report_hosts_xml (print_report_context_t *ctx,
 /**
  * @brief Update filtered per-host result counts in the report context.
  *
- * @param ctx       Report print context holding per-host count tables.
- * @param results   Result iterator positioned at the current result.
- * @param host_key  Key identifying the host for aggregation.
+ * @param[in,out] ctx       Report print context holding per-host count tables.
+ * @param[in]     results   Result iterator positioned at the current result.
+ * @param[in]     host_key  Key identifying the host for aggregation.
  */
 static void
 update_filtered_host_result_counts (print_report_context_t *ctx,
@@ -849,12 +957,14 @@ update_filtered_host_result_counts (print_report_context_t *ctx,
 /**
  * @brief Initialize the result iterator and collect all result hosts.
  *
- * @param result_hosts Array to be filled with host keys (must be initialized).
- * @param get Request data used for iterator initialization.
- * @param report Report identifier.
- * @param results Result iterator to use.
- * @param is_container_scanning_report Whether to generate container-aware host keys.
- * @param ctx Report print context used to store filtered per-host counts.
+ * @param[in, out] result_hosts Array to be filled with host keys (must be initialized).
+ * @param[in]      get Request data used for iterator initialization.
+ * @param[in]      report Report identifier.
+ * @param[in, out] results Result iterator to use.
+ * @param[in]      is_container_scanning_report Whether to generate
+ *                                              container-aware host keys.
+ * @param[in, out] ctx  Report print context used to store filtered per-host counts.
+ * @param[in]      is_get_report_hosts  Whether called from get_report_hosts.
  *
  * @return 0 on success, non-zero on failure.
  */
@@ -864,7 +974,8 @@ fill_filtered_result_hosts (array_t **result_hosts,
                             report_t report,
                             iterator_t *results,
                             gboolean is_container_scanning_report,
-                            print_report_context_t *ctx)
+                            print_report_context_t *ctx,
+                            gboolean is_get_report_hosts)
 {
   int ret;
 
@@ -893,7 +1004,11 @@ fill_filtered_result_hosts (array_t **result_hosts,
       array_add_new_string (*result_hosts, host_key);
 
       if (ctx != NULL)
-        update_filtered_host_result_counts (ctx, results, host_key);
+        {
+          update_filtered_host_result_counts (ctx, results, host_key);
+          if (is_get_report_hosts)
+            update_filtered_host_max_severity (ctx, results, host_key);
+        }
     }
 
   return 0;

--- a/src/manage_sql_report_hosts.c
+++ b/src/manage_sql_report_hosts.c
@@ -131,53 +131,6 @@ DEF_ACCESS (report_host_os_iterator_cpe, 0);
 static
 DEF_ACCESS (report_host_os_iterator_name, 1);
 
-
-/**
- * @brief Maximum severity information for a host.
- */
-typedef struct
-{
-  double severity_double; ///< Numeric severity value.
-  gchar *severity;        ///< Severity string representation.
-} host_max_severity_t;
-
-/**
- * @brief Free a host maximum severity entry.
- *
- * @param[in]  data  Host maximum severity entry.
- */
-void
-host_max_severity_free (gpointer data)
-{
-  host_max_severity_t *item = data;
-
-  if (item == NULL)
-    return;
-
-  g_free (item->severity);
-  g_free (item);
-}
-
-/**
- * @brief Create a new host maximum severity entry.
- *
- * @param[in]  severity_double  Numeric severity value.
- * @param[in]  severity         Severity string representation.
- *
- * @return Newly allocated host maximum severity entry.
- */
-static host_max_severity_t *
-host_max_severity_new (double severity_double, const char *severity)
-{
-  host_max_severity_t *item;
-
-  item = g_malloc0 (sizeof (*item));
-  item->severity_double = severity_double;
-  item->severity = g_strdup (severity ? severity : "");
-
-  return item;
-}
-
 /**
  * @brief Update maximum severity information for a host.
  *
@@ -190,31 +143,27 @@ update_filtered_host_max_severity (print_report_context_t *ctx,
                                    iterator_t *results,
                                    const gchar *host_key)
 {
-  host_max_severity_t *item;
   double cvss_double;
-  const char *severity;
+  double *existing_severity;
 
   if (ctx == NULL || results == NULL || host_key == NULL)
     return;
 
   cvss_double = result_iterator_severity_double (results);
-  severity = result_iterator_severity (results);
 
-  item = g_hash_table_lookup (ctx->f_host_max_severity, host_key);
+  existing_severity = g_hash_table_lookup (ctx->f_host_max_severity, host_key);
 
-  if (item == NULL)
+  if (existing_severity == NULL)
     {
-      item = host_max_severity_new (cvss_double, severity);
-
+      double *new_severity = g_malloc (sizeof (double));
+      *new_severity = cvss_double;
       g_hash_table_replace (ctx->f_host_max_severity,
                             g_strdup (host_key),
-                            item);
+                            new_severity);
     }
-  else if (item->severity_double <= cvss_double)
+  else if (*existing_severity <= cvss_double)
     {
-      item->severity_double = cvss_double;
-      g_free (item->severity);
-      item->severity = g_strdup (severity ? severity : "");
+      *existing_severity = cvss_double;
     }
 }
 
@@ -295,7 +244,7 @@ print_report_host_summary_xml (print_report_context_t *ctx,
                                int lean)
 {
   iterator_t os_iterator;
-  host_max_severity_t *max_severity;
+  double *max_severity;
   int apps_count;
   const char *os_cpe = NULL;
   const char *os_name = NULL;
@@ -344,12 +293,12 @@ print_report_host_summary_xml (print_report_context_t *ctx,
          "<hostname></hostname>");
 
   max_severity = g_hash_table_lookup (ctx->f_host_max_severity, host_key);
-  if (max_severity)
+  if (*max_severity)
     PRINT (stream,
          "<severity>%1.1f</severity>"
          "<threat>%s</threat>",
-         max_severity->severity_double,
-         severity_to_level (max_severity->severity_double, 0));
+         *max_severity,
+         severity_to_level (*max_severity, 0));
   else if (lean == 0)
     PRINT (stream,
          "<severity>0.0</severity>"

--- a/src/manage_sql_report_hosts.c
+++ b/src/manage_sql_report_hosts.c
@@ -196,6 +196,23 @@ update_filtered_host_max_severity (print_report_context_t *ctx,
 }
 
 /**
+ * @brief Get the number of applications for a report host.
+ *
+ * @param[in]  report_host  Report host.
+ *
+ * @return Number of application entries for the report host.
+ */
+static int
+report_host_app_count (report_host_t report_host)
+{
+  return sql_int_ps ("SELECT count(*) FROM report_host_details"
+                     " WHERE report_host = $1"
+                     "   AND name = 'App';",
+                     SQL_RESOURCE_PARAM (report_host),
+                     NULL);
+}
+
+/**
  * @brief Write report host detail to file stream.
  *
  * @param[in]  stream   Stream to write to.
@@ -540,10 +557,14 @@ print_report_host_xml (print_report_context_t *ctx,
       /* get_report_hosts: print severity/threat instead of host details */
       max_severity = g_hash_table_lookup (ctx->f_host_max_severity,
                                           current_host);
+      int apps_count =
+        report_host_app_count (host_iterator_report_host (hosts));
       if (max_severity)
         PRINT (stream,
+             "<app_count><page>%d</page></app_count>"
              "<severity>%1.1f</severity>"
              "<threat>%s</threat>",
+             apps_count,
              max_severity->severity_double,
              severity_to_level (g_strtod (max_severity->severity, NULL), 0));
     }
@@ -923,7 +944,8 @@ update_filtered_host_port_counts (print_report_context_t *ctx,
   gchar *host_port_key;
   int port_count;
 
-  if (ctx == NULL || host_key == NULL || port == NULL || seen_host_ports == NULL)
+  if (ctx == NULL || host_key == NULL || port == NULL || seen_host_ports ==
+      NULL)
     return;
 
   if (*port == '\0')
@@ -943,7 +965,7 @@ update_filtered_host_port_counts (print_report_context_t *ctx,
   g_hash_table_add (seen_host_ports, host_port_key);
 
   port_count = GPOINTER_TO_INT (g_hash_table_lookup (ctx->f_host_ports,
-                                                     host_key));
+    host_key));
 
   g_hash_table_replace (ctx->f_host_ports,
                         g_strdup (host_key),
@@ -1051,9 +1073,9 @@ fill_filtered_result_hosts (array_t **result_hosts,
         {
           update_filtered_host_result_counts (ctx, results, host_key);
           update_filtered_host_port_counts (ctx,
-                                          host_key,
-                                          result_iterator_port (results),
-                                          ctx->f_host_ports);
+                                            host_key,
+                                            result_iterator_port (results),
+                                            ctx->f_host_ports);
 
           if (is_get_report_hosts)
             update_filtered_host_max_severity (ctx, results, host_key);

--- a/src/manage_sql_report_hosts.c
+++ b/src/manage_sql_report_hosts.c
@@ -907,6 +907,50 @@ print_report_hosts_xml (print_report_context_t *ctx,
 }
 
 /**
+ * @brief Update filtered per-host port counts in the report context.
+ *
+ * @param[in,out]  ctx              Report print context holding per-host port counts.
+ * @param[in]      host_key         Key identifying the host for aggregation.
+ * @param[in]      port             Port of the current result.
+ * @param[in,out]  seen_host_ports  Set of already counted host/port pairs.
+ */
+static void
+update_filtered_host_port_counts (print_report_context_t *ctx,
+                                  const gchar *host_key,
+                                  const gchar *port,
+                                  GHashTable *seen_host_ports)
+{
+  gchar *host_port_key;
+  int port_count;
+
+  if (ctx == NULL || host_key == NULL || port == NULL || seen_host_ports == NULL)
+    return;
+
+  if (*port == '\0')
+    return;
+
+  if (g_str_has_prefix (port, "general/"))
+    return;
+
+  host_port_key = g_strdup_printf ("%s|%s", host_key, port);
+
+  if (g_hash_table_lookup (seen_host_ports, host_port_key))
+    {
+      g_free (host_port_key);
+      return;
+    }
+
+  g_hash_table_add (seen_host_ports, host_port_key);
+
+  port_count = GPOINTER_TO_INT (g_hash_table_lookup (ctx->f_host_ports,
+                                                     host_key));
+
+  g_hash_table_replace (ctx->f_host_ports,
+                        g_strdup (host_key),
+                        GINT_TO_POINTER (port_count + 1));
+}
+
+/**
  * @brief Update filtered per-host result counts in the report context.
  *
  * @param[in,out] ctx       Report print context holding per-host count tables.
@@ -1006,6 +1050,11 @@ fill_filtered_result_hosts (array_t **result_hosts,
       if (ctx != NULL)
         {
           update_filtered_host_result_counts (ctx, results, host_key);
+          update_filtered_host_port_counts (ctx,
+                                          host_key,
+                                          result_iterator_port (results),
+                                          ctx->f_host_ports);
+
           if (is_get_report_hosts)
             update_filtered_host_max_severity (ctx, results, host_key);
         }

--- a/src/manage_sql_report_hosts.h
+++ b/src/manage_sql_report_hosts.h
@@ -38,7 +38,4 @@ fill_filtered_result_hosts (array_t **,
                             print_report_context_t *,
                             gboolean);
 
-void
-host_max_severity_free (gpointer);
-
 #endif /* _GVM_MANAGE_SQL_REPORT_HOSTS_H */

--- a/src/manage_sql_report_hosts.h
+++ b/src/manage_sql_report_hosts.h
@@ -26,7 +26,8 @@ print_report_hosts_xml (print_report_context_t *,
                         gboolean,
                         gboolean,
                         array_t *,
-                        GString *);
+                        GString *,
+                        gboolean);
 
 int
 fill_filtered_result_hosts (array_t **,
@@ -34,6 +35,10 @@ fill_filtered_result_hosts (array_t **,
                             report_t,
                             iterator_t *,
                             gboolean,
-                            print_report_context_t *);
+                            print_report_context_t *,
+                            gboolean);
+
+void
+host_max_severity_free (gpointer);
 
 #endif /* _GVM_MANAGE_SQL_REPORT_HOSTS_H */

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -21967,6 +21967,11 @@ END:VCALENDAR
         Otherwise only filter, sort and count information is returned.
       </p>
       <p>
+        Host entries include summary information derived from matching results,
+        such as application count, best OS information, hostname, severity and
+        threat, as well as host detail elements.
+      </p>
+      <p>
         Currently "lean" omits selected optional or redundant XML elements from the
         report hosts output to reduce response size.
       </p>
@@ -22095,6 +22100,12 @@ END:VCALENDAR
           <o><e>end</e></o>
           <o><e>port_count</e></o>
           <o><e>result_count</e></o>
+          <o><e>app_count</e></o>
+          <o><e>best_os_cpe</e></o>
+          <o><e>best_os_txt</e></o>
+          <o><e>hostname</e></o>
+          <o><e>severity</e></o>
+          <o><e>threat</e></o>
           <any><e>detail</e></any>
         </pattern>
         <ele>
@@ -22245,6 +22256,43 @@ END:VCALENDAR
               <pattern><t>integer</t></pattern>
             </ele>
           </ele>
+        </ele>
+        <ele>
+          <name>app_count</name>
+          <summary>Count of applications for the host on the current page</summary>
+          <pattern>
+            <e>page</e>
+          </pattern>
+          <ele>
+            <name>page</name>
+            <summary>Number of applications on the current page</summary>
+            <pattern><t>integer</t></pattern>
+          </ele>
+        </ele>
+        <ele>
+          <name>best_os_cpe</name>
+          <summary>Best detected operating system CPE for the host</summary>
+          <pattern>text</pattern>
+        </ele>
+        <ele>
+          <name>best_os_txt</name>
+          <summary>Best detected operating system name for the host</summary>
+          <pattern>text</pattern>
+        </ele>
+        <ele>
+          <name>hostname</name>
+          <summary>Hostname of the host</summary>
+          <pattern>text</pattern>
+        </ele>
+        <ele>
+          <name>severity</name>
+          <summary>Highest severity of matching results for the host</summary>
+          <pattern>severity</pattern>
+        </ele>
+        <ele>
+          <name>threat</name>
+          <summary>Threat level derived from the highest severity</summary>
+          <pattern>text</pattern>
         </ele>
         <ele>
           <name>detail</name>
@@ -22413,41 +22461,41 @@ END:VCALENDAR
       <request>
         <get_report_hosts report_id="2f628a42-13f3-4420-9f2b-5754aa1aafe9"
                           details="1"
-                          filter="levels=chml rows=100 min_qod=70 first=1 sort-reverse=severity result_hosts_only=0">
+                          filter="levels=chml rows=10 min_qod=70 first=1 sort-reverse=severity result_hosts_only=1">
         </get_report_hosts>
       </request>
       <response>
         <get_report_hosts_response status="200" status_text="OK">
           <host>
-            <ip>192.168.178.87</ip>
-            <asset asset_id="49c2947e-17ab-429b-b68d-e183b4387da7"/>
-            <start>2026-03-30T06:44:34Z</start>
-            <end>2026-03-30T06:45:44Z</end>
+            <ip>127.0.0.1</ip>
+            <asset asset_id="9fd3aff1-4550-42cb-8339-1b6776f555d0"/>
+            <start>2026-04-08T06:48:21Z</start>
+            <end>2026-04-08T07:32:37Z</end>
             <port_count>
-              <page>0</page>
+              <page>4</page>
             </port_count>
             <result_count>
-              <page>0</page>
+              <page>5</page>
               <critical>
                 <page>0</page>
               </critical>
               <hole deprecated="1">
-                <page>0</page>
+                <page>1</page>
               </hole>
               <high>
-                <page>0</page>
+                <page>1</page>
               </high>
               <warning deprecated="1">
-                <page>0</page>
+                <page>3</page>
               </warning>
               <medium>
-                <page>0</page>
+                <page>3</page>
               </medium>
               <info deprecated="1">
-                <page>0</page>
+                <page>1</page>
               </info>
               <low>
-                <page>0</page>
+                <page>1</page>
               </low>
               <log>
                 <page>0</page>
@@ -22456,19 +22504,24 @@ END:VCALENDAR
                 <page>0</page>
               </false_positive>
             </result_count>
+            <app_count>
+              <page>13</page>
+            </app_count>
+            <best_os_cpe>cpe:/o:canonical:ubuntu_linux:24.04</best_os_cpe>
+            <best_os_txt>Ubuntu 24.04</best_os_txt>
+            <hostname>localhost</hostname>
+            <severity>7.3</severity>
+            <threat>High</threat>
             <detail>
-              <name>hostname</name>
-              <value>levoit-purifier.fritz.box</value>
+              <name>App</name>
+              <value>cpe:/a:ietf:transport_layer_security:1.2</value>
               <source>
-                <type>nvt</type>
-                <name>1.3.6.1.4.1.25623.1.0.103997</name>
-                <description>Host Details</description>
+                <name>1.3.6.1.4.1.25623.1.0.105782</name>
               </source>
-              <extra/>
             </detail>
           </host>
           <filters id="">
-            <term>apply_overrides=0 levels=chml rows=100 min_qod=70 first=1 sort-reverse=severity result_hosts_only=0</term>
+            <term>apply_overrides=0 levels=chml rows=10 min_qod=70 first=1 sort-reverse=severity result_hosts_only=1</term>
             <keywords>
               <keyword>
                 <column>apply_overrides</column>
@@ -22483,7 +22536,7 @@ END:VCALENDAR
               <keyword>
                 <column>rows</column>
                 <relation>=</relation>
-                <value>100</value>
+                <value>10</value>
               </keyword>
               <keyword>
                 <column>min_qod</column>
@@ -22503,14 +22556,14 @@ END:VCALENDAR
               <keyword>
                 <column>result_hosts_only</column>
                 <relation>=</relation>
-                <value>0</value>
+                <value>1</value>
               </keyword>
             </keywords>
           </filters>
           <sort>
             <field>severity<order>descending</order></field>
           </sort>
-          <report_hosts start="1" max="100"/>
+          <report_hosts start="1" max="10"/>
           <report_host_count>1<filtered>1</filtered><page>0</page></report_host_count>
         </get_report_hosts_response>
       </response>


### PR DESCRIPTION
## What

- Add per-host severity and threat
- Add app_count, hostname, and OS info to host output
- Include port_count aggregation
- Reuse logic for container scans
- Update GMP documentation and example response

## Why

- Make `get_report_hosts` more useful with key host summary data
- Keep documentation aligned with the actual response

## References
GEA-1710


