### PR TITLE
Add: Add scanner verification for web application scanner.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,7 +14,7 @@ Prerequisites:
 * glib-2.0 >= 2.42
 * gnutls >= 3.2.15
 * gpgme
-* [gvm-libs](https://github.com/greenbone/gvm-libs/) >= 23.0 (or 23.6 if ENABLE_AGENTS and 23.3 if ENABLE_OPENVASD and 23.4 if ENABLE_WEB_APPLICATION_SCANNING and 23.7 if ENABLE_SECURITY_INTELLIGENCE_EXPORT)
+* [gvm-libs](https://github.com/greenbone/gvm-libs/) >= 23.0 (or 23.6 if ENABLE_AGENTS and 23.3 if ENABLE_OPENVASD and 23.8 if ENABLE_WEB_APPLICATION_SCANNING and 23.7 if ENABLE_SECURITY_INTELLIGENCE_EXPORT)
 * [gvm-auth-lib](https://github.com/greenbone/gvm-auth-lib/) >= 0.2 (if ENABLE_SECURITY_INTELLIGENCE_EXPORT or ENABLE_JWT_AUTH is enabled)
 * libical >= 1.0.0
 * libbsd

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,7 +74,7 @@ if(ENABLE_WEB_APPLICATION_SCANNING)
   pkg_check_modules(
     LIBGVM_WEB_APPLICATION_SCANNER
     REQUIRED
-    libgvm_web_application_scanner>=23.4
+    libgvm_web_application_scanner>=23.8
   )
 else(ENABLE_WEB_APPLICATION_SCANNING)
   message(STATUS "ENABLE_WEB_APPLICATION_SCANNING flag is not enabled")

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -24843,8 +24843,9 @@ verify_scanner (const char *scanner_id, char **version)
            || scanner_iterator_type (&scanner) == SCANNER_TYPE_OPENVASD_SENSOR)
     {
       scanner_t scanner_row_id = get_iterator_resource (&scanner);
-      int res = verify_openvasd_scanner_connection (scanner_row_id);
       cleanup_iterator (&scanner);
+
+      int res = verify_openvasd_scanner_connection (scanner_row_id);
       if (res)
         return 2;
       return 0;
@@ -24856,9 +24857,9 @@ verify_scanner (const char *scanner_id, char **version)
                 == SCANNER_TYPE_AGENT_CONTROLLER_SENSOR)
     {
       scanner_t scanner_row_id = get_iterator_resource (&scanner);
-      int res = verify_agent_controller_connection (scanner_row_id);
       cleanup_iterator (&scanner);
 
+      int res = verify_agent_controller_connection (scanner_row_id);
       if (res == 1)
         return 2;
 
@@ -24869,8 +24870,9 @@ verify_scanner (const char *scanner_id, char **version)
   else if (scanner_iterator_type (&scanner) == SCANNER_TYPE_CONTAINER_IMAGE)
     {
       scanner_t scanner_row_id = get_iterator_resource (&scanner);
-      int res = verify_container_image_scanner_connection (scanner_row_id);
       cleanup_iterator (&scanner);
+
+      int res = verify_container_image_scanner_connection (scanner_row_id);
       if (res)
         return 2;
       return 0;
@@ -24880,8 +24882,9 @@ verify_scanner (const char *scanner_id, char **version)
   else if (scanner_iterator_type (&scanner) == SCANNER_TYPE_WEB_APPLICATION)
     {
       scanner_t scanner_row_id = get_iterator_resource (&scanner);
-      int res = verify_web_application_scanner_connection (scanner_row_id);
       cleanup_iterator (&scanner);
+
+      int res = verify_web_application_scanner_connection (scanner_row_id);
       if (res)
         return 2;
       return 0;

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -124,6 +124,7 @@
 #include "manage_sql_report_tls_certificates.h"
 #if ENABLE_WEB_APPLICATION_SCANNING
 #include "manage_web_application_targets.h"
+#include "manage_web_application_scanner.h"
 #endif /* ENABLE_WEB_APPLICATION_SCANNING */
 #if ENABLE_OPENVASD
 #include "manage_openvasd.h"
@@ -24878,11 +24879,11 @@ verify_scanner (const char *scanner_id, char **version)
 #if ENABLE_WEB_APPLICATION_SCANNING
   else if (scanner_iterator_type (&scanner) == SCANNER_TYPE_WEB_APPLICATION)
     {
-      // TODO: replace with actual version from the scanner
-      if (version)
-        *version = g_strdup ("TestVersion");
-
+      scanner_t scanner_row_id = get_iterator_resource (&scanner);
+      int res = verify_web_application_scanner_connection (scanner_row_id);
       cleanup_iterator (&scanner);
+      if (res)
+        return 2;
       return 0;
     }
 #endif

--- a/src/manage_web_application_scanner.c
+++ b/src/manage_web_application_scanner.c
@@ -33,7 +33,7 @@
  */
 #define G_LOG_DOMAIN "md manage"
 
-#define WEB_APPLICATION_SCAN_PREFIX "api/v1"
+#define WEB_APPLICATION_PATH_PREFIX "api/v1"
 
 /**
  * @brief Create a new connection to a web application scanner.
@@ -53,8 +53,8 @@ web_application_scanner_connect (scanner_t scanner, const char *scan_id)
 
   if (connection)
     http_scanner_connector_builder (connection,
-                                    HTTP_SCANNER_SCAN_PREFIX,
-                                    WEB_APPLICATION_SCAN_PREFIX);
+                                    HTTP_SCANNER_PATH_PREFIX,
+                                    WEB_APPLICATION_PATH_PREFIX);
   else
     g_warning ("%s: Could not connect to web application scanner", __func__);
 
@@ -1092,6 +1092,64 @@ end_stop_task:
   current_scanner_task = previous_task;
   global_current_report = previous_report;
 
+  return ret;
+}
+
+/**
+ * @brief Verify the connection to the web application scanner.
+ *
+ * @param[in]  scanner  The scanner to verify the connection to.
+ *
+ * @return 0 if the connection is verified, 1 otherwise.
+ */
+int
+verify_web_application_scanner_connection (scanner_t scanner)
+{
+  http_scanner_connector_t connector;
+  http_scanner_resp_t response = NULL;
+  int ret;
+
+  connector = web_application_scanner_connect (scanner, NULL);
+  if (!connector)
+    {
+      g_warning ("%s: Failed to build web application scanner connector",
+                 __func__);
+      return 1;
+    }
+  response = http_scanner_get_health_ready (connector);
+  http_scanner_connector_free (connector);
+
+  if (!response)
+    {
+      g_warning ("%s: Failed to get web application scanner health status",
+                 __func__);
+      return 1;
+    }
+
+  if (response->code == 200)
+    {
+      ret = 0;
+    }
+  else if (response->code == -1)
+    {
+      gboolean has_relay = scanner_has_relay (scanner);
+      char *host = scanner_host (scanner, has_relay);
+      g_warning ("%s: failed to connect to %s:%d",
+                 __func__,
+                 host,
+                 scanner_port (scanner, has_relay));
+      g_free (host);
+      ret = 1;
+    }
+  else
+    {
+      g_warning ("%s: web application scanner could not be verified,"
+                  " HTTP status code: %ld",
+                 __func__, response->code);
+      ret = 1;
+    }
+
+  http_scanner_response_cleanup (response);
   return ret;
 }
 

--- a/src/manage_web_application_scanner.h
+++ b/src/manage_web_application_scanner.h
@@ -28,5 +28,8 @@ run_web_application_task (task_t, int, char **);
 int
 stop_web_application_task (task_t);
 
+int
+verify_web_application_scanner_connection (scanner_t);
+
 #endif // not _GVMD_MANAGE_WEB_APPLICATION_SCANNER_H
 #endif // ENABLE_WEB_APPLICATION_SCANNING


### PR DESCRIPTION
## What
Add scanner verification for web application scanner. 
Use HTTP_SCANNER_PATH_PREFIX instead of HTTP_SCANNER_SCAN_PREFIX.

## Why
Verification was missing.
Path prefix is used for all endpoints. Scan prefix is only used for scan endpoints.

Requires https://github.com/greenbone/gvm-libs/pull/1088

## References
GEA-1861

