### PR TITLE
chore: update libgvm_http to version 23.9

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,7 +14,7 @@ Prerequisites:
 * glib-2.0 >= 2.42
 * gnutls >= 3.2.15
 * gpgme
-* [gvm-libs](https://github.com/greenbone/gvm-libs/) >= 23.0 (or 23.6 if ENABLE_AGENTS and 23.3 if ENABLE_OPENVASD and 23.8 if ENABLE_WEB_APPLICATION_SCANNING and 23.7 if ENABLE_SECURITY_INTELLIGENCE_EXPORT)
+* [gvm-libs](https://github.com/greenbone/gvm-libs/) >= 23.9
 * [gvm-auth-lib](https://github.com/greenbone/gvm-auth-lib/) >= 0.3 (if ENABLE_SECURITY_INTELLIGENCE_EXPORT or ENABLE_JWT_AUTH is enabled)
 * libical >= 1.0.0
 * libbsd

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,7 +20,7 @@ pkg_check_modules(LIBGVM_OSP REQUIRED libgvm_osp>=23.00)
 pkg_check_modules(LIBGVM_GMP REQUIRED libgvm_gmp>=22.30)
 
 if(ENABLE_HTTP_SCANNER)
-  pkg_check_modules(LIBGVM_HTTP REQUIRED libgvm_http>=22.37)
+  pkg_check_modules(LIBGVM_HTTP REQUIRED libgvm_http>=23.9)
   pkg_check_modules(LIBGVM_HTTP_SCANNER REQUIRED libgvm_http_scanner>=22.41)
 endif(ENABLE_HTTP_SCANNER)
 if(ENABLE_OPENVASD)
@@ -60,7 +60,7 @@ endif(ENABLE_JWT_AUTH)
 
 if(ENABLE_SECURITY_INTELLIGENCE_EXPORT)
   pkg_check_modules(LIBGVM_AUTH REQUIRED libgvm_auth>=0.3)
-  pkg_check_modules(LIBGVM_HTTP REQUIRED libgvm_http>=22.37)
+  pkg_check_modules(LIBGVM_HTTP REQUIRED libgvm_http>=23.9)
   pkg_check_modules(
     LIBGVM_SECURITY_INTELLIGENCE
     REQUIRED


### PR DESCRIPTION
## What

- Update `libgvm_http` to version `23.9`.

## Why

- To use the latest HTTP wrapper changes and TLS verification behavior.


## References

GEA-1951


