### PR TITLE
Fix: use sql_ps in auth_cache_insert

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -5135,12 +5135,15 @@ auth_cache_find (const char *username, const char *password, int method)
 static void
 auth_cache_insert (const char *username, const char *password, int method)
 {
-  char *hash, *quoted_username;
+  char *hash;
 
-  quoted_username = sql_quote (username);
   hash = manage_authentication_hash (password);
-  sql ("INSERT INTO auth_cache (username, hash, method, creation_time)"
-       " VALUES ('%s', '%s', %i, m_now ());", quoted_username, hash, method);
+  sql_ps ("INSERT INTO auth_cache (username, hash, method, creation_time)"
+          " VALUES ($1, $2, $3, m_now ());",
+          SQL_STR_PARAM (username),
+          SQL_STR_PARAM (hash),
+          SQL_INT_PARAM (method),
+          NULL);
   /* Cleanup cache */
   sql ("DELETE FROM auth_cache WHERE creation_time < m_now () - %d",
        get_auth_timeout()*60);


### PR DESCRIPTION
## What

Use `sql_ps` in `auth_cache_insert`.

## Why

Closes leak of `quoted_username`.

## Testing

On main with Asan I ran GMP commands that showed the leak warnings.
Then with the patch I ran the same commands and the warnings were gone.