### PR TITLE
Fix: free iterator in reset_stale_report_exports

### DIFF
--- a/src/manage_report_export_scheduler.c
+++ b/src/manage_report_export_scheduler.c
@@ -138,6 +138,8 @@ reset_stale_report_exports ()
     }
 
   sql_commit ();
+
+  cleanup_iterator (&report_exports);
 }
 
 /**


### PR DESCRIPTION
## What

Close iterator leak in `reset_stale_report_exports`.

## Why

Cleaner.

## References

From /pull/2889.

## Testing

Set up a stale `report_exports` row, watched for the stale threshold message. Looks OK. (Requires /pull/2897 to work.)


