### PR TITLE
fix: copy agent group fields when cloning tasks

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -17803,6 +17803,7 @@ copy_task (const char* name, const char* comment, const char *task_id,
                             " config_location, target_location,"
                             " schedule_location, scanner_location,"
                             " oci_image_target_location, usage_type,"
+                            " agent_group, agent_group_location,"
                             " alterable",
                             1, &new, &old);
   if (ret)


### PR DESCRIPTION
## What

This PR fixes cloning for agent tasks by also copying `agent_group` and `agent_group_location`.


## Why

Without these fields, a cloned agent task could lose its agent group information.

## References

GEA-1790


