### PR TITLE
Fix: use len as terminator in print_report_port_xml loop

### DIFF
--- a/src/manage_sql_report_ports.c
+++ b/src/manage_sql_report_ports.c
@@ -346,12 +346,13 @@ print_report_port_xml (print_report_context_t *ctx, report_t report, FILE *out,
          report_port_count (report));
   {
     result_buffer_t *item;
-    int index = 0;
+    int index;
 
-    while ((item = g_array_index (ports, result_buffer_t*, index++)))
+    for (index = 0; index < ports->len; index++)
       {
         int port_count;
 
+        item = g_array_index (ports, result_buffer_t*, index);
         port_count = GPOINTER_TO_INT (g_hash_table_lookup (ctx->f_host_ports,
           item->host));
 


### PR DESCRIPTION
## What

In `print_report_port_xml` use `for` with the actual array length to see when to stop processing.

## Why

Using `while` was depending on there being a zero item after the last port item. That usually works because the array is initially zeroed, but when we remove duplicates there may be old entries after the end of the array. This was leading to double frees, because we were trying to free those old entries.

## References

| Event | Commit | Date | Description |
|-------|--------|------|-------------|
| Port dedup introduced | 3bd83727b | 2010-09-16 | Added dedup using `g_array_remove_index_fast` (swap-with-last). Unbounded `while` loop worked fine since swap-remove doesn't leave stale pointers past `len`. |
| **Bug introduced** | d80c5a56b | **2010-11-22** | Changed `g_array_remove_index_fast` → `g_array_remove_index` (shift-left) to preserve order. This *does* leave stale pointers at position `len`, but the unbounded `while` loop was **never updated** to be bounded by `ports->len`. |

## Testing

I ran GMP command on main that showed Asan double free warnings.
I did the same with the path and the warnings were gone.


