### PR TITLE
Fix: prevent heap buffer overflow in severity_data_add

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -21575,6 +21575,19 @@ gmp_xml_handle_result ()
         }
     }
 
+  if (create_report_data->result_severity
+      && strlen (create_report_data->result_severity))
+    {
+      double s;
+
+      s = atof (create_report_data->result_severity);
+      if (s > 10.0)
+        {
+          g_free (create_report_data->result_severity);
+          create_report_data->result_severity = g_strdup ("10.0");
+        }
+    }
+
   result = g_malloc (sizeof (create_report_result_t));
   result->description = create_report_data->result_description;
   // sometimes host has newlines in it, so we 0 terminate first newline

--- a/src/manage.c
+++ b/src/manage.c
@@ -1210,7 +1210,11 @@ severity_data_index (double severity)
 {
   int ret;
   if (severity >= 0.0)
-    ret = (int)(round (severity * SEVERITY_SUBDIVISIONS)) + ZERO_SEVERITY_INDEX;
+    {
+      if (severity > SEVERITY_MAX)
+        severity = SEVERITY_MAX;
+      ret = (int)(round (severity * SEVERITY_SUBDIVISIONS)) + ZERO_SEVERITY_INDEX;
+    }
   else if (severity == SEVERITY_FP || severity == SEVERITY_ERROR)
     ret = (int)(round (severity)) + ZERO_SEVERITY_INDEX;
   else


### PR DESCRIPTION
## What

Prevent severity that comes in during CREATE_REPORT from going above 10.

## Why

If severity is above 10
 - `severity_data_add` will write to the `severity_data->counts` array out of bounds
 - SQL function `severity_to_type` aborts

I put a second explicit clamp on `severity_data_index`, just to be safe, because
that's where the heap buffer overflow on the `counts` array is happening.

## Testing

I ran GMP commands on main that showed the errors. In particular
```xml
  <create_report>
  <report type="scan">
    <results>
      <result>
        <severity>500.0</severity>
...
```
I ran the same GMP with the patches and the errors were gone.