### PR TITLE
Fix: free detect_oid in buffer_results_xml

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -10390,6 +10390,7 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
                                 "</result>"
                                 "</detection>");
     }
+  g_free (detect_oid);
   g_free (detect_ref);
   g_free (detect_cpe);
   g_free (detect_loc);


### PR DESCRIPTION
## What

Free `detect_oid` in `buffer_results_xml`

## Why

It was leaking.

## Testing

I ran GMP commands on main and noticed Asan warnings for this leak in the log.
I ran the same commands with the patch and the logs were gone.

