### PR TITLE
fix: ignore pagination when calculating report host counts

### DIFF
--- a/src/manage_report_hosts.c
+++ b/src/manage_report_hosts.c
@@ -88,10 +88,18 @@ manage_send_report_hosts (report_t report,
   ctx.report = report;
   ctx.tsk_usage_type = g_strdup (usage_type);
 
+  /* Copy the get with ignored pagination for result iterator*/
+  get_data_t get_ignore_pagination;
+
+  memcpy (&get_ignore_pagination, get, sizeof (get_ignore_pagination));
+  get_ignore_pagination.ignore_pagination = 1;
+  get_ignore_pagination.ignore_max_rows_per_page = 1;
+
   /* Derive filter controls, including whether only hosts with results
    * should be included.
    */
-  ret = manage_report_filter_controls_from_get (get,
+
+  ret = manage_report_filter_controls_from_get (&get_ignore_pagination,
                                                 &term,
                                                 NULL,
                                                 NULL,
@@ -126,10 +134,11 @@ manage_send_report_hosts (report_t report,
 
   xml_dir_created = TRUE;
 
-  if (get->details && result_hosts_only)
+  if (get_ignore_pagination.details)
     {
+      // this fills the severity counts in the context, which are needed for the report host summary
       ret = fill_filtered_result_hosts (&result_hosts,
-                                        get,
+                                        &get_ignore_pagination,
                                         report,
                                         &results,
                                         is_container_scanning_report,
@@ -156,7 +165,7 @@ manage_send_report_hosts (report_t report,
   ret = print_report_hosts_xml (&ctx,
                                 stream,
                                 report,
-                                get,
+                                &get_ignore_pagination,
                                 usage_type,
                                 lean,
                                 is_container_scanning_report,
@@ -164,7 +173,6 @@ manage_send_report_hosts (report_t report,
                                 result_hosts,
                                 NULL,
                                 TRUE);
-
 
   if (fclose (stream))
     {


### PR DESCRIPTION
## What

Calculate report host counts and severity without pagination.

## Why

Pagination caused incomplete host summary values.




