### PR TITLE
Fix: use sql_string_ps in scan time functions

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -13087,11 +13087,11 @@ scan_start_time_epoch (report_t report)
 char*
 scan_start_time_uuid (const char *uuid)
 {
-  char *time, *quoted_uuid;
-  quoted_uuid = sql_quote (uuid);
-  time = sql_string ("SELECT iso_time (start_time)"
-                     " FROM reports WHERE uuid = '%s';",
-                     quoted_uuid);
+  char *time;
+  time = sql_string_ps ("SELECT iso_time (start_time)"
+                        " FROM reports WHERE uuid = $1;",
+                        SQL_STR_PARAM (uuid),
+                        NULL);
   return time ? time : g_strdup ("");
 }
 
@@ -13148,11 +13148,11 @@ scan_end_time (report_t report)
 char*
 scan_end_time_uuid (const char *uuid)
 {
-  char *time, *quoted_uuid;
-  quoted_uuid = sql_quote (uuid);
-  time = sql_string ("SELECT iso_time (end_time)"
-                     " FROM reports WHERE uuid = '%s';",
-                     quoted_uuid);
+  char *time;
+  time = sql_string_ps ("SELECT iso_time (end_time)"
+                        " FROM reports WHERE uuid = $1;",
+                        SQL_STR_PARAM (uuid),
+                        NULL);
   return time ? time : g_strdup ("");
 }
 


### PR DESCRIPTION
## What

Convert `scan_end_time_uuid` and `scan_start_time_uuid` to use `sql_string_ps`.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why

This closes the leaks of quoted_uuid.

<!-- Describe why are these changes necessary? -->

## Testing

I ran some GMP on main and saw Asan leak reports in the log.
I ran the same GMP with the PR and the leak reports were gone.