### PR TITLE
Fix: free report_id in add_assets_from_host_in_report

### DIFF
--- a/src/manage_sql_assets.c
+++ b/src/manage_sql_assets.c
@@ -3986,5 +3986,6 @@ add_assets_from_host_in_report (report_t report, const char *host_ip)
       return ret;
     }
 
+  free (report_id);
   return 0;
 }


### PR DESCRIPTION
## What

Free `report_id` in success case in `add_assets_from_host_in_report`.

## Why

The report ID was leaking.

## Testing

I ran GMP commands on main that showed the leak in the Asan output.
I ran the same commands with the patch and confirmed the leak warning was gone.

