### PR TITLE
Fix rename of web_application_vt_refs_rebuild

### DIFF
--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -7199,7 +7199,7 @@ abort_web_application_vts_update ()
           sql ("ALTER TABLE IF EXISTS vts.web_application_vts_rebuild"
                " RENAME TO web_application_vts;");
           sql ("ALTER TABLE IF EXISTS vts.web_application_vt_refs_rebuild"
-               " RENAME TO web_application_vt_refs_rebuild;");
+               " RENAME TO web_application_vt_refs;");
         }
     }
 


### PR DESCRIPTION
## What
When aborting the Web Application VTs sync with no previous table, rename the `web_application_vt_refs_rebuild` to `web_application_vt_refs` as expected.

## Why
The table was being renamed to its existing name, causing SQL errors.

## References
GEA-1883