### PR TITLE
Fix: free quoted values in add_tls_certificates_from_report_host

### DIFF
--- a/src/manage_sql_tls_certificates.c
+++ b/src/manage_sql_tls_certificates.c
@@ -1618,6 +1618,7 @@ add_tls_certificates_from_report_host (report_host_t report_host,
           g_free (subject);
           g_free (issuer);
           g_free (serial);
+          g_free (quoted_scanner_fpr);
           continue;
         }
 
@@ -1685,6 +1686,7 @@ add_tls_certificates_from_report_host (report_host_t report_host,
       g_free (subject);
       g_free (issuer);
       g_free (serial);
+      g_free (quoted_scanner_fpr);
     }
   cleanup_iterator (&tls_certs);
 

--- a/src/manage_sql_tls_certificates.c
+++ b/src/manage_sql_tls_certificates.c
@@ -1659,6 +1659,7 @@ add_tls_certificates_from_report_host (report_host_t report_host,
               if (versions->len)
                 g_string_append (versions, ", ");
               g_string_append (versions, quoted_version);
+              g_free (quoted_version);
             }
           cleanup_iterator (&versions_iter);
 


### PR DESCRIPTION
## What

Free `quoted_scanner_fpr` and `quoted_version` in `add_tls_certificates_from_report_host`.

## Why

They were leaking.

## Testing

I ran GMP on main that showed the leaks from Asan.
I ran the same GMP with the patches and the leak warnings were gone.