### PR TITLE
Fix: always free keyword in split_filter [mem-scan-146]

### DIFF
--- a/src/manage_filter_utils.c
+++ b/src/manage_filter_utils.c
@@ -728,6 +728,11 @@ split_filter (const gchar* given_filter)
             cleanup_keyword (keyword);
             if (keyword_applies (parts, keyword))
               array_add (parts, keyword);
+            else
+              {
+                keyword_free (keyword);
+                g_free (keyword);
+              }
             keyword = NULL;
             between = 1;
             break;
@@ -748,6 +753,11 @@ split_filter (const gchar* given_filter)
                 cleanup_keyword (keyword);
                 if (keyword_applies (parts, keyword))
                   array_add (parts, keyword);
+                else
+                  {
+                    keyword_free (keyword);
+                    g_free (keyword);
+                  }
                 keyword = NULL;
                 in_quote = 0;
                 between = 1;
@@ -801,6 +811,11 @@ split_filter (const gchar* given_filter)
           cleanup_keyword (keyword);
           if (keyword_applies (parts, keyword))
             array_add (parts, keyword);
+          else
+            {
+              keyword_free (keyword);
+              g_free (keyword);
+            }
           keyword = NULL;
         }
     }

--- a/src/manage_filter_utils_tests.c
+++ b/src/manage_filter_utils_tests.c
@@ -144,6 +144,16 @@ Ensure (manage_filter_utils, filter_term_value_not_found)
   assert_that (value, is_null);
 }
 
+/* split_filter tests */
+
+Ensure (manage_filter_utils, split_filter_redundant_sort_does_not_leak)
+{
+  array_t *parts;
+
+  parts = split_filter ("sort=name sort=host");
+  filter_free (parts);
+}
+
 /* Test suite. */
 
 int
@@ -192,6 +202,9 @@ main (int argc, char **argv)
                          filter_term_value_with_underscore);
   add_test_with_context (suite, manage_filter_utils,
                          filter_term_value_not_found);
+
+  add_test_with_context (suite, manage_filter_utils,
+                         split_filter_redundant_sort_does_not_leak);
 
   if (argc > 1)
     ret = run_single_test (suite, argv[1], create_text_reporter ());


### PR DESCRIPTION
## What

Close leak in `split_filter` in `manage_filter_utils.c`.

Includes test that shows leak with `-fsanitize=address`.

## Why

Cleaner.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


