### PR TITLE
fix: use scan_report_id in get_scan_report

### DIFF
--- a/src/gmp_scan_report.c
+++ b/src/gmp_scan_report.c
@@ -30,7 +30,6 @@
 typedef struct
 {
   get_data_t get;
-  gchar *report_id;
 } get_scan_report_data_t;
 
 /**
@@ -45,7 +44,6 @@ static void
 get_scan_report_reset (void)
 {
   get_data_reset (&get_scan_report_data.get);
-  g_free (get_scan_report_data.report_id);
 
   memset (&get_scan_report_data, 0, sizeof (get_scan_report_data));
 }
@@ -539,24 +537,10 @@ void
 get_scan_report_start (const gchar **attribute_names,
                        const gchar **attribute_values)
 {
-  const gchar *attribute;
-
   get_data_parse_attributes (&get_scan_report_data.get,
-                             "report",
+                             "scan_report",
                              attribute_names,
                              attribute_values);
-
-  if (find_attribute (attribute_names,
-                      attribute_values,
-                      "report_id",
-                      &attribute))
-    {
-      get_scan_report_data.report_id = g_strdup (attribute);
-
-      get_data_set_extra (&get_scan_report_data.get,
-                          "report_id",
-                          attribute);
-    }
 }
 
 /**
@@ -573,12 +557,12 @@ get_scan_report_run (gmp_parser_t *gmp_parser,
   report_summary_t summary = NULL;
   int ret;
 
-  if (get_scan_report_data.report_id == NULL)
+  if (get_scan_report_data.get.id == NULL)
     {
       SEND_TO_CLIENT_OR_FAIL (
         XML_ERROR_SYNTAX (
           "get_scan_report",
-          "Missing report_id attribute"));
+          "Missing scan_report_id attribute"));
 
       get_scan_report_reset ();
       return;
@@ -614,7 +598,7 @@ get_scan_report_run (gmp_parser_t *gmp_parser,
   g_free (get_scan_report_data.get.subtype);
   get_scan_report_data.get.subtype = g_strdup ("report");
   response = manage_get_scan_report_summary (
-    get_scan_report_data.report_id,
+    get_scan_report_data.get.id,
     &get_scan_report_data.get,
     &summary);
 
@@ -627,7 +611,7 @@ get_scan_report_run (gmp_parser_t *gmp_parser,
       if (send_find_error_to_client (
         "get_scan_report",
         "report",
-        get_scan_report_data.report_id,
+        get_scan_report_data.get.id,
         gmp_parser))
         error_send_to_client (error);
 

--- a/src/gmp_scan_report.c
+++ b/src/gmp_scan_report.c
@@ -598,7 +598,6 @@ get_scan_report_run (gmp_parser_t *gmp_parser,
   g_free (get_scan_report_data.get.subtype);
   get_scan_report_data.get.subtype = g_strdup ("report");
   response = manage_get_scan_report_summary (
-    get_scan_report_data.get.id,
     &get_scan_report_data.get,
     &summary);
 

--- a/src/manage_resources.c
+++ b/src/manage_resources.c
@@ -325,8 +325,7 @@ type_owned (const char* type)
          && strcasecmp (type, "report_operating_system")
          && strcasecmp (type, "report_port")
          && strcasecmp (type, "report_tls_certificate")
-         && strcasecmp (type, "report_vuln")
-         && strcasecmp (type, "scan_report");
+         && strcasecmp (type, "report_vuln");
 }
 
 /**

--- a/src/manage_scan_report.c
+++ b/src/manage_scan_report.c
@@ -315,15 +315,13 @@ resolve_get_report_controls (const get_data_t *get,
 /**
  * @brief Load a structured vulnerability report summary.
  *
- * @param[in]  report_id  UUID of the report.
- * @param[in]  get        GET command data.
+ * @param[in]  get          GET command data.
  * @param[out] summary      Loaded report summary.
  *
  * @return Status describing the result of the operation.
  */
 manage_get_scan_report_response_t
-manage_get_scan_report_summary (const gchar *report_id,
-                                const get_data_t *get,
+manage_get_scan_report_summary (const get_data_t *get,
                                 report_summary_t *summary)
 {
   get_report_controls_t controls = {0};
@@ -331,14 +329,14 @@ manage_get_scan_report_summary (const gchar *report_id,
   report_t report = 0;
   int ret;
 
-  if (report_id == NULL
-      || get == NULL
-      || summary == NULL)
+  if (get == NULL
+      || summary == NULL
+      || get->id == NULL)
     return MANAGE_GET_SCAN_REPORT_ERROR;
 
   *summary = NULL;
 
-  ret = find_report_with_permission (report_id,
+  ret = find_report_with_permission (get->id,
                                      &report,
                                      "get_reports");
 

--- a/src/manage_scan_report.h
+++ b/src/manage_scan_report.h
@@ -179,7 +179,7 @@ void
 report_summary_free (report_summary_t);
 
 manage_get_scan_report_response_t
-manage_get_scan_report_summary (const gchar *, const get_data_t *,
+manage_get_scan_report_summary (const get_data_t *,
                                 report_summary_t *);
 
 const gchar *

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -20099,7 +20099,7 @@ END:VCALENDAR
     </description>
     <pattern>
       <attrib>
-        <name>report_id</name>
+        <name>scan_report_id</name>
         <summary>ID of the report to retrieve</summary>
         <type>uuid</type>
         <required>1</required>
@@ -20713,7 +20713,7 @@ END:VCALENDAR
       <summary>Get a structured vulnerability report</summary>
       <request>
         <get_scan_report
-          report_id="c00e2b2b-6b3a-4be9-a6df-337f76262fe0"
+          scan_report_id="c00e2b2b-6b3a-4be9-a6df-337f76262fe0"
           filter="apply_overrides=0 levels=chml min_qod=70 result_hosts_only=1">
         </get_scan_report>
       </request>


### PR DESCRIPTION
## What

- Use `scan_report_id` in the `get_scan_report` command.
- Reuse the generic ID field instead of storing the report ID separately.
- Update the GMP schema example.
- Remove `scan_report` from the owned resource types.

## Why

- To keep `get_scan_report` consistent with other GMP get commands.
- To simplify the command implementation and avoid duplicate ID handling.


## References

GEA-1937


