### PR TITLE
[GEA-1931] Accommodating for `target_type` when using `target`

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -1669,7 +1669,11 @@ run_osp_task (task_t task, int from, char **report_id)
 {
   target_t target;
 
-  target = task_target (task);
+  if (task_target_type (task) != TASKS_TARGET_TYPE_REGULAR)
+    target = 0;
+  else
+    target = task_target (task);
+
   if (target)
     {
       char *uuid;
@@ -1879,7 +1883,11 @@ run_cve_task (task_t task)
 {
   target_t target;
 
-  target = task_target (task);
+  if (task_target_type (task) != TASKS_TARGET_TYPE_REGULAR)
+    target = 0;
+  else
+    target = task_target (task);
+
   if (target)
     {
       char *uuid;
@@ -6770,7 +6778,11 @@ run_openvasd_task (task_t task, int from, char **report_id)
     }
   target_t target;
 
-  target = task_target (task);
+  if (task_target_type (task) != TASKS_TARGET_TYPE_REGULAR)
+    target = 0;
+  else
+    target = task_target (task);
+
   if (target)
     {
       char *uuid;

--- a/src/manage_scan_handler.c
+++ b/src/manage_scan_handler.c
@@ -51,7 +51,13 @@ handle_queued_osp_scan (const char *scan_id, report_t report,
       case TASK_STATUS_REQUESTED:
         {
           int rc;
-          target_t target = task_target (task);
+          target_t target;
+
+          if (task_target_type (task) != TASKS_TARGET_TYPE_REGULAR)
+            target = 0;
+          else
+            target = task_target (task);
+
           rc = handle_osp_scan_start (task, target, scan_id, start_from,
                                       TRUE, &discovery_scan);
           /* Set discovery flag to the report */
@@ -94,8 +100,13 @@ handle_queued_openvasd_scan (const char *scan_id, report_t report,
       case TASK_STATUS_REQUESTED:
         {
           int rc;
-          target_t target = task_target (task);
-          // TODO: target_type?
+          target_t target;
+
+          if (task_target_type (task) != TASKS_TARGET_TYPE_REGULAR)
+            target = 0;
+          else
+            target = task_target (task);
+
           rc = handle_openvasd_scan_start (task, target, scan_id, start_from,
                                            TRUE, &discovery_scan);
           /* Set discovery flag to the report */

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -6080,6 +6080,8 @@ agent_group_hidden_tasks_exist_by_scanner (scanner_t scanner)
 agent_group_t
 task_agent_group (task_t task)
 {
+  if (task_target_type (task) != TASKS_TARGET_TYPE_AGENT_GROUP)
+    return 0;
   return task_target (task);
 }
 
@@ -6093,6 +6095,8 @@ task_agent_group (task_t task)
 int
 task_agent_group_in_trash (task_t task)
 {
+  if (task_target_type (task) != TASKS_TARGET_TYPE_AGENT_GROUP)
+    return 0;
   return task_target_in_trash (task);
 }
 #endif /*ENABLE_AGENTS*/
@@ -6108,6 +6112,8 @@ task_agent_group_in_trash (task_t task)
 oci_image_target_t
 task_oci_image_target (task_t task)
 {
+  if (task_target_type (task) != TASKS_TARGET_TYPE_OCI_IMAGE)
+    return 0;
   return task_target (task);
 }
 
@@ -6121,6 +6127,8 @@ task_oci_image_target (task_t task)
 int
 task_oci_image_target_in_trash (task_t task)
 {
+  if (task_target_type (task) != TASKS_TARGET_TYPE_OCI_IMAGE)
+    return 0;
   return task_target_in_trash (task);
 }
 
@@ -6150,6 +6158,8 @@ set_task_oci_image_target (task_t task, oci_image_target_t oci_image_target)
 web_application_target_t
 task_web_application_target (task_t task)
 {
+  if (task_target_type (task) != TASKS_TARGET_TYPE_WEB_APPLICATION)
+    return 0;
   return task_target (task);
 }
 
@@ -6163,6 +6173,8 @@ task_web_application_target (task_t task)
 int
 task_web_application_target_in_trash (task_t task)
 {
+  if (task_target_type (task) != TASKS_TARGET_TYPE_WEB_APPLICATION)
+    return 0;
   return task_target_in_trash (task);
 }
 
@@ -16317,19 +16329,28 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
 
       comment = task_comment (task);
 
-      target = task_target (task);
-      // TODO: target_type?
-      if (task_target_in_trash (task))
+      if (task_target_type (task) != TASKS_TARGET_TYPE_REGULAR)
+        target = 0;
+      else
+        target = task_target (task);
+
+      if (target && task_target_in_trash (task))
         {
           task_target_uuid = trash_target_uuid (target);
           task_target_name = trash_target_name (target);
           task_target_comment = trash_target_comment (target);
         }
-      else
+      else if (target)
         {
           task_target_uuid = target_uuid (target);
           task_target_name = target_name (target);
           task_target_comment = target_comment (target);
+        }
+      else
+        {
+          task_target_uuid = NULL;
+          task_target_name = NULL;
+          task_target_comment = NULL;
         }
 
       if ((target == 0)
@@ -16344,7 +16365,6 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
           progress_xml = g_strdup_printf ("%i", progress);
         }
 
-      // TODO: target_type?
       PRINT (out,
              "<task id=\"%s\">"
              "<name>%s</name>"
@@ -16358,7 +16378,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
              tsk_name ? tsk_name : "",
              comment ? comment : "",
              task_target_uuid ? task_target_uuid : "",
-             task_target_in_trash (task),
+             (target != 0) ? task_target_in_trash (task) : 0,
              task_target_name ? task_target_name : "",
              task_target_comment ? task_target_comment : "");
 


### PR DESCRIPTION
## What

Some more functions, like starting a task or generating reports, use the `target` column and did not respect `target_type` yet accordingly

## Why

Don't break stuff

## References

GEA-1931
