### PR TITLE
Forbid empty password in authentication

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -5250,6 +5250,12 @@ authenticate_any_method (const gchar *username, const gchar *password,
   gchar *hash;
   gboolean use_cache = TRUE;
 
+  if (password == NULL || *password == '\0')
+    {
+      g_debug ("%s: Empty password rejected", __func__);
+      return 1;
+    }
+
   sql_begin_immediate ();
 
   ret = sql_table_lock_wait ("auth_cache", 30000);


### PR DESCRIPTION
## What
The `authenticate_any_method` function now rejects any authentication attempts with a missing or empty password.

## Why
This prevents authentication bypass issues in cases where insecure authentication servers skip the password check if the password is empty.

## References
GEA-1943
