### PR TITLE
Fix: always free GError in check_db_report_formats_trash

### DIFF
--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -4988,6 +4988,7 @@ check_db_report_formats_trash ()
           g_free (dir);
           return -1;
         }
+      g_error_free (error);
     }
   else
     {


### PR DESCRIPTION
## What

Free GError in both error cases in `check_db_report_formats_trash`.

## Why

Was leaking the error.

## Testing

Ran a sequence of GMP commands on main, and noticed the `check_db_report_formats_trash` leak warning from Asan.
Ran same sequence with the patch, warning was gone.