### PR TITLE
Fix: always free versions in manage_update_nvt_cache_osp

### DIFF
--- a/src/manage_sql_nvts_osp.c
+++ b/src/manage_sql_nvts_osp.c
@@ -927,6 +927,8 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
 
   /* Try update VTs. */
 
+  db_feed_version = NULL;
+  scanner_feed_version = NULL;
   ret = nvts_feed_version_status_internal_osp (update_socket,
                                                &db_feed_version,
                                                &scanner_feed_version);
@@ -939,10 +941,9 @@ manage_update_nvt_cache_osp (const gchar *update_socket)
 
       ret = update_nvt_cache_osp (update_socket, db_feed_version,
                                   scanner_feed_version, 0);
-      g_free (db_feed_version);
-      g_free (scanner_feed_version);
-      return ret;
     }
 
+  g_free (db_feed_version);
+  g_free (scanner_feed_version);
   return ret;
 }


### PR DESCRIPTION
## What

Free version vars in `manage_update_nvt_cache_osp`.

## Why

They were leaking.

## Testing

I ran GMP commands on main that showed the leaks in the Asan logs.
I ran same commands with patch, logs gone.
