### PR TITLE
docs: fix typo in comment (adress → address)

### DIFF
--- a/src/manage_oci_image_targets.c
+++ b/src/manage_oci_image_targets.c
@@ -120,7 +120,7 @@ valid_oci_url (const gchar *oci_url)
       gchar **host_port_parts = g_strsplit (parts[0], ":", -1);
       int host_port_len = g_strv_length (host_port_parts);
 
-      if (host_port_len > 2)  // ipv6 adress without a port
+      if (host_port_len > 2)  // ipv6 address without a port
         {
           host = g_strjoinv (":", host_port_parts);
           port = NULL;


### PR DESCRIPTION
## Summary

Fix typo in `src/manage_oci_image_targets.c`: `adress` → `address` in an inline comment describing IPv6 address handling.

No functional changes — comment only.