### PR TITLE
Fix: handle missing report in asset_snapshots

### DIFF
--- a/src/manage_sql_assets.c
+++ b/src/manage_sql_assets.c
@@ -2272,19 +2272,20 @@ manage_asset_snapshot_delete_stale (int days)
 static gboolean
 asset_type_for_report (report_t report, asset_type_t *asset_type)
 {
-  int type;
+  long long int type;
 
   if (!report || !asset_type)
     return FALSE;
 
-  type = sql_int_ps (
-    "SELECT asset_type"
-    " FROM asset_snapshots"
-    " WHERE report_id = $1"
-    " ORDER BY id"
-    " LIMIT 1;",
-    SQL_RESOURCE_PARAM (report),
-    NULL);
+  if (sql_int64_ps (&type,
+                    "SELECT asset_type"
+                    " FROM asset_snapshots"
+                    " WHERE report_id = $1"
+                    " ORDER BY id"
+                    " LIMIT 1;",
+                    SQL_RESOURCE_PARAM (report),
+                    NULL))
+    return FALSE;
 
   if (type != ASSET_TYPE_TARGET
       && type != ASSET_TYPE_AGENT


### PR DESCRIPTION
## What

Use `sql_int_ps` in `asset_type_for_report`.

## Why

Prevent `asset_type_for_report` from aborting when the report is missing. The report can legitimately be missing, for example for CVE scans.

## Testing

I ran a CVE scan test with main and saw aborts in the log. I ran the exact same test with the patch and the abort was gone.
