### PR TITLE
Fix: free hr_name in preference_free [mem-scan-202]

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -599,6 +599,16 @@ set(
 set(EXTRA_SRC ${ALL_MANAGE_SRC})
 add_unit_test(manage-asset-keys "${ALL_OBJECTS}" "${EXTRA_SRC}")
 
+set(
+  ALL_OBJECTS
+  $<TARGET_OBJECTS:all-gmp-obj>
+  $<TARGET_OBJECTS:all-manage-sql-obj>
+  $<TARGET_OBJECTS:all-misc-obj>
+  $<TARGET_OBJECTS:all-sql-obj>
+)
+set(EXTRA_SRC ${ALL_MANAGE_SRC})
+add_unit_test(manage-preferences "${ALL_OBJECTS}" "${EXTRA_SRC}")
+
 add_custom_target(tests DEPENDS ${TEST_DEPENDENCIES})
 
 if(DEBUG_FUNCTION_NAMES)

--- a/src/manage_preferences.c
+++ b/src/manage_preferences.c
@@ -80,6 +80,7 @@ preference_free (preference_t *preference)
       free (preference->nvt_name);
       free (preference->nvt_oid);
       free (preference->default_value);
+      free (preference->hr_name);
     }
 
   g_free (preference);

--- a/src/manage_preferences_tests.c
+++ b/src/manage_preferences_tests.c
@@ -1,0 +1,53 @@
+/* Copyright (C) 2019-2022 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "manage_preferences.c"
+
+#include <cgreen/cgreen.h>
+#include <cgreen/mocks.h>
+
+Describe (manage_preferences);
+BeforeEach (manage_preferences)
+{
+}
+AfterEach (manage_preferences)
+{
+}
+
+Ensure (manage_preferences, preference_free_frees_hr_name)
+{
+  gchar *hr_name;
+  preference_t *pref;
+
+  hr_name = g_strdup ("human readable name");
+
+  pref = preference_new (g_strdup ("1"), g_strdup ("name"),
+                         g_strdup ("entry"), g_strdup ("value"),
+                         g_strdup ("nvt"), g_strdup ("1.2.3"),
+                         NULL, g_strdup ("default"),
+                         hr_name, TRUE);
+  preference_free (pref);
+}
+
+int
+main (int argc, char **argv)
+{
+  int ret;
+  TestSuite *suite;
+
+  suite = create_test_suite ();
+
+  add_test_with_context (suite, manage_preferences,
+                         preference_free_frees_hr_name);
+
+  if (argc > 1)
+    ret = run_single_test (suite, argv[1], create_text_reporter ());
+  else
+    ret = run_test_suite (suite, create_text_reporter ());
+
+  destroy_test_suite (suite);
+
+  return ret;
+}


### PR DESCRIPTION
## What

Close leak in `preference_free`.

## Why

Cleaner.

Confirmed the leak by running the test with `-fsanitize=address`.

Looks like callers always pass `hr_name` as NULL, but we may as well close the leak in case it's ever used.

<!-- Describe why are these changes necessary? -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


