### PR TITLE
Fix: also unlock lockfile in parent in manage_process_report_imports

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -3990,6 +3990,7 @@ manage_process_report_imports ()
           default:
             /* Parent. */
             g_debug ("%s: %i forked %i", __func__, getpid (), pid);
+            lockfile_unlock (&lockfile);
             g_free (lockfile_path);
             continue;
           }


### PR DESCRIPTION

## What

Also unlock `lockfile` in the parent case in manage_process_report_imports.

## Why

This closes the fd and frees the lockfile name (which was leaking).

## Testing

I ran GMP commands on main that showed the leak in the Asan logs.
I ran the same GMP with the patch and the leak warnings were gone.

