### PR TITLE
Fix: free openvasd_targets in launch_openvasd_openvas_task

### DIFF
--- a/src/manage_openvasd.c
+++ b/src/manage_openvasd.c
@@ -500,7 +500,8 @@ launch_openvasd_openvas_task (task_t task, target_t target, const char *scan_id,
   else
     g_warning ("%s: Failed to create scan: %ld", __func__, response->code);
 
-  openvasd_target_free(openvasd_target);
+  g_slist_free_full (openvasd_targets,
+                     (GDestroyNotify) openvasd_target_free);
   // Credentials are freed with target
   g_slist_free_full (vts, (GDestroyNotify) openvasd_vt_single_free);
   g_hash_table_destroy (scanner_options);


### PR DESCRIPTION
## What
Free `openvasd_targets` in `launch_openvasd_openvas_task`.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why

The slist itself was leaking. Now we're freeing both the target and the list, like the other returns do.

## Testing

Ran GMP on main that showed Asan warnings.
Ran again with patch, warning gone.

