### PR TITLE
Fix: close leaks in lsc_crypt.c

### DIFF
--- a/src/lsc_crypt.c
+++ b/src/lsc_crypt.c
@@ -215,6 +215,7 @@ create_the_key (lsc_crypt_ctx_t ctx)
 
   log_gpgme (G_LOG_LEVEL_INFO, 0, "starting key generation ...");
   err = gpgme_op_genkey (ctx->encctx, parms, NULL, NULL);
+  g_free (parms);
   if (err)
     {
       log_gpgme(G_LOG_LEVEL_WARNING, err, "error creating OpenPGP key '%s'",

--- a/src/lsc_crypt.c
+++ b/src/lsc_crypt.c
@@ -611,7 +611,12 @@ gboolean
 lsc_crypt_enckey_exists (lsc_crypt_ctx_t ctx)
 {
   gpgme_key_t key = find_the_key (ctx, TRUE);
-  return key != NULL;
+  if (key)
+    {
+      gpgme_key_unref (key);
+      return TRUE;
+    }
+  return FALSE;
 }
 
 /**

--- a/src/lsc_crypt.c
+++ b/src/lsc_crypt.c
@@ -567,6 +567,8 @@ lsc_crypt_release (lsc_crypt_ctx_t ctx)
   if (!ctx)
     return;
   lsc_crypt_flush (ctx);
+  if (ctx->enckey)
+    gpgme_key_unref (ctx->enckey);
   if (ctx->encctx) /* Check required for gpgme < 1.3.1 */
     gpgme_release (ctx->encctx);
   g_free (ctx->enckey_uid);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -2290,11 +2290,11 @@ current_encryption_key_uid (gboolean with_fallback)
   lsc_crypt_ctx_t ctx = lsc_crypt_new (OLD_ENCRYPTION_KEY_UID);
   if (lsc_crypt_enckey_exists (ctx))
     {
-      lsc_crypt_flush(ctx);
+      lsc_crypt_release (ctx);
       set_current_encryption_key_uid (OLD_ENCRYPTION_KEY_UID);
       return strdup (OLD_ENCRYPTION_KEY_UID);
     }
-  lsc_crypt_flush(ctx);
+  lsc_crypt_release (ctx);
 
   // Generate a new key UID
   time_t now = time(NULL);


### PR DESCRIPTION
## What

Close a few leaks lin `lsc_crypt.c`.

## Why

Cleaner.

## Testing

Each commit corresponds to a particular leak shown by Asan when running a test sequence of GMP commands.
I ran the test with main, and noted the Asan leak warnings in the logs.
Then I ran the test with the patches, and noted that the warnings were gone. 
