### PR TITLE
Fix: free compliance_levels in results_extra_where

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -11556,6 +11556,7 @@ results_extra_where (int trash, report_t report, const gchar* host,
 
   compliance_levels_clause = where_compliance_levels (compliance_levels);
 
+  g_free (compliance_levels);
   g_free (levels);
   g_free (new_severity_sql);
 


### PR DESCRIPTION
## What

Free `compliance_levels` in `results_extra_where`.

## Why

Was leaking.

## Testing

I ran GMP commands to produce an Asan warning for the leak.
I ran the same commands with the patch and the warning is gone.