### PR TITLE
Fix: free iter in target_openvas_ssh_credential_*

### DIFF
--- a/src/manage_openvas.c
+++ b/src/manage_openvas.c
@@ -301,7 +301,7 @@ target_openvas_ssh_credential (target_t target,
 
   if (credential)
     {
-      iterator_t iter, ssh_elevate_iter;
+      iterator_t iter;
       const char *type;
       char *ssh_port;
       scan_credential_t *scan_credential;
@@ -349,6 +349,7 @@ target_openvas_ssh_credential (target_t target,
       free (ssh_port);
       if (ssh_elevate_credential)
         {
+          iterator_t ssh_elevate_iter;
           const char *elevate_type;
 
           init_credential_iterator_one (&ssh_elevate_iter,

--- a/src/manage_openvas.c
+++ b/src/manage_openvas.c
@@ -871,11 +871,11 @@ target_openvas_ssh_credential_db (target_t target)
       scan_credential = scan_credential_new (type, "ssh", ssh_port);
       free (ssh_port);
       scan_credential_set_auth_data (scan_credential,
-                                    "username",
-                                    credential_iterator_login (&iter));
+                                     "username",
+                                     credential_iterator_login (&iter));
       scan_credential_set_auth_data (scan_credential,
-                                    "password",
-                                    credential_iterator_password (&iter));
+                                     "password",
+                                     credential_iterator_password (&iter));
 
       if (strcmp (type, "usk") == 0)
         {
@@ -883,11 +883,11 @@ target_openvas_ssh_credential_db (target_t target)
           gchar *base64 = g_base64_encode ((guchar *) private_key,
                                            strlen (private_key));
           scan_credential_set_auth_data (scan_credential,
-                                        "private", base64);
+                                         "private", base64);
           g_free (base64);
         }
 
-      if(ssh_elevate_credential)
+      if (ssh_elevate_credential)
         {
           const char *elevate_type;
 
@@ -897,7 +897,7 @@ target_openvas_ssh_credential_db (target_t target)
             {
               g_warning ("%s: SSH Elevate Credential not found.", __func__);
               cleanup_iterator (&ssh_elevate_iter);
-              scan_credential_free(scan_credential);
+              scan_credential_free (scan_credential);
               return NULL;
             }
           elevate_type = credential_iterator_type (&ssh_elevate_iter);
@@ -905,16 +905,16 @@ target_openvas_ssh_credential_db (target_t target)
             {
               g_warning ("%s: SSH Elevate Credential not of type up", __func__);
               cleanup_iterator (&ssh_elevate_iter);
-              scan_credential_free(scan_credential);
+              scan_credential_free (scan_credential);
               return NULL;
             }
           scan_credential_set_auth_data (scan_credential,
-                                        "priv_username",
-                                        credential_iterator_login
+                                         "priv_username",
+                                         credential_iterator_login
                                           (&ssh_elevate_iter));
           scan_credential_set_auth_data (scan_credential,
-                                        "priv_password",
-                                        credential_iterator_password
+                                         "priv_password",
+                                         credential_iterator_password
                                           (&ssh_elevate_iter));
           cleanup_iterator (&ssh_elevate_iter);
         }

--- a/src/manage_openvas.c
+++ b/src/manage_openvas.c
@@ -898,6 +898,7 @@ target_openvas_ssh_credential_db (target_t target)
               g_warning ("%s: SSH Elevate Credential not found.", __func__);
               cleanup_iterator (&ssh_elevate_iter);
               scan_credential_free (scan_credential);
+              cleanup_iterator (&iter);
               return NULL;
             }
           elevate_type = credential_iterator_type (&ssh_elevate_iter);
@@ -906,6 +907,7 @@ target_openvas_ssh_credential_db (target_t target)
               g_warning ("%s: SSH Elevate Credential not of type up", __func__);
               cleanup_iterator (&ssh_elevate_iter);
               scan_credential_free (scan_credential);
+              cleanup_iterator (&iter);
               return NULL;
             }
           scan_credential_set_auth_data (scan_credential,

--- a/src/manage_openvas.c
+++ b/src/manage_openvas.c
@@ -404,6 +404,7 @@ target_openvas_ssh_credential (target_t target,
                                             scan_credential);
           if (ret)
             {
+              cleanup_iterator (&iter);
               scan_credential_free (scan_credential);
               return ret;
             }

--- a/src/manage_openvas.c
+++ b/src/manage_openvas.c
@@ -277,6 +277,55 @@ set_auth_data_snmp_from_credential_store (iterator_t *iter,
 }
 
 /**
+ * @brief Get the SSH elevate credential for target_openvas_ssh_credential
+ *
+ * @param[in]  ssh_elevate_credential  Elevate credential.
+ * @param[out] scan_credential         Credential.
+ *
+ * @return A target_credential_return_t return code.
+ */
+static target_credential_return_t
+get_ssh_elevate_credential (credential_t ssh_elevate_credential,
+                            scan_credential_t *scan_credential)
+{
+  iterator_t ssh_elevate_iter;
+  const char *elevate_type;
+
+  init_credential_iterator_one (&ssh_elevate_iter,
+                                ssh_elevate_credential);
+  if (!next (&ssh_elevate_iter))
+    {
+      g_warning ("%s: SSH Elevate Credential not found.", __func__);
+      cleanup_iterator (&ssh_elevate_iter);
+      return TARGET_INTERNAL_ERROR;
+    }
+  elevate_type = credential_iterator_type (&ssh_elevate_iter);
+  if (strcmp (elevate_type, "up") == 0)
+    {
+      set_auth_data_ssh_from_db (&ssh_elevate_iter, scan_credential, 1);
+    }
+  else if (strcmp (elevate_type, "cs_up") == 0)
+    {
+      if (set_auth_data_ssh_from_credential_store (&ssh_elevate_iter,
+                                                   scan_credential, 1))
+        {
+          cleanup_iterator (&ssh_elevate_iter);
+          g_warning ("%s: Failed to retrieve SSH elevate"
+                     " credential from credential store.", __func__);
+          return TARGET_FAILED_CS_RETRIEVAL;
+        }
+    }
+  else
+    {
+      g_warning ("%s: SSH Elevate Credential not of type up or cs_up", __func__);
+      cleanup_iterator (&ssh_elevate_iter);
+      return TARGET_CREDENTIAL_TYPE_MISMATCH;
+    }
+  cleanup_iterator (&ssh_elevate_iter);
+  return TARGET_CREDENTIAL_OK;
+}
+
+/**
  * @brief Get the SSH credential of a target from database or credential store
  *        as an scan_credential_t
  *
@@ -349,43 +398,15 @@ target_openvas_ssh_credential (target_t target,
       free (ssh_port);
       if (ssh_elevate_credential)
         {
-          iterator_t ssh_elevate_iter;
-          const char *elevate_type;
+          target_credential_return_t ret;
 
-          init_credential_iterator_one (&ssh_elevate_iter,
-                                        ssh_elevate_credential);
-          if (!next (&ssh_elevate_iter))
+          ret = get_ssh_elevate_credential (ssh_elevate_credential,
+                                            scan_credential);
+          if (ret)
             {
-              g_warning ("%s: SSH Elevate Credential not found.", __func__);
-              cleanup_iterator (&ssh_elevate_iter);
               scan_credential_free (scan_credential);
-              return TARGET_INTERNAL_ERROR;
+              return ret;
             }
-          elevate_type = credential_iterator_type (&ssh_elevate_iter);
-          if (strcmp (elevate_type, "up") == 0)
-            {
-              set_auth_data_ssh_from_db (&ssh_elevate_iter, scan_credential, 1);
-            }
-          else if (strcmp (elevate_type, "cs_up") == 0)
-            {
-              if (set_auth_data_ssh_from_credential_store (&ssh_elevate_iter,
-                                                           scan_credential, 1))
-                {
-                  cleanup_iterator (&ssh_elevate_iter);
-                  scan_credential_free (scan_credential);
-                  g_warning ("%s: Failed to retrieve SSH elevate"
-                             " credential from credential store.", __func__);
-                  return TARGET_FAILED_CS_RETRIEVAL;
-                }
-            }
-          else
-            {
-              g_warning ("%s: SSH Elevate Credential not of type up or cs_up", __func__);
-              cleanup_iterator (&ssh_elevate_iter);
-              scan_credential_free (scan_credential);
-              return TARGET_CREDENTIAL_TYPE_MISMATCH;
-            }
-          cleanup_iterator (&ssh_elevate_iter);
         }
       cleanup_iterator (&iter);
       *ssh_credential = scan_credential;


### PR DESCRIPTION
## What

Always free `iter` in `target_openvas_ssh_credential` and `target_openvas_ssh_credential_db`.

## Why

Cleaner.

## References

Likely from /pull/2606.

## Testing

Confirmed in logs that credential was retrieved OK when starting scan.