### PR TITLE
fix: validate SCAP EPSS tables before creating result_vt_epss

### DIFF
--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -2031,11 +2031,18 @@ create_view_result_vt_epss ()
 {
   sql ("DROP MATERIALIZED VIEW IF EXISTS result_vt_epss;");
 
-  if (sql_int ("SELECT EXISTS (SELECT * FROM information_schema.tables"
-               "               WHERE table_catalog = '%s'"
-               "               AND table_schema = 'scap'"
-               "               AND table_name = 'cves')"
-               " ::integer;",
+  if (sql_int ("SELECT ("
+               "  EXISTS (SELECT 1 FROM information_schema.tables"
+               "          WHERE table_catalog = '%s'"
+               "          AND table_schema = 'scap'"
+               "          AND table_name = 'cves')"
+               "  AND"
+               "  EXISTS (SELECT 1 FROM information_schema.tables"
+               "          WHERE table_catalog = '%s'"
+               "          AND table_schema = 'scap'"
+               "          AND table_name = 'epss_scores')"
+               ")::integer;",
+               sql_database (),
                sql_database ()))
     sql ("CREATE MATERIALIZED VIEW result_vt_epss AS ("
          "  SELECT cve AS vt_id,"


### PR DESCRIPTION
## What

- Fixed the `result_vt_epss` materialized view creation.
- Check for `scap.epss_scores` as well as `scap.cves`.
- Use the `nvts` fallback view when SCAP EPSS data is not available.

## Why

- The view needs both SCAP tables.
- Before, only `scap.cves` was checked.
- This could make view creation fail and leave `result_vt_epss` missing.
- Then result queries failed with `relation "result_vt_epss" does not exist`.

## References

GEA-1798


