### PR TITLE
Fix: Make include of libpq-fe.h work on Fedora/Enterprise Linux too

### DIFF
--- a/src/sql_pg.c
+++ b/src/sql_pg.c
@@ -21,7 +21,11 @@
 #include <gvm/base/array.h>
 #include <inttypes.h>
 #include <netinet/in.h>
-#include <postgresql/libpq-fe.h>
+#if __has_include(<postgresql/libpq-fe.h>)
+#  include <postgresql/libpq-fe.h>
+#else
+#  include <libpq-fe.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 


### PR DESCRIPTION
## What

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

Make include of libpq-fe.h work on Fedora/Enterprise Linux too
using __has_include.

## Why

<!-- Describe why are these changes necessary? -->

On Fedora and Enterprise Linux libpq-fe.h is not installed under postgresql so the include fails. Check for the expected location and fall back to looking directly on the include path.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

Gcc supports __has_include since at least version 9.5: https://gcc.gnu.org/onlinedocs/gcc-9.5.0/cpp/_005f_005fhas_005finclude.html

Clang supports __has_include since at least 5.0.0: https://releases.llvm.org/5.0.0/tools/clang/docs/LanguageExtensions.html#include-file-checking-macros

I considered adding a version requirement on Gcc in the install instructions but as i don't know what version is required for other features used i decided against it. Please let me know if i should reconsider.