### PR TITLE
fix: avoid null dereference in report host severity output

### DIFF
--- a/src/manage_sql_report_hosts.c
+++ b/src/manage_sql_report_hosts.c
@@ -293,7 +293,7 @@ print_report_host_summary_xml (print_report_context_t *ctx,
          "<hostname></hostname>");
 
   max_severity = g_hash_table_lookup (ctx->f_host_max_severity, host_key);
-  if (*max_severity)
+  if (max_severity && *max_severity)
     PRINT (stream,
          "<severity>%1.1f</severity>"
          "<threat>%s</threat>",


### PR DESCRIPTION
## What

* Add a null check for the per-host severity lookup in `print_report_host_summary_xml`
* Prevent dereferencing a missing hash table value when no severity entry exists for a host

## Why

* The current code can dereference a `NULL` pointer when a host has no entry in `ctx->f_host_max_severity`
* This can cause a segmentation fault while generating `get_report_hosts` output


## References

GEA-1710

