### PR TITLE
Fix: always check find_report_with_permission ret before using report

### DIFF
--- a/src/manage_sql_resources.c
+++ b/src/manage_sql_resources.c
@@ -777,7 +777,8 @@ resource_count (const char *type, const get_data_t *get)
       const gchar *report_uuid = get_data_get_extra (get, "report_id");
       if (!str_blank (report_uuid))
         {
-          find_report_with_permission (report_uuid, &report, "get_reports");
+          if (find_report_with_permission (report_uuid, &report, "get_reports"))
+            return 0;
           if (report != 0)
             {
               return report_applications_count (report);
@@ -791,7 +792,8 @@ resource_count (const char *type, const get_data_t *get)
       const gchar *report_uuid = get_data_get_extra (get, "report_id");
       if (!str_blank (report_uuid))
         {
-          find_report_with_permission (report_uuid, &report, "get_reports");
+          if (find_report_with_permission (report_uuid, &report, "get_reports"))
+            return 0;
           if (report != 0)
             {
               return report_closed_cve_count (report);
@@ -805,7 +807,8 @@ resource_count (const char *type, const get_data_t *get)
       const gchar *report_uuid = get_data_get_extra (get, "report_id");
       if (!str_blank (report_uuid))
         {
-          find_report_with_permission (report_uuid, &report, "get_reports");
+          if (find_report_with_permission (report_uuid, &report, "get_reports"))
+            return 0;
           if (report != 0)
             {
               return report_error_count (report);
@@ -827,7 +830,8 @@ resource_count (const char *type, const get_data_t *get)
       const gchar *report_uuid = get_data_get_extra (get, "report_id");
       if (!str_blank (report_uuid))
         {
-          find_report_with_permission (report_uuid, &report, "get_reports");
+          if (find_report_with_permission (report_uuid, &report, "get_reports"))
+            return 0;
           if (report != 0)
             {
               return report_operating_systems_count (report);
@@ -840,7 +844,8 @@ resource_count (const char *type, const get_data_t *get)
       const gchar *report_uuid = get_data_get_extra (get, "report_id");
       if (!str_blank (report_uuid))
         {
-          find_report_with_permission (report_uuid, &report, "get_reports");
+          if (find_report_with_permission (report_uuid, &report, "get_reports"))
+            return 0;
           if (report != 0)
             {
               return report_port_count (report);
@@ -854,7 +859,8 @@ resource_count (const char *type, const get_data_t *get)
       const gchar *report_uuid = get_data_get_extra (get, "report_id");
       if (!str_blank (report_uuid))
         {
-          find_report_with_permission (report_uuid, &report, "get_reports");
+          if (find_report_with_permission (report_uuid, &report, "get_reports"))
+            return 0;
           if (report != 0)
             {
               return report_ssl_cert_count (report);
@@ -868,7 +874,8 @@ resource_count (const char *type, const get_data_t *get)
       const gchar *report_uuid = get_data_get_extra (get, "report_id");
       if (!str_blank (report_uuid))
         {
-          find_report_with_permission (report_uuid, &report, "get_reports");
+          if (find_report_with_permission (report_uuid, &report, "get_reports"))
+            return 0;
           if (report != 0)
             {
               return report_vulns_count (report, get);


### PR DESCRIPTION
## What

In `resource_count` check the return from `find_report_with_permissions` before using the report.

## Why

It's cleaner because `report` is only set if the find succeeds.

Theoretically this might have lead to a segv reading report that's removed mid GET_REPORT_*, but chances are extremely low.

## References

Spotted in /pull/2891.

## Testing

I ran the report GMP commands and compared with main:
```
o m m '<get_report_applications report_id="82f3531c-43cd-4453-8300-990dc423d96b" details="1"/>' > /tmp/report-app-pr
o m m '<get_report_applications report_id="82f3531c-43cd-4453-8300-990dc423d96b" details="1"/>' > /tmp/report-app-main
o m m '<get_report_closed_cves report_id="82f3531c-43cd-4453-8300-990dc423d96b" details="1"/>' > /tmp/report-cve-pr
o m m '<get_report_closed_cves report_id="82f3531c-43cd-4453-8300-990dc423d96b" details="1"/>' > /tmp/report-cve-main
o m m '<get_report_errors report_id="82f3531c-43cd-4453-8300-990dc423d96b" details="1"/>' > /tmp/report-err-pr
o m m '<get_report_errors report_id="82f3531c-43cd-4453-8300-990dc423d96b" details="1"/>' > /tmp/report-err-main
o m m '<get_report_operating_systems report_id="82f3531c-43cd-4453-8300-990dc423d96b" details="1"/>' > /tmp/report-os-pr
o m m '<get_report_operating_systems report_id="82f3531c-43cd-4453-8300-990dc423d96b" details="1"/>' > /tmp/report-os-main
o m m '<get_report_ports report_id="82f3531c-43cd-4453-8300-990dc423d96b" details="1"/>' > /tmp/report-ports-pr
o m m '<get_report_ports report_id="82f3531c-43cd-4453-8300-990dc423d96b" details="1"/>' > /tmp/report-ports-main
o m m '<get_report_tls_certificates report_id="82f3531c-43cd-4453-8300-990dc423d96b" details="1"/>' > /tmp/report-tls-pr
o m m '<get_report_tls_certificates report_id="82f3531c-43cd-4453-8300-990dc423d96b" details="1"/>' > /tmp/report-tls-main
o m m '<get_report_vulns report_id="82f3531c-43cd-4453-8300-990dc423d96b" details="1"/>' > /tmp/report-vulns-pr
o m m '<get_report_vulns report_id="82f3531c-43cd-4453-8300-990dc423d96b" details="1"/>' > /tmp/report-vulns-main
diff -u /tmp/report-app-main /tmp/report-app-pr ; diff -u /tmp/report-cve-main /tmp/report-cve-pr ; diff -u /tmp/report-err-main /tmp/report-err-pr ; diff -u /tmp/report-os-main /tmp/report-os-pr ; diff -u /tmp/report-ports-main /tmp/report-ports-pr ; diff -u /tmp/report-tls-main /tmp/report-tls-pr ; diff -u /tmp/report-vulns-main /tmp/report-vulns-pr
```


