### PR TITLE
Fix: free members of os_by_cpe [mem-scan-191]

### DIFF
--- a/src/manage_report_operating_systems.c
+++ b/src/manage_report_operating_systems.c
@@ -137,7 +137,7 @@ get_report_operating_systems (report_t report,
         }
     }
 
-  os_by_cpe = g_hash_table_new (g_str_hash, g_str_equal);
+  os_by_cpe = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
 
   init_report_os_iterator (&report_os, report);
 


### PR DESCRIPTION
## What

Free keys of `os_by_cpe` hashtable, when freeing the hashtable.

The keys are allocated with `g_strdup` so they need to be freed. The values are fine because they're added to `report_os_list`.

## Why

Closes leak.

## Testing

Built gvmd with -fsanitize=address. Ran GMP GET_REPORT_OPERATING_SYSTEMS (with details and a report that has OSs). Watched for ASAN leak output in log.

