### PR TITLE
fix: Fix closed CVE queries to use explicit SQL aliases

### DIFF
--- a/src/manage_sql_report_closed_cves.c
+++ b/src/manage_sql_report_closed_cves.c
@@ -128,13 +128,13 @@ report_closed_cve_count (report_t report)
     "   JOIN nvts n"
     "     ON n.oid = rhd.source_name"
     "   CROSS JOIN LATERAL regexp_split_to_table(n.cve, ',')"
-    "   AS split_cve"
+    "     AS split_cve"
     "   WHERE rh.report = $1"
     "     AND rhd.name = 'EXIT_CODE'"
     "     AND rhd.value = 'EXIT_NOTVULN'"
     "     AND n.cve != ''"
     "     AND n.family IN (" LSC_FAMILY_LIST ")"
-    " );",
+    " ) AS closed_cves;",
     SQL_RESOURCE_PARAM (report),
     NULL);
 }


### PR DESCRIPTION
## What

Fix the closed CVE SQL queries by adding the required subquery alias and using an explicit alias for the lateral CVE split.

## Why

This prevents PostgreSQL from failing with subquery in FROM must have an alias and makes the closed CVE queries clearer and more robust.

## References

GEA-1710


