### PR TITLE
Fix: free quoted_name in create_port_list_unique

### DIFF
--- a/src/manage_sql_port_lists.c
+++ b/src/manage_sql_port_lists.c
@@ -1123,6 +1123,7 @@ create_port_list_unique (const char *name, const char *comment,
   ret = create_port_list_lock (NULL, quoted_name, comment, ranges, 0,
                                port_list);
 
+  g_free (quoted_name);
   array_free (ranges);
 
   return ret;


### PR DESCRIPTION
## What

Free `quoted_name` in `create_port_list_unique`.

## Why

Was leaking.

## Testing

I ran GMP commands on main that showed the leak with Asan.
I ran the same commands with the patch and the leak warning was gone.