### PR TITLE
Fix/require gvm auth lib 0.2

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,6 +15,7 @@ Prerequisites:
 * gnutls >= 3.2.15
 * gpgme
 * [gvm-libs](https://github.com/greenbone/gvm-libs/) >= 23.0 (or 23.6 if ENABLE_AGENTS and 23.3 if ENABLE_OPENVASD and 23.4 if ENABLE_WEB_APPLICATION_SCANNING and 23.7 if ENABLE_SECURITY_INTELLIGENCE_EXPORT)
+* [gvm-auth-lib](https://github.com/greenbone/gvm-auth-lib/) >= 0.2 (if ENABLE_SECURITY_INTELLIGENCE_EXPORT or ENABLE_JWT_AUTH is enabled)
 * libical >= 1.0.0
 * libbsd
 * pkg-config

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,13 +53,13 @@ else(ENABLE_CONTAINER_SCANNING)
 endif(ENABLE_CONTAINER_SCANNING)
 
 if(ENABLE_JWT_AUTH)
-  pkg_check_modules(LIBGVM_AUTH REQUIRED libgvm_auth>=0.1.3)
+  pkg_check_modules(LIBGVM_AUTH REQUIRED libgvm_auth>=0.2)
 else(ENABLE_JWT_AUTH)
   message(STATUS "ENABLE_JWT_AUTH flag is not enabled")
 endif(ENABLE_JWT_AUTH)
 
 if(ENABLE_SECURITY_INTELLIGENCE_EXPORT)
-  pkg_check_modules(LIBGVM_AUTH REQUIRED libgvm_auth>=0.1.3)
+  pkg_check_modules(LIBGVM_AUTH REQUIRED libgvm_auth>=0.2)
   pkg_check_modules(LIBGVM_HTTP REQUIRED libgvm_http>=22.37)
   pkg_check_modules(
     LIBGVM_SECURITY_INTELLIGENCE


### PR DESCRIPTION
## What

- Require `gvm-auth-lib >= 0.2` instead of a specific patch version.
- Add `gvm-auth-lib` to `INSTALL.md` as a conditional prerequisite for `ENABLE_SECURITY_INTELLIGENCE_EXPORT` and `ENABLE_JWT_AUTH`.

## Why

The `0.2` release series contains the required SONAME change. A specific patch version is not necessary, and the installation documentation should clearly mention when `gvm-auth-lib` is required.


## References

GEA-1901

