### PR TITLE
Fix: size group arrays before assigning into them

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -11392,6 +11392,11 @@ buffer_aggregate_xml (GString *xml, iterator_t* aggregate, const gchar* type,
       group_sums = g_array_new (TRUE, TRUE, sizeof (double));
 
       group_c_sums = g_array_new (TRUE, TRUE, sizeof (GTree*));
+      g_array_set_size (group_mins, data_columns->len);
+      g_array_set_size (group_maxs, data_columns->len);
+      g_array_set_size (group_mean_sums, data_columns->len);
+      g_array_set_size (group_sums, data_columns->len);
+      g_array_set_size (group_c_sums, data_columns->len);
       for (index = 0; index < data_columns->len; index++)
         g_array_index (group_c_sums, GTree*, index)
           = g_tree_new_full ((GCompareDataFunc) g_strcmp0, NULL,


### PR DESCRIPTION
## What

Set the size of the `group_*` arrays before assigning into them, in `buffer_aggregate_xml`.

## Why

Otherwise the assignments write out of bounds.

## Testing

I ran GMP commands on main that showed the oob in the Asan logs, in particular:
```
  <get_aggregates type="nvt" subgroup_column="family"
  first_group="1" max_groups="1">
    <data_column>cvss_base</data_column>
    <data_column>cvss_base</data_column>
    <data_column>cvss_base</data_column>
  </get_aggregates>
```
Then I ran the same GMP commands with the patch and the log was gone.