### PR TITLE
Fix: check for colon when working with certs

### DIFF
--- a/src/manage_sql_report_tls_certificates.c
+++ b/src/manage_sql_report_tls_certificates.c
@@ -69,7 +69,13 @@ print_report_host_tls_certificates_xml (report_host_t report_host,
       certificate = g_base64_decode (certificate_b64, &certificate_size);
 
       scanner_fpr_prefixed = iterator_string (&tls_certs, 1);
-      scanner_fpr = g_strrstr (scanner_fpr_prefixed, ":") + 1;
+      scanner_fpr = g_strrstr (scanner_fpr_prefixed, ":");
+      if (scanner_fpr == NULL)
+        {
+          g_free (certificate);
+          continue;
+        }
+      scanner_fpr++;
 
       quoted_scanner_fpr = sql_quote (scanner_fpr);
 

--- a/src/manage_sql_report_tls_certificates.c
+++ b/src/manage_sql_report_tls_certificates.c
@@ -61,7 +61,10 @@ print_report_host_tls_certificates_xml (report_host_t report_host,
       time_t now;
 
       certificate_prefixed = iterator_string (&tls_certs, 0);
-      certificate_b64 = g_strrstr (certificate_prefixed, ":") + 1;
+      certificate_b64 = g_strrstr (certificate_prefixed, ":");
+      if (certificate_b64 == NULL)
+        continue;
+      certificate_b64++;
 
       certificate = g_base64_decode (certificate_b64, &certificate_size);
 

--- a/src/manage_sql_tls_certificates.c
+++ b/src/manage_sql_tls_certificates.c
@@ -1530,7 +1530,13 @@ add_tls_certificates_from_report_host (report_host_t report_host,
       certificate = g_base64_decode (certificate_b64, &certificate_size);
 
       scanner_fpr_prefixed = iterator_string (&tls_certs, 1);
-      scanner_fpr = g_strrstr (scanner_fpr_prefixed, ":") + 1;
+      scanner_fpr = g_strrstr (scanner_fpr_prefixed, ":");
+      if (scanner_fpr == NULL)
+        {
+          g_free (certificate);
+          continue;
+        }
+      scanner_fpr++;
 
       quoted_scanner_fpr = sql_quote (scanner_fpr);
 

--- a/src/manage_sql_tls_certificates.c
+++ b/src/manage_sql_tls_certificates.c
@@ -1522,7 +1522,10 @@ add_tls_certificates_from_report_host (report_host_t report_host,
       gboolean has_ports;
 
       certificate_prefixed = iterator_string (&tls_certs, 0);
-      certificate_b64 = g_strrstr (certificate_prefixed, ":") + 1;
+      certificate_b64 = g_strrstr (certificate_prefixed, ":");
+      if (certificate_b64 == NULL)
+        continue;
+      certificate_b64++;
 
       certificate = g_base64_decode (certificate_b64, &certificate_size);
 


### PR DESCRIPTION
## What

Remove assumption that a colon exists in the base64 cert or fingerprint, when printing and adding them.

## Why

This was leading to segfaults when the colon is missing.

## Testing

On main I ran GMP commands that showed these segfaults (eg CREATE_REPORT with cert, then GET_REPORT).
I ran the same with the patches and the segfaults were gone.