### PR TITLE
fix: check integration_configs table before migration cleanup

### DIFF
--- a/src/manage_migrators.c
+++ b/src/manage_migrators.c
@@ -4120,8 +4120,6 @@ migrate_277_to_278 ()
 /**
  * @brief Migrate the database from version 278 to version 279.
  *
- * Remove integration configurations whose owner no longer exists.
- *
  * @return 0 success, -1 error.
  */
 int
@@ -4137,16 +4135,23 @@ migrate_278_to_279 ()
       return -1;
     }
 
-  /*
-   * Remove orphaned integration configurations left behind by previously
-   * deleted users.
-   */
-  sql ("DELETE FROM integration_configs"
-       " WHERE owner IS NOT NULL"
-       " AND NOT EXISTS"
-       "   (SELECT 1"
-       "    FROM users"
-       "    WHERE users.id = integration_configs.owner);");
+  const char *schema = sql_schema ();
+  int integration_configs_exists =
+    (sql_table_exists (schema, "integration_configs") == 1);
+
+  if (integration_configs_exists)
+    {
+      /*
+       * Remove orphaned integration configurations left behind by previously
+       * deleted users.
+       */
+      sql ("DELETE FROM integration_configs"
+           " WHERE owner IS NOT NULL"
+           " AND NOT EXISTS"
+           "   (SELECT 1"
+           "    FROM users"
+           "    WHERE users.id = integration_configs.owner);");
+    }
 
   /* Set the database version to 279. */
 


### PR DESCRIPTION
## What

Check whether the `integration_configs` table exists before deleting orphaned integration configurations in the database migration from version 278 to 279.

## Why

The table may not exist in some database setups. Without this check, the migration fails when it tries to execute the `DELETE` statement.


## References

GEA-1859



