### PR TITLE
Fix: Add missing comma to family name

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -992,7 +992,7 @@ move_task (const char*, const char*);
   " 'Mac OS X Local Security Checks',"             \
   " 'Mageia Linux Local Security Checks',"         \
   " 'Mandrake Local Security Checks',"             \
-  " 'Microsoft Office Local Security Checks'"      \
+  " 'Microsoft Office Local Security Checks',"     \
   " 'openEuler Local Security Checks',"            \
   " 'openSUSE Local Security Checks',"             \
   " 'Oracle Linux Local Security Checks',"         \


### PR DESCRIPTION
## What
Add missing comma to family name.

## Why

Was missing when adding the family name in https://github.com/greenbone/gvmd/pull/3024



