### PR TITLE
fix: move agent-related includes behind ENABLE_AGENTS

### DIFF
--- a/src/manage_agent_groups.c
+++ b/src/manage_agent_groups.c
@@ -8,11 +8,11 @@
  * @brief Agent group data utilities and access control checks for GVMD.
  */
 
+#if ENABLE_AGENTS
+#include "manage_agent_groups.h"
 #include "manage_agents.h"
 #include "manage_sql_agents.h"
 #include "manage_sql_agent_groups.h"
-#if ENABLE_AGENTS
-#include "manage_agent_groups.h"
 
 #undef G_LOG_DOMAIN
 /**


### PR DESCRIPTION
## What

Moved agent-related includes behind the `ENABLE_AGENTS` feature flag.

## Why

This prevents agent-specific headers from being included when agent support is disabled.



