### PR TITLE
fix: pass report_id directly to get_data_set_extra

### DIFF
--- a/src/gmp_report_applications.c
+++ b/src/gmp_report_applications.c
@@ -73,7 +73,7 @@ get_report_applications_start (const gchar **attribute_names,
       get_report_apps_data.report_id = g_strdup (attribute);
 
       get_data_set_extra (&get_report_apps_data.get, "report_id",
-                          g_strdup (attribute));
+                          attribute);
     }
 }
 

--- a/src/gmp_report_errors.c
+++ b/src/gmp_report_errors.c
@@ -66,7 +66,7 @@ get_report_errors_start (const gchar **attribute_names,
 
       get_data_set_extra (&get_report_errors_data.get,
                           "report_id",
-                          g_strdup (attribute));
+                          attribute);
     }
 }
 

--- a/src/gmp_report_hosts.c
+++ b/src/gmp_report_hosts.c
@@ -67,7 +67,7 @@ get_report_hosts_start (const gchar **attribute_names,
       get_report_hosts_data.report_id = g_strdup (attribute);
 
       get_data_set_extra (&get_report_hosts_data.get, "report_id",
-                          g_strdup (attribute));
+                          attribute);
     }
   if (find_attribute (attribute_names, attribute_values,
                       "lean", &attribute))

--- a/src/gmp_report_operating_systems.c
+++ b/src/gmp_report_operating_systems.c
@@ -73,7 +73,7 @@ get_report_operating_systems_start (const gchar **attribute_names,
       get_report_os_data.report_id = g_strdup (attribute);
 
       get_data_set_extra (&get_report_os_data.get, "report_id",
-                          g_strdup (attribute));
+                          attribute);
     }
 }
 

--- a/src/gmp_report_ports.c
+++ b/src/gmp_report_ports.c
@@ -67,7 +67,7 @@ get_report_ports_start (const gchar **attribute_names,
       get_report_ports_data.report_id = g_strdup (attribute);
 
       get_data_set_extra (&get_report_ports_data.get, "report_id",
-                          g_strdup (attribute));
+                          attribute);
     }
 }
 

--- a/src/gmp_report_tls_certificates.c
+++ b/src/gmp_report_tls_certificates.c
@@ -69,7 +69,7 @@ get_report_tls_certificates_start (const gchar **attribute_names,
 
       get_data_set_extra (&get_report_tls_certificates_data.get,
                           "report_id",
-                          g_strdup (attribute));
+                          attribute);
     }
 }
 

--- a/src/gmp_report_vulns.c
+++ b/src/gmp_report_vulns.c
@@ -73,7 +73,7 @@ get_report_vulns_start (const gchar **attribute_names,
       get_report_vulns_data.report_id = g_strdup (attribute);
 
       get_data_set_extra (&get_report_vulns_data.get, "report_id",
-                          g_strdup (attribute));
+                          attribute);
     }
 }
 


### PR DESCRIPTION
## What

- Fixed unnecessary `g_strdup()` calls in several `get_report_*` parsers.
- The original attribute value is now passed directly to `get_data_set_extra()`.
- Updated the same issue in reports like ports, applications, operating systems, vulnerabilities, and hosts.

## Why

- `get_data_set_extra()` already duplicates the value internally.
- Calling `g_strdup()` before passing the value caused memory leaks.
- This fix keeps the same behavior and avoids the leaks.
<!-- Describe why are these changes necessary? -->

## References

GEA-1710


