### PR TITLE
change: remove unused integration config service type iterator

### DIFF
--- a/src/manage_integration_configs.h
+++ b/src/manage_integration_configs.h
@@ -87,9 +87,6 @@ int
 init_integration_config_iterator_one (iterator_t*, const gchar *);
 
 const gchar *
-integration_config_iterator_service_type (iterator_t *);
-
-const gchar *
 integration_config_iterator_service_url (iterator_t *);
 
 const gchar *


### PR DESCRIPTION
## What

The integration config lookup now relies on UUIDs to distinguish configs, so `integration_config_iterator_service_type()` is no longer needed.

## Why

Remove the leftover declaration because there is no implementation for it.



