### PR TITLE
Fix: free name in else case of add_user_scan_preferences

### DIFF
--- a/src/manage_openvas.c
+++ b/src/manage_openvas.c
@@ -60,7 +60,10 @@ add_user_scan_preferences (GHashTable *scanner_options)
                           name,
                           hosts ? hosts : g_strdup (""));
   else
-    g_free (hosts);
+    {
+      g_free (name);
+      g_free (hosts);
+    }
 }
 
 #if ENABLE_CREDENTIAL_STORES


### PR DESCRIPTION
## What

Free `name` in else case of `add_user_scan_preferences`.

## Why

Was leaking.

## Testing

I ran GMP commands on main and saw the leak in the Asan logs.
I ran the same commands with the patch and the logs were gone.