### PR TITLE
Fix: a couple cert related leaks

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -470,6 +470,7 @@ get_certificate_info (const gchar* certificate, gssize certificate_len,
                                     certificate_format_internal);
       if (err)
         {
+          gnutls_x509_crt_deinit (gnutls_cert);
           g_free (cert_truncated);
           return -1;
         }

--- a/src/manage_sql_report_tls_certificates.c
+++ b/src/manage_sql_report_tls_certificates.c
@@ -54,7 +54,7 @@ print_report_host_tls_certificates_xml (report_host_t report_host,
       gsize certificate_size;
       unsigned char *certificate;
       const char *scanner_fpr_prefixed, *scanner_fpr;
-      gchar *quoted_scanner_fpr;
+      gchar *quoted_scanner_fpr, *activation_time_str, *expiration_time_str;;
       char *ssldetails;
       iterator_t ports;
       gboolean valid;
@@ -141,6 +141,9 @@ print_report_host_tls_certificates_xml (report_host_t report_host,
                                    "   AND name = 'hostname'",
                                    report_host);
 
+      activation_time_str = certificate_iso_time (activation_time);
+      expiration_time_str = certificate_iso_time (expiration_time);
+
       PRINT (stream,
              "<tls_certificate>"
              "<name>%s</name>"
@@ -160,13 +163,16 @@ print_report_host_tls_certificates_xml (report_host_t report_host,
              sha256_fingerprint,
              md5_fingerprint,
              valid,
-             certificate_iso_time (activation_time),
-             certificate_iso_time (expiration_time),
+             activation_time_str,
+             expiration_time_str,
              subject,
              issuer,
              serial,
              host_ip,
              hostname ? hostname : "");
+
+      g_free (activation_time_str);
+      g_free (expiration_time_str);
 
       g_free (certificate);
       g_free (md5_fingerprint);


### PR DESCRIPTION
## What

Call  gnutls_x509_crt_deinit in err case of get_certificate_info.

Free times in print_report_host_tls_certificates_xml.

## Why

Were leaking.

## Testing

I saw the leaks in Asan output running GMP on main.
I ran again with the patches and the ouput was gone.