### PR TITLE
Fix: free tz in mktime_with_tz

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -226,6 +226,7 @@ mktime_with_tz (struct tm *tm, const char *new_tz)
   else
     unsetenv ("TZ");
 
+  g_free (tz);
   return epoch_time;
 }
 


### PR DESCRIPTION
## What

Free tz in `mktime_with_tz`.

## Why

Was leaking.

## Testing

I ran GMP commands on main, and saw Asan leak warnings.
I ran the same commands with the patch, and the warnings were gone.