### PR TITLE
Change: remove unused macros

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -4882,17 +4882,6 @@ set_read_over (gmp_parser_t *gmp_parser)
     }                                                           \
   break
 
-/**
- * @brief Insert else clause for gmp_xml_handle_start_element in create_task.
- */
-#define ELSE_READ_OVER_CREATE_TASK                              \
-  else                                                          \
-    {                                                           \
-      request_delete_task (&create_task_data->task);            \
-      set_read_over (gmp_parser);                               \
-    }                                                           \
-  break
-
 /** @todo Free globals when tags open, in case of duplicate tags. */
 /**
  * @brief Handle the start of a GMP XML element.

--- a/src/manage_utils.c
+++ b/src/manage_utils.c
@@ -28,11 +28,6 @@
 #define G_LOG_DOMAIN "md  utils"
 
 /**
- * @brief Number of seconds in a day.
- */
-#define SECS_PER_DAY 86400
-
-/**
  * @brief Add months to a time.
  *
  * @param[in]  time    Time.


### PR DESCRIPTION
## What

Remove unused macros.

## Why

Cleaner.

## Testing

Compile with `-Wunused-macros`, warnings are gone.

