### PR TITLE
fix: change MAC matches in asset key scoring as strong

### DIFF
--- a/src/manage_asset_keys.c
+++ b/src/manage_asset_keys.c
@@ -26,12 +26,8 @@
  * @brief Score weights.
  *
  * For target assets:
- * - Hostname, MAC and IP are treated as weak
- * identifiers because none of them is guaranteed to uniquely identify a target
- * machine.
- *
- * SCORE_STRONG is kept for consistency with the scoring model and for future
- * identifier types that may be considered strong.
+ * - MAC is treated as strong
+ * - hostname and IP are treated as weak
  */
 #define SCORE_STRONG 1.0f
 #define SCORE_WEAK   0.4f
@@ -388,7 +384,7 @@ candidate_score (const asset_candidate_t *candidate,
   score += (float) asset_identifier_map_intersection_count_for_type (
     candidate->identifiers,
     obs->identifiers,
-    ASSET_IDENTIFIER_TYPE_MAC) * SCORE_WEAK;
+    ASSET_IDENTIFIER_TYPE_MAC) * SCORE_STRONG;
 
   score += (float) asset_identifier_map_intersection_count_for_type (
     candidate->identifiers,
@@ -495,8 +491,8 @@ asset_merge_decision_clear_empty_merges (asset_merge_decision_t *out)
  * Rules:
  * - If an existing candidate contains all observed identifiers, reuse the best
  *   matching candidate key.
- * - Else if the observation contains one or more existing candidates, caller
- *   should create a new key and merge those candidate keys into it.
+ * - If the observation also connects other matching candidates, merge those
+ *   candidate keys into the selected best match.
  * - Else create a new key and do not merge.
  *
  * @param[in]     obs             Observed identifiers (ip/hostname/mac).

--- a/src/manage_asset_keys_tests.c
+++ b/src/manage_asset_keys_tests.c
@@ -380,6 +380,29 @@ Ensure (manage_asset_keys, decide_by_last_seen_when_score_equal)
   candidate_ptrs_free (ptrs, 2);
 }
 
+Ensure (manage_asset_keys, candidate_score_treats_mac_as_strong)
+{
+  asset_target_obs_t *o = asset_target_obs_new ();
+  obs_add_ip (o, "1.2.3.4");
+  obs_add_hostname (o, "host");
+  obs_add_mac (o, "aa:bb:cc:dd:ee:ff");
+
+  asset_candidate_t *mac_match = candidate_new_test ("mac-match", 10);
+  candidate_add_mac (mac_match, "aa:bb:cc:dd:ee:ff");
+
+  asset_candidate_t *ip_and_hostname_match =
+    candidate_new_test ("ip-host-match", 20);
+  candidate_add_ip (ip_and_hostname_match, "1.2.3.4");
+  candidate_add_hostname (ip_and_hostname_match, "host");
+
+  assert_true (candidate_score (mac_match, o)
+               > candidate_score (ip_and_hostname_match, o));
+
+  asset_target_obs_free (o);
+  asset_candidate_free (mac_match);
+  asset_candidate_free (ip_and_hostname_match);
+}
+
 Ensure (manage_asset_keys,
         reuses_existing_key_when_candidate_contains_observation)
 {
@@ -645,6 +668,8 @@ main (int argc, char **argv)
                          creates_new_key_when_no_candidate_contains_all_observed_identifiers);
   add_test_with_context (suite, manage_asset_keys,
                          decide_by_last_seen_when_score_equal);
+  add_test_with_context (suite, manage_asset_keys,
+                         candidate_score_treats_mac_as_strong);
   add_test_with_context (suite, manage_asset_keys,
                          reuses_existing_key_when_candidate_contains_observation);
   add_test_with_context (suite, manage_asset_keys,


### PR DESCRIPTION
## What

Treat MAC matches as strong matches in target asset scoring and clarify the merge decision comment.

## Why

This makes candidate selection prefer the more reliable identifier and keeps the comment aligned with the intended behavior.

## References

GEA-1773

## Checklist

- [x] Tests


