### PR TITLE
Harmonise gvm-libs prerequisite with cmakelists

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,8 +14,7 @@ Prerequisites:
 * glib-2.0 >= 2.42
 * gnutls >= 3.2.15
 * gpgme
-* [gvm-libs](https://github.com/greenbone/gvm-libs/) >= 22.34 (or 22.41 if you ENABLE_CONTAINER_SCANNING or
-  ENABLE_OPENVASD or ENABLE_AGENTS)
+* [gvm-libs](https://github.com/greenbone/gvm-libs/) >= 23.0
 * libical >= 1.0.0
 * libbsd
 * pkg-config


### PR DESCRIPTION
## What

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

Harmonise gvm-libs prerequisite with cmakelists.

## Why

<!-- Describe why are these changes necessary? -->

6d4868f05 bumps the required version of (most parts of) gvm-libs in src/CMakeLists.txt, require the same version in the install instructions.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

