### PR TITLE
Fix: remove leading whitespace in nl handling in gmp_xml_handle_result

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -21582,8 +21582,11 @@ gmp_xml_handle_result ()
   // strcspn returns the number of chars spanned so it should be safe
   // without double checking.
   if (create_report_data->result_host)
-    create_report_data
-      ->result_host[strcspn (create_report_data->result_host, "\n")] = 0;
+    {
+      g_strchug (create_report_data->result_host);
+      create_report_data->result_host
+        [strcspn (create_report_data->result_host, "\n")] = 0;
+    }
   result->host = create_report_data->result_host;
   result->hostname = create_report_data->result_hostname;
   result->nvt_oid = create_report_data->result_nvt_oid;


### PR DESCRIPTION
## What

This is about the newline processing of `report_host` in `gmp_xml_handle_result`.

Instead of just ending the `result_host` string at the first newline, remove all leading whitespace first, then end the string at the first nl.

## Why

This was causing problems when importing formatted reports. For example there's a leading newline in the host value below, which was causing the imported host to be empty.

```xml
        <host>
          172.17.0.4
          <asset asset_id="83301b40-233f-42fb-93ec-e1b25e13868f"/>
          <hostname>heartbleed.utopia</hostname>
        </host>
```

## References

Introduced in /pull/1405

## Testing

I needed this to reproduce the `create_asset_report` leak in /pull/3005.