### PR TITLE
Fix: require group col when subgroup col is given in GET_AGGREGATES

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -11948,6 +11948,17 @@ handle_get_aggregates (gmp_parser_t *gmp_parser, GError **error)
   group_column = get_aggregates_data->group_column;
   subgroup_column = get_aggregates_data->subgroup_column;
 
+  if (subgroup_column && group_column == NULL)
+    {
+      SEND_TO_CLIENT_OR_FAIL
+        (XML_ERROR_SYNTAX ("get_aggregates",
+                           "A 'group_column' attribute is required when"
+                           " 'subgroup_column' is given"));
+      get_aggregates_data_reset (get_aggregates_data);
+      set_client_state (CLIENT_AUTHENTIC);
+      return;
+    }
+
   init_aggregate_lists (group_column,
                         subgroup_column,
                         get_aggregates_data->data_columns,


### PR DESCRIPTION
## What

Require `@group_column` in GET_AGGREGATES when `@subgroup_column` is given.

## Why

The point of the subgroup column is to refine the group column.

The XML response was broken anyway. This GMP
```xml
<get_aggregates type="nvt" subgroup_column="family"/>
```
was giving
```xml
<get_aggregates_response  status_text="OK"  status="200">
  <aggregate>
    <data_type>nvt</data_type>
    <subgroup_column>family</subgroup_column>
    <overall> <!-- MISSING CLOSE -->
      <count>95089</count>
      <c_count>95089</c_count>
    </subgroup> <!-- MISSING OPEN -->
      <count>0</count>
      <c_count>0</c_count>
    </group> <!-- MISSING OPEN -->
    <subgroups></subgroups>
    <column_info>
      ...
    </column_info>
  </aggregate>
  ...
</get_aggregates_response>
```

## References

Calling GET_AGGREGATES like this showed the OOB in #3026.