### PR TITLE
Fix: free xml_start and xml_file in manage_send_report

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -17298,6 +17298,9 @@ manage_send_report (report_t report, report_t delta_report,
       output_file = g_strdup(xml_file);
     }
 
+  g_free (xml_start);
+  g_free (xml_file);
+
   if (output_file == NULL)
     {
       g_warning ("%s: No file returned for report format", __func__);


### PR DESCRIPTION
## What

Free `xml_start` and `xml_file` in manage_send_report

## Why

Was leaking.

## Testing

I ran a sequence of GMP commands on main, and noticed the leaks in the Asan logs.
I ran the sequence again with the patch and the logs were gone.
