### PR TITLE
Add: Add new whole family Microsoft Office LSC.

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -992,6 +992,7 @@ move_task (const char*, const char*);
   " 'Mac OS X Local Security Checks',"             \
   " 'Mageia Linux Local Security Checks',"         \
   " 'Mandrake Local Security Checks',"             \
+  " 'Microsoft Office Local Security Checks'"      \
   " 'openEuler Local Security Checks',"            \
   " 'openSUSE Local Security Checks',"             \
   " 'Oracle Linux Local Security Checks',"         \
@@ -1024,6 +1025,7 @@ move_task (const char*, const char*);
     "Huawei EulerOS Local Security Checks",        \
     "Mageia Linux Local Security Checks",          \
     "Mandrake Local Security Checks",              \
+    "Microsoft Office Local Security Checks",      \
     "openEuler Local Security Checks",             \
     "openSUSE Local Security Checks",              \
     "Oracle Linux Local Security Checks",          \


### PR DESCRIPTION
## What

Add new whole scan config family Microsoft Office LSC.

## Why
Should be added

## References
GEA-1576


