### PR TITLE
Fix: remove duplicate g_hash_table_destroy

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -16491,7 +16491,6 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
                                  NULL, NULL))
         {
           g_free (term);
-          g_hash_table_destroy (ctx.f_host_ports);
           goto fail;
         }
     }


### PR DESCRIPTION
## What

Remove a doubled `g_hash_table_destroy` in `print_report_xml_start`.

## Why

Already freed at fail by `print_report_context_cleanup`.

## Testing

I ran GMP GET_REPORTS on main in such a way that the `print_report_port_xml` failed, and saw the Asan warning in the log.
I did the same with the patch and the warning was gone.