### PR TITLE
Fix: use used_relay_host in the TCP case in create_scanner

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -22968,7 +22968,7 @@ create_scanner (const char* name, const char *comment, const char *host,
         }
 
       insert_scanner (name, comment, host, ca_pub, iport, itype,
-                      relay_host, irelay_port, new_scanner);
+                      used_relay_host, irelay_port, new_scanner);
       g_free (file_relay_host);
 
       if (credential)


### PR DESCRIPTION
## What

Also use `used_relay_host` in the TCP case in `create_scanner`.

## Why

This makes create_scanner use the file relays when they are present.

## References

Noticed in /pull/2859.

## Testing

- Create a scanner with main: `gvmd --create-scanner=2859-main --scanner-type=OSP-Sensor --scanner-port=9390 --scanner-host=10.0.0.1 --relays-path=$HOME/etc/relays.json`
- Check in the db, the `relay_host` field is empty
- Create a scanner with PR: `gvmd --create-scanner=2859-pr --scanner-type=OSP-Sensor --scanner-port=9390 --scanner-host=10.0.0.1 --relays-path=$HOME/etc/relays.json`
- Check in db, `relay_host` is there.
