### PR TITLE
Fix: free removed result buffer in print_report_port_xml

### DIFF
--- a/src/manage_sql_report_ports.c
+++ b/src/manage_sql_report_ports.c
@@ -314,6 +314,7 @@ print_report_port_xml (print_report_context_t *ctx, report_t report, FILE *out,
                   last_item->severity_double = item->severity_double;
                 }
               g_array_remove_index (ports, index);
+              result_buffer_free (item);
               length = ports->len;
               index--;
             }


### PR DESCRIPTION
## What

Free the result buffer when it is removed (due to duplicates) in `print_report_port_xml`.

## Why

The removed result buffer was leaking.

## Testing

I noticed an Asan warning for this when running GMP commands on main.
I ran the same commands with the patch and the warning was gone.