### PR TITLE
[GEA-1900] Migrate common `tasks` functionality, utilizing new `target_type` column

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -19936,7 +19936,7 @@ handle_get_tasks (gmp_parser_t *gmp_parser, GError **error)
         }
 
       index = get_iterator_resource (&tasks);
-      target = task_target (index);
+      target = task_target (index, TASKS_TARGET_TYPE_REGULAR);
 
       task_schedule_xml = get_task_schedule_xml (index);
 
@@ -19955,7 +19955,7 @@ handle_get_tasks (gmp_parser_t *gmp_parser, GError **error)
       else
         {
           SEND_GET_COMMON (task, &get_tasks_data->get, &tasks);
-          target_in_trash = task_target_in_trash (index);
+          target_in_trash = task_target_in_trash (index, TASKS_TARGET_TYPE_REGULAR);
           if (target && (target == 0)
               && (task_iterator_run_status (&tasks)
                   == TASK_STATUS_RUNNING))
@@ -25756,7 +25756,8 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
             {
               /* Import task. */
 
-              set_task_target (create_task_data->task, 0);
+              set_task_target (create_task_data->task, 0,
+                               TASKS_TARGET_TYPE_IMPORT_TASK);
               set_task_usage_type (create_task_data->task,
                                    create_task_data->usage_type);
               SENDF_TO_CLIENT_OR_FAIL (XML_OK_CREATED_ID ("create_task"),
@@ -25929,7 +25930,8 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                     error_send_to_client (error);
                   goto create_task_fail;
                 }
-              set_task_target (create_task_data->task, target);
+              set_task_target (create_task_data->task, target,
+                               TASKS_TARGET_TYPE_REGULAR);
             }
 
           set_task_scanner (create_task_data->task, scanner);

--- a/src/manage.c
+++ b/src/manage.c
@@ -1665,7 +1665,7 @@ run_osp_task (task_t task, int from, char **report_id)
 {
   target_t target;
 
-  target = task_target (task);
+  target = task_target (task, TASKS_TARGET_TYPE_REGULAR);
   if (target)
     {
       char *uuid;
@@ -1875,7 +1875,7 @@ run_cve_task (task_t task)
 {
   target_t target;
 
-  target = task_target (task);
+  target = task_target (task, TASKS_TARGET_TYPE_REGULAR);
   if (target)
     {
       char *uuid;
@@ -6765,7 +6765,7 @@ run_openvasd_task (task_t task, int from, char **report_id)
     }
   target_t target;
 
-  target = task_target (task);
+  target = task_target (task, TASKS_TARGET_TYPE_REGULAR);
   if (target)
     {
       char *uuid;

--- a/src/manage.h
+++ b/src/manage.h
@@ -656,13 +656,25 @@ void
 set_task_config (task_t, config_t);
 
 target_t
-task_target (task_t);
+task_target (task_t, tasks_target_type_t);
+
+tasks_target_type_t
+task_target_type (task_t);
 
 int
-task_target_in_trash (task_t);
+task_target_in_trash (task_t, tasks_target_type_t);
 
 void
-set_task_target (task_t, target_t);
+set_task_target (task_t, target_t, tasks_target_type_t);
+
+void
+set_task_target_and_location (task_t, target_t, tasks_target_type_t);
+
+void
+task_update_delete_target (target_t, target_t, tasks_target_type_t);
+
+void
+task_update_restore_target (target_t, target_t, tasks_target_type_t);
 
 #if ENABLE_AGENTS
 void

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -1285,7 +1285,32 @@ manage_create_sql_functions ()
             "$$ LANGUAGE SQL;");
 
       /* column hostname in table report_hosts was added in version 273 */
-      if (current_db_version >= 273)
+      if (current_db_version >= 281)
+          {
+            sql ("CREATE OR REPLACE FUNCTION report_result_host_count (report integer,"
+                 "                                                     min_qod integer)"
+                 " RETURNS bigint AS $$"
+                 "  SELECT CASE"
+                 "         WHEN EXISTS (SELECT id"
+                 "                      FROM tasks"
+                 "                      WHERE id = (SELECT task"
+                 "                                  FROM reports WHERE id = $1)"
+                 "                        AND target_type = 3)" // TASKS_TARGET_TYPE_OCI_IMAGE
+                 "         THEN (SELECT count (DISTINCT id) FROM report_hosts"
+                 "               WHERE report_hosts.report = $1"
+                 "               AND EXISTS (SELECT * FROM results"
+                 "                           WHERE results.host = report_hosts.host"
+                 "                             AND results.hostname = report_hosts.hostname"
+                 "                             AND results.qod >= $2))"
+                 "         ELSE (SELECT count (DISTINCT id) FROM report_hosts"
+                 "               WHERE report_hosts.report = $1"
+                 "               AND EXISTS (SELECT * FROM results"
+                 "                           WHERE results.host = report_hosts.host"
+                 "                             AND results.qod >= $2))"
+                 "         END;"
+                 "$$ LANGUAGE SQL;");
+          }
+      else if (current_db_version >= 273)
           {
             sql ("CREATE OR REPLACE FUNCTION report_result_host_count (report integer,"
                  "                                                     min_qod integer)"
@@ -1436,8 +1461,31 @@ manage_create_sql_functions ()
                TASK_STATUS_DONE);
         }
 
+     /* target_type was added in version 281 */
+     if (current_db_version >= 281)
+       {
+          sql ("CREATE OR REPLACE FUNCTION task_severity (integer," // task
+               "                                          integer," // overrides
+               "                                          integer)" // min_qod
+               " RETURNS double precision AS $$"
+               /* Calculate the severity of a task. */
+               "  SELECT CASE"
+               "         WHEN (SELECT target = 0 "
+               "               AND target_type = 0 " // TASKS_TARGET_TYPE_IMPORT_TASK
+               "               FROM tasks WHERE id = $1)"
+               "         THEN CAST (NULL AS double precision)"
+               "         ELSE"
+               "         (SELECT report_severity ((SELECT id FROM reports"
+               "                                   WHERE task = $1"
+               "                                   AND scan_run_status = %u"
+               "                                   ORDER BY creation_time DESC"
+               "                                   LIMIT 1 OFFSET 0), $2, $3))"
+               "         END;"
+               "$$ LANGUAGE SQL;",
+               TASK_STATUS_DONE);
+       }
      /* column web_application_target in table task was added in version 277 */
-     if (current_db_version >= 277)
+     else if (current_db_version >= 277)
        {
           sql ("CREATE OR REPLACE FUNCTION task_severity (integer," // task
                "                                          integer," // overrides
@@ -1531,7 +1579,139 @@ manage_create_sql_functions ()
                TASK_STATUS_DONE);
         }
 
-      sql ("CREATE OR REPLACE FUNCTION task_trend (integer, integer, integer)"
+      if (current_db_version >= 281)
+        {
+          sql ("CREATE OR REPLACE FUNCTION task_trend (integer, integer, integer)"
+               " RETURNS text AS $$"
+               /* Calculate the trend of a task. */
+               " DECLARE"
+               "   last_report integer;"
+               "   second_last_report integer;"
+               "   severity_a double precision;"
+               "   severity_b double precision;"
+               "   critical_a bigint;"
+               "   critical_b bigint;"
+               "   high_a bigint;"
+               "   high_b bigint;"
+               "   medium_a bigint;"
+               "   medium_b bigint;"
+               "   low_a bigint;"
+               "   low_b bigint;"
+               "   threat_a integer;"
+               "   threat_b integer;"
+               " BEGIN"
+               "   CASE"
+               /*  Ensure there are enough reports. */
+               "   WHEN (SELECT count(*) <= 1 FROM reports"
+               "         WHERE task = $1"
+               "         AND scan_run_status = %u)"
+               "   THEN RETURN ''::text;"
+               /*  Get trend only for authenticated users. */
+               "   WHEN gvmd_user () = 0"
+               "   THEN RETURN ''::text;"
+               /*  Skip running and import tasks. */
+               "   WHEN (SELECT run_status = %u OR (target = 0 OR target_type = 0)" // TASKS_TARGET_TYPE_IMPORT_TASK
+               "         FROM tasks WHERE id = $1)"
+               "   THEN RETURN ''::text;"
+               "   ELSE"
+               "   END CASE;"
+               /*  Check if the severity score changed. */
+               "   last_report := task_last_report ($1);"
+               "   second_last_report := task_second_last_report ($1);"
+               "   severity_a := report_severity (last_report, $2, $3);"
+               "   severity_b := report_severity (second_last_report, $2, $3);"
+               "   IF severity_a > severity_b THEN"
+               "     RETURN 'up'::text;"
+               "   ELSIF severity_b > severity_a THEN"
+               "     RETURN 'down'::text;"
+               "   END IF;"
+               /*  Calculate trend. */
+               "   critical_a := report_severity_count (last_report, $2, $3,"
+               "                                    'critical');"
+               "   critical_b := report_severity_count (second_last_report, $2, $3,"
+               "                                    'critical');"
+               "   high_a := report_severity_count (last_report, $2, $3,"
+               "                                    'high');"
+               "   high_b := report_severity_count (second_last_report, $2, $3,"
+               "                                    'high');"
+               "   medium_a := report_severity_count (last_report, $2, $3,"
+               "                                      'medium');"
+               "   medium_b := report_severity_count (second_last_report, $2, $3,"
+               "                                      'medium');"
+               "   low_a := report_severity_count (last_report, $2, $3,"
+               "                                   'low');"
+               "   low_b := report_severity_count (second_last_report, $2, $3,"
+               "                                   'low');"
+               "   IF critical_a > 0 THEN"
+               "     threat_a := 5;"
+               "   ELSEIF high_a > 0 THEN"
+               "     threat_a := 4;"
+               "   ELSIF medium_a > 0 THEN"
+               "     threat_a := 3;"
+               "   ELSIF low_a > 0 THEN"
+               "     threat_a := 2;"
+               "   ELSE"
+               "     threat_a := 1;"
+               "   END IF;"
+               "   IF critical_b > 0 THEN"
+               "     threat_b := 5;"
+               "   ELSEIF high_b > 0 THEN"
+               "     threat_b := 4;"
+               "   ELSIF medium_b > 0 THEN"
+               "     threat_b := 3;"
+               "   ELSIF low_b > 0 THEN"
+               "     threat_b := 2;"
+               "   ELSE"
+               "     threat_b := 1;"
+               "   END IF;"
+               /*  Check if the threat level changed. */
+               "   IF threat_a > threat_b THEN"
+               "     RETURN 'up'::text;"
+               "   ELSIF threat_b > threat_a THEN"
+               "     RETURN 'down'::text;"
+               "   END IF;"
+               /*  Check if the threat count changed. */
+               "   IF critical_a > 0 THEN"
+               "     IF critical_a > critical_b THEN"
+               "       RETURN 'more'::text;"
+               "     ELSIF critical_a < critical_b THEN"
+               "       RETURN 'less'::text;"
+               "     END IF;"
+               "     RETURN 'same'::text;"
+               "   END IF;"
+               "   IF high_a > 0 THEN"
+               "     IF high_a > high_b THEN"
+               "       RETURN 'more'::text;"
+               "     ELSIF high_a < high_b THEN"
+               "       RETURN 'less'::text;"
+               "     END IF;"
+               "     RETURN 'same'::text;"
+               "   END IF;"
+               "   IF medium_a > 0 THEN"
+               "     IF medium_a > medium_b THEN"
+               "       RETURN 'more'::text;"
+               "     ELSIF medium_a < medium_b THEN"
+               "       RETURN 'less'::text;"
+               "     END IF;"
+               "     RETURN 'same'::text;"
+               "   END IF;"
+               "   IF low_a > 0 THEN"
+               "     IF low_a > low_b THEN"
+               "       RETURN 'more'::text;"
+               "     ELSIF low_a < low_b THEN"
+               "       RETURN 'less'::text;"
+               "     END IF;"
+               "     RETURN 'same'::text;"
+               "   END IF;"
+               "   RETURN 'same'::text;"
+               " END;"
+               "$$ LANGUAGE plpgsql;",
+               TASK_STATUS_DONE,
+               TASK_STATUS_RUNNING);
+        }
+      else
+        {
+          sql ("CREATE OR REPLACE FUNCTION task_trend (integer, integer, integer)"
            " RETURNS text AS $$"
            /* Calculate the trend of a task. */
            " DECLARE"
@@ -1658,6 +1838,7 @@ manage_create_sql_functions ()
            "$$ LANGUAGE plpgsql;",
            TASK_STATUS_DONE,
            TASK_STATUS_RUNNING);
+        }
     }
 
   sql ("CREATE OR REPLACE FUNCTION run_status_name (integer)"

--- a/src/manage_scan_handler.c
+++ b/src/manage_scan_handler.c
@@ -51,7 +51,7 @@ handle_queued_osp_scan (const char *scan_id, report_t report,
       case TASK_STATUS_REQUESTED:
         {
           int rc;
-          target_t target = task_target (task);
+          target_t target = task_target (task, TASKS_TARGET_TYPE_REGULAR);
           rc = handle_osp_scan_start (task, target, scan_id, start_from,
                                       TRUE, &discovery_scan);
           /* Set discovery flag to the report */
@@ -94,7 +94,7 @@ handle_queued_openvasd_scan (const char *scan_id, report_t report,
       case TASK_STATUS_REQUESTED:
         {
           int rc;
-          target_t target = task_target (task);
+          target_t target = task_target (task, TASKS_TARGET_TYPE_REGULAR);
           rc = handle_openvasd_scan_start (task, target, scan_id, start_from,
                                            TRUE, &discovery_scan);
           /* Set discovery flag to the report */

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -66,6 +66,7 @@
 #include "manage_sql_tickets.h"
 #include "manage_sql_tls_certificates.h"
 #include "manage_sql_users.h"
+#include "manage_tasks.h"
 #include "manage_acl.h"
 #include "manage_commands.h"
 #include "manage_authentication.h"
@@ -5817,17 +5818,21 @@ set_task_config (task_t task, config_t config)
 /**
  * @brief Return the target of a task.
  *
- * @param[in]  task  Task.
+ * @param[in]  task         Task.
+ * @param[in]  target_type  Target type of task.
  *
  * @return Target of task.
  */
 target_t
-task_target (task_t task)
+task_target (task_t task, tasks_target_type_t target_type)
 {
   target_t target = 0;
-  switch (sql_int64 (&target,
-                     "SELECT target FROM tasks WHERE id = %llu;",
-                     task))
+  switch (sql_int64_ps (&target,
+                       "SELECT target FROM tasks WHERE id = $1"
+                       "                         AND target_type = $2;",
+                       SQL_RESOURCE_PARAM (task),
+                       SQL_INT_PARAM (target_type),
+                       NULL))
     {
       case 0:
         return target;
@@ -5841,19 +5846,110 @@ task_target (task_t task)
     }
 }
 
+tasks_target_type_t
+task_target_type (task_t task)
+{
+  // sql_int_ps does not support return value through parameter
+  resource_t target_type = 0;
+  switch (sql_int64_ps (&target_type,
+                        "SELECT target_type FROM tasks WHERE id = $1;",
+                        SQL_RESOURCE_PARAM (task), NULL))
+    {
+    case 0:
+      return (tasks_target_type_t)target_type;
+      break;
+    case 1:        /* Too few rows in result of query. */
+    default:       /* Programming error. */
+      assert (0);
+    case -1:
+      return 0;
+      break;
+    }
+}
+
 /**
  * @brief Set the target of a task.
  *
- * @param[in]  task    Task.
- * @param[in]  target  Target.
+ * @param[in]  task          Task.
+ * @param[in]  target        Target.
+ * @param[in]  target_type   The type of the target
  */
 void
-set_task_target (task_t task, target_t target)
+set_task_target (task_t task, target_t target, tasks_target_type_t target_type)
 {
-  sql ("UPDATE tasks SET target = %llu, modification_time = m_now ()"
-       " WHERE id = %llu;",
-       target,
-       task);
+  sql_ps ("UPDATE tasks SET target = $1, target_type = $2,"
+          " modification_time = m_now ()"
+          " WHERE id = $3;",
+          SQL_RESOURCE_PARAM (target),
+          SQL_INT_PARAM (target_type),
+          SQL_RESOURCE_PARAM (task),
+          NULL);
+}
+
+/**
+ * @brief Set the target of a task, also updating the agent group location.
+ *
+ * @param[in]  task          Task.
+ * @param[in]  target        Target.
+ * @param[in]  target_type   The type of the target
+ */
+void
+set_task_target_and_location (task_t task, target_t target,
+                              tasks_target_type_t target_type)
+{
+  sql_ps ("UPDATE tasks SET target = $1, target_type = $2, target_location = 0"
+          " modification_time = m_now ()"
+          " WHERE id = $3;",
+          SQL_RESOURCE_PARAM (target),
+          SQL_INT_PARAM (target_type),
+          SQL_RESOURCE_PARAM (task),
+          NULL);
+}
+
+/**
+ * @brief Update a task after a target was deleted.
+ *
+ * @param[in]  trash_id      The new ID of the target in trash.
+ * @param[in]  resource_id   The old ID of the target in the table.
+ * @param[in]  target_type   The type of the target being deleted
+ */
+void
+task_update_delete_target (target_t trash_id, target_t resource_id,
+                           tasks_target_type_t target_type)
+{
+  sql_ps ("UPDATE tasks"
+          " SET target = $1,"
+          "     target_location = " G_STRINGIFY (LOCATION_TRASH)
+          " WHERE target = $2"
+          " AND target_location = " G_STRINGIFY (LOCATION_TABLE)
+          " AND target_type = $3;",
+          SQL_RESOURCE_PARAM (trash_id),
+          SQL_RESOURCE_PARAM (resource_id),
+          SQL_INT_PARAM (target_type),
+          NULL);
+}
+
+/**
+ * @brief Update a task after a target was restored.
+ *
+ * @param[in]  restored_id  The new ID of the target in the table.
+ * @param[in]  trash_id     The old ID of the target in trash.
+ * @param[in]  target_type  The type of the target being restored
+ */
+void
+task_update_restore_target (target_t restored_id, target_t trash_id,
+                            tasks_target_type_t target_type)
+{
+  sql_ps ("UPDATE tasks"
+          " SET target = $1,"
+          "     target_location = " G_STRINGIFY (LOCATION_TABLE)
+          " WHERE target = $2"
+          " AND target_location = " G_STRINGIFY (LOCATION_TRASH)
+          " AND target_type = $3;",
+          SQL_RESOURCE_PARAM (restored_id),
+          SQL_RESOURCE_PARAM (trash_id),
+          SQL_INT_PARAM (target_type),
+          NULL);
 }
 
 #if ENABLE_AGENTS
@@ -5866,11 +5962,8 @@ set_task_target (task_t task, target_t target)
 void
 set_task_agent_group_and_location (task_t task, agent_group_t agent_group)
 {
-  sql ("UPDATE tasks SET agent_group = %llu, agent_group_location = 0,"
-       " modification_time = m_now ()"
-       " WHERE id = %llu;",
-       agent_group,
-       task);
+  set_task_target_and_location (task, agent_group,
+                                TASKS_TARGET_TYPE_AGENT_GROUP);
 }
 
 /**
@@ -5883,14 +5976,15 @@ set_task_agent_group_and_location (task_t task, agent_group_t agent_group)
 int
 agent_group_tasks_exist_by_scanner (scanner_t scanner)
 {
-  return !!sql_int (
+  return !!sql_int_ps (
     "SELECT COUNT(*) FROM tasks"
-    " WHERE agent_group IN ("
-    "  SELECT id FROM agent_groups WHERE scanner = %llu)"
-    " AND agent_group_location = "
-    G_STRINGIFY (LOCATION_TABLE)
-    " AND hidden = 0;",
-    scanner);
+    " WHERE target IN ("
+    "  SELECT id FROM agent_groups WHERE scanner = $1)"
+    " AND target_type = $2"
+    " AND target_location = " G_STRINGIFY (LOCATION_TABLE) " AND hidden = 0;",
+    SQL_RESOURCE_PARAM (scanner),
+    SQL_INT_PARAM (TASKS_TARGET_TYPE_AGENT_GROUP),
+    NULL);
 }
 /**
  * @brief Return whether any hidden task exists for agent groups of a scanner.
@@ -5902,19 +5996,24 @@ agent_group_tasks_exist_by_scanner (scanner_t scanner)
 int
 agent_group_hidden_tasks_exist_by_scanner (scanner_t scanner)
 {
-  return !!sql_int (
+  return !!sql_int_ps (
     "SELECT COUNT(*) FROM tasks "
     "WHERE hidden != 0 "
+    " AND target_type = $1"
     " AND ("
-    "  (agent_group_location = %d"
-    "   AND agent_group IN ("
-    "    SELECT id FROM agent_groups WHERE scanner = %llu ))"
+    "  (target_location = $2"
+    "   AND target IN ("
+    "    SELECT id FROM agent_groups WHERE scanner = $3 ))"
     " OR "
-    "  (agent_group_location = %d "
-    "   AND agent_group IN ("
-    "    SELECT id FROM agent_groups_trash WHERE scanner = %llu ))"
+    "  (target_location = $4 "
+    "   AND target IN ("
+    "    SELECT id FROM agent_groups_trash WHERE scanner = $3 ))"
     ");",
-    LOCATION_TABLE, scanner, LOCATION_TRASH, scanner);
+    SQL_INT_PARAM (TASKS_TARGET_TYPE_AGENT_GROUP),
+    SQL_INT_PARAM (LOCATION_TABLE),
+    SQL_RESOURCE_PARAM (scanner),
+    SQL_INT_PARAM (LOCATION_TRASH),
+    NULL);
 }
 
 /**
@@ -5927,21 +6026,7 @@ agent_group_hidden_tasks_exist_by_scanner (scanner_t scanner)
 agent_group_t
 task_agent_group (task_t task)
 {
-  agent_group_t agent_group = 0;
-  switch (sql_int64 (&agent_group,
-                     "SELECT agent_group FROM tasks WHERE id = %llu;",
-                     task))
-    {
-    case 0:
-      return agent_group;
-      break;
-    case 1:        /* Too few rows in result of query. */
-    default:       /* Programming error. */
-      assert (0);
-    case -1:
-      return 0;
-      break;
-    }
+  return task_target (task, TASKS_TARGET_TYPE_AGENT_GROUP);
 }
 
 /**
@@ -5954,10 +6039,7 @@ task_agent_group (task_t task)
 int
 task_agent_group_in_trash (task_t task)
 {
-  return sql_int ("SELECT agent_group_location = "
-                  G_STRINGIFY (LOCATION_TRASH)
-                  " FROM tasks WHERE id = %llu;",
-                  task);
+  return task_target_in_trash (task, TASKS_TARGET_TYPE_AGENT_GROUP);
 }
 #endif /*ENABLE_AGENTS*/
 
@@ -5972,21 +6054,7 @@ task_agent_group_in_trash (task_t task)
 oci_image_target_t
 task_oci_image_target (task_t task)
 {
-  oci_image_target_t oci_image_target = 0;
-  switch (sql_int64 (&oci_image_target,
-                     "SELECT oci_image_target FROM tasks WHERE id = %llu;",
-                     task))
-    {
-      case 0:
-        return oci_image_target;
-        break;
-      case 1:        /* Too few rows in result of query. */
-      default:       /* Programming error. */
-        assert (0);
-      case -1:
-        return 0;
-        break;
-    }
+  return task_target (task, TASKS_TARGET_TYPE_OCI_IMAGE);
 }
 
 /**
@@ -5999,27 +6067,20 @@ task_oci_image_target (task_t task)
 int
 task_oci_image_target_in_trash (task_t task)
 {
-  return sql_int ("SELECT oci_image_target_location = "
-                  G_STRINGIFY (LOCATION_TRASH)
-                  " FROM tasks WHERE id = %llu;",
-                  task);
+  return task_target_in_trash (task, TASKS_TARGET_TYPE_OCI_IMAGE);
 }
 
 /**
  * @brief Set the OCI image target of a task.
  *
- * @param[in]  task    Task.
- * @param[in]  target  Target.
+ * @param[in]  task              Task.
+ * @param[in]  oci_image_target  Target.
  */
 void
 set_task_oci_image_target (task_t task, oci_image_target_t oci_image_target)
 {
-  sql ("UPDATE tasks SET oci_image_target = %llu,"
-       " oci_image_target_location = 0,"
-       " modification_time = m_now ()"
-       " WHERE id = %llu;",
-       oci_image_target,
-       task);
+  set_task_target_and_location (task, oci_image_target,
+                                TASKS_TARGET_TYPE_OCI_IMAGE);
 }
 
 #endif
@@ -6035,13 +6096,7 @@ set_task_oci_image_target (task_t task, oci_image_target_t oci_image_target)
 web_application_target_t
 task_web_application_target (task_t task)
 {
-  web_application_target_t web_application_target = 0;
-  sql_int64_ps (&web_application_target,
-                "SELECT web_application_target FROM tasks"
-                " WHERE id = $1;",
-                SQL_RESOURCE_PARAM(task),
-                NULL);
-  return web_application_target;
+  return task_target (task, TASKS_TARGET_TYPE_WEB_APPLICATION);
 }
 
 /**
@@ -6054,29 +6109,20 @@ task_web_application_target (task_t task)
 int
 task_web_application_target_in_trash (task_t task)
 {
-  return sql_int_ps ("SELECT web_application_target_location = "
-                     G_STRINGIFY (LOCATION_TRASH)
-                     " FROM tasks WHERE id = $1;",
-                     SQL_RESOURCE_PARAM(task),
-                     NULL);
+  return task_target_in_trash (task, TASKS_TARGET_TYPE_WEB_APPLICATION);
 }
 
 /**
  * @brief Set the web application target of a task.
  *
- * @param[in]  task    Task.
- * @param[in]  target  Target.
+ * @param[in]  task                    Task.
+ * @param[in]  web_application_target  Target.
  */
 void
 set_task_web_application_target (task_t task, web_application_target_t web_application_target)
 {
-  sql_ps ("UPDATE tasks SET web_application_target = $1,"
-          " web_application_target_location = 0,"
-          " modification_time = m_now ()"
-          " WHERE id = $2;",
-          SQL_RESOURCE_PARAM(web_application_target),
-          SQL_RESOURCE_PARAM(task),
-          NULL);
+  set_task_target_and_location (task, web_application_target,
+                                TASKS_TARGET_TYPE_WEB_APPLICATION);
 }
 
 #endif
@@ -6109,16 +6155,20 @@ clear_task_asset_preferences (task_t task)
 /**
  * @brief Return whether the target of a task is in the trashcan.
  *
- * @param[in]  task  Task.
+ * @param[in]  task         Task.
+ * @param[in]  target_type  Type of the target
  *
  * @return 1 if in trash, else 0.
  */
 int
-task_target_in_trash (task_t task)
+task_target_in_trash (task_t task, tasks_target_type_t target_type)
 {
-  return sql_int ("SELECT target_location = " G_STRINGIFY (LOCATION_TRASH)
-                  " FROM tasks WHERE id = %llu;",
-                  task);
+  return sql_int_ps ("SELECT target_location = " G_STRINGIFY (LOCATION_TRASH)
+                      " FROM tasks WHERE id = $1"
+                      " AND target_type = $2;",
+                      SQL_RESOURCE_PARAM (task),
+                      SQL_INT_PARAM (target_type),
+                      NULL);
 }
 
 /**
@@ -18115,10 +18165,10 @@ make_task (char* name, char* comment, int in_assets, int event)
   sql ("INSERT into tasks"
        " (owner, uuid, name, hidden, comment, schedule,"
        "  schedule_next_time, config_location, target, target_location,"
-       "  scanner_location, schedule_location, alterable,"
+       "  target_type, scanner_location, schedule_location, alterable,"
        "  creation_time, modification_time, usage_type)"
        " VALUES ((SELECT id FROM users WHERE users.uuid = '%s'),"
-       "         '%s', '%s', 0, '%s', 0, 0, 0, 0, 0, 0, 0, 0, m_now (),"
+       "         '%s', '%s', 0, '%s', 0, 0, 0, 0, 0, 0, 0, 0, 0, m_now (),"
        "         m_now (), 'scan');",
        current_credentials.uuid,
        uuid,
@@ -18226,17 +18276,12 @@ copy_task (const char* name, const char* comment, const char *task_id,
   sql_begin_immediate ();
 
   ret = copy_resource_lock ("task", name, comment, task_id,
-                            "config, target, oci_image_target,"
-                            " web_application_target,"
+                            "config, target, target_type,"
                             " schedule, schedule_periods,"
                             " scanner, schedule_next_time,"
                             " config_location, target_location,"
                             " schedule_location, scanner_location,"
-                            " oci_image_target_location,"
-                            " web_application_target_location,"
-                            " usage_type,"
-                            " agent_group, agent_group_location,"
-                            " alterable",
+                            " usage_type, alterable",
                             1, &new, &old);
   if (ret)
     {

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -7191,7 +7191,7 @@ task_severity_double (task_t task, int overrides, int min_qod, int offset)
   report_t report;
 
   if (current_credentials.uuid == NULL
-      || task_target (task) == 0 /* import task. */)
+      || task_target_type (task) == TASKS_TARGET_TYPE_REGULAR/* import task. */)
     return SEVERITY_MISSING;
 
   report = sql_int64_0 ("SELECT id FROM reports"
@@ -9394,7 +9394,7 @@ create_report (array_t *results, const char *task_id, const char *in_assets,
     rc = -1;
   else if (task == 0)
     rc = -4;
-  else if (task_target (task))
+  else if (task_target (task, TASKS_TARGET_TYPE_REGULAR))
     rc = -5;
   if (rc)
     {
@@ -16265,8 +16265,8 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
 
       comment = task_comment (task);
 
-      target = task_target (task);
-      if (task_target_in_trash (task))
+      target = task_target (task, TASKS_TARGET_TYPE_REGULAR);
+      if (task_target_in_trash (task, TASKS_TARGET_TYPE_REGULAR))
         {
           task_target_uuid = trash_target_uuid (target);
           task_target_name = trash_target_name (target);
@@ -16304,7 +16304,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
              tsk_name ? tsk_name : "",
              comment ? comment : "",
              task_target_uuid ? task_target_uuid : "",
-             task_target_in_trash (task),
+             task_target_in_trash (task, TASKS_TARGET_TYPE_REGULAR),
              task_target_name ? task_target_name : "",
              task_target_comment ? task_target_comment : "");
 
@@ -19041,7 +19041,7 @@ modify_task (const gchar *task_id, const gchar *name,
     return MODIFY_TASK_NOT_FOUND;
 
 
-  if ((task_target (task) == 0
+  if ((task_target_type (task) == TASKS_TARGET_TYPE_IMPORT_TASK
        && (agent_group_id == NULL)
        && (oci_image_target_id == NULL)
        && (web_application_target_id == NULL))
@@ -19215,7 +19215,7 @@ modify_task (const gchar *task_id, const gchar *name,
       else if (target == 0)
         return MODIFY_TASK_TARGET_NOT_FOUND;
       else
-        set_task_target (task, target);
+        set_task_target (task, target, TASKS_TARGET_TYPE_REGULAR);
     }
 #if ENABLE_AGENTS
   if (agent_group_id) {


### PR DESCRIPTION
## What

Migrate common functions, like `set_target_type`, `task_target_in_trash`, ...

## Why

After introducing the new `target_type` column, we can simplify and generalize a lot of these functions

## References

GEA-1900

