### PR TITLE
fix: return agent group sync validation errors

### DIFF
--- a/src/gmp_agent_groups.c
+++ b/src/gmp_agent_groups.c
@@ -292,6 +292,7 @@ create_agent_group_run (gmp_parser_t *gmp_parser, GError **error)
   agent_group_data_t group_data;
   agent_uuid_list_t agent_uuids = NULL;
   agent_group_t new_agent_group;
+  GPtrArray *errs = NULL;
 
   if (!acl_user_may ("create_agent_group"))
     {
@@ -420,7 +421,7 @@ create_agent_group_run (gmp_parser_t *gmp_parser, GError **error)
 
   // Execute creation
   agent_group_resp_t response = create_and_sync_agent_group (
-    group_data, agent_uuids);
+    group_data, agent_uuids, &errs);
 
   switch (response)
   {
@@ -465,8 +466,35 @@ create_agent_group_run (gmp_parser_t *gmp_parser, GError **error)
       break;
 
     case AGENT_GROUP_RESP_INVALID_ARGUMENT:
-      SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX ("create_agent_group", "Invalid input"));
-      log_event_fail ("agent_group", "Agent Group", NULL, "created");
+      if (errs)
+        {
+          gchar *status_text = concat_error_messages (
+            errs, "; ", "Validation failed for config: ");
+          if (!status_text)
+            status_text = g_markup_escape_text ("Validation failed for config.",
+                                                -1);
+
+          gchar *xml = g_markup_printf_escaped (
+            "<create_agent_group_response status=\""
+            STATUS_ERROR_SYNTAX
+            "\" status_text=\"%s\"/>",
+            status_text ? status_text : "Validation failed for <config>."
+            );
+
+          if (send_to_client (xml, gmp_parser->client_writer,
+                              gmp_parser->client_writer_data))
+            error_send_to_client (error);
+
+          g_free (xml);
+          g_free (status_text);
+          log_event_fail ("agent_group", "Agent Groups", NULL, "created");
+        }
+      else
+        {
+          SEND_TO_CLIENT_OR_FAIL (
+            XML_ERROR_SYNTAX ("create_agent_group", "Invalid input"));
+          log_event_fail ("agent_group", "Agent Group", NULL, "created");
+        }
     break;
 
     case AGENT_GROUP_RESP_AGENT_NOT_FOUND:
@@ -505,6 +533,8 @@ create_agent_group_run (gmp_parser_t *gmp_parser, GError **error)
   // Cleanup
   agent_uuid_list_free (agent_uuids);
   agent_group_data_free(group_data);
