### PR TITLE
fix: add scanner join to agent UUID list iterator

### DIFF
--- a/src/manage_sql_agents.c
+++ b/src/manage_sql_agents.c
@@ -445,6 +445,11 @@ init_agent_uuid_list_iterator (iterator_t *iterator,
   get.ignore_pagination = 1;
   get.ignore_max_rows_per_page = 1;
   get.filter = "rows=-1";
+  const char *join_clause = " LEFT JOIN"
+    " (SELECT id as scanner_id, name AS scanner_name, uuid "
+    "  AS scanner_uuid FROM scanners)"
+    "  AS scanner_data"
+    "  ON scanner_data.scanner_id = scanner";
 
   GString *where_clause = g_string_new (NULL);
 
@@ -467,7 +472,7 @@ init_agent_uuid_list_iterator (iterator_t *iterator,
                      NULL, // no trash columns
                      filter_columns,
                      0,    // no trashcan
-                     NULL, // no joins
+                     join_clause, // scanners joins
                      where_clause->str, 0);
 
   g_string_free (where_clause, TRUE);


### PR DESCRIPTION


## What

Added the scanner join to `init_agent_uuid_list_iterator`.

This makes `scanner_uuid` available when filtering agents.


## Why

Agents only store the scanner ID, not the scanner UUID.

Because of that, the UUID list iterator also needs the scanner join. Without it, filtering agents by `scanner_uuid` did not work correctly.

## References

GEA-1800


