### PR TITLE
Add: Add new scanner type for web application scanning.

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -17845,6 +17845,19 @@ send_scanner_info (iterator_t *scanners, gmp_parser_t *gmp_parser,
         }
         break;
 #endif
+#if ENABLE_WEB_APPLICATION_SCANNING
+      case SCANNER_TYPE_WEB_APPLICATION:
+        {
+          // TODO: Get real info from the scanner.
+          SENDF_TO_CLIENT_OR_FAIL
+           ("<info><scanner><name>web-application</name><version>0.1</version>"
+            "</scanner><daemon><name>WebAppScanner</name><version>1.0</version>"
+            "</daemon><protocol><name>SCANNER API</name><version>0.1"
+            "</version></protocol><description>Web Application Scanner</description>"
+            "<params></params></info>");
+        }
+        break;
+#endif
       default:
         {
           SENDF_TO_CLIENT_OR_FAIL
@@ -21001,6 +21014,14 @@ handle_create_scanner (gmp_parser_t *gmp_parser, GError **error)
         ));
         log_event_fail ("scanner", "Scanner", NULL, "created");
         break;
+      case CREATE_SCANNER_WEB_SCANNING_DISABLED:
+        SEND_TO_CLIENT_OR_FAIL
+        (XML_ERROR_SYNTAX ("create_scanner",
+          "Web application scanner type is not supported "
+          "because the Web scanning feature flag is disabled."
+        ));
+        log_event_fail ("scanner", "Scanner", NULL, "created");
+        break;
       case CREATE_SCANNER_PERMISSION_DENIED:
         SEND_TO_CLIENT_OR_FAIL
          (XML_ERROR_SYNTAX ("create_scanner", "Permission denied"));
@@ -21173,6 +21194,15 @@ handle_modify_scanner (gmp_parser_t *gmp_parser, GError **error)
         (XML_ERROR_SYNTAX ("modify_scanner",
           "Container image scanner type is not supported "
           "because the Container scanning feature flag is disabled."
+        ));
+        log_event_fail ("scanner", "Scanner", modify_scanner_data->scanner_id,
+                        "modified");
+        break;
+      case MODIFY_SCANNER_WEB_SCANNING_DISABLED:
+        SEND_TO_CLIENT_OR_FAIL
+        (XML_ERROR_SYNTAX ("modify_scanner",
+          "Web application scanner type is not supported "
+          "because the Web scanning feature flag is disabled."
         ));
         log_event_fail ("scanner", "Scanner", modify_scanner_data->scanner_id,
                         "modified");

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -3021,6 +3021,9 @@ gvmd (int argc, char** argv, char *env[])
 #if ENABLE_JWT_AUTH == 1
       printf ("JWT authentication is enabled\n");
 #endif
+#if ENABLE_WEB_APPLICATION_SCANNING == 1
+      printf ("Web application scanning is enabled\n");
+#endif
       printf ("Copyright (C) 2009-2026 Greenbone AG\n");
       printf ("License: AGPL-3.0-or-later\n");
       printf
@@ -3648,6 +3651,10 @@ gvmd (int argc, char** argv, char *env[])
 #if ENABLE_CONTAINER_SCANNING
           else if (!strcasecmp (scanner_type, "container-image"))
             type = SCANNER_TYPE_CONTAINER_IMAGE;
+#endif
+#if ENABLE_WEB_APPLICATION_SCANNING
+          else if (!strcasecmp (scanner_type, "web-application-scanner"))
+            type = SCANNER_TYPE_WEB_APPLICATION;
 #endif
           else
             {

--- a/src/manage.c
+++ b/src/manage.c
@@ -830,6 +830,13 @@ check_scanner_feature (scanner_type_t scanner_type)
       return SCANNER_FEATURE_OK;
     }
 
+  if (scanner_type == SCANNER_TYPE_WEB_APPLICATION)
+    {
+      if (!feature_enabled (FEATURE_ID_WEB_APPLICATION_SCANNING))
+        return SCANNER_FEATURE_WEB_APPLICATION_DISABLED;
+      return SCANNER_FEATURE_OK;
+    }
+
   return SCANNER_FEATURE_OK;
 }
 

--- a/src/manage.h
+++ b/src/manage.h
@@ -364,7 +364,8 @@ typedef enum scanner_type
   SCANNER_TYPE_OPENVASD_SENSOR = 8,
   SCANNER_TYPE_AGENT_CONTROLLER_SENSOR = 9,
   SCANNER_TYPE_CONTAINER_IMAGE = 10,
