### PR TITLE
fix: finish openvasd scans based on succeeded status

### DIFF
--- a/src/manage_http_scanner.c
+++ b/src/manage_http_scanner.c
@@ -361,8 +361,7 @@ update_http_scanner_scan (http_scanner_connector_t connector, task_t task,
               http_scanner_response_cleanup (response);
               return -1;
             }
-          else if (progress == 100
-                   && current_status == HTTP_SCANNER_SCAN_STATUS_SUCCEEDED)
+          else if (current_status == HTTP_SCANNER_SCAN_STATUS_SUCCEEDED)
             {
               response = http_scanner_delete_scan (connector);
               http_scanner_response_cleanup (response);


### PR DESCRIPTION
## What

- Removed the `progress == 100` check when handling succeeded openvasd scans.
- Finish and delete the scan when the scanner reports `HTTP_SCANNER_SCAN_STATUS_SUCCEEDED`.
- Prevent gvmd from keeping the task in progress when openvasd already considers the scan completed.

## Why

- openvasd can return `status == succeeded` with `progress == 0` in some cases, for example when the target is invalid.
- gvmd previously expected `progress == 100`, so it did not finish the task properly.
- This caused gvmd to keep polling the scan forever even though the scanner had already completed it.



