### PR TITLE
Fix: Free fields in create_report_data_reset

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -977,6 +977,10 @@ create_report_data_reset (create_report_data_t *data)
   free (data->result_detection_location);
   free (data->result_detection_source_oid);
   free (data->result_detection_source_name);
+  free (data->result_qod_type);
+  free (data->result_qod);
+  free (data->result_scan_nvt_version);
+  free (data->result_severity);
 
   memset (data, 0, sizeof (create_report_data_t));
 }

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -981,6 +981,8 @@ create_report_data_reset (create_report_data_t *data)
   free (data->result_qod);
   free (data->result_scan_nvt_version);
   free (data->result_severity);
+  free (data->host_end_host);
+  free (data->host_start_host);
 
   memset (data, 0, sizeof (create_report_data_t));
 }

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -957,6 +957,7 @@ create_report_data_reset (create_report_data_t *data)
               free (result->qod_type);
               free (result->scan_nvt_version);
               free (result->severity);
+              free (result->threat);
             }
         }
       array_free (data->results);

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -967,6 +967,16 @@ create_report_data_reset (create_report_data_t *data)
   free (data->scan_start);
   free (data->task_id);
   free (data->type);
+  free (data->detail_name);
+  free (data->detail_value);
+  free (data->detail_source_desc);
+  free (data->detail_source_name);
+  free (data->detail_source_type);
+  free (data->result_detection_name);
+  free (data->result_detection_product);
+  free (data->result_detection_location);
+  free (data->result_detection_source_oid);
+  free (data->result_detection_source_name);
 
   memset (data, 0, sizeof (create_report_data_t));
 }


### PR DESCRIPTION
## What

Free fields in `create_report_data_reset`.

## Why

They were leaking.

## Testing

I ran GMP commands on main with Asan and some extra patches (to call command data reset on cleanup). Asan warned about the leaks.
I ran the same commands with the PR and the warnings were gone.
