### PR TITLE
Fix: Add missing comma

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -992,7 +992,7 @@ move_task (const char*, const char*);
   " 'Mac OS X Local Security Checks',"             \
   " 'Mageia Linux Local Security Checks',"         \
   " 'Mandrake Local Security Checks',"             \
-  " 'Microsoft Office Local Security Checks'"      \
+  " 'Microsoft Office Local Security Checks',"     \
   " 'openEuler Local Security Checks',"            \
   " 'openSUSE Local Security Checks',"             \
   " 'Oracle Linux Local Security Checks',"         \


### PR DESCRIPTION
## What

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

Add missing comma.

## Why

<!-- Describe why are these changes necessary? -->

No comma is syntax error:

```
md manage[205296]: sql_exec_internal: PQexec failed: ERROR:  syntax error at or near "'openEuler Local Security Checks'"
LINE 1: ...Checks', 'Microsoft Office Local Security Checks' 'openEuler...
                                                             ^
 (7)
md manage[205296]: sql_exec_internal: SQL: SELECT COUNT(*) FROM (   SELECT DISTINCT rh.host, trim(split_cve) AS cve   FROM report_hosts rh   JOIN report_host_details rhd     ON rhd.report_host = rh.id   JOIN nvts n     ON n.oid = rhd.source_name   CROSS JOIN LATERAL regexp_split_to_ta>
md manage[205296]: geia Linux Local Security Checks', 'Mandrake Local Security Checks', 'Microsoft Office Local Security Checks' 'openEuler Local Security Checks', 'openSUSE Local Security Checks', 'Oracle Linux Local Security Checks', 'Palo Alto PAN-OS Local Security Checks', 'Red Ha>
md manage[205296]: sql_x: sql_exec_internal failed
md   main[205296]: BACKTRACE: gvmd: Serving (+0xd85bd) [0x565077f065bd]
md   main[205296]: BACKTRACE: /lib64/libc.so.6(+0x411c0) [0x7f0da989e1c0]
md   main[205296]: BACKTRACE: /lib64/libc.so.6(+0x9781c) [0x7f0da98f481c]
md   main[205296]: BACKTRACE: /lib64/libc.so.6(gsignal+0x16) [0x7f0da989e116]
md   main[205296]: BACKTRACE: /lib64/libc.so.6(abort+0xd7) [0x7f0da98858fa]
md   main[205296]: BACKTRACE: gvmd: Serving (+0xee367) [0x565077f1c367]
md   main[205296]: BACKTRACE: gvmd: Serving (+0xee70d) [0x565077f1c70d]
md   main[205296]: BACKTRACE: gvmd: Serving (+0xcb936) [0x565077ef9936]
md   main[205296]: BACKTRACE: gvmd: Serving (+0x9deaf) [0x565077ecbeaf]
md   main[205296]: BACKTRACE: gvmd: Serving (+0xf47f9) [0x565077f227f9]
md   main[205296]: BACKTRACE: gvmd: Serving (+0x33c10) [0x565077e61c10]
md   main[205296]: BACKTRACE: /lib64/libglib-2.0.so.0(+0x625c2) [0x7f0da9b135c2]
md   main[205296]: BACKTRACE: /lib64/libglib-2.0.so.0(g_markup_parse_context_parse+0xb42) [0x7f0da9b152c2]
md   main[205296]: BACKTRACE: gvmd: Serving (+0xfbd33) [0x565077f29d33]
md   main[205296]: BACKTRACE: gvmd: Serving (+0xd81ea) [0x565077f061ea]
md   main[205296]: BACKTRACE: gvmd: Serving (+0xe0cd0) [0x565077f0ecd0]
md   main[205296]: BACKTRACE: gvmd: Serving (+0xe5b43) [0x565077f13b43]
md   main[205296]: BACKTRACE: gvmd: Serving (+0xe9d68) [0x565077f17d68]
md   main[205296]: BACKTRACE: /lib64/libc.so.6(+0x2a58e) [0x7f0da988758e]
md   main[205296]: BACKTRACE: /lib64/libc.so.6(__libc_start_main+0x89) [0x7f0da9887649]
md   main[205296]: BACKTRACE: gvmd: Serving (+0x12575) [0x565077e40575]
md manage[205296]: Received Aborted signal
```

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->