-  SCANNER_TYPE_MAX = 11,
+  SCANNER_TYPE_WEB_APPLICATION = 11,
+  SCANNER_TYPE_MAX = 12,
 } scanner_type_t;
 
 /**
@@ -378,7 +379,8 @@ typedef enum
  SCANNER_FEATURE_OK = 0,
  SCANNER_FEATURE_OPENVASD_DISABLED = 1,
  SCANNER_FEATURE_AGENTS_DISABLED = 2,
- SCANNER_FEATURE_CONTAINER_DISABLED = 3
+ SCANNER_FEATURE_CONTAINER_DISABLED = 3,
+ SCANNER_FEATURE_WEB_APPLICATION_DISABLED = 4
 } scanner_feature_status_t;
 
 int
@@ -2143,6 +2145,7 @@ typedef enum {
   CREATE_SCANNER_OPENVASD_DISABLED,           ///< openvasd feature is disabled
   CREATE_SCANNER_AGENT_DISABLED,              ///< Agent feature is disabled
   CREATE_SCANNER_CONTAINER_SCANNING_DISABLED, ///< Container scanning feature is disabled
+  CREATE_SCANNER_WEB_SCANNING_DISABLED,       ///< Web application scanning feature is disabled
   CREATE_SCANNER_PERMISSION_DENIED = 99       ///< Permission denied
 } create_scanner_return_t;
 
@@ -2171,6 +2174,7 @@ typedef enum {
   MODIFY_SCANNER_OPENVASD_DISABLED,           ///< openvasd feature is disabled
   MODIFY_SCANNER_AGENT_DISABLED,              ///< Agent feature is disabled
   MODIFY_SCANNER_CONTAINER_SCANNING_DISABLED, ///< Container scanning feature is disabled
+  MODIFY_SCANNER_WEB_SCANNING_DISABLED,       ///< Web application scanning feature is disabled
   MODIFY_SCANNER_PERMISSION_DENIED = 99       ///< Permission denied
 } modify_scanner_return_t;
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -3444,6 +3444,20 @@ check_db_scanners ()
     }
 #endif
 
+#if ENABLE_WEB_APPLICATION_SCANNING
+  if (sql_int ("SELECT count(*) FROM scanners WHERE uuid = '%s';",
+                SCANNER_UUID_WEB_APPLICATION_DEFAULT) == 0)
+    {
+      sql ("INSERT INTO scanners"
+        " (uuid, owner, name, host, port, type, ca_pub, credential,"
+        "  creation_time, modification_time)"
+        " VALUES ('" SCANNER_UUID_WEB_APPLICATION_DEFAULT "', NULL, "
+        " 'Web Application Default', 'localhost', 8030, %d, NULL, NULL,"
+        " m_now (), m_now ());",
+        SCANNER_TYPE_WEB_APPLICATION);
+    }
+#endif
+
   if (sql_int ("SELECT count(*) FROM scanners WHERE uuid = '%s';",
                SCANNER_UUID_CVE) == 0)
     sql ("INSERT INTO scanners"
@@ -22855,6 +22869,12 @@ create_scanner (const char* name, const char *comment, const char *host,
       sql_rollback ();
       return CREATE_SCANNER_CONTAINER_SCANNING_DISABLED;
     }
+    else if (feature_res == SCANNER_FEATURE_WEB_APPLICATION_DISABLED)
+    {
+      /* Web application scanning feature disabled */
+      sql_rollback ();
+      return CREATE_SCANNER_WEB_SCANNING_DISABLED;
+    }
   if (unix_socket)
     {
       ca_pub = NULL;
@@ -23093,6 +23113,12 @@ modify_scanner (const char *scanner_id, const char *name, const char *comment,
       /* Container scanning feature disabled */
       sql_rollback ();
       return MODIFY_SCANNER_CONTAINER_SCANNING_DISABLED;
+    }
+  else if (feature_res == SCANNER_FEATURE_WEB_APPLICATION_DISABLED)
+    {
+      /* Web application scanning feature disabled */
+      sql_rollback ();
+      return MODIFY_SCANNER_WEB_SCANNING_DISABLED;
     }
 
   if (port)
@@ -24306,6 +24332,17 @@ verify_scanner (const char *scanner_id, char **version)
       return 0;
     }
 #endif
+#if ENABLE_WEB_APPLICATION_SCANNING
+  else if (scanner_iterator_type (&scanner) == SCANNER_TYPE_WEB_APPLICATION)
+    {
+      // TODO: replace with actual version from the scanner
+      if (version)
+        *version = g_strdup ("TestVersion");
+
+      cleanup_iterator (&scanner);
+      return 0;
+    }
+#endif
   else if (scanner_iterator_type (&scanner) == SCANNER_TYPE_CVE)
     {
       if (version)
@@ -24378,6 +24415,9 @@ manage_get_scanners (GSList *log_config, const db_conn_info_t *database)
             break;
           case SCANNER_TYPE_CONTAINER_IMAGE:
             scanner_type_str = "container-image";
+            break;
+          case SCANNER_TYPE_WEB_APPLICATION:
+            scanner_type_str = "web-application-scanner";
             break;
           default:
             scanner_type_str = NULL;

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -80,7 +80,15 @@
  */
 #define SCANNER_UUID_OPENVASD_DEFAULT "8154d8e3-30ee-4959-9151-1863c89a8e62"
 
+/**
+ * @brief UUID of 'Container Image Default' scanner.
+ */
 #define SCANNER_UUID_CONTAINER_IMAGE_DEFAULT "1facb485-10e8-4520-9110-66f929d9ac2e"
+
+/**
+ * @brief UUID of 'Web Application Default' scanner.
+ */
+#define SCANNER_UUID_WEB_APPLICATION_DEFAULT "c0e29580-6183-43e5-a081-c781ac2b4623"
 
 /**
  * @brief UUID of 'CVE' scanner.


### PR DESCRIPTION
## What
Add a new scanner type for web application scanning.

A default web application scanner is created if the feature flag `ENABLE_WEB_APPLICATION_SCANNING` is enabled.

## Why
Required for the integration of web application scanner.

## References
GEA-1784


