### PR TITLE
Fix: check clean_array length before accessing first element

### DIFF
--- a/src/manage_utils.c
+++ b/src/manage_utils.c
@@ -1365,6 +1365,13 @@ clean_hosts (const char *given_hosts, int *max)
       point += 1;
     }
 
+  if (clean_array->len == 0)
+    {
+      g_strfreev (split);
+      g_ptr_array_free (clean_array, TRUE);
+      return g_strdup ("");
+    }
+
   clean = g_string_new ("");
 
   host = (gchar*) g_ptr_array_index (clean_array, 0);


### PR DESCRIPTION
## What

In `clean_hosts`, check the length of `clean_array` before trying to access index 0.

## Why

The array can be empty when given hosts like `,` which will cause gvmd to segfault.

## Testing

I ran GMP commands on main that show the segfault under Asan, in particular:
```xml
<create_target><name>crash-null-deref</name><hosts>,</hosts><port_range>1-1000</port_range></create_target>
```
Then I ran the same commands with the patch and the segfault was gone.
