### PR TITLE
Add: Add scan queue handling for openvasd.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -182,6 +182,7 @@ set(
   manage_license.c
   manage_notes.c
   manage_openvas.c
+  manage_openvasd.c
   manage_osp.c
   manage_overrides.c
   manage_permissions.c

--- a/src/manage.c
+++ b/src/manage.c
@@ -51,6 +51,7 @@
 #include "manage_settings.h"
 #include "manage_oci_image_targets.h"
 #include "manage_http_scanner.h"
+#include "manage_openvasd.h"
 #include "manage_report_hosts.h"
 #include "manage_runtime_flags.h"
 #include "manage_scanner_relays.h"
@@ -1590,7 +1591,7 @@ fork_osp_scan_handler (task_t task, target_t target, int start_from,
 }
 
 /**
- * @brief Prepare an OSP scan and add it to the gvmd scan queue.
+ * @brief Prepare a scan and add it to the gvmd scan queue.
  *
  * @param[in]   task       The task.
  * @param[in]   start_from 0 start from beginning, 1 continue from stopped,
@@ -1600,7 +1601,7 @@ fork_osp_scan_handler (task_t task, target_t target, int start_from,
  * @return 0 on success, -1 on failure.
  */
 static int
-queue_osp_task (task_t task, int start_from, char **report_id_return)
+queue_scan_task (task_t task, int start_from, char **report_id_return)
 {
   char *report_id = NULL;
   report_t report = 0;
@@ -1631,7 +1632,10 @@ queue_osp_task (task_t task, int start_from, char **report_id_return)
   set_report_scan_run_status (report, TASK_STATUS_REQUESTED);
   g_debug ("%s: report %s (%llu) added to scan queue",
            __func__, report_id, report);
-  g_free (report_id);
+  if (report_id_return)
+    *report_id_return = report_id;
+  else
+    g_free (report_id);
   return 0;
 }
 
@@ -1669,7 +1673,7 @@ run_osp_task (task_t task, int from, char **report_id)
 
   if (get_use_scan_queue ())
     {
-      if (queue_osp_task (task, from, report_id))
+      if (queue_scan_task (task, from, report_id))
         {
           g_warning ("Couldn't queue OSP scan");
           return -1;
@@ -6930,6 +6934,77 @@ delete_resource (const char *type, const char *resource_id, int ultimate)
   return -1;
 }
 
+/**
+ * @brief Handles the semaphore for the start of a scan update.
+ *
+ * @param[in]  add_result_on_error  Whether to create a result on error.
+ * @param[in]  task   The current task (for error result).
+ * @param[in]  report The current report (for error result).
+ *
+ * @return 0 success, -1 error.
+ */
+int
+scan_semaphore_update_start (int add_result_on_error,
+                             task_t task, report_t report)
+{
+  if (get_max_concurrent_scan_updates () == 0)
+    return 0;
+
+  int sem_op_ret = semaphore_op (SEMAPHORE_SCAN_UPDATE, -1, 5);
+  if (sem_op_ret == 1)
+    return 1;
+  else if (sem_op_ret)
+    {
+      g_warning ("%s: error waiting for scan update semaphore",
+                __func__);
+      if (add_result_on_error)
+        {
+          result_t result = make_osp_result
+            (task, "", "", "",
+              threat_message_type ("Error"),
+              "Error waiting for scan update semaphore", "", "",
+              QOD_DEFAULT, NULL, NULL);
+          report_add_result (report, result);
+        }
+      return -1;
+    }
+  return 0;
+}
+
+/**
+ * @brief Handles the semaphore for the end of a scan update.
+ *
+ * @param[in]  add_result_on_error  Whether to create a result on error.
+ * @param[in]  task   The current task (for error result).
+ * @param[in]  report The current report (for error result).
+ *
+ * @return 0 success, -1 error.
+*/
+int
+scan_semaphore_update_end (int add_result_on_error,
+                           task_t task, report_t report)
+{
+  if (get_max_concurrent_scan_updates () == 0)
+    return 0;
+
+  if (semaphore_op (SEMAPHORE_SCAN_UPDATE, +1, 0))
+    {
+      g_warning ("%s: error signaling scan update semaphore",
+                __func__);
+      if (add_result_on_error)
+        {
+          result_t result = make_osp_result
+            (task, "", "", "",
+              threat_message_type ("Error"),
+              "Error signaling scan update semaphore", "", "",
+              QOD_DEFAULT, NULL, NULL);
+          report_add_result (report, result);
+        }
+      return -1;
+    }
+  return 0;
+}
+
 #if ENABLE_OPENVASD
 /* openvasd */
 
@@ -7011,411 +7086,6 @@ end_stop_openvasd:
 }
 
 /**
- * @brief Prepare a report for resuming an OSP scan
- *
- * @param[in]  task     The task of the scan.
- * @param[in]  scan_id  The scan uuid.
- * @param[out] error    Error return.
- *
- * @return 0 scan finished or still running,
- *         1 scan must be started,
- *         -1 error
- */
-static int
-prepare_openvasd_scan_for_resume (task_t task, const char *scan_id,
-                                  char **error)
-{
-  http_scanner_connector_t connection;
-  int ret;
-
-  assert (task);
-  assert (scan_id);
-  assert (global_current_report);
-  assert (error);
-
-  connection = http_scanner_connect (task_scanner (task), scan_id);
-  if (!connection)
-    {
-      *error = g_strdup ("Could not connect to openvasd Scanner");
-      return -1;
-    }
-
-  g_debug ("%s: Preparing scan %s for resume", __func__, scan_id);
-
-  ret = prepare_http_scanner_scan_for_resume (connection, error);
-
-  if (ret == 1)
-    trim_partial_report (global_current_report);
-
-  return ret;
-}
-
-/**
- * @brief Launch an OpenVAS via openvasd task.
- *
- * @param[in]   task           The task.
- * @param[in]   target         The target.
- * @param[in]   scan_id        The scan uuid.
- * @param[in]   from           0 start from beginning, 1 continue from stopped,
- *                             2 continue if stopped else start from beginning.
- * @param[out]  error          Error return.
- * @param[out]  discovery_out  Returns TRUE if all OIDs are labeled
- *                             as discovery in the used scan config.
- *
- * @return An http code on success, -1 if error.
- */
-static int
-launch_openvasd_openvas_task (task_t task, target_t target, const char *scan_id,
-                         int from, char **error, gboolean *discovery_out)
-{
-  http_scanner_connector_t connection;
-  char *hosts_str, *ports_str, *exclude_hosts_str, *finished_hosts_str;
-  gchar *clean_hosts, *clean_exclude_hosts, *clean_finished_hosts_str;
-  int alive_test, reverse_lookup_only, reverse_lookup_unify;
-  int arp = 0, icmp = 0, tcp_ack = 0, tcp_syn = 0, consider_alive = 0;
-  openvasd_target_t *openvasd_target;
-  GSList *openvasd_targets, *vts;
-  GHashTable *vts_hash_table;
-  gchar *max_checks, *max_hosts;
-  GHashTable *scanner_options;
-  http_scanner_resp_t response;
-  int ret, empty;
-  config_t config;
-  iterator_t scanner_prefs_iter, families, prefs;
-
-  connection = NULL;
-  config = task_config (task);
-
-  alive_test = 0;
-  reverse_lookup_unify = 0;
-  reverse_lookup_only = 0;
-
-  /* Prepare the report */
-  if (from)
-    {
-      ret = prepare_openvasd_scan_for_resume (task, scan_id, error);
-      if (ret == 0)
-        return 0;
-      else if (ret == -1)
-        return -1;
-      finished_hosts_str = report_finished_hosts_str (global_current_report);
-      clean_finished_hosts_str = clean_hosts_string (finished_hosts_str);
-    }
-  else
-    {
-      finished_hosts_str = NULL;
-      clean_finished_hosts_str = NULL;
-    }
-
-  /* Set up target(s) */
-  hosts_str = target_hosts (target);
-  ports_str = target_port_range (target);
-  exclude_hosts_str = target_exclude_hosts (target);
-
-  clean_hosts = clean_hosts_string (hosts_str);
-  clean_exclude_hosts = clean_hosts_string (exclude_hosts_str);
-
-  alive_test = 0;
-  if (target_alive_tests (target) > 0)
-    alive_test = target_alive_tests (target);
-
-  if (target_reverse_lookup_only (target) != NULL)
-    reverse_lookup_only = atoi (target_reverse_lookup_only (target));
-
-  if (target_reverse_lookup_unify (target) != NULL)
-    reverse_lookup_unify = atoi (target_reverse_lookup_unify (target));
-
-  if (finished_hosts_str)
-    {
-      gchar *new_exclude_hosts;
-
-      new_exclude_hosts = g_strdup_printf ("%s,%s",
-                                           clean_exclude_hosts,
-                                           clean_finished_hosts_str);
-      free (clean_exclude_hosts);
-      clean_exclude_hosts = new_exclude_hosts;
-    }
-
-  openvasd_target = openvasd_target_new (scan_id, clean_hosts, ports_str,
-                                         clean_exclude_hosts,
-                                         reverse_lookup_unify,
-                                         reverse_lookup_only);
-  if (finished_hosts_str)
-    openvasd_target_set_finished_hosts (openvasd_target, finished_hosts_str);
-
-  if (alive_test & ALIVE_TEST_ARP)
-    arp = 1;
-  if (alive_test & ALIVE_TEST_ICMP)
-    icmp = 1;
-  if (alive_test & ALIVE_TEST_TCP_ACK_SERVICE)
-    tcp_ack = 1;
-  if (alive_test & ALIVE_TEST_TCP_SYN_SERVICE)
-    tcp_syn = 1;
-  if (alive_test & ALIVE_TEST_CONSIDER_ALIVE)
-    consider_alive = 1;
-
-  openvasd_target_add_alive_test_methods (openvasd_target, icmp, tcp_syn,
-                                          tcp_ack, arp, consider_alive);
-
-  free (hosts_str);
-  free (ports_str);
-  free (exclude_hosts_str);
-  free (finished_hosts_str);
-  g_free (clean_hosts);
-  g_free (clean_exclude_hosts);
-  g_free (clean_finished_hosts_str);
-  openvasd_targets = g_slist_append (NULL, openvasd_target);
-
-#if ENABLE_CREDENTIAL_STORES == 0
-
-  openvasd_credential_t *ssh_credential, *smb_credential, *esxi_credential;
-  openvasd_credential_t *snmp_credential;
-
-  ssh_credential = (openvasd_credential_t *) target_osp_ssh_credential_db (target);
-  if (ssh_credential)
-    openvasd_target_add_credential (openvasd_target, ssh_credential);
-
-  smb_credential = (openvasd_credential_t *) target_osp_smb_credential_db (target);
-  if (smb_credential)
-    openvasd_target_add_credential (openvasd_target, smb_credential);
-
-  esxi_credential =
-    (openvasd_credential_t *) target_osp_esxi_credential_db (target);
-  if (esxi_credential)
-    openvasd_target_add_credential (openvasd_target, esxi_credential);
-
-  snmp_credential =
-    (openvasd_credential_t *) target_osp_snmp_credential_db (target);
-  if (snmp_credential)
-    openvasd_target_add_credential (openvasd_target, snmp_credential);
-
-#endif
-
-  /* Initialize vts table for vulnerability tests and their preferences */
-  vts = NULL;
-  vts_hash_table
-    = g_hash_table_new_full (g_str_hash, g_str_equal, g_free,
-                             /* Value is freed in vts list. */
-                             NULL);
-
-  /*  Setup of vulnerability tests (without preferences) */
-  init_family_iterator (&families, 0, NULL, 1);
-  GSList *oids = NULL;
-  empty = 1;
-  while (next (&families))
-    {
-      const char *family = family_iterator_name (&families);
-      if (family)
-        {
-          iterator_t nvts;
-          init_nvt_iterator (&nvts, 0, config, family, NULL, 1, NULL);
-          while (next (&nvts))
-            {
-              const char *oid;
-              openvasd_vt_single_t *new_vt;
-
-              empty = 0;
-              oid = nvt_iterator_oid (&nvts);
-              new_vt = openvasd_vt_single_new (oid);
-              oids = g_slist_prepend (oids, g_strdup (oid));
-
-              vts = g_slist_prepend (vts, new_vt);
-              g_hash_table_replace (vts_hash_table, g_strdup (oid), new_vt);
-            }
-          cleanup_iterator (&nvts);
-        }
-    }
-  cleanup_iterator (&families);
-
-  /* check oids are discovery or not */
-  *discovery_out = nvts_oids_all_discovery_cached (oids);
-  /* clean up oids list */
-  g_slist_free_full (oids, g_free);
-
-  if (empty) {
-    if (error)
-      *error = g_strdup ("Exiting because VT list is empty "
-                         "(e.g. feed not synced yet)");
-    g_slist_free_full (openvasd_targets, (GDestroyNotify) openvasd_target_free);
-    // Credentials are freed with target
-    g_slist_free_full (vts, (GDestroyNotify) openvasd_vt_single_free);
-    return -1;
-  }
-
-  /* Setup general scanner preferences */
-  scanner_options
-    = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
-  init_preference_iterator (&scanner_prefs_iter, config, "SERVER_PREFS");
-  while (next (&scanner_prefs_iter))
-    {
-      const char *name, *value;
-      name = preference_iterator_name (&scanner_prefs_iter);
-      value = preference_iterator_value (&scanner_prefs_iter);
-      if (name && value && !g_str_has_prefix (name, "timeout."))
-        {
-          const char *openvasd_value;
-
-          // Workaround for boolean scanner preferences
-          if (strcmp (value, "no") == 0)
-            openvasd_value = "0";
-          else if (strcmp (value, "yes") == 0)
-            openvasd_value = "1";
-          else
-            openvasd_value = value;
-          g_hash_table_replace (scanner_options, g_strdup (name),
-                                g_strdup (openvasd_value));
-        }
-      /* Timeouts are stored as SERVER_PREFS, but are actually
-         script preferences. This prefs is converted into a
-         script preference to be sent to the scanner. */
-      else if (name && value && g_str_has_prefix (name, "timeout."))
-        {
-          char **oid = NULL;
-          openvasd_vt_single_t *openvasd_vt = NULL;
-
-          oid = g_strsplit (name, ".", 2);
-          openvasd_vt = g_hash_table_lookup (vts_hash_table, oid[1]);
-          if (openvasd_vt)
-            openvasd_vt_single_add_value (openvasd_vt, "0", value);
-          g_strfreev (oid);
-        }
-    }
-  cleanup_iterator (&scanner_prefs_iter);
-
-  /* Setup user-specific scanner preference */
-  add_user_scan_preferences (scanner_options);
-
-  /* Setup general task preferences */
-  max_checks = task_preference_value (task, "max_checks");
-  g_hash_table_insert (scanner_options, g_strdup ("max_checks"),
-                       max_checks ? max_checks : g_strdup (MAX_CHECKS_DEFAULT));
-
-  max_hosts = task_preference_value (task, "max_hosts");
-  g_hash_table_insert (scanner_options, g_strdup ("max_hosts"),
-                       max_hosts ? max_hosts : g_strdup (MAX_HOSTS_DEFAULT));
-
-  /* Setup VT preferences */
-  init_preference_iterator (&prefs, config, "PLUGINS_PREFS");
-  while (next (&prefs))
-    {
-      const char *full_name, *value;
-      openvasd_vt_single_t *openvasd_vt;
-      gchar **split_name;
-
-      full_name = preference_iterator_name (&prefs);
-      value = preference_iterator_value (&prefs);
-      split_name = g_strsplit (full_name, ":", 4);
-
-      openvasd_vt = NULL;
-      if (split_name && split_name[0] && split_name[1] && split_name[2])
-        {
-          const char *oid = split_name[0];
-          const char *pref_id = split_name[1];
-          const char *type = split_name[2];
-          gchar *openvasd_value = NULL;
-
-          if (strcmp (type, "checkbox") == 0)
-            {
-              if (strcmp (value, "yes") == 0)
-                openvasd_value = g_strdup ("1");
-              else
-                openvasd_value = g_strdup ("0");
-            }
-          else if (strcmp (type, "radio") == 0)
-            {
-              gchar** split_value;
-              split_value = g_strsplit (value, ";", 2);
-              openvasd_value = g_strdup (split_value[0]);
-              g_strfreev (split_value);
-            }
-          else if (strcmp (type, "file") == 0)
-            openvasd_value = g_base64_encode ((guchar*) value, strlen (value));
-
-          openvasd_vt = g_hash_table_lookup (vts_hash_table, oid);
-          if (openvasd_vt)
-            openvasd_vt_single_add_value (openvasd_vt, pref_id,
-                                     openvasd_value ? openvasd_value : value);
-          g_free (openvasd_value);
-        }
-
-      g_strfreev (split_name);
-    }
-  cleanup_iterator (&prefs);
-  g_hash_table_destroy (vts_hash_table);
-
-  /* Start the scan */
-  connection = http_scanner_connect (task_scanner (task), scan_id);
-  if (!connection)
-    {
-      if (error)
-        *error = g_strdup ("Could not connect to Scanner");
-      g_slist_free_full (openvasd_targets,
-                         (GDestroyNotify) openvasd_target_free);
-      // Credentials are freed with target
-      g_slist_free_full (vts, (GDestroyNotify) openvasd_vt_single_free);
-      g_hash_table_destroy (scanner_options);
-      return -1;
-    }
-
-  gchar *scan_config = NULL;
-  scan_config =
-    openvasd_build_scan_config_json(openvasd_target, scanner_options, vts);
-
-  response = http_scanner_create_scan (connection, scan_config);
-  if (response->code == 201)
-    {
-      http_scanner_response_cleanup (response);
-      response = http_scanner_start_scan (connection);
-    }
-  else
-    g_warning ("%s: Failed to create scan: %ld", __func__, response->code);
-
-  openvasd_target_free(openvasd_target);
-  // Credentials are freed with target
-  g_slist_free_full (vts, (GDestroyNotify) openvasd_vt_single_free);
-  g_hash_table_destroy (scanner_options);
-  ret = response->code;
-  http_scanner_response_cleanup (response);
-
-  return ret;
-}
-
-/**
- * @brief Handle an ongoing openvasd scan, until success or failure.
- *
- * @param[in]   task      The task.
- * @param[in]   report    The report.
- * @param[in]   scan_id   The UUID of the scan on the scanner.
- *
- * @return 0 if success, -1 if error, -2 if scan was stopped,
- *         -3 if the scan was interrupted, -4 already stopped.
- */
-static int
-handle_openvasd_scan (task_t task, report_t report, const char *scan_id)
-{
-  scanner_t scanner;
-  http_scanner_connector_t connector;
-  int ret;
-
-  scanner = task_scanner (task);
-  connector = http_scanner_connect (scanner, scan_id);
-
-  if (!connector)
-    {
-      g_warning ("%s: Could not connect to openvasd scanner", __func__);
-      return -1;
-    }
-
-  ret = handle_http_scanner_scan (connector, task, report,
-                                  parse_http_scanner_report);
-
-  http_scanner_connector_free (connector);
-
-  return ret;
-
-}
-
-/**
  * @brief Fork a child to handle an openvasd scan's fetching and inserting.
  *
  * @param[in]   task       The task.
@@ -7429,9 +7099,9 @@ handle_openvasd_scan (task_t task, report_t report, const char *scan_id)
  */
 static int
 fork_openvasd_scan_handler (task_t task, target_t target, int from,
-                       char **report_id_return)
+                            char **report_id_return)
 {
-  char *report_id, *error = NULL;
+  char *report_id;
   gboolean discovery_scan = FALSE;
   int rc;
 
@@ -7485,24 +7155,9 @@ fork_openvasd_scan_handler (task_t task, target_t target, int from,
   reinit_manage_process ();
   manage_session_init (current_credentials.uuid);
 
-  rc = launch_openvasd_openvas_task (task, target, report_id, from, &error,
-                                     &discovery_scan);
-
-  if (rc < 0)
+  if (handle_openvasd_scan_start (task, target, report_id, from, FALSE,
+                                  &discovery_scan))
     {
-      result_t result;
-
-      g_warning ("openvasd start_scan %s: %s", report_id, error);
-      result = make_osp_result (task, "", "", "",
-                                threat_message_type ("Error"),
-                                error, "", "", QOD_DEFAULT, NULL, NULL);
-      report_add_result (global_current_report, result);
-      set_task_run_status (task, TASK_STATUS_DONE);
-      set_report_scan_run_status (global_current_report, TASK_STATUS_DONE);
-      set_task_end_time_epoch (task, time (NULL));
-      set_scan_end_time_epoch (global_current_report, time (NULL));
-
-      g_free (error);
       g_free (report_id);
       gvm_close_sentry ();
       exit (-1);
@@ -7510,41 +7165,9 @@ fork_openvasd_scan_handler (task_t task, target_t target, int from,
 
   setproctitle ("openvasd: Handling scan %s", report_id);
 
-  rc = handle_openvasd_scan (task, global_current_report, report_id);
+  rc = handle_openvasd_scan (task, global_current_report, report_id, 0);
   g_free (report_id);
-
-  if (rc >= 0)
-    {
-      set_task_run_status (task, TASK_STATUS_PROCESSING);
-      set_report_scan_run_status (global_current_report,
-                                  TASK_STATUS_PROCESSING);
-      asset_snapshots_target (global_current_report, task, discovery_scan);
-      hosts_set_identifiers (global_current_report);
-      hosts_set_max_severity (global_current_report, NULL, NULL);
-      hosts_set_details (global_current_report);
-      set_task_run_status (task, TASK_STATUS_DONE);
-      set_report_scan_run_status (global_current_report, TASK_STATUS_DONE);
-      if (feature_enabled (FEATURE_ID_SECURITY_INTELLIGENCE_EXPORT))
-        {
-          queue_report_for_export (global_current_report);
-        }
-    }
-  else if (rc == -1 || rc == -2)
-    {
-      set_task_run_status (task, TASK_STATUS_STOPPED);
-      set_report_scan_run_status (global_current_report, TASK_STATUS_STOPPED);
-    }
-  else if (rc == -3)
-    {
-      set_task_run_status (task, TASK_STATUS_INTERRUPTED);
-      set_report_scan_run_status (global_current_report,
-                                  TASK_STATUS_INTERRUPTED);
-    }
-
-  set_task_end_time_epoch (task, time (NULL));
-  set_scan_end_time_epoch (global_current_report, time (NULL));
-  global_current_report = 0;
-  current_scanner_task = (task_t) 0;
+  rc = handle_openvasd_scan_end (task, rc, discovery_scan);
   gvm_close_sentry ();
   exit (rc);
 }
@@ -7586,11 +7209,23 @@ run_openvasd_task (task_t task, int from, char **report_id)
         return 99;
     }
 
-  if (fork_openvasd_scan_handler (task, target, from, report_id))
+  if (get_use_scan_queue ())
     {
-      g_warning ("Couldn't fork openvasd scan handler");
-      return -1;
+      if (queue_scan_task (task, from, report_id))
+        {
+          g_warning ("Couldn't queue openvasd scan");
+          return -1;
+        }
     }
+  else
+    {
+      if (fork_openvasd_scan_handler (task, target, from, report_id))
+        {
+          g_warning ("Couldn't fork openvasd scan handler");
+          return -1;
+        }
+    }
+
   return 0;
 }
 #endif

--- a/src/manage.c
+++ b/src/manage.c
@@ -6979,7 +6979,7 @@ scan_semaphore_update_start (int add_result_on_error,
  * @param[in]  report The current report (for error result).
  *
  * @return 0 success, -1 error.
-*/
+ */
 int
 scan_semaphore_update_end (int add_result_on_error,
                            task_t task, report_t report)

--- a/src/manage.h
+++ b/src/manage.h
@@ -2853,4 +2853,10 @@ get_vt_verification_collation ();
 void
 set_vt_verification_collation (const char *);
 
+int
+scan_semaphore_update_start (int, task_t, report_t);
+
+int
+scan_semaphore_update_end (int, task_t, report_t);
+
 #endif /* not _GVMD_MANAGE_H */

--- a/src/manage_container_image_scanner.c
+++ b/src/manage_container_image_scanner.c
@@ -905,7 +905,8 @@ handle_container_image_scan (task_t task,
 {
   scanner_t scanner;
   http_scanner_connector_t connector;
-  int ret;
+  http_scanner_resp_t response;
+  int rc;
 
   scanner = task_scanner (task);
   connector = container_image_scanner_connect (scanner, scan_id);
@@ -916,12 +917,52 @@ handle_container_image_scan (task_t task,
       return -1;
     }
 
-  ret = handle_http_scanner_scan (connector, task, report,
-                                  parse_container_image_scan_report);
+  gboolean started, queued_status_updated;
+  int retry, connection_retry;
 
+  if (connector == NULL)
+    {
+      g_warning ("%s: Could not connect to http scanner", __func__);
+      return -1;
+    }
+
+  response = NULL;
+  started = FALSE;
+  queued_status_updated = FALSE;
+  connection_retry = get_scanner_connection_retry ();
+
+  retry = connection_retry;
+  rc = -1;
+  while (retry >= 0)
+    {
+      int run_status;
+
+      run_status = task_run_status (task);
+      if (run_status == TASK_STATUS_STOPPED
+          || run_status == TASK_STATUS_STOP_REQUESTED)
+        {
+          rc = -4;
+          break;
+        }
+
+      rc = update_http_scanner_scan (connector, task, report,
+                                     parse_container_image_scan_report, &retry,
+                                     &queued_status_updated, &started);
+
+      if (rc <= 0)
+        break;
+
+      if (rc != 1)
+        {
+          retry = connection_retry;
+          gvm_sleep (5);
+        }
+    }
+
+  http_scanner_response_cleanup (response);
   http_scanner_connector_free (connector);
 
-  return ret;
+  return rc;
 }
 
 /**

--- a/src/manage_http_scanner.c
+++ b/src/manage_http_scanner.c
@@ -13,6 +13,7 @@
 #if ENABLE_HTTP_SCANNER
 #include "manage_http_scanner.h"
 #include "manage_sql.h"
+#include "manage_scan_queue.h"
 
 #undef G_LOG_DOMAIN
 /**
@@ -203,210 +204,182 @@ prepare_http_scanner_scan_for_resume (http_scanner_connector_t connector,
 }
 
 /**
- * @brief Handle an ongoing scan on HTTP scanner, until success or failure.
+ * @brief Update the status and results of an HTTP scanner scan.
  *
- * @param[in]   connector  The connector to the scanner.
- * @param[in]   task       The task.
- * @param[in]   report     The report.
- * @param[in]   parse_report_callback  Callback to parse and insert results.
+ * @param[in]      connector  The connector to the scanner.
+ * @param[in]      task       The task of the HTTP scanner scan
+ * @param[in]      report     Row id of the scan report
+ * @param[in]      parse_report_callback  Callback to parse and insert results.
+ * @param[in,out]  retry_ptr              How many times to retry.
+ * @param[in,out]  queued_status_updated  Whether the "queued" status was set.
+ * @param[in,out]  started                Whether the scan was started.
  *
- * @return 0 if success, -1 if error, -2 if scan was stopped,
+ * @return 0 if scan finished, 1 if caller should retry if appropriate,
+ *         2 if scan is running or queued by the scanner,
+ *         -1 if error, -2 if scan was stopped,
  *         -3 if the scan was interrupted, -4 already stopped.
  */
 int
-handle_http_scanner_scan (http_scanner_connector_t connector,
-                          task_t task, report_t report,
+update_http_scanner_scan (http_scanner_connector_t connector, task_t task,
+                          report_t report,
                           void (*parse_report_callback)
-                            (task_t, report_t, GSList *, time_t, time_t))
+                            (task_t, report_t, GSList *, time_t, time_t),
+                          int *retry_ptr, int *queued_status_updated,
+                          int *started)
 {
-  int rc;
-  gboolean started, queued_status_updated;
-  int retry, connection_retry;
-  http_scanner_resp_t response;
+  http_scanner_resp_t response = NULL;
+  int progress = http_scanner_get_scan_progress (connector);
 
-  if (connector == NULL)
+  if (progress < 0 || progress > 100)
     {
-      g_warning ("%s: Could not connect to http scanner", __func__);
+      if (*retry_ptr > 0 && progress == -1)
+        {
+          (*retry_ptr)--;
+          g_warning ("Connection lost with the scanner."
+                      "Trying again in 1 second.");
+          gvm_sleep (1);
+          return 1;
+        }
+      else if (progress == -2)
+        {
+          return -2;
+        }
+      result_t result = make_osp_result
+                          (task, "", "", "",
+                          threat_message_type ("Error"),
+                          "Erroneous scan progress value", "", "",
+                          QOD_DEFAULT, NULL, NULL);
+      report_add_result (report, result);
+      response = http_scanner_delete_scan(connector);
+      http_scanner_response_cleanup (response);
       return -1;
     }
-
-  response = NULL;
-  started = FALSE;
-  queued_status_updated = FALSE;
-  connection_retry = get_scanner_connection_retry ();
-
-  retry = connection_retry;
-  rc = -1;
-  while (retry >= 0)
+  else
     {
-      int run_status, progress;
-
-      run_status = task_run_status (task);
-      if (run_status == TASK_STATUS_STOPPED
-          || run_status == TASK_STATUS_STOP_REQUESTED)
-        {
-          rc = -4;
-          break;
-        }
-
+      /* Get the full report. */
       progress = http_scanner_get_scan_progress (connector);
 
       if (progress < 0 || progress > 100)
         {
-          if (retry > 0 && progress == -1)
+          if (*retry_ptr > 0 && progress == -1)
             {
-              retry--;
-              g_warning ("Connection lost with the scanner."
-                         "Trying again in 1 second.");
+              (*retry_ptr)--;
+              g_warning ("Connection lost with the scanner. "
+                          "Trying again in 1 second.");
               gvm_sleep (1);
-              continue;
+              return 1;
             }
           else if (progress == -2)
             {
-              rc = -2;
-              break;
+              return -2;
             }
           result_t result = make_osp_result
-                             (task, "", "", "",
+                              (task, "", "", "",
                               threat_message_type ("Error"),
                               "Erroneous scan progress value", "", "",
                               QOD_DEFAULT, NULL, NULL);
           report_add_result (report, result);
-          response = http_scanner_delete_scan(connector);
-          rc = -1;
-          break;
+          return -1;
         }
       else
         {
-          /* Get the full report. */
-          progress = http_scanner_get_scan_progress (connector);
+          GSList *results = NULL;
+          static unsigned long result_start = 0;
+          static unsigned long result_end = -1; // get up to the end
+          http_scanner_status_t current_status;
+          time_t start_time, end_time;
+          http_scanner_scan_status_t scan_status;
 
-          if (progress < 0 || progress > 100)
+          if (progress > 0)
+            set_report_slave_progress (report, progress);
+
+          scan_status
+            = http_scanner_parsed_scan_status (connector);
+          start_time = scan_status->start_time;
+          end_time = scan_status->end_time;
+          current_status = scan_status->status;
+          progress = scan_status->progress;
+          g_free (scan_status);
+
+          gvm_sleep (1);
+
+          http_scanner_parsed_results (connector, result_start,
+                                        result_end, &results);
+
+          result_start += g_slist_length (results);
+
+          parse_report_callback (task, report, results, start_time,
+                                  end_time);
+          if (results != NULL)
             {
-              if (retry > 0 && progress == -1)
-                {
-                  retry--;
-                  g_warning ("Connection lost with the scanner. "
-                             "Trying again in 1 second.");
-                  gvm_sleep (1);
-                  continue;
-                }
-              else if (progress == -2)
-                {
-                  rc = -2;
-                  break;
-                }
-              result_t result = make_osp_result
-                                 (task, "", "", "",
-                                  threat_message_type ("Error"),
-                                  "Erroneous scan progress value", "", "",
-                                  QOD_DEFAULT, NULL, NULL);
-              report_add_result (report, result);
-              rc = -1;
-              break;
+              g_slist_free_full (results,
+                                  (GDestroyNotify) http_scanner_result_free);
             }
-          else
+          if (current_status == HTTP_SCANNER_SCAN_STATUS_STORED)
             {
-              GSList *results = NULL;
-              static unsigned long result_start = 0;
-              static unsigned long result_end = -1; // get up to the end
-              http_scanner_status_t current_status;
-              time_t start_time, end_time;
-              http_scanner_scan_status_t scan_status;
-
-              if (progress > 0)
-                set_report_slave_progress (report, progress);
-
-              scan_status
-                = http_scanner_parsed_scan_status (connector);
-              start_time = scan_status->start_time;
-              end_time = scan_status->end_time;
-              current_status = scan_status->status;
-              progress = scan_status->progress;
-              g_free (scan_status);
-
-              gvm_sleep (1);
-
-              http_scanner_parsed_results (connector, result_start,
-                                           result_end, &results);
-
-              result_start += g_slist_length (results);
-
-              parse_report_callback (task, report, results, start_time,
-                                     end_time);
-              if (results != NULL)
+              if (*queued_status_updated == FALSE)
                 {
-                  g_slist_free_full (results,
-                                     (GDestroyNotify) http_scanner_result_free);
-                }
-              if (current_status == HTTP_SCANNER_SCAN_STATUS_STORED)
-                {
-                  if (queued_status_updated == FALSE)
-                    {
-                      set_task_run_status (task, TASK_STATUS_QUEUED);
-                      set_report_scan_run_status (global_current_report,
-                                                  TASK_STATUS_QUEUED);
-                      queued_status_updated = TRUE;
-                    }
-                }
-              else if (current_status == HTTP_SCANNER_SCAN_STATUS_FAILED
-                       || current_status == HTTP_SCANNER_SCAN_STATUS_ERROR)
-                {
-                  result_t result = make_osp_result
-                    (task, "", "", "",
-                     threat_message_type ("Error"),
-                     "Task interrupted unexpectedly", "", "",
-                     QOD_DEFAULT, NULL, NULL);
-                  report_add_result (report, result);
-                  response = http_scanner_delete_scan (connector);
-                  rc = -3;
-                  break;
-                }
-              else if (progress >= 0 && progress < 100
-                  && current_status == HTTP_SCANNER_SCAN_STATUS_STOPPED)
-                {
-                  if (retry > 0)
-                    {
-                      retry--;
-                      g_warning ("Connection lost with the scanner. "
-                                 "Trying again in 1 second.");
-                      gvm_sleep (1);
-                      continue;
-                    }
-
-                  result_t result = make_osp_result
-                    (task, "", "", "",
-                     threat_message_type ("Error"),
-                     "Scan stopped unexpectedly by the server", "", "",
-                     QOD_DEFAULT, NULL, NULL);
-                  report_add_result (report, result);
-                  response = http_scanner_delete_scan (connector);
-                  rc = -1;
-                  break;
-                }
-              else if (progress == 100
-                       && current_status == HTTP_SCANNER_SCAN_STATUS_SUCCEEDED)
-                {
-                  response = http_scanner_delete_scan (connector);
-                  rc = response->code;
-                  break;
-                }
-              else if (current_status == HTTP_SCANNER_SCAN_STATUS_RUNNING
-                       && started == FALSE)
-                {
-                  set_task_run_status (task, TASK_STATUS_RUNNING);
+                  set_task_run_status (task, TASK_STATUS_QUEUED);
                   set_report_scan_run_status (global_current_report,
-                                              TASK_STATUS_RUNNING);
-                  started = TRUE;
+                                              TASK_STATUS_QUEUED);
+                  *queued_status_updated = TRUE;
+                  return 2;
                 }
+            }
+          else if (current_status == HTTP_SCANNER_SCAN_STATUS_FAILED
+                   || current_status == HTTP_SCANNER_SCAN_STATUS_ERROR)
+            {
+              result_t result = make_osp_result
+                (task, "", "", "",
+                  threat_message_type ("Error"),
+                  "Task interrupted unexpectedly", "", "",
+                  QOD_DEFAULT, NULL, NULL);
+              report_add_result (report, result);
+              response = http_scanner_delete_scan (connector);
+              http_scanner_response_cleanup (response);
+              return -3;
+            }
+          else if (progress >= 0 && progress < 100
+                   && current_status == HTTP_SCANNER_SCAN_STATUS_STOPPED)
+            {
+              if (*retry_ptr > 0)
+                {
+                  (*retry_ptr)--;
+                  g_warning ("Connection lost with the scanner. "
+                              "Trying again in 1 second.");
+                  gvm_sleep (1);
+                  return 1;
+                }
+
+              result_t result = make_osp_result
+                (task, "", "", "",
+                  threat_message_type ("Error"),
+                  "Scan stopped unexpectedly by the server", "", "",
+                  QOD_DEFAULT, NULL, NULL);
+              report_add_result (report, result);
+              response = http_scanner_delete_scan (connector);
+              http_scanner_response_cleanup (response);
+              return -1;
+            }
+          else if (progress == 100
+                   && current_status == HTTP_SCANNER_SCAN_STATUS_SUCCEEDED)
+            {
+              response = http_scanner_delete_scan (connector);
+              http_scanner_response_cleanup (response);
+              return 0;
+            }
+          else if (current_status == HTTP_SCANNER_SCAN_STATUS_RUNNING
+                   && *started == FALSE)
+            {
+              set_task_run_status (task, TASK_STATUS_RUNNING);
+              set_report_scan_run_status (global_current_report,
+                                          TASK_STATUS_RUNNING);
+              *started = TRUE;
+              return 2;
             }
         }
-
-      retry = connection_retry;
-      gvm_sleep (5);
     }
-  http_scanner_response_cleanup (response);
-  return rc;
+    return 2;
 }
 
 /**

--- a/src/manage_http_scanner.c
+++ b/src/manage_http_scanner.c
@@ -250,7 +250,7 @@ update_http_scanner_scan (http_scanner_connector_t connector, task_t task,
                           "Erroneous scan progress value", "", "",
                           QOD_DEFAULT, NULL, NULL);
       report_add_result (report, result);
-      response = http_scanner_delete_scan(connector);
+      response = http_scanner_delete_scan (connector);
       http_scanner_response_cleanup (response);
       return -1;
     }

--- a/src/manage_http_scanner.h
+++ b/src/manage_http_scanner.h
@@ -27,10 +27,11 @@ prepare_http_scanner_scan_for_resume (http_scanner_connector_t,
                                       char **);
 
 int
-handle_http_scanner_scan (http_scanner_connector_t,
-                          task_t, report_t,
+update_http_scanner_scan (http_scanner_connector_t, task_t,
+                          report_t,
                           void (*)
-                            (task_t, report_t, GSList *, time_t, time_t));
+                            (task_t, report_t, GSList *, time_t, time_t),
+                          int *, int *, int *);
 
 int
 delete_http_scanner_scan_with_retry (http_scanner_connector_t, const char *);

--- a/src/manage_openvasd.c
+++ b/src/manage_openvasd.c
@@ -1,0 +1,673 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file
+ * @brief Headers for Greenbone Vulnerability Manager OpenVASD scan handling.
+ */
+
+#if ENABLE_OPENVASD
+
+#include "manage_openvasd.h"
+
+#include "ipc.h"
+#include "manage_assets.h"
+#include "manage_report_exports.h"
+#include "manage_runtime_flags.h"
+#include "manage_scan_queue.h"
+#include "manage_sql.h"
+#include "manage_sql_nvts.h"
+#include "manage_sql_targets.h"
+#include "manage_openvas.h"
+
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md manage"
+
+/**
+ * @brief Prepare a report for resuming an OSP scan
+ *
+ * @param[in]  task     The task of the scan.
+ * @param[in]  scan_id  The scan uuid.
+ * @param[out] error    Error return.
+ *
+ * @return 0 scan finished or still running,
+ *         1 scan must be started,
+ *         -1 error
+ */
+static int
+prepare_openvasd_scan_for_resume (task_t task, const char *scan_id,
+                                  char **error)
+{
+  http_scanner_connector_t connection;
+  int ret;
+
+  assert (task);
+  assert (scan_id);
+  assert (global_current_report);
+  assert (error);
+
+  connection = http_scanner_connect (task_scanner (task), scan_id);
+  if (!connection)
+    {
+      *error = g_strdup ("Could not connect to openvasd Scanner");
+      return -1;
+    }
+
+  g_debug ("%s: Preparing scan %s for resume", __func__, scan_id);
+
+  ret = prepare_http_scanner_scan_for_resume (connection, error);
+
+  if (ret == 1)
+    trim_partial_report (global_current_report);
+
+  return ret;
+}
+
+/**
+ * @brief Launch an OpenVAS via openvasd task.
+ *
+ * @param[in]   task           The task.
+ * @param[in]   target         The target.
+ * @param[in]   scan_id        The scan uuid.
+ * @param[in]   from           0 start from beginning, 1 continue from stopped,
+ *                             2 continue if stopped else start from beginning.
+ * @param[out]  error          Error return.
+ * @param[out]  discovery_out  Returns TRUE if all OIDs are labeled
+ *                             as discovery in the used scan config.
+ *
+ * @return An http code on success, -1 if error.
+ */
+static int
+launch_openvasd_openvas_task (task_t task, target_t target, const char *scan_id,
+                         int from, char **error, gboolean *discovery_out)
+{
+  http_scanner_connector_t connection;
+  char *hosts_str, *ports_str, *exclude_hosts_str, *finished_hosts_str;
+  gchar *clean_hosts, *clean_exclude_hosts, *clean_finished_hosts_str;
+  int alive_test, reverse_lookup_only, reverse_lookup_unify;
+  int arp = 0, icmp = 0, tcp_ack = 0, tcp_syn = 0, consider_alive = 0;
+  openvasd_target_t *openvasd_target;
+  GSList *openvasd_targets, *vts;
+  GHashTable *vts_hash_table;
+  gchar *max_checks, *max_hosts;
+  GHashTable *scanner_options;
+  http_scanner_resp_t response;
+  int ret, empty;
+  config_t config;
+  iterator_t scanner_prefs_iter, families, prefs;
+
+  connection = NULL;
+  config = task_config (task);
+
+  alive_test = 0;
+  reverse_lookup_unify = 0;
+  reverse_lookup_only = 0;
+
+  /* Prepare the report */
+  if (from)
+    {
+      ret = prepare_openvasd_scan_for_resume (task, scan_id, error);
+      if (ret == 0)
+        return 0;
+      else if (ret == -1)
+        return -1;
+      finished_hosts_str = report_finished_hosts_str (global_current_report);
+      clean_finished_hosts_str = clean_hosts_string (finished_hosts_str);
+    }
+  else
+    {
+      finished_hosts_str = NULL;
+      clean_finished_hosts_str = NULL;
+    }
+
+  /* Set up target(s) */
+  hosts_str = target_hosts (target);
+  ports_str = target_port_range (target);
+  exclude_hosts_str = target_exclude_hosts (target);
+
+  clean_hosts = clean_hosts_string (hosts_str);
+  clean_exclude_hosts = clean_hosts_string (exclude_hosts_str);
+
+  alive_test = 0;
+  if (target_alive_tests (target) > 0)
+    alive_test = target_alive_tests (target);
+
+  if (target_reverse_lookup_only (target) != NULL)
+    reverse_lookup_only = atoi (target_reverse_lookup_only (target));
+
+  if (target_reverse_lookup_unify (target) != NULL)
+    reverse_lookup_unify = atoi (target_reverse_lookup_unify (target));
+
+  if (finished_hosts_str)
+    {
+      gchar *new_exclude_hosts;
+
+      new_exclude_hosts = g_strdup_printf ("%s,%s",
+                                           clean_exclude_hosts,
+                                           clean_finished_hosts_str);
+      free (clean_exclude_hosts);
+      clean_exclude_hosts = new_exclude_hosts;
+    }
+
+  openvasd_target = openvasd_target_new (scan_id, clean_hosts, ports_str,
+                                         clean_exclude_hosts,
+                                         reverse_lookup_unify,
+                                         reverse_lookup_only);
+  if (finished_hosts_str)
+    openvasd_target_set_finished_hosts (openvasd_target, finished_hosts_str);
+
+  if (alive_test & ALIVE_TEST_ARP)
+    arp = 1;
+  if (alive_test & ALIVE_TEST_ICMP)
+    icmp = 1;
+  if (alive_test & ALIVE_TEST_TCP_ACK_SERVICE)
+    tcp_ack = 1;
+  if (alive_test & ALIVE_TEST_TCP_SYN_SERVICE)
+    tcp_syn = 1;
+  if (alive_test & ALIVE_TEST_CONSIDER_ALIVE)
+    consider_alive = 1;
+
+  openvasd_target_add_alive_test_methods (openvasd_target, icmp, tcp_syn,
+                                          tcp_ack, arp, consider_alive);
+
+  free (hosts_str);
+  free (ports_str);
+  free (exclude_hosts_str);
+  free (finished_hosts_str);
+  g_free (clean_hosts);
+  g_free (clean_exclude_hosts);
+  g_free (clean_finished_hosts_str);
+  openvasd_targets = g_slist_append (NULL, openvasd_target);
+
+#if ENABLE_CREDENTIAL_STORES == 0
+
+  openvasd_credential_t *ssh_credential, *smb_credential, *esxi_credential;
+  openvasd_credential_t *snmp_credential;
+
+  ssh_credential = (openvasd_credential_t *) target_osp_ssh_credential_db (target);
+  if (ssh_credential)
+    openvasd_target_add_credential (openvasd_target, ssh_credential);
+
+  smb_credential = (openvasd_credential_t *) target_osp_smb_credential_db (target);
+  if (smb_credential)
+    openvasd_target_add_credential (openvasd_target, smb_credential);
+
+  esxi_credential =
+    (openvasd_credential_t *) target_osp_esxi_credential_db (target);
+  if (esxi_credential)
+    openvasd_target_add_credential (openvasd_target, esxi_credential);
+
+  snmp_credential =
+    (openvasd_credential_t *) target_osp_snmp_credential_db (target);
+  if (snmp_credential)
+    openvasd_target_add_credential (openvasd_target, snmp_credential);
+
+#endif
+
+  /* Initialize vts table for vulnerability tests and their preferences */
+  vts = NULL;
+  vts_hash_table
+    = g_hash_table_new_full (g_str_hash, g_str_equal, g_free,
+                             /* Value is freed in vts list. */
+                             NULL);
+
+  /*  Setup of vulnerability tests (without preferences) */
+  init_family_iterator (&families, 0, NULL, 1);
+  GSList *oids = NULL;
+  empty = 1;
+  while (next (&families))
+    {
+      const char *family = family_iterator_name (&families);
+      if (family)
+        {
+          iterator_t nvts;
+          init_nvt_iterator (&nvts, 0, config, family, NULL, 1, NULL);
+          while (next (&nvts))
+            {
+              const char *oid;
+              openvasd_vt_single_t *new_vt;
+
+              empty = 0;
+              oid = nvt_iterator_oid (&nvts);
+              new_vt = openvasd_vt_single_new (oid);
+              oids = g_slist_prepend (oids, g_strdup (oid));
+
+              vts = g_slist_prepend (vts, new_vt);
+              g_hash_table_replace (vts_hash_table, g_strdup (oid), new_vt);
+            }
+          cleanup_iterator (&nvts);
+        }
+    }
+  cleanup_iterator (&families);
+
+  /* check oids are discovery or not */
+  *discovery_out = nvts_oids_all_discovery_cached (oids);
+  /* clean up oids list */
+  g_slist_free_full (oids, g_free);
+
+  if (empty) {
+    if (error)
+      *error = g_strdup ("Exiting because VT list is empty "
+                         "(e.g. feed not synced yet)");
+    g_slist_free_full (openvasd_targets, (GDestroyNotify) openvasd_target_free);
+    // Credentials are freed with target
+    g_slist_free_full (vts, (GDestroyNotify) openvasd_vt_single_free);
+    return -1;
+  }
+
+  /* Setup general scanner preferences */
+  scanner_options
+    = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+  init_preference_iterator (&scanner_prefs_iter, config, "SERVER_PREFS");
+  while (next (&scanner_prefs_iter))
+    {
+      const char *name, *value;
+      name = preference_iterator_name (&scanner_prefs_iter);
+      value = preference_iterator_value (&scanner_prefs_iter);
+      if (name && value && !g_str_has_prefix (name, "timeout."))
+        {
+          const char *openvasd_value;
+
+          // Workaround for boolean scanner preferences
+          if (strcmp (value, "no") == 0)
+            openvasd_value = "0";
+          else if (strcmp (value, "yes") == 0)
+            openvasd_value = "1";
+          else
+            openvasd_value = value;
+          g_hash_table_replace (scanner_options, g_strdup (name),
+                                g_strdup (openvasd_value));
+        }
+      /* Timeouts are stored as SERVER_PREFS, but are actually
+         script preferences. This prefs is converted into a
+         script preference to be sent to the scanner. */
+      else if (name && value && g_str_has_prefix (name, "timeout."))
+        {
+          char **oid = NULL;
+          openvasd_vt_single_t *openvasd_vt = NULL;
+
+          oid = g_strsplit (name, ".", 2);
+          openvasd_vt = g_hash_table_lookup (vts_hash_table, oid[1]);
+          if (openvasd_vt)
+            openvasd_vt_single_add_value (openvasd_vt, "0", value);
+          g_strfreev (oid);
+        }
+    }
+  cleanup_iterator (&scanner_prefs_iter);
+
+  /* Setup user-specific scanner preference */
+  add_user_scan_preferences (scanner_options);
+
+  /* Setup general task preferences */
+  max_checks = task_preference_value (task, "max_checks");
+  g_hash_table_insert (scanner_options, g_strdup ("max_checks"),
+                       max_checks ? max_checks : g_strdup (MAX_CHECKS_DEFAULT));
+
+  max_hosts = task_preference_value (task, "max_hosts");
+  g_hash_table_insert (scanner_options, g_strdup ("max_hosts"),
+                       max_hosts ? max_hosts : g_strdup (MAX_HOSTS_DEFAULT));
+
+  /* Setup VT preferences */
+  init_preference_iterator (&prefs, config, "PLUGINS_PREFS");
+  while (next (&prefs))
+    {
+      const char *full_name, *value;
+      openvasd_vt_single_t *openvasd_vt;
+      gchar **split_name;
+
+      full_name = preference_iterator_name (&prefs);
+      value = preference_iterator_value (&prefs);
+      split_name = g_strsplit (full_name, ":", 4);
+
+      openvasd_vt = NULL;
+      if (split_name && split_name[0] && split_name[1] && split_name[2])
+        {
+          const char *oid = split_name[0];
+          const char *pref_id = split_name[1];
+          const char *type = split_name[2];
+          gchar *openvasd_value = NULL;
+
+          if (strcmp (type, "checkbox") == 0)
+            {
+              if (strcmp (value, "yes") == 0)
+                openvasd_value = g_strdup ("1");
+              else
+                openvasd_value = g_strdup ("0");
+            }
+          else if (strcmp (type, "radio") == 0)
+            {
+              gchar** split_value;
+              split_value = g_strsplit (value, ";", 2);
+              openvasd_value = g_strdup (split_value[0]);
+              g_strfreev (split_value);
+            }
+          else if (strcmp (type, "file") == 0)
+            openvasd_value = g_base64_encode ((guchar*) value, strlen (value));
+
+          openvasd_vt = g_hash_table_lookup (vts_hash_table, oid);
+          if (openvasd_vt)
+            openvasd_vt_single_add_value (openvasd_vt, pref_id,
+                                     openvasd_value ? openvasd_value : value);
+          g_free (openvasd_value);
+        }
+
+      g_strfreev (split_name);
+    }
+  cleanup_iterator (&prefs);
+  g_hash_table_destroy (vts_hash_table);
+
+  /* Start the scan */
+  connection = http_scanner_connect (task_scanner (task), scan_id);
+  if (!connection)
+    {
+      if (error)
+        *error = g_strdup ("Could not connect to Scanner");
+      g_slist_free_full (openvasd_targets,
+                         (GDestroyNotify) openvasd_target_free);
+      // Credentials are freed with target
+      g_slist_free_full (vts, (GDestroyNotify) openvasd_vt_single_free);
+      g_hash_table_destroy (scanner_options);
+      return -1;
+    }
+
+  gchar *scan_config = NULL;
+  scan_config =
+    openvasd_build_scan_config_json(openvasd_target, scanner_options, vts);
+
+  response = http_scanner_create_scan (connection, scan_config);
+  if (response->code == 201)
+    {
+      http_scanner_response_cleanup (response);
+      response = http_scanner_start_scan (connection);
+    }
+  else
+    g_warning ("%s: Failed to create scan: %ld", __func__, response->code);
+
+  openvasd_target_free(openvasd_target);
+  // Credentials are freed with target
+  g_slist_free_full (vts, (GDestroyNotify) openvasd_vt_single_free);
+  g_hash_table_destroy (scanner_options);
+  ret = response->code;
+  http_scanner_response_cleanup (response);
+
+  return ret;
+}
+
+/**
+ * @brief Handle the start of an OpenVASD scan.
+ *
+ * @param[in]  task        The task of the OpenVASD scan
+ * @param[in]  target      The target of the scan task
+ * @param[in]  scan_id     UUID of the scan / report
+ * @param[in]  start_from  0 start from beginning, 1 continue from stopped,
+ *                         2 continue if stopped else start from beginning.
+ * @param[in]  wait_until_active  Whether to wait until scan is queued or
+ *                                running
+ * @param[out] discovery_out  Discovery flag for scan config.
+ *
+ * @return 0 success, -1 if error.
+ */
+int
+handle_openvasd_scan_start (task_t task, target_t target, const char *scan_id,
+                            int start_from, gboolean wait_until_active,
+                            gboolean *discovery_out)
+{
+  char *error = NULL;
+  int rc;
+
+  rc = launch_openvasd_openvas_task (task, target, scan_id, start_from, &error,
+                                     discovery_out);
+  if (rc < 0)
+    {
+      result_t result;
+
+      g_warning ("openvasd start_scan %s: %s", scan_id, error);
+      result = make_osp_result (task, "", "", "",
+                                threat_message_type ("Error"),
+                                error, "", "", QOD_DEFAULT, NULL, NULL);
+      report_add_result (global_current_report, result);
+      set_task_run_status (task, TASK_STATUS_DONE);
+      set_report_scan_run_status (global_current_report, TASK_STATUS_DONE);
+      set_task_end_time_epoch (task, time (NULL));
+      set_scan_end_time_epoch (global_current_report, time (NULL));
+
+      g_free (error);
+
+      return -1;
+    }
+
+  if (wait_until_active)
+    {
+      report_t report = global_current_report;
+      scanner_t scanner = task_scanner (task);
+      http_scanner_connector_t connector = http_scanner_connect (scanner,
+                                                                 scan_id);
+      if (connector == NULL)
+        {
+          g_warning ("%s: Could not connect to container image scanner",
+                     __func__);
+          return -1;
+        }
+
+      http_scanner_resp_t response = NULL;
+      gboolean started = FALSE;
+      gboolean queued_status_updated = FALSE;
+      int connection_retry = get_scanner_connection_retry ();
+
+      int retry = connection_retry;
+      rc = -1;
+      while (retry >= 0)
+        {
+          int run_status, sem_op_ret;
+
+          run_status = task_run_status (task);
+          if (run_status == TASK_STATUS_STOPPED
+              || run_status == TASK_STATUS_STOP_REQUESTED)
+            {
+              rc = -4;
+              break;
+            }
+
+          sem_op_ret = scan_semaphore_update_start (TRUE, task, report);
+          if (sem_op_ret == 1)
+            continue;
+          else if (sem_op_ret)
+            {
+              response = http_scanner_delete_scan (connector);
+              rc = -3;
+              break;
+            }
+
+          rc = update_http_scanner_scan (connector, task, report,
+                                         parse_http_scanner_report, &retry,
+                                         &queued_status_updated, &started);
+
+          // Exit loop on error or if scan finished
+          if (rc <= 0)
+            break;
+
+          if (scan_semaphore_update_end (TRUE, task, report))
+            {
+              response = http_scanner_delete_scan (connector);
+              rc = -3;
+              break;
+            }
+
+          // Exit loop if scan is queued or started
+          if (rc == 2)
+            break;
+        }
+
+      http_scanner_connector_free (connector);
+      http_scanner_response_cleanup (response);
+    }
+  else
+    rc = 0;
+
+  return rc < 0 ? -1 : 0;
+}
+
+/**
+ * @brief Handle an ongoing openvasd scan, until success or failure.
+ *
+ * @param[in]   task        The task.
+ * @param[in]   report      The report.
+ * @param[in]   scan_id     The UUID of the scan on the scanner.
+ * @param[in]   yield_time  Time after which to yield if there are more
+ * .                        queued scans than the maximum active count or
+ *                          0 for non-queued scans running until the end.
+ *
+ * @return 0 if success, -1 if error, -2 if scan was stopped,
+ *         -3 if the scan was interrupted, -4 already stopped.
+ */
+int
+handle_openvasd_scan (task_t task, report_t report, const char *scan_id,
+                      time_t yield_time)
+{
+  scanner_t scanner;
+  http_scanner_connector_t connector;
+  http_scanner_resp_t response = NULL;
+  int rc;
+
+  scanner = task_scanner (task);
+  connector = http_scanner_connect (scanner, scan_id);
+
+  if (!connector)
+    {
+      g_warning ("%s: Could not connect to openvasd scanner", __func__);
+      return -1;
+    }
+
+  gboolean started, queued_status_updated;
+  int retry, connection_retry, max_active_scans;
+
+  if (connector == NULL)
+    {
+      g_warning ("%s: Could not connect to http scanner", __func__);
+      return -1;
+    }
+
+  if (yield_time)
+    {
+      max_active_scans = get_max_active_scan_handlers ();
+    }
+
+  task_status_t task_status = task_run_status (task);
+  started = (task_status == TASK_STATUS_RUNNING);
+  queued_status_updated = started || (task_status == TASK_STATUS_QUEUED);
+  connection_retry = get_scanner_connection_retry ();
+
+  retry = connection_retry;
+  rc = -1;
+  while (retry >= 0)
+    {
+      int run_status, sem_op_ret;
+
+      run_status = task_run_status (task);
+      if (run_status == TASK_STATUS_STOPPED
+          || run_status == TASK_STATUS_STOP_REQUESTED)
+        {
+          rc = -4;
+          break;
+        }
+
+      sem_op_ret = scan_semaphore_update_start (TRUE, task, report);
+      if (sem_op_ret == 1)
+        continue;
+      else if (sem_op_ret)
+        {
+          response = http_scanner_delete_scan (connector);
+          rc = -3;
+          break;
+        }
+
+      rc = update_http_scanner_scan (connector, task, report,
+                                     parse_http_scanner_report, &retry,
+                                     &queued_status_updated, &started);
+
+      int ret = scan_semaphore_update_end (TRUE, task, report);
+
+      if (rc <= 0)
+        break;
+
+      if (ret)
+        {
+          response = http_scanner_delete_scan (connector);
+          rc = -3;
+          break;
+        }
+
+      if (yield_time
+          && time (NULL) >= yield_time
+          && scan_queue_length () > max_active_scans)
+            break;
+
+      if (rc != 1)
+        {
+          retry = connection_retry;
+          gvm_sleep (5);
+        }
+    }
+
+  http_scanner_response_cleanup (response);
+  http_scanner_connector_free (connector);
+
+  return rc;
+}
+
+/**
+ * @brief Handle the end of an OpenVASD scan.
+ *
+ * @param[in]  task                 The task of the scan
+ * @param[in]  handle_progress_rc   Return code from handle_openvasd_scan_start
+ * @param[in] discovery             Discovery flag for scan config.
+ *
+ * @return The given handle_openvasd_scan_start return code.
+ */
+int
+handle_openvasd_scan_end (task_t task, int handle_progress_rc, gboolean discovery)
+{
+  if (handle_progress_rc == 0)
+   {
+      set_task_run_status (task, TASK_STATUS_PROCESSING);
+      set_report_scan_run_status (global_current_report,
+                                  TASK_STATUS_PROCESSING);
+
+      // add semaphores check
+      hosts_set_identifiers (global_current_report);
+      hosts_set_max_severity (global_current_report, NULL, NULL);
+      hosts_set_details (global_current_report);
+
+      asset_snapshots_target (global_current_report, task, discovery);
+      set_task_run_status (task, TASK_STATUS_DONE);
+      set_report_scan_run_status (global_current_report, TASK_STATUS_DONE);
+      if (feature_enabled (FEATURE_ID_SECURITY_INTELLIGENCE_EXPORT))
+        {
+          queue_report_for_export (global_current_report);
+        }
+    }
+    else if (handle_progress_rc == -1 || handle_progress_rc == -2)
+      {
+        set_task_run_status (task, TASK_STATUS_STOPPED);
+        set_report_scan_run_status (global_current_report, TASK_STATUS_STOPPED);
+      }
+    else if (handle_progress_rc == -3)
+      {
+        set_task_run_status (task, TASK_STATUS_INTERRUPTED);
+        set_report_scan_run_status (global_current_report,
+                                    TASK_STATUS_INTERRUPTED);
+      }
+    set_task_end_time_epoch (task, time (NULL));
+    set_scan_end_time_epoch (global_current_report, time (NULL));
+    global_current_report = 0;
+    current_scanner_task = (task_t) 0;
+
+    return handle_progress_rc;
+}
+
+#endif /* ENABLE_OPENVASD */

--- a/src/manage_openvasd.c
+++ b/src/manage_openvasd.c
@@ -625,7 +625,7 @@ handle_openvasd_scan (task_t task, report_t report, const char *scan_id,
  *
  * @param[in]  task                 The task of the scan
  * @param[in]  handle_progress_rc   Return code from handle_openvasd_scan_start
- * @param[in] discovery             Discovery flag for scan config.
+ * @param[in]  discovery            Discovery flag for scan config.
  *
  * @return The given handle_openvasd_scan_start return code.
  */

--- a/src/manage_openvasd.h
+++ b/src/manage_openvasd.h
@@ -1,0 +1,31 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file
+ * @brief Greenbone Vulnerability Manager OpenVASD scan handling.
+ */
+
+#if ENABLE_OPENVASD
+
+#ifndef _GVMD_MANAGE_OPENVASD_H
+#define _GVMD_MANAGE_OPENVASD_H
+
+#include <glib.h>
+#include "manage_resources_types.h"
+#include <gvm/openvasd/openvasd.h>
+
+int
+handle_openvasd_scan_start (task_t, target_t, const char *,
+                            int, gboolean, gboolean *);
+
+int
+handle_openvasd_scan (task_t, report_t, const char *, time_t);
+
+int
+handle_openvasd_scan_end (task_t, int, gboolean);
+
+#endif /* not _GVMD_MANAGE_OPENVASD_H */
+#endif /* ENABLE_OPENVASD */

--- a/src/manage_osp.c
+++ b/src/manage_osp.c
@@ -344,77 +344,6 @@ get_osp_scan_status (const char *scan_id, osp_connect_data_t *conn_data)
 }
 
 /**
- * @brief Handles the semaphore for the start of an OSP scan update.
- *
- * @param[in]  add_result_on_error  Whether to create an OSP result on error.
- * @param[in]  task   The current task (for error result).
- * @param[in]  report The current report (for error result).
- *
- * @return 0 success, -1 error.
- */
-static int
-osp_scan_semaphore_update_start (int add_result_on_error,
-                                 task_t task, report_t report)
-{
-  if (get_max_concurrent_scan_updates () == 0)
-    return 0;
-
-  int sem_op_ret = semaphore_op (SEMAPHORE_SCAN_UPDATE, -1, 5);
-  if (sem_op_ret == 1)
-    return 1;
-  else if (sem_op_ret)
-    {
-      g_warning ("%s: error waiting for scan update semaphore",
-                __func__);
-      if (add_result_on_error)
-        {
-          result_t result = make_osp_result
-            (task, "", "", "",
-              threat_message_type ("Error"),
-              "Error waiting for scan update semaphore", "", "",
-              QOD_DEFAULT, NULL, NULL);
-          report_add_result (report, result);
-        }
-      return -1;
-    }
-  return 0;
-}
-
-/**
- * @brief Handles the semaphore for the end of an OSP scan update.
- *
- * @param[in]  add_result_on_error  Whether to create an OSP result on error.
- * @param[in]  task   The current task (for error result).
- * @param[in]  report The current report (for error result).
- *
- * @return 0 success, -1 error.
- */
-static int
-osp_scan_semaphore_update_end (int add_result_on_error,
-                               task_t task, report_t report)
-{
-  if (get_max_concurrent_scan_updates () == 0)
-    return 0;
-
-  if (semaphore_op (SEMAPHORE_SCAN_UPDATE, +1, 0))
-    {
-      g_warning ("%s: error signaling scan update semaphore",
-                __func__);
-      if (add_result_on_error)
-        {
-          result_t result = make_osp_result
-            (task, "", "", "",
-              threat_message_type ("Error"),
-              "Error signaling scan update semaphore", "", "",
-              QOD_DEFAULT, NULL, NULL);
-          report_add_result (report, result);
-        }
-      return -1;
-    }
-  return 0;
-}
-
-/**
  * @brief Prepare a report for resuming an OSP scan
  *
  * @param[in]  task     The task of the scan.
@@ -938,7 +867,7 @@ update_osp_scan (task_t task, report_t report, const char *scan_id,
           g_warning ("Connection lost with the scanner at %s. "
                       "Trying again in 1 second.", conn_data->host);
           gvm_sleep (1);
-          if (osp_scan_semaphore_update_end (TRUE, task, report))
+          if (scan_semaphore_update_end (TRUE, task, report))
             {
               delete_osp_scan (scan_id, conn_data);
               return -3;
@@ -947,7 +876,7 @@ update_osp_scan (task_t task, report_t report, const char *scan_id,
         }
       else if (progress == -2)
         {
-          osp_scan_semaphore_update_end (FALSE, task, report);
+          scan_semaphore_update_end (FALSE, task, report);
           return -2;
         }
       result_t result = make_osp_result
@@ -956,7 +885,7 @@ update_osp_scan (task_t task, report_t report, const char *scan_id,
                           "Erroneous scan progress value", "", "",
                           QOD_DEFAULT, NULL, NULL);
       report_add_result (report, result);
-      osp_scan_semaphore_update_end (FALSE, task, report);
+      scan_semaphore_update_end (FALSE, task, report);
       delete_osp_scan (scan_id, conn_data);
       return -1;
     }
@@ -973,7 +902,7 @@ update_osp_scan (task_t task, report_t report, const char *scan_id,
               (*retry_ptr)--;
               g_warning ("Connection lost with the scanner at %s. "
                           "Trying again in 1 second.", conn_data->host);
-              if (osp_scan_semaphore_update_end (TRUE, task, report))
+              if (scan_semaphore_update_end (TRUE, task, report))
                 {
                   delete_osp_scan (scan_id, conn_data);
                   return -3;
@@ -983,7 +912,7 @@ update_osp_scan (task_t task, report_t report, const char *scan_id,
             }
           else if (progress == -2)
             {
-              osp_scan_semaphore_update_end (FALSE, task, report);
+              scan_semaphore_update_end (FALSE, task, report);
               return -2;
             }
           g_free (report_xml);
@@ -993,7 +922,7 @@ update_osp_scan (task_t task, report_t report, const char *scan_id,
                               "Erroneous scan progress value", "", "",
                               QOD_DEFAULT, NULL, NULL);
           report_add_result (report, result);
-          osp_scan_semaphore_update_end (FALSE, task, report);
+          scan_semaphore_update_end (FALSE, task, report);
           return -1;
         }
       else
@@ -1024,7 +953,7 @@ update_osp_scan (task_t task, report_t report, const char *scan_id,
                   QOD_DEFAULT, NULL, NULL);
               report_add_result (report, result);
               delete_osp_scan (scan_id, conn_data);
-              osp_scan_semaphore_update_end (FALSE, task, report);
+              scan_semaphore_update_end (FALSE, task, report);
               return -3;
             }
           else if (progress >= 0 && progress < 100
@@ -1035,7 +964,7 @@ update_osp_scan (task_t task, report_t report, const char *scan_id,
                   (*retry_ptr)--;
                   g_warning ("Connection lost with the scanner at %s. "
                               "Trying again in 1 second.", conn_data->host);
-                  if (osp_scan_semaphore_update_end (TRUE, task, report))
+                  if (scan_semaphore_update_end (TRUE, task, report))
                     {
                       delete_osp_scan (scan_id, conn_data);
                       return -3;
@@ -1051,14 +980,14 @@ update_osp_scan (task_t task, report_t report, const char *scan_id,
                   QOD_DEFAULT, NULL, NULL);
               report_add_result (report, result);
               delete_osp_scan (scan_id, conn_data);
-              osp_scan_semaphore_update_end (FALSE, task, report);
+              scan_semaphore_update_end (FALSE, task, report);
               return -1;
             }
           else if (progress == 100
                    && osp_scan_status == OSP_SCAN_STATUS_FINISHED)
             {
               delete_osp_scan (scan_id, conn_data);
-              osp_scan_semaphore_update_end (FALSE, task, report);
+              scan_semaphore_update_end (FALSE, task, report);
               if (*started == FALSE)
                 {
                   set_task_run_status (task, TASK_STATUS_RUNNING);
@@ -1153,7 +1082,7 @@ handle_osp_scan_start (task_t task, target_t target, const char *scan_id,
               break;
             }
 
-          sem_op_ret = osp_scan_semaphore_update_start (TRUE, task, report);
+          sem_op_ret = scan_semaphore_update_start (TRUE, task, report);
           if (sem_op_ret == 1)
             continue;
           else if (sem_op_ret)
@@ -1170,7 +1099,7 @@ handle_osp_scan_start (task_t task, target_t target, const char *scan_id,
           if (rc <= 0)
             break;
 
-          if (osp_scan_semaphore_update_end (TRUE, task, report))
+          if (scan_semaphore_update_end (TRUE, task, report))
             {
               delete_osp_scan (scan_id, conn_data);
               rc = -3;
@@ -1245,7 +1174,7 @@ handle_osp_scan (task_t task, report_t report, const char *scan_id,
           break;
         }
 
-      sem_op_ret = osp_scan_semaphore_update_start (TRUE, task, report);
+      sem_op_ret = scan_semaphore_update_start (TRUE, task, report);
       if (sem_op_ret == 1)
         continue;
       else if (sem_op_ret)
@@ -1262,7 +1191,7 @@ handle_osp_scan (task_t task, report_t report, const char *scan_id,
       if (rc <= 0)
         break;
 
-      if (osp_scan_semaphore_update_end (TRUE, task, report))
+      if (scan_semaphore_update_end (TRUE, task, report))
         {
           delete_osp_scan (scan_id, conn_data);
           rc = -3;

--- a/src/manage_scan_handler.c
+++ b/src/manage_scan_handler.c
@@ -13,6 +13,7 @@
 #include "manage_sql.h"
 #include "manage_sql_scan_queue.h"
 #include "manage_scan_handler.h"
+#include "manage_openvasd.h"
 #include "manage_users.h"
 #include <gvm/base/gvm_sentry.h>
 #include <unistd.h>
@@ -67,6 +68,50 @@ handle_queued_osp_scan (const char *scan_id, report_t report,
 
 }
 
+#if ENABLE_OPENVASD
+/**
+ * @brief Handle a OpenVASD scan in the gvmd scan queue.
+ *
+ * @param[in]  scan_id    UUID of the scan / report to handle.
+ * @param[in]  report     Row id of the report.
+ * @param[in]  task       Row id of the task.
+ * @param[in]  start_from 0 start from beginning, 1 continue from stopped,
+ *                        2 continue if stopped else start from beginning.
+ *
+ * @return 0 scan finished, 2 scan running,
+ *         -1 if error, -2 if scan was stopped,
+ *         -3 if the scan was interrupted, -4 already stopped.
+ */
+static int
+handle_queued_openvasd_scan (const char *scan_id, report_t report,
+                             task_t task, int start_from)
+{
+  task_status_t status = task_run_status (task);
+  gboolean discovery_scan = FALSE;
+
+  switch (status)
+    {
+      case TASK_STATUS_REQUESTED:
+        {
+          int rc;
+          target_t target = task_target (task);
+          rc = handle_openvasd_scan_start (task, target, scan_id, start_from,
+                                           TRUE, &discovery_scan);
+          /* Set discovery flag to the report */
+          report_set_discovery (report, discovery_scan);
+          return (rc == 0) ? 2 : rc;
+        }
+      default:
+        {
+          time_t yield_time = time (NULL) + get_scan_handler_active_time ();
+          int ret = handle_openvasd_scan (task, report, scan_id, yield_time);
+          return ret;
+        }
+    }
+
+}
+#endif /* ENABLE_OPENVASD */
+
 /**
  * @brief Handle a scan in the gvmd scan queue.
  *
@@ -91,6 +136,11 @@ handle_queued_scan (const char *scan_id, report_t report, task_t task,
       case SCANNER_TYPE_OPENVAS:
       case SCANNER_TYPE_OSP_SENSOR:
         return handle_queued_osp_scan (scan_id, report, task, start_from);
+#if ENABLE_OPENVASD
+      case SCANNER_TYPE_OPENVASD:
+      case SCANNER_TYPE_OPENVASD_SENSOR:
+        return handle_queued_openvasd_scan (scan_id, report, task, start_from);
+#endif /* ENABLE_OPENVASD */
       default:
         {
           g_warning ("%s: Scanner type not supported by queue: %d",


### PR DESCRIPTION
## What
Add scan queue handling for OpenVASD.
Move functions for handling an OpenVASD scan to a separate file.

## Why
Was only used for OSP scanner.

## References
GEA-1712


