### PR TITLE
Fix:  Remove g_strdup from array_add_new_string calls

### DIFF
--- a/src/manage_sql_assets.c
+++ b/src/manage_sql_assets.c
@@ -943,7 +943,7 @@ create_asset_report (const char *report_id, const char *term)
                = g_strdup (report_host_details_iterator_source_name (&details));
 
               array_add (identifiers, identifier);
-              array_add_new_string (identifier_hosts, g_strdup (host));
+              array_add_new_string (identifier_hosts, host);
             }
         }
       cleanup_iterator (&details);

--- a/src/manage_sql_assets.c
+++ b/src/manage_sql_assets.c
@@ -528,7 +528,7 @@ add_host_identifier_to_arrays (array_t **ids, array_t **hosts,
   identifier->source_data = g_strdup (source_data);
 
   array_add (*ids, identifier);
-  array_add_new_string (*hosts, g_strdup (ip));
+  array_add_new_string (*hosts, ip);
 }
 
 /**

--- a/src/manage_sql_assets.c
+++ b/src/manage_sql_assets.c
@@ -662,7 +662,7 @@ manage_report_host_details (report_t report, const char *ip,
                   identifier->source_data
                     = g_strdup (entity_text (source_name));
                   array_add (identifiers, identifier);
-                  array_add_new_string (identifier_hosts, g_strdup (ip));
+                  array_add_new_string (identifier_hosts, ip);
                 }
               if (strcmp (entity_text (name), "MAC") == 0)
                 {
@@ -677,7 +677,7 @@ manage_report_host_details (report_t report, const char *ip,
                   identifier->source_data
                     = g_strdup (entity_text (source_name));
                   array_add (identifiers, identifier);
-                  array_add_new_string (identifier_hosts, g_strdup (ip));
+                  array_add_new_string (identifier_hosts, ip);
                 }
               if (strcmp (entity_text (name), "OS") == 0
                   && g_str_has_prefix (entity_text (value), "cpe:"))
@@ -693,7 +693,7 @@ manage_report_host_details (report_t report, const char *ip,
                   identifier->source_data
                     = g_strdup (entity_text (source_name));
                   array_add (identifiers, identifier);
-                  array_add_new_string (identifier_hosts, g_strdup (ip));
+                  array_add_new_string (identifier_hosts, ip);
                 }
               if (strcmp (entity_text (name), "ssh-key") == 0)
                 {
@@ -708,7 +708,7 @@ manage_report_host_details (report_t report, const char *ip,
                   identifier->source_data
                     = g_strdup (entity_text (source_name));
                   array_add (identifiers, identifier);
-                  array_add_new_string (identifier_hosts, g_strdup (ip));
+                  array_add_new_string (identifier_hosts, ip);
                 }
             }
         }


### PR DESCRIPTION
## What

Remove `g_strdup` from `array_add_new_string` calls.

## Why

The args were leaking because `array_add_new_string` is already doing a `g_strdup`.

## Testing

I ran GMP commands on main that showed the leaks in the Asan logs.
I ran the same GMP with the PR patches, and the logs were gone.
