### PR TITLE
Fix: always cleanup db copy buffer in create_report

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -9495,7 +9495,7 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
       g_debug ("%s: add results: index: %i", __func__, index);
 
       if (sql_int64 (&result_rowid,
-        "SELECT nextval('results_id_seq');"))
+                     "SELECT nextval('results_id_seq');"))
         {
           g_warning ("%s: failed to get result row ID", __func__);
           db_copy_buffer_cleanup (&copy_buffer);
@@ -9605,10 +9605,10 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
   if (count > 0)
     {
       if (db_copy_buffer_commit (&copy_buffer, TRUE))
-      {
-        db_copy_buffer_cleanup (&copy_buffer);
-        return -1;
-      }
+        {
+          db_copy_buffer_cleanup (&copy_buffer);
+          return -1;
+        }
       report_cache_counts (report, 1, 1, NULL);
       sql_commit ();
       gvm_usleep (CREATE_REPORT_CHUNK_SLEEP);
@@ -9691,18 +9691,17 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
        * COALESCE ensures that the query always returns one row.
        * A value of 0 means that the report host does not exist yet.
        */
-      if (sql_int64_ps (
-        &report_host,
-        "SELECT coalesce ("
-        "  (SELECT id"
-        "   FROM report_hosts"
-        "   WHERE report = $1"
-        "     AND host = $2"
-        "   LIMIT 1),"
-        "  0);",
-        SQL_RESOURCE_PARAM (report),
-        SQL_STR_PARAM (detail->ip),
-        NULL))
+      if (sql_int64_ps (&report_host,
+                        "SELECT coalesce ("
+                        "  (SELECT id"
+                        "   FROM report_hosts"
+                        "   WHERE report = $1"
+                        "     AND host = $2"
+                        "   LIMIT 1),"
+                        "  0);",
+                        SQL_RESOURCE_PARAM (report),
+                        SQL_STR_PARAM (detail->ip),
+                        NULL))
         {
           g_warning ("%s: Failed to look up report host '%s'"
                      " in report %llu",
@@ -9726,18 +9725,17 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
           /*
            * Look up the ID of the newly created report host.
            */
-          if (sql_int64_ps (
-            &report_host,
-            "SELECT coalesce ("
-            "  (SELECT id"
-            "   FROM report_hosts"
-            "   WHERE report = $1"
-            "     AND host = $2"
-            "   LIMIT 1),"
-            "  0);",
-            SQL_RESOURCE_PARAM (report),
-            SQL_STR_PARAM (detail->ip),
-            NULL))
+          if (sql_int64_ps (&report_host,
+                            "SELECT coalesce ("
+                            "  (SELECT id"
+                            "   FROM report_hosts"
+                            "   WHERE report = $1"
+                            "     AND host = $2"
+                            "   LIMIT 1),"
+                            "  0);",
+                            SQL_RESOURCE_PARAM (report),
+                            SQL_STR_PARAM (detail->ip),
+                            NULL))
             {
               g_warning ("%s: Failed to look up newly created report host '%s'"
                          " in report %llu",

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -9494,6 +9494,22 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
       gchar *quoted_qod, *quoted_qod_type;
       g_debug ("%s: add results: index: %i", __func__, index);
 
+      if (sql_int64 (&result_rowid,
+        "SELECT nextval('results_id_seq');"))
+        {
+          g_warning ("%s: failed to get result row ID", __func__);
+          db_copy_buffer_cleanup (&copy_buffer);
+          return -1;
+        }
+
+      char* uuid = gvm_uuid_make ();
+      if (uuid == NULL)
+        {
+          g_warning ("%s: failed to generate result UUID", __func__);
+          db_copy_buffer_cleanup (&copy_buffer);
+          return -2;
+        }
+
       quoted_host = sql_copy_escape (result->host ? result->host : "");
       quoted_hostname = sql_copy_escape (result->hostname ? result->hostname : "");
       quoted_port = sql_copy_escape (result->port ? result->port : "");
@@ -9512,19 +9528,6 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
       quoted_qod_type = sql_copy_escape (result->qod_type ? result->qod_type : "");
       result_nvt_notice (quoted_nvt_oid);
 
-      if (sql_int64 (&result_rowid,
-        "SELECT nextval('results_id_seq');"))
-        {
-          g_warning ("%s: failed to get result row ID", __func__);
-          return -1;
-        }
-
-      char* uuid = gvm_uuid_make ();
-      if (uuid == NULL)
-        {
-          g_warning ("%s: failed to generate result UUID", __func__);
-          return -2;
-        }
       time_t date = time (NULL);
 
       resource_t result_nvt;

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -9456,6 +9456,14 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
 
   /* Add the results. */
 
+  if (sql_int64 (&owner,
+                 "SELECT owner FROM tasks WHERE tasks.id = %llu",
+                 task))
+    {
+      g_warning ("%s: failed to get owner of task", __func__);
+      return -1;
+    }
+
   db_copy_buffer_init (&copy_buffer,
                        BUFFER_SIZE,
                        "COPY results"
@@ -9464,14 +9472,6 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
                        "  nvt_version, severity, qod, qod_type,"
                        "  result_nvt, report)"
                        " FROM STDIN;");
-
-  if (sql_int64 (&owner,
-                 "SELECT owner FROM tasks WHERE tasks.id = %llu",
-                 task))
-    {
-      g_warning ("%s: failed to get owner of task", __func__);
-      return -1;
-    }
 
   sql_begin_immediate ();
   g_debug ("%s: add hosts", __func__);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -9510,10 +9510,24 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
           return -2;
         }
 
+      quoted_nvt_oid = sql_copy_escape (result->nvt_oid ? result->nvt_oid : "");
+      result_nvt_notice (quoted_nvt_oid);
+
+      resource_t result_nvt;
+      if (sql_int64 (&result_nvt,
+                     "SELECT id FROM result_nvts WHERE nvt = '%s';",
+                     quoted_nvt_oid))
+        {
+          g_warning ("%s: failed to get result_nvt ID", __func__);
+          g_free (quoted_nvt_oid);
+          g_free (uuid);
+          db_copy_buffer_cleanup (&copy_buffer);
+          return -1;
+        }
+
       quoted_host = sql_copy_escape (result->host ? result->host : "");
       quoted_hostname = sql_copy_escape (result->hostname ? result->hostname : "");
       quoted_port = sql_copy_escape (result->port ? result->port : "");
-      quoted_nvt_oid = sql_copy_escape (result->nvt_oid ? result->nvt_oid : "");
       quoted_description = sql_copy_escape (result->description
                                        ? result->description
                                        : "");
@@ -9526,19 +9540,8 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
       else
         quoted_qod = g_strdup (G_STRINGIFY (QOD_DEFAULT));
       quoted_qod_type = sql_copy_escape (result->qod_type ? result->qod_type : "");
-      result_nvt_notice (quoted_nvt_oid);
 
       time_t date = time (NULL);
-
-      resource_t result_nvt;
-
-      if (sql_int64 (&result_nvt,
-                     "SELECT id FROM result_nvts WHERE nvt = '%s';",
-                     quoted_nvt_oid))
-        {
-          g_warning ("%s: failed to get result_nvt ID", __func__);
-          return -1;
-        }
 
       int ret = db_copy_buffer_append_printf
                   (&copy_buffer,

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -9614,6 +9614,8 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
       gvm_usleep (CREATE_REPORT_CHUNK_SLEEP);
       sql_begin_immediate ();
     }
+  else
+    db_copy_buffer_cleanup (&copy_buffer);
 
   sql ("INSERT INTO result_nvt_reports (result_nvt, report)"
        " SELECT distinct result_nvt, %llu FROM results"


### PR DESCRIPTION
## What

Always call `db_copy_buffer_cleanup` in create_report.

## Why

The copy buffer was sometimes leaking.

## Testing

For 6dc4f87, I ran GMP commands on main and saw Asan leak logs.
Then I ran the same commands with the PR and the logs were gone.

The others are all internal/OOM errors, so are hard to test in a reproducible way.
