### PR TITLE
add: pass origin URL for agent installer instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,7 +14,7 @@ Prerequisites:
 * glib-2.0 >= 2.42
 * gnutls >= 3.2.15
 * gpgme
-* [gvm-libs](https://github.com/greenbone/gvm-libs/) >= 23.0 (or 23.5 if ENABLE_AGENTS and 23.3 if ENABLE_OPENVASD and 23.4 if ENABLE_WEB_APPLICATION_SCANNING)
+* [gvm-libs](https://github.com/greenbone/gvm-libs/) >= 23.0 (or 23.6 if ENABLE_AGENTS and 23.3 if ENABLE_OPENVASD and 23.4 if ENABLE_WEB_APPLICATION_SCANNING)
 * libical >= 1.0.0
 * libbsd
 * pkg-config

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,7 +32,7 @@ if(ENABLE_AGENTS)
   pkg_check_modules(
     LIBGVM_AGENT_CONTROLLER
     REQUIRED
-    libgvm_agent_controller>=23.5
+    libgvm_agent_controller>=23.6
   )
 else(ENABLE_AGENTS)
   message(STATUS "ENABLE_AGENTS flag is not enabled")

--- a/src/gmp_agent_installer_instructions.c
+++ b/src/gmp_agent_installer_instructions.c
@@ -29,6 +29,7 @@ typedef struct
 {
   gchar *scanner_id;  ///< UUID of the scanner.
   gchar *language;    ///< Requested instruction language, e.g. "en" or "de".
+  gchar *origin_url;  ///< Origin URL used in the generated command.
 } get_agent_installer_instruction_t;
 
 /**
@@ -46,6 +47,7 @@ get_agent_installer_instruction_reset ()
 {
   g_free (get_agent_installer_instruction_data.scanner_id);
   g_free (get_agent_installer_instruction_data.language);
+  g_free (get_agent_installer_instruction_data.origin_url);
 
   memset (&get_agent_installer_instruction_data,
           0,
@@ -55,7 +57,7 @@ get_agent_installer_instruction_reset ()
 /**
  * @brief Check whether an instruction language is supported.
  *
- * @param[in] language  Language string.
+ * @param[in] language Language string.
  *
  * @return TRUE if supported, FALSE otherwise.
  */
@@ -69,8 +71,8 @@ instruction_language_is_supported (const gchar *language)
 /**
  * @brief Handle command start element.
  *
- * @param[in] attribute_names   All attribute names.
- * @param[in] attribute_values  All attribute values.
+ * @param[in] attribute_names  All attribute names.
+ * @param[in] attribute_values All attribute values.
  */
 void
 get_agent_installer_instruction_start (const gchar **attribute_names,
@@ -89,13 +91,19 @@ get_agent_installer_instruction_start (const gchar **attribute_names,
     get_agent_installer_instruction_data.language = g_strdup (attribute);
   else
     get_agent_installer_instruction_data.language = NULL;
+
+  if (find_attribute (attribute_names, attribute_values,
+                      "origin_url", &attribute))
+    get_agent_installer_instruction_data.origin_url = g_strdup (attribute);
+  else
+    get_agent_installer_instruction_data.origin_url = NULL;
 }
 
 /**
  * @brief Handle end element.
  *
- * @param[in] gmp_parser  GMP parser.
- * @param[in] error       Error parameter.
+ * @param[in] gmp_parser GMP parser.
+ * @param[in] error      Error parameter.
  */
 void
 get_agent_installer_instruction_run (gmp_parser_t *gmp_parser, GError **error)
@@ -130,6 +138,16 @@ get_agent_installer_instruction_run (gmp_parser_t *gmp_parser, GError **error)
       return;
     }
 
+  if (get_agent_installer_instruction_data.origin_url == NULL
+      || *get_agent_installer_instruction_data.origin_url == '\0')
+    {
+      SEND_TO_CLIENT_OR_FAIL
+        (XML_ERROR_SYNTAX ("get_agent_installer_instruction",
+                           "Required origin_url is missing"));
+      get_agent_installer_instruction_reset ();
+      return;
+    }
+
   if (!instruction_language_is_supported
         (get_agent_installer_instruction_data.language))
     {
@@ -141,12 +159,18 @@ get_agent_installer_instruction_run (gmp_parser_t *gmp_parser, GError **error)
       return;
     }
 
-  lang_type = lang_type_from_string
-                (get_agent_installer_instruction_data.language);
+  lang_type =
+    lang_type_from_string (get_agent_installer_instruction_data.language);
 
-  instruction = get_agent_installer_instruction
-                  (get_agent_installer_instruction_data.scanner_id,
-                   lang_type);
+  /*
+   * The origin URL is used by the Agent Controller to generate an executable
+   * installation command that connects the agent to the correct gvmd endpoint.
+   */
+  instruction =
+    get_agent_installer_instruction (
+      get_agent_installer_instruction_data.scanner_id,
+      lang_type,
+      get_agent_installer_instruction_data.origin_url);
 
   if (instruction == NULL)
     {
@@ -166,8 +190,7 @@ get_agent_installer_instruction_run (gmp_parser_t *gmp_parser, GError **error)
      get_agent_installer_instruction_data.language,
      instruction->instruction ? instruction->instruction : "");
 
-  g_free (instruction->instruction);
-  g_free (instruction);
+  agent_controller_installer_instruction_free (instruction);
 
   get_agent_installer_instruction_reset ();
 }

--- a/src/manage_agent_installer_instructions.c
+++ b/src/manage_agent_installer_instructions.c
@@ -54,13 +54,15 @@ lang_type_from_string (const char *lang_str)
  *
  * @param[in] scanner_uuid  UUID of the scanner to get instructions for.
  * @param[in] lang         Language for the instructions.
+ * @param[in] origin_url   Origin URL to include in the instructions.
  *
  * @return Allocated agent_controller_installer_instruction_t on success,
  *         NULL on failure (e.g., invalid scanner UUID, connection issues).
  */
 agent_controller_installer_instruction_t
 get_agent_installer_instruction (const gchar *scanner_uuid,
-                                 instructions_lang_type_t lang)
+                                 instructions_lang_type_t lang,
+                                 const gchar *origin_url)
 {
   scanner_t scanner;
   if (!scanner_uuid)
@@ -90,7 +92,7 @@ get_agent_installer_instruction (const gchar *scanner_uuid,
     }
 
   agent_controller_installer_instruction_t instr =
-    agent_controller_get_installer_instruction (conn->base, lang);
+    agent_controller_get_installer_instruction (conn->base, lang, origin_url);
 
   gvmd_agent_connector_free (conn);
 

--- a/src/manage_agent_installer_instructions.h
+++ b/src/manage_agent_installer_instructions.h
@@ -22,7 +22,8 @@ lang_type_from_string (const char *);
 
 agent_controller_installer_instruction_t
 get_agent_installer_instruction (const gchar *,
-                                 instructions_lang_type_t);
+                                 instructions_lang_type_t,
+                                 const gchar *);
 
 #endif /* not _GVMD_MANAGE_AGENT_INSTALLER_INSTRUCTIONS_H */
 

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -8993,6 +8993,14 @@ END:VCALENDAR
         <type>text</type>
         <required>1</required>
       </attrib>
+      <attrib>
+        <name>origin_url</name>
+        <summary>
+          Origin URL used to generate the executable agent installation command
+        </summary>
+        <type>text</type>
+        <required>1</required>
+      </attrib>
     </pattern>
     <response>
       <pattern>
@@ -9023,7 +9031,10 @@ END:VCALENDAR
     <example>
       <summary>Get an agent installer instruction</summary>
       <request>
-        <get_agent_installer_instruction scanner_id="xy" language="en"/>
+        <get_agent_installer_instruction
+          scanner_id="xy"
+          language="en"
+          origin_url="https://example.com"/>
       </request>
       <response>
         <get_agent_installer_instruction_response status="200" status_text="OK">


### PR DESCRIPTION
## What

Add the required `origin_url` attribute to the agent installer instruction GMP command and pass it to the Agent Controller.

Update the GMP documentation and example request.

## Why

The origin URL is needed to generate an executable agent installation command with the correct gvmd address.


## References

GEA-1848


