### PR TITLE
fix: drop unused agent_installer_cpes table

### DIFF
--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -3984,6 +3984,7 @@ migrate_275_to_276 ()
     }
 
   /* Drop agent installers table. */
+  sql ("DROP TABLE IF EXISTS agent_installer_cpes;");
   sql ("DROP TABLE IF EXISTS agent_installers;");
 
   /* Set the database version to 276. */


### PR DESCRIPTION
## What

- Drop the `agent_installer_cpes` table in migration 276 before dropping `agent_installers`.

## Why

-  `agent_installer_cpes` has a foreign key dependency on `agent_installers`.
-  Since `agent_installers` is removed in this migration, the dependent table must be dropped first to avoid migration errors.