+  if (errs)
+    g_ptr_array_free(errs, TRUE);
 
 #else
   SEND_TO_CLIENT_OR_FAIL (XML_ERROR_UNAVAILABLE ("create_agent_group",
@@ -630,6 +660,7 @@ modify_agent_group_run (gmp_parser_t *gmp_parser, GError **error)
 #if ENABLE_AGENTS
   entity_t root, name, comment, scheduler_cron_time, agents_elem;
   const char *agent_group_uuid, *name_text, *scheduler_cron_time_text;
+  GPtrArray *errs = NULL;
 
   if (!acl_user_may ("modify_agent_group"))
     {
@@ -730,7 +761,7 @@ modify_agent_group_run (gmp_parser_t *gmp_parser, GError **error)
   group_data->modification_time = time (NULL);
 
   agent_group_resp_t response = modify_and_sync_agent_group (
-    agent_group, group_data, agent_uuids);
+    agent_group, group_data, agent_uuids, &errs);
 
   switch (response)
     {
@@ -774,8 +805,34 @@ modify_agent_group_run (gmp_parser_t *gmp_parser, GError **error)
         break;
 
       case AGENT_GROUP_RESP_INVALID_ARGUMENT:
-        SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX ("modify_agent_group", "Invalid input"));
-        log_event_fail ("agent_group", "Agent Group", NULL, "modified");
+        if (errs)
+          {
+            gchar *status_text = concat_error_messages (
+              errs, "; ", "Validation failed for config: ");
+            if (!status_text)
+              status_text = g_markup_escape_text ("Validation failed for config.",
+                                                  -1);
+
+            gchar *xml = g_markup_printf_escaped (
+              "<modify_agent_group_response status=\""
+              STATUS_ERROR_SYNTAX
+              "\" status_text=\"%s\"/>",
+              status_text ? status_text : "Validation failed for <config>."
+              );
+
+            if (send_to_client (xml, gmp_parser->client_writer,
+                                gmp_parser->client_writer_data))
+              error_send_to_client (error);
+
+            g_free (xml);
+            g_free (status_text);
+            log_event_fail ("agent_group", "Agent Groups", NULL, "modified");
+          }
+        else
+          {
+            SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX ("modify_agent_group", "Invalid input"));
+            log_event_fail ("agent_group", "Agent Group", NULL, "modified");
+          }
         break;
 
       case AGENT_GROUP_RESP_AGENT_NOT_FOUND:
@@ -828,6 +885,8 @@ modify_agent_group_run (gmp_parser_t *gmp_parser, GError **error)
   // Cleanup
   agent_group_data_free (group_data);
   agent_uuid_list_free (agent_uuids);
+  if (errs)
+    g_ptr_array_free (errs, TRUE);
 
 #else
   SEND_TO_CLIENT_OR_FAIL (XML_ERROR_UNAVAILABLE ("modify_agent_group",

--- a/src/gmp_agent_groups.c
+++ b/src/gmp_agent_groups.c
@@ -470,16 +470,15 @@ create_agent_group_run (gmp_parser_t *gmp_parser, GError **error)
         {
           gchar *status_text = concat_error_messages (
             errs, "; ", "Validation failed for config: ");
+
           if (!status_text)
-            status_text = g_markup_escape_text ("Validation failed for config.",
-                                                -1);
+            status_text = g_strdup ("Validation failed for config.");
 
           gchar *xml = g_markup_printf_escaped (
             "<create_agent_group_response status=\""
             STATUS_ERROR_SYNTAX
             "\" status_text=\"%s\"/>",
-            status_text ? status_text : "Validation failed for <config>."
-            );
+            status_text);
 
           if (send_to_client (xml, gmp_parser->client_writer,
                               gmp_parser->client_writer_data))
@@ -809,16 +808,15 @@ modify_agent_group_run (gmp_parser_t *gmp_parser, GError **error)
           {
             gchar *status_text = concat_error_messages (
               errs, "; ", "Validation failed for config: ");
+
             if (!status_text)
-              status_text = g_markup_escape_text ("Validation failed for config.",
-                                                  -1);
+              status_text = g_strdup ("Validation failed for config.");
 
             gchar *xml = g_markup_printf_escaped (
               "<modify_agent_group_response status=\""
               STATUS_ERROR_SYNTAX
               "\" status_text=\"%s\"/>",
-              status_text ? status_text : "Validation failed for <config>."
-              );
+              status_text);
 
             if (send_to_client (xml, gmp_parser->client_writer,
                                 gmp_parser->client_writer_data))

--- a/src/manage_agent_groups.c
+++ b/src/manage_agent_groups.c
@@ -45,6 +45,7 @@ agent_response_to_agent_group_resp (agent_response_t response)
       return AGENT_GROUP_RESP_AGENT_SCANNER_MISMATCH;
 
     case AGENT_RESPONSE_INVALID_ARGUMENT:
+    case AGENT_RESPONSE_CONTROLLER_UPDATE_REJECTED:
       return AGENT_GROUP_RESP_INVALID_ARGUMENT;
 
     case AGENT_RESPONSE_AGENT_NOT_FOUND:
@@ -57,7 +58,6 @@ agent_response_to_agent_group_resp (agent_response_t response)
     case AGENT_RESPONSE_CONTROLLER_DELETE_FAILED:
     case AGENT_RESPONSE_SYNC_FAILED:
     case AGENT_RESPONSE_IN_USE_ERROR:
-    case AGENT_RESPONSE_CONTROLLER_UPDATE_REJECTED:
     default:
       return AGENT_GROUP_RESP_INTERNAL_ERROR;
     }
@@ -218,12 +218,11 @@ get_agent_group_scanner (agent_group_data_t group_data,
  */
 static agent_group_resp_t
 sync_agent_group_agents_from_group_crons (agent_uuid_list_t agent_uuids,
-                                          scanner_t scanner)
+                                          scanner_t scanner, GPtrArray **errs)
 {
   agent_controller_agent_update_list_t update_list = NULL;
   agent_group_resp_t group_response;
   agent_response_t agent_response;
-  GPtrArray *errs = NULL;
 
   if (agent_uuids == NULL || agent_uuids->count == 0)
     return AGENT_GROUP_RESP_NO_AGENTS_PROVIDED;
@@ -246,20 +245,14 @@ sync_agent_group_agents_from_group_crons (agent_uuid_list_t agent_uuids,
 
   agent_response =
     modify_and_resync_agents_with_update_list (
-      scanner, update_list, &errs);
+      scanner, update_list, errs);
 
   agent_controller_agent_update_list_free (update_list);
 
   if (agent_response != AGENT_RESPONSE_SUCCESS)
     {
-      if (errs)
-        g_ptr_array_free (errs, TRUE);
-
       return agent_response_to_agent_group_resp (agent_response);
     }
-
-  if (errs)
-    g_ptr_array_free (errs, TRUE);
 
   return AGENT_GROUP_RESP_SUCCESS;
 }
@@ -379,13 +372,16 @@ agent_group_data_free (agent_group_data_t data)
  *
  * @param group_data Agent group metadata and configuration.
  * @param agent_uuids List of agent UUIDs to associate with the group.
+ * @param errs Optional output parameter for collecting agent controller sync errors.
+ *             Caller must free with g_ptr_array_unref() if not NULL.
  *
  * @return AGENT_GROUP_RESP_SUCCESS on success,
  *         or a specific AGENT_GROUP_RESP_* error code on failure.
  */
 agent_group_resp_t
 create_and_sync_agent_group (agent_group_data_t group_data,
-                             agent_uuid_list_t agent_uuids)
+                             agent_uuid_list_t agent_uuids,
+                             GPtrArray **errs)
 {
   scanner_t scanner = 0;
   agent_group_resp_t response;
@@ -407,7 +403,8 @@ create_and_sync_agent_group (agent_group_data_t group_data,
   if (response != AGENT_GROUP_RESP_SUCCESS)
     return response;
 
-  response = sync_agent_group_agents_from_group_crons (agent_uuids, scanner);
+  response = sync_agent_group_agents_from_group_crons (
+    agent_uuids, scanner, errs);
 
   if (response != AGENT_GROUP_RESP_SUCCESS)
     {
@@ -434,6 +431,8 @@ create_and_sync_agent_group (agent_group_data_t group_data,
  * @param agent_group Agent group ID to modify
  * @param group_data Agent group metadata and configuration to update
  * @param agent_uuids Agent UUIDs to associate with the group
+ * @param errs Optional output parameter for collecting agent controller sync errors.
+ *             Caller must free with g_ptr_array_unref() if not NULL.
  *
  * @return AGENT_GROUP_RESP_SUCCESS on success,
  *         or a specific AGENT_GROUP_RESP_* error code on failure.
@@ -441,7 +440,8 @@ create_and_sync_agent_group (agent_group_data_t group_data,
 agent_group_resp_t
 modify_and_sync_agent_group (agent_group_t agent_group,
                              agent_group_data_t group_data,
-                             agent_uuid_list_t agent_uuids)
+                             agent_uuid_list_t agent_uuids,
+                             GPtrArray **errs)
 {
   scanner_t scanner = 0;
   agent_group_resp_t response;
@@ -485,7 +485,8 @@ modify_and_sync_agent_group (agent_group_t agent_group,
 
   if (sync_agent_uuids)
     sync_response =
-      sync_agent_group_agents_from_group_crons (sync_agent_uuids, scanner);
+      sync_agent_group_agents_from_group_crons (sync_agent_uuids, scanner,
+                                                errs);
   else
     sync_response = AGENT_GROUP_RESP_SUCCESS;
 

--- a/src/manage_agent_groups.h
+++ b/src/manage_agent_groups.h
@@ -60,12 +60,15 @@ void
 agent_group_data_free (agent_group_data_t);
 
 agent_group_resp_t
-create_and_sync_agent_group (agent_group_data_t, agent_uuid_list_t);
+create_and_sync_agent_group (agent_group_data_t,
+                             agent_uuid_list_t,
+                             GPtrArray **);
 
 agent_group_resp_t
 modify_and_sync_agent_group (agent_group_t,
                              agent_group_data_t,
-                             agent_uuid_list_t);
+                             agent_uuid_list_t,
+                             GPtrArray **);
 
 int
 delete_agent_group (const gchar *, int);


### PR DESCRIPTION
## What

- Passed agent controller sync errors back when creating or modifying agent groups.
- Included validation error details in the GMP response when agent group sync fails.

## Why

- Users should see the real validation error instead of a generic invalid input error.
- This makes agent group create/modify failures easier to understand and debug.


## References

GEA-1701



