### PR TITLE
Fix/security intelligence tls config

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,7 +15,7 @@ Prerequisites:
 * gnutls >= 3.2.15
 * gpgme
 * [gvm-libs](https://github.com/greenbone/gvm-libs/) >= 23.0 (or 23.6 if ENABLE_AGENTS and 23.3 if ENABLE_OPENVASD and 23.8 if ENABLE_WEB_APPLICATION_SCANNING and 23.7 if ENABLE_SECURITY_INTELLIGENCE_EXPORT)
-* [gvm-auth-lib](https://github.com/greenbone/gvm-auth-lib/) >= 0.2 (if ENABLE_SECURITY_INTELLIGENCE_EXPORT or ENABLE_JWT_AUTH is enabled)
+* [gvm-auth-lib](https://github.com/greenbone/gvm-auth-lib/) >= 0.3 (if ENABLE_SECURITY_INTELLIGENCE_EXPORT or ENABLE_JWT_AUTH is enabled)
 * libical >= 1.0.0
 * libbsd
 * pkg-config

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,13 +53,13 @@ else(ENABLE_CONTAINER_SCANNING)
 endif(ENABLE_CONTAINER_SCANNING)
 
 if(ENABLE_JWT_AUTH)
-  pkg_check_modules(LIBGVM_AUTH REQUIRED libgvm_auth>=0.2)
+  pkg_check_modules(LIBGVM_AUTH REQUIRED libgvm_auth>=0.3)
 else(ENABLE_JWT_AUTH)
   message(STATUS "ENABLE_JWT_AUTH flag is not enabled")
 endif(ENABLE_JWT_AUTH)
 
 if(ENABLE_SECURITY_INTELLIGENCE_EXPORT)
-  pkg_check_modules(LIBGVM_AUTH REQUIRED libgvm_auth>=0.2)
+  pkg_check_modules(LIBGVM_AUTH REQUIRED libgvm_auth>=0.3)
   pkg_check_modules(LIBGVM_HTTP REQUIRED libgvm_http>=22.37)
   pkg_check_modules(
     LIBGVM_SECURITY_INTELLIGENCE

--- a/src/manage_report_export_scheduler.c
+++ b/src/manage_report_export_scheduler.c
@@ -277,7 +277,7 @@ process_report_export (report_t report, int retry_count,
         reason = g_strdup ("The request has timed out");
       else if (result == EXPORT_REPORT_RESULT_TOKEN_GENERATION_FAILED)
         reason = g_strdup ("Could not generate access_token");
-      if (errors && errors->len > 0)
+      else if (errors && errors->len > 0)
         {
           reason = errors_to_string (errors);
         }

--- a/src/manage_report_export_scheduler.c
+++ b/src/manage_report_export_scheduler.c
@@ -195,6 +195,48 @@ calculate_next_retry_time (const int retry_count)
 }
 
 /**
+ * @brief Converts a GPtrArray of error strings into a single string,
+ *        with each error separated by "; ".
+ *
+ * @param[in] errors A GPtrArray containing error strings.
+ *
+ * @return Newly allocated string containing all errors concatenated,
+ *         or NULL if the array is empty or NULL.
+ *         The caller is responsible for freeing the returned string.
+ */
+static gchar *
+errors_to_string (GPtrArray *errors)
+{
+  GString *result;
+
+  if (!errors || errors->len == 0)
+    return NULL;
+
+  result = g_string_new (NULL);
+
+  for (guint i = 0; i < errors->len; ++i)
+    {
+      const gchar *error = g_ptr_array_index (errors, i);
+
+      if (!error || !*error)
+        continue;
+
+      if (result->len > 0)
+        g_string_append (result, "; ");
+
+      g_string_append (result, error);
+    }
+
+  if (result->len == 0)
+    {
+      g_string_free (result, TRUE);
+      return NULL;
+    }
+
+  return g_string_free (result, FALSE);
+}
+
+/**
  * @brief  Process a single report, which is due for export.
  *         Used to separate iterating over all reports from the handling
  *         of the export.
@@ -212,10 +254,11 @@ process_report_export (report_t report, int retry_count,
                                        NULL);
 
   export_report_result_t result = EXPORT_REPORT_RESULT_SUCCESS;
+  GPtrArray *errors = NULL;
 # if ENABLE_SECURITY_INTELLIGENCE_EXPORT
   /* Run the export */
   result =
-    export_report_security_intelligence (report, config);
+    export_report_security_intelligence (report, config, &errors);
 #endif
   gchar *reason = NULL;
 
@@ -231,9 +274,13 @@ process_report_export (report_t report, int retry_count,
   else
     {
       if (result == EXPORT_REPORT_RESULT_TIMEOUT)
-          reason = g_strdup ("The request has timed out");
+        reason = g_strdup ("The request has timed out");
       else if (result == EXPORT_REPORT_RESULT_TOKEN_GENERATION_FAILED)
         reason = g_strdup ("Could not generate access_token");
+      if (errors && errors->len > 0)
+        {
+          reason = errors_to_string (errors);
+        }
 
       set_report_export_status_and_reason (report, REPORT_EXPORT_STATUS_FAILED,
                                            reason);
@@ -250,6 +297,8 @@ process_report_export (report_t report, int retry_count,
       g_free (reason);
       reason = NULL;
     }
+  if (errors)
+    g_ptr_array_free (errors, TRUE);
 
   sql_commit ();
 }
@@ -274,7 +323,6 @@ run_due_exports ()
         __func__);
       return;
     }
-
 
   g_debug ("%s: iterating over due exports", __func__);
 

--- a/src/manage_report_exports.c
+++ b/src/manage_report_exports.c
@@ -55,6 +55,7 @@ generate_access_token (integration_config_data_t config)
       config->oidc_client_secret,
       "",
       30,
+      TRUE,
       &new_err);
 
   if (!token_provider)
@@ -817,6 +818,8 @@ cleanup:
  *
  * @param[in] report Local report.
  * @param[in] config Security Intelligence integration configuration.
+ * @param[in, out] errors List of error strings. If the pointer is NULL,
+ *                        a new list is created.
  *
  * @return EXPORT_REPORT_RESULT_SUCCESS on success,
  *         EXPORT_REPORT_RESULT_TIMEOUT when a request times out,
@@ -826,13 +829,13 @@ cleanup:
  */
 export_report_result_t
 export_report_security_intelligence (report_t report,
-                                     integration_config_data_t config)
+                                     integration_config_data_t config,
+                                     GPtrArray **errors)
 {
   export_report_result_t result = EXPORT_REPORT_RESULT_FAILURE;
   security_intelligence_connector_t conn = NULL;
   security_intelligence_managed_report_t remote_report = NULL;
   security_intelligence_managed_report_page_list_t remote_pages = NULL;
-  GPtrArray *errors = NULL;
   get_data_t count_get;
   gboolean count_get_initialized = FALSE;
   gchar *report_id = NULL;
@@ -901,16 +904,18 @@ export_report_security_intelligence (report_t report,
       goto cleanup;
     }
 
-  if (config->service_cacert
-      && security_intelligence_connector_builder (
-        conn,
-        SECURITY_INTELLIGENCE_CA_CERT,
-        config->service_cacert)
-      != SECURITY_INTELLIGENCE_OK)
+  if (config->service_cacert && !str_blank (config->service_cacert))
     {
-      g_warning ("%s: Failed to configure Security Intelligence CA",
-                 __func__);
-      goto cleanup;
+      if (security_intelligence_connector_builder (
+            conn,
+            SECURITY_INTELLIGENCE_CA_CERT,
+            config->service_cacert)
+          != SECURITY_INTELLIGENCE_OK)
+        {
+          g_warning ("%s: Failed to configure Security Intelligence CA",
+                     __func__);
+          goto cleanup;
+        }
     }
 
   if (!refresh_connector_access_token (conn, config))
@@ -923,14 +928,14 @@ export_report_security_intelligence (report_t report,
     security_intelligence_get_report (
       conn,
       report_id,
-      &errors);
+      errors);
 
   if (!remote_report)
     {
-      if (errors)
+      if (errors && *errors)
         {
-          g_ptr_array_free (errors, TRUE);
-          errors = NULL;
+          g_ptr_array_free (*errors, TRUE);
+          *errors = NULL;
         }
 
       g_debug ("%s: Remote report %s not found, creating it",
@@ -941,7 +946,7 @@ export_report_security_intelligence (report_t report,
             conn,
             report_id,
             &remote_report,
-            &errors)
+            errors)
           != SECURITY_INTELLIGENCE_RESP_OK)
         {
           g_warning ("%s: Failed to create remote report %s",
@@ -975,7 +980,7 @@ export_report_security_intelligence (report_t report,
             conn,
             report_id,
             SECURITY_INTELLIGENCE_REPORT_UPLOAD_STATUS_STARTED,
-            &errors)
+            errors)
           != SECURITY_INTELLIGENCE_RESP_OK)
         {
           g_warning ("%s: Failed to mark report %s as started",
@@ -1030,7 +1035,7 @@ export_report_security_intelligence (report_t report,
     security_intelligence_get_report_pages (
       conn,
       report_id,
-      &errors);
+      errors);
 
   if (!remote_pages)
     {
@@ -1077,7 +1082,7 @@ export_report_security_intelligence (report_t report,
         report,
         report_id,
         page_index,
-        &errors))
+        errors))
         {
           goto cleanup;
         }
@@ -1087,7 +1092,7 @@ export_report_security_intelligence (report_t report,
         conn,
         report_id,
         SECURITY_INTELLIGENCE_REPORT_UPLOAD_STATUS_COMPLETED,
-        &errors)
+        errors)
       != SECURITY_INTELLIGENCE_RESP_OK)
     {
       g_warning ("%s: Failed to complete remote report %s",
@@ -1099,13 +1104,11 @@ export_report_security_intelligence (report_t report,
   result = EXPORT_REPORT_RESULT_SUCCESS;
 
 cleanup:
-  if (result != EXPORT_REPORT_RESULT_SUCCESS && errors)
+  if (result != EXPORT_REPORT_RESULT_SUCCESS && errors && *errors)
     {
-      for (guint i = 0; i < errors->len; ++i)
+      for (guint i = 0; i < (*errors)->len; ++i)
         {
-          const gchar *message;
-
-          message = g_ptr_array_index (errors, i);
+          const gchar *message = g_ptr_array_index (*errors, i);
 
           g_warning ("%s: Security Intelligence error: %s",
                      __func__,
@@ -1115,9 +1118,6 @@ cleanup:
 
   if (count_get_initialized)
     cleanup_report_export_get_data (&count_get);
-
-  if (errors)
-    g_ptr_array_free (errors, TRUE);
 
   security_intelligence_managed_report_page_list_free (remote_pages);
   security_intelligence_managed_report_free (remote_report);

--- a/src/manage_report_exports.h
+++ b/src/manage_report_exports.h
@@ -41,7 +41,8 @@ typedef enum export_report_result
 #if ENABLE_SECURITY_INTELLIGENCE_EXPORT
 export_report_result_t
 export_report_security_intelligence (report_t report,
-                                     integration_config_data_t config);
+                                     integration_config_data_t config,
+                                     GPtrArray **);
 #endif
 
 gboolean


### PR DESCRIPTION
## What

- Upgrade the `gvm-auth-lib` version.
- Adapt the authentication interface to the updated library API.
- Improve Security Intelligence error handling and logging.
- Preserve raw response errors and pass them back to the caller.
- Fix `GPtrArray` NULL handling during report export.

## Why

- The updated authentication library requires interface changes.
- Better error propagation makes failed exports easier to diagnose.
- The pointer handling fix prevents crashes when no error array is available.


## References

GEA-1920


