### PR TITLE
Fix: free uuid and name in get_task_schedule_xml

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -19760,6 +19760,9 @@ get_task_schedule_xml (task_t task)
                      "</schedule_periods>",
                      task_schedule_periods (task));
 
+  g_free (task_schedule_uuid);
+  g_free (task_schedule_name);
+
   return g_string_free (xml, FALSE);
 }
 


### PR DESCRIPTION
## What

Free uuid and name in `get_task_schedule_xml`.

## Why

They were leaking.

## Testing

I ran GMP commands on main that show the leaks in the Asan log output.
I rand the same commands with the patch and the logs were gone.