### PR TITLE
Fix/security intelligence export asset key

### DIFF
--- a/src/manage_assets.h
+++ b/src/manage_assets.h
@@ -166,4 +166,7 @@ void
 asset_snapshots_container_image (report_t report, task_t task);
 #endif
 
+gchar *
+asset_key_for_report_host (report_t, report_host_t, const gchar *);
+
 #endif /* not _GVMD_MANAGE_ASSETS_H */

--- a/src/manage_sql_assets.c
+++ b/src/manage_sql_assets.c
@@ -2262,6 +2262,169 @@ manage_asset_snapshot_delete_stale (int days)
 }
 
 /**
+ * @brief Resolve asset snapshot type for a report.
+ *
+ * @param[in]  report      Report ID.
+ * @param[out] asset_type  Resolved asset type.
+ *
+ * @return TRUE if a type was found, FALSE otherwise.
+ */
+static gboolean
+asset_type_for_report (report_t report, asset_type_t *asset_type)
+{
+  int type;
+
+  if (!report || !asset_type)
+    return FALSE;
+
+  type = sql_int_ps (
+    "SELECT asset_type"
+    " FROM asset_snapshots"
+    " WHERE report_id = $1"
+    " ORDER BY id"
+    " LIMIT 1;",
+    SQL_RESOURCE_PARAM (report),
+    NULL);
+
+  if (type != ASSET_TYPE_TARGET
+      && type != ASSET_TYPE_AGENT
+      && type != ASSET_TYPE_CONTAINER_IMAGE)
+    return FALSE;
+
+  *asset_type = (asset_type_t) type;
+  return TRUE;
+}
+
+/**
+ * @brief Lookup agent_id from report_host_details.
+ *
+ * @param[in] report_host  Report host ID.
+ *
+ * @return Newly allocated agent_id, or NULL if not found.
+ */
+static gchar *
+asset_agent_id_from_report_host_details (report_host_t report_host)
+{
+  if (!report_host)
+    return NULL;
+
+  return sql_string_ps (
+    "SELECT value"
+    " FROM report_host_details"
+    " WHERE report_host = $1"
+    "   AND name = 'agentID'"
+    "   AND value IS NOT NULL"
+    "   AND value <> ''"
+    " ORDER BY id"
+    " LIMIT 1;",
+    SQL_RESOURCE_PARAM (report_host),
+    NULL);
+}
+
+/**
+ * @brief Lookup asset_key by report, asset type and one identifier.
+ *
+ * @param[in] report            Report ID.
+ * @param[in] asset_type        Asset snapshot type.
+ * @param[in] identifier_type   Asset identifier type.
+ * @param[in] identifier_value  Asset identifier value.
+ *
+ * @return Newly allocated asset_key, or NULL if not found.
+ */
+static gchar *
+asset_key_by_report_identifier (report_t report,
+                                asset_type_t asset_type,
+                                int identifier_type,
+                                const gchar *identifier_value)
+{
+  if (!report || !identifier_value || !*identifier_value)
+    return NULL;
+
+  return sql_string_ps (
+    "SELECT s.asset_key"
+    " FROM asset_snapshots s"
+    " JOIN asset_snapshot_identifiers i"
+    "   ON i.asset_snapshot = s.id"
+    " WHERE s.report_id = $1"
+    "   AND s.asset_type = $2"
+    "   AND i.identifier_type = $3"
+    "   AND i.identifier_value = $4"
+    "   AND s.asset_key IS NOT NULL"
+    " ORDER BY s.modification_time DESC"
+    " LIMIT 1;",
+    SQL_RESOURCE_PARAM (report),
+    SQL_INT_PARAM (asset_type),
+    SQL_INT_PARAM (identifier_type),
+    SQL_STR_PARAM (identifier_value),
+    NULL);
+}
+
+/**
+ * @brief Resolve optional asset_key for one report host.
+ *
+ * @param[in] report       Report ID.
+ * @param[in] report_host  Report host ID.
+ * @param[in] host_value   Value from report_hosts.host.
+ *
+ * @return Newly allocated asset_key, or NULL if no key is available.
+ */
+gchar *
+asset_key_for_report_host (report_t report,
+                           report_host_t report_host,
+                           const gchar *host_value)
+{
+  asset_type_t asset_type;
+
+  if (!report)
+    return NULL;
+
+  if (asset_type_for_report (report, &asset_type) == FALSE)
+    return NULL;
+
+  switch (asset_type)
+    {
+    case ASSET_TYPE_AGENT:
+      {
+        gchar *agent_id;
+        gchar *asset_key;
+
+        agent_id = asset_agent_id_from_report_host_details (report_host);
+        if (!agent_id || !*agent_id)
+          {
+            g_free (agent_id);
+            return NULL;
+          }
+
+        asset_key =
+          asset_key_by_report_identifier (report,
+                                          ASSET_TYPE_AGENT,
+                                          ASSET_IDENTIFIER_TYPE_AGENT_ID,
+                                          agent_id);
+
+        g_free (agent_id);
+        return asset_key;
+      }
+
+    case ASSET_TYPE_CONTAINER_IMAGE:
+      return asset_key_by_report_identifier (
+        report,
+        ASSET_TYPE_CONTAINER_IMAGE,
+        ASSET_IDENTIFIER_TYPE_CONTAINER_DIGEST,
+        host_value);
+
+    case ASSET_TYPE_TARGET:
+      return asset_key_by_report_identifier (
+        report,
+        ASSET_TYPE_TARGET,
+        ASSET_IDENTIFIER_TYPE_IP,
+        host_value);
+
+    default:
+      return NULL;
+    }
+}
+
+/**
  * @brief Setup hosts and their identifiers after a scan, from host details.
  *
  * At the end of a scan this revises the decision about which asset host to use

--- a/src/manage_sql_report_hosts.c
+++ b/src/manage_sql_report_hosts.c
@@ -20,6 +20,8 @@
 
 #include "manage_sql_report_hosts.h"
 
+#include "manage_assets.h"
+
 #undef G_LOG_DOMAIN
 /**
  * @brief GLib log domain.
@@ -493,6 +495,57 @@ host_summary_append (GString *host_summary_buffer, const char *host,
 }
 
 /**
+ * @brief Print the asset XML element for a report host.
+ *
+ * @param[in] ctx     Report print context.
+ * @param[in] stream  File stream to write to.
+ * @param[in] hosts   Host iterator.
+ * @param[in] host    Single host override, or NULL.
+ * @param[in] lean    Whether to return lean report.
+ *
+ * @return 0 on success, -1 on error.
+ */
+static int
+print_report_host_asset_xml (print_report_context_t *ctx,
+                             FILE *stream,
+                             iterator_t *hosts,
+                             const char *host,
+                             int lean)
+{
+  const char *asset_uuid;
+  const char *host_value;
+  gchar *asset_key;
+
+  if (ctx == NULL || stream == NULL || hosts == NULL)
+    return -1;
+
+  asset_uuid = host_iterator_asset_uuid (hosts);
+  host_value = host ? host : host_iterator_host (hosts);
+
+  asset_key = asset_key_for_report_host (ctx->report,
+                                         host_iterator_report_host (hosts),
+                                         host_value);
+
+  if ((!asset_uuid || !*asset_uuid) && lean != 0)
+    {
+      g_free (asset_key);
+      return 0;
+    }
+
+  PRINT (stream,
+         "<asset asset_id=\"%s\"/>",
+         asset_uuid ? asset_uuid : "");
+
+  if (asset_key && *asset_key)
+    PRINT (stream,
+           "<asset_snapshot asset_key=\"%s\"/>",
+           asset_key);
+
+  g_free (asset_key);
+  return 0;
+}
+
+/**
  * @brief Print the XML for a report's host to a file stream.
  *
  * @param[in]  ctx                  Printing context.
@@ -535,14 +588,7 @@ print_report_host_xml (print_report_context_t *ctx,
          "<ip>%s</ip>",
          host ? host : host_iterator_host (hosts));
 
-  if (host_iterator_asset_uuid (hosts)
-      && strlen (host_iterator_asset_uuid (hosts)))
-    PRINT (stream,
-         "<asset asset_id=\"%s\"/>",
-         host_iterator_asset_uuid (hosts));
-  else if (lean == 0)
-    PRINT (stream,
-         "<asset asset_id=\"\"/>");
+  print_report_host_asset_xml (ctx, stream, hosts, host, lean);
 
   if (strcmp (usage_type, "audit") == 0)
     {
@@ -719,14 +765,7 @@ print_container_scan_report_host_xml (print_report_context_t *ctx,
          "<ip>%s</ip>",
          host);
 
-  if (host_iterator_asset_uuid (hosts)
-      && strlen (host_iterator_asset_uuid (hosts)))
-    PRINT (stream,
-         "<asset asset_id=\"%s\"/>",
-         host_iterator_asset_uuid (hosts));
-  else if (lean == 0)
-    PRINT (stream,
-         "<asset asset_id=\"\"/>");
+  print_report_host_asset_xml (ctx, stream, hosts, host, lean);
 
   criticals_count
     = GPOINTER_TO_INT


### PR DESCRIPTION
## What

- Added optional `asset_key` to report host XML.
- Added it as `<asset_snapshot asset_key="..."/>`.
- Kept it optional, so exports still work without it.

## Why

- OSI needs `asset_key` for asset deduplication.
- The existing `<asset asset_id="..."/>` stays unchanged.

## References

GEA-1910


