### PR TITLE
Fix: call identifier_free on snapshot arrays

### DIFF
--- a/src/manage_sql_assets.c
+++ b/src/manage_sql_assets.c
@@ -1056,6 +1056,27 @@ identifier_free (identifier_t *identifier)
 }
 
 /**
+ * @brief Free snapshot identifier arrays and reset them to NULL.
+ */
+static void
+clear_snapshot_identifiers ()
+{
+  if (snapshot_identifiers)
+    {
+      guint index = 0;
+      while (index < snapshot_identifiers->len)
+        identifier_free (g_ptr_array_index (snapshot_identifiers, index++));
+      array_free (snapshot_identifiers);
+      snapshot_identifiers = NULL;
+    }
+  if (snapshot_identifier_hosts)
+    {
+      array_free (snapshot_identifier_hosts);
+      snapshot_identifier_hosts = NULL;
+    }
+}
+
+/**
  * @brief Check whether an interface name should be ignored for asset matching.
  *
  * @param[in] iface  Interface name, for example "docker0" or "eth0".
@@ -1861,21 +1882,8 @@ asset_snapshots_insert_target (report_t report, task_t task, scanner_t scanner)
   g_hash_table_destroy (seen);
 
 cleanup:
-  /* Consume snapshot arrays: free then NULL. */
-  if (snapshot_identifiers)
-    {
-      guint index = 0;
-      while (index < snapshot_identifiers->len)
-        identifier_free (g_ptr_array_index (snapshot_identifiers, index++));
-      array_free (snapshot_identifiers);
-      snapshot_identifiers = NULL;
-    }
-
-  if (snapshot_identifier_hosts)
-    {
-      array_free (snapshot_identifier_hosts);
-      snapshot_identifier_hosts = NULL;
-    }
+  /* Consume snapshot arrays. */
+  clear_snapshot_identifiers ();
 }
 
 /**
@@ -1893,19 +1901,7 @@ asset_snapshots_target (report_t report, task_t task, gboolean discovery)
       g_debug ("%s: Discovery scan assets will not stored for counting",
                __func__);
       /* Free snapshot arrays. */
-      if (snapshot_identifiers)
-        {
-          guint index = 0;
-          while (index < snapshot_identifiers->len)
-            identifier_free (g_ptr_array_index (snapshot_identifiers, index++));
-          array_free (snapshot_identifiers);
-          snapshot_identifiers = NULL;
-        }
-      if (snapshot_identifier_hosts)
-        {
-          array_free (snapshot_identifier_hosts);
-          snapshot_identifier_hosts = NULL;
-        }
+      clear_snapshot_identifiers ();
       return;
     }
 

--- a/src/manage_sql_assets.c
+++ b/src/manage_sql_assets.c
@@ -1861,16 +1861,19 @@ asset_snapshots_insert_target (report_t report, task_t task, scanner_t scanner)
   g_hash_table_destroy (seen);
 
 cleanup:
-  /* Consume snapshot arrays: terminate then free. */
+  /* Consume snapshot arrays: free then NULL. */
   if (snapshot_identifiers)
     {
-      array_terminate (snapshot_identifiers);
+      guint index = 0;
+      while (index < snapshot_identifiers->len)
+        identifier_free (g_ptr_array_index (snapshot_identifiers, index++));
+      array_free (snapshot_identifiers);
       snapshot_identifiers = NULL;
     }
 
   if (snapshot_identifier_hosts)
     {
-      array_terminate (snapshot_identifier_hosts);
+      array_free (snapshot_identifier_hosts);
       snapshot_identifier_hosts = NULL;
     }
 }
@@ -1889,15 +1892,18 @@ asset_snapshots_target (report_t report, task_t task, gboolean discovery)
     {
       g_debug ("%s: Discovery scan assets will not stored for counting",
                __func__);
-      /* Terminate and free snapshot arrays. */
+      /* Free snapshot arrays. */
       if (snapshot_identifiers)
         {
-          array_terminate (snapshot_identifiers);
+          guint index = 0;
+          while (index < snapshot_identifiers->len)
+            identifier_free (g_ptr_array_index (snapshot_identifiers, index++));
+          array_free (snapshot_identifiers);
           snapshot_identifiers = NULL;
         }
       if (snapshot_identifier_hosts)
         {
-          array_terminate (snapshot_identifier_hosts);
+          array_free (snapshot_identifier_hosts);
           snapshot_identifier_hosts = NULL;
         }
       return;


### PR DESCRIPTION
## What

Clean up identifiers when clearing the snapshot arrays in `manage_sql_assets.c`.

## Why

The fields in the identifiers were leaking.

## Testing

I ran a GMP sequence on main and saw Asan leak warnings in the logs.
I ran the same sequence with the PR and the warnings were gone.


