### PR TITLE
Add missing _GNU_SOURCE definition

### DIFF
--- a/src/manage_sql_permissions.c
+++ b/src/manage_sql_permissions.c
@@ -2,6 +2,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+#define _GNU_SOURCE
 
 #include "manage_sql_permissions.h"
 #include "manage_sql_permissions_cache.h"


### PR DESCRIPTION
## What
Add _GNU_SOURCE definition

## Why
Resolve build warning for `strcasestr`