### PR TITLE
Fix: free sort_data in gmp_xml_handle_start_element

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -5537,6 +5537,8 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
                   = g_list_append (get_aggregates_data->sort_data,
                                   sort_data);
               }
+            else
+              sort_data_free (sort_data);
 
             append_attribute (attribute_names, attribute_values, "mode",
                               &get_aggregates_data->mode);


### PR DESCRIPTION
## What
Free `sort_data` in `gmp_xml_handle_start_element`.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
It was leaking in this case. The other case frees it with `get_aggregates_data`.
<!-- Describe why are these changes necessary? -->

## Testing
Ran GMP on main, saw Asan logs.
Ran again with patch, Asan logs gone.