### PR TITLE
Fix: iteration in column_array_free

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -669,7 +669,7 @@ static void
 column_array_free (column_t *columns)
 {
   column_t *point = columns;
-  while (point->filter)
+  while (point->select)
     {
       g_free (point->select);
       g_free (point->filter);


### PR DESCRIPTION
## What

Use the right sentinel when iterating columns in `column_array_free`

## Why

If you look at column_array_copy it's `->select` that determines where the end of the array is. The `->filter` field is sometimes NULL before the end of the array.

This was causing leaks when freeing the column arrays.

## Testing

I ran GMP commands on main, and saw Asan leaks logged.
I ran the same commands with the patch and the leaks were gone.