### PR TITLE
Fix: always free reports_extra_where return

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -10582,6 +10582,7 @@ report_count (const get_data_t *get)
                 TRUE);
 
   g_free (extra_tables);
+  g_free (extra_where);
   return ret;
 }
 
@@ -10645,6 +10646,7 @@ init_report_iterator (iterator_t* iterator, const get_data_t *get)
                             FALSE,
                             NULL);
   g_free (extra_tables);
+  g_free (extra_where);
   return ret;
 }
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -10572,7 +10572,7 @@ report_count (const get_data_t *get)
   extra_tables = report_iterator_opts_table (0, MIN_QOD_DEFAULT);
 
   const gchar *usage_type = get_data_get_extra (get, "usage_type");
-  extra_where = reports_extra_where(get->trash, get->filter, usage_type);
+  extra_where = reports_extra_where (get->trash, get->filter, usage_type);
 
   ret = count2 ("report", get, columns, NULL, where_columns, NULL,
                 filter_columns, 0,


### PR DESCRIPTION
## What

Free `reports_extra_where` return in `report_count` and `init_report_iterator`.

## Why

Returns were leaking.

## Testing

I ran GMP commands with main and saw Asan warnings for these leaks.
I ran the same commands again with the patch and the warnings were gone.

