### PR TITLE
fix: allow filtering agents by scanner UUID

### DIFF
--- a/src/gmp_agents.c
+++ b/src/gmp_agents.c
@@ -153,8 +153,6 @@ get_agents_run (gmp_parser_t *gmp_parser, GError **error)
     {
       ret = get_next (&agents, &get_agents_data.get, &first, &count,
                       init_agent_iterator);
-      scanner_t scanner;
-      char *agent_scanner_name, *agent_scanner_uuid;
 
       if (ret == 1)
         break;
@@ -165,9 +163,6 @@ get_agents_run (gmp_parser_t *gmp_parser, GError **error)
           return;
         }
 
-      scanner = agent_iterator_scanner (&agents);
-      agent_scanner_uuid = scanner_uuid (scanner);
-      agent_scanner_name = scanner_name (scanner);
       SEND_GET_COMMON_NO_TRASH (agent, &get_agents_data.get, &agents);
 
       // Remaining fields
@@ -204,8 +199,8 @@ get_agents_run (gmp_parser_t *gmp_parser, GError **error)
         agent_iterator_updater_update_available (&agents),
         agent_iterator_latest_agent_version (&agents),
         agent_iterator_latest_updater_version (&agents),
-        agent_scanner_uuid ? agent_scanner_uuid : "",
-        agent_scanner_name ? agent_scanner_name : "");
+        agent_iterator_scanner_uuid (&agents),
+        agent_iterator_scanner_name (&agents));
 
       // IPs
       agent_ip_data_list_t ip_list =
@@ -306,9 +301,6 @@ get_agents_run (gmp_parser_t *gmp_parser, GError **error)
       // Close agent
       SEND_TO_CLIENT_OR_FAIL ("</agent>");
       count++;
-
-      g_free (agent_scanner_name);
-      g_free (agent_scanner_uuid);
     }
 
   cleanup_iterator (&agents);

--- a/src/manage_agents.h
+++ b/src/manage_agents.h
@@ -207,6 +207,12 @@ agent_iterator_latest_agent_version (iterator_t*);
 const gchar*
 agent_iterator_latest_updater_version (iterator_t*);
 
+const gchar*
+agent_iterator_scanner_name (iterator_t*);
+
+const gchar*
+agent_iterator_scanner_uuid (iterator_t*);
+
 int
 agent_count (const get_data_t *);
 

--- a/src/manage_sql_agents.c
+++ b/src/manage_sql_agents.c
@@ -400,6 +400,11 @@ init_agent_iterator (iterator_t *iterator, get_data_t *get)
 
   static column_t columns[] = AGENT_ITERATOR_COLUMNS;
   static const char *filter_columns[] = AGENT_ITERATOR_FILTER_COLUMNS;
+  const char *join_clause = " LEFT JOIN"
+    " (SELECT id as scanner_id, name AS scanner_name, uuid "
+    "  AS scanner_uuid FROM scanners)"
+    "  AS scanner_data"
+    "  ON scanner_data.scanner_id = scanner";
 
   gchar *quoted = NULL;
   gchar *where_clause = NULL;
@@ -413,8 +418,8 @@ init_agent_iterator (iterator_t *iterator, get_data_t *get)
   int ret = init_get_iterator (iterator, "agent", get, columns,
                                NULL, // no trash columns
                                filter_columns,
-                               0,    // no trashcan
-                               NULL, // no joins
+                               0,           // no trashcan
+                               join_clause, // joins for scanners
                                where_clause, 0);
 
   g_free (where_clause);
@@ -655,7 +660,7 @@ agent_iterator_updater_update_available (iterator_t *iterator)
 /**
  * @brief Retrieve latest agent version.
  */
-const gchar*
+const gchar *
 agent_iterator_latest_agent_version (iterator_t *iterator)
 {
   return iterator_string (iterator, GET_ITERATOR_COLUMN_COUNT + 15);
@@ -664,10 +669,28 @@ agent_iterator_latest_agent_version (iterator_t *iterator)
 /**
  * @brief Retrieve latest updater version.
  */
-const gchar*
+const gchar *
 agent_iterator_latest_updater_version (iterator_t *iterator)
 {
   return iterator_string (iterator, GET_ITERATOR_COLUMN_COUNT + 16);
+}
+
+/**
+ * @brief Retrieve latest updater version.
+ */
+const gchar *
+agent_iterator_scanner_name (iterator_t *iterator)
+{
+  return iterator_string (iterator, GET_ITERATOR_COLUMN_COUNT + 17);
+}
+
+/**
+ * @brief Retrieve latest updater version.
+ */
+const gchar *
+agent_iterator_scanner_uuid (iterator_t *iterator)
+{
+  return iterator_string (iterator, GET_ITERATOR_COLUMN_COUNT + 18);
 }
 
 /**
@@ -681,8 +704,14 @@ agent_count (const get_data_t *get)
 {
   static const char *extra_columns[] = AGENT_ITERATOR_FILTER_COLUMNS;
   static column_t columns[] = AGENT_ITERATOR_COLUMNS;
+  const char *join_clause = " LEFT JOIN"
+    " (SELECT id as scanner_id, name AS scanner_name, uuid "
+    "  AS scanner_uuid FROM scanners)"
+    "  AS scanner_data"
+    "  ON scanner_data.scanner_id = scanner";
 
-  return count ("agent", get, columns, NULL, extra_columns, 0, 0, 0, TRUE);
+  return count ("agent", get, columns, NULL, extra_columns, 0, join_clause, 0,
+                TRUE);
 }
 
 /**

--- a/src/manage_sql_agents.c
+++ b/src/manage_sql_agents.c
@@ -676,7 +676,7 @@ agent_iterator_latest_updater_version (iterator_t *iterator)
 }
 
 /**
- * @brief Retrieve latest updater version.
+ * @brief Retrieve scanner name.
  */
 const gchar *
 agent_iterator_scanner_name (iterator_t *iterator)
@@ -685,7 +685,7 @@ agent_iterator_scanner_name (iterator_t *iterator)
 }
 
 /**
- * @brief Retrieve latest updater version.
+ * @brief Retrieve scanner UUID.
  */
 const gchar *
 agent_iterator_scanner_uuid (iterator_t *iterator)

--- a/src/manage_sql_agents.h
+++ b/src/manage_sql_agents.h
@@ -42,6 +42,8 @@
       {"updater_update_available", NULL, KEYWORD_TYPE_INTEGER},             \
       {"latest_agent_version", NULL, KEYWORD_TYPE_STRING},                  \
       {"latest_updater_version", NULL, KEYWORD_TYPE_STRING},                \
+      {"scanner_name", "scanner_name", KEYWORD_TYPE_STRING },               \
+      {"scanner_uuid", "scanner_id", KEYWORD_TYPE_STRING },                 \
     {                                                                       \
       NULL, NULL, KEYWORD_TYPE_UNKNOWN                                      \
     }                                                                       \
@@ -58,6 +60,7 @@
       "agent_version", "operating_system", "architecture", "update_to_latest", \
       "agent_update_available", "updater_update_available",                    \
       "latest_agent_version", "latest_updater_version", "connection_status",   \
+      "scanner_name", "scanner_uuid",                                          \
       NULL                                                                     \
   }
 


### PR DESCRIPTION
## What

Add a scanner join to the agent iterator so agents can be filtered by scanner UUID.


## Why

The agent table only stores the scanner ID. Filtering by scanner UUID requires joining scanner data so the filter column is available for both the iterator and count query.


## References

GEA-1800




