### PR TITLE
Fix: always free hosts in create_scanner and modify_scanner

### DIFF
--- a/src/manage_scanner_relays.c
+++ b/src/manage_scanner_relays.c
@@ -323,7 +323,8 @@ scanner_type_matches_relay (int scanner_type,
  * @param[in]  scanner_type   The type of scanner to match
  * @param[in]  original_host  Original host of the scanner to match
  * @param[in]  original_port  Original port of the scanner to match, 0 for any
- * @param[out] relay_host     Output of the relay host
+ * @param[out] relay_host     Destination address for freshly allocated relay
+ *                            host. Caller must g_free.
  * @param[out] relay_port     Output of the relay port
  *
  * @return 0 success, -1 error

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -22932,8 +22932,11 @@ create_scanner (const char* name, const char *comment, const char *host,
     }
 
   if (unix_socket)
-    insert_scanner (name, comment, host, ca_pub, iport, itype,
-                    used_relay_host, irelay_port, new_scanner);
+    {
+      insert_scanner (name, comment, host, ca_pub, iport, itype,
+                      used_relay_host, irelay_port, new_scanner);
+      g_free (file_relay_host);
+    }
   else
     {
       credential = 0;

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -23264,6 +23264,8 @@ modify_scanner (const char *scanner_id, const char *name, const char *comment,
                    credential))
         {
           sql_rollback ();
+          g_free (used_host);
+          g_free (used_relay_host);
           return MODIFY_SCANNER_CREDENTIAL_NOT_CC;
         }
     }
@@ -23274,6 +23276,8 @@ modify_scanner (const char *scanner_id, const char *name, const char *comment,
       if (resource_with_name_exists (name, "scanner", scanner))
         {
           sql_rollback ();
+          g_free (used_host);
+          g_free (used_relay_host);
           return MODIFY_SCANNER_ALREADY_EXISTS;
         }
     }
@@ -23282,6 +23286,8 @@ modify_scanner (const char *scanner_id, const char *name, const char *comment,
   quoted_comment = comment ? sql_insert (comment) : g_strdup ("comment");
   quoted_host = sql_insert (used_host);
   quoted_relay_host = sql_insert (used_relay_host);
+  g_free (used_host);
+  g_free (used_relay_host);
 
   sql ("UPDATE scanners SET name = %s, comment = %s, type = %d,"
        " host = %s, port = %d, relay_host = %s, relay_port = %d,"


### PR DESCRIPTION
## What

Close leaks of hosts and relay hosts in `create_scanner` and `modify_scanner`.

## Why

Cleaner.

## References

Noticed in /pull/2859.

## Testing

Created and modified scanners from the `gvmd` command line with a relays file. Seems OK.

