### PR TITLE
Add web_application_vt subtype to GMP get_info

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -14563,6 +14563,17 @@ handle_get_info (gmp_parser_t *gmp_parser, GError **error)
       set_client_state (CLIENT_AUTHENTIC);
       return;
     }
+  if (feature_enabled (FEATURE_ID_WEB_APPLICATION_SCANNING)
+      && g_strcmp0 (get_info_data->type, "web_application_vt") == 0
+      && manage_web_application_vts_loaded () == 0)
+    {
+      SEND_TO_CLIENT_OR_FAIL
+       (XML_ERROR_SYNTAX ("get_info",
+                          "The Web Application VTs database is required"));
+      get_info_data_reset (get_info_data);
+      set_client_state (CLIENT_AUTHENTIC);
+      return;
+    }
 
   if (get_info_data->name && get_info_data->get.id)
     {
@@ -14600,6 +14611,8 @@ handle_get_info (gmp_parser_t *gmp_parser, GError **error)
         name = g_strdup ("DFN-CERT");
       else if (strcmp (get_info_data->type, "nvt") == 0)
         name = g_strdup ("NVT");
+      else if (strcmp (get_info_data->type, "web_application_vt") == 0)
+        name = g_strdup ("Web Application VT");
       else
         {
           if (send_find_error_to_client ("get_info", "type",
@@ -14656,6 +14669,13 @@ handle_get_info (gmp_parser_t *gmp_parser, GError **error)
       init_info_iterator = init_dfn_cert_adv_info_iterator;
       info_count = dfn_cert_adv_info_count;
       get_info_data->get.subtype = g_strdup ("dfn_cert_adv");
+    }
+  else if (feature_enabled (FEATURE_ID_WEB_APPLICATION_SCANNING)
+           && g_strcmp0 ("web_application_vt", get_info_data->type) == 0)
+    {
+      init_info_iterator = init_web_application_vt_info_iterator;
+      info_count = web_application_vt_info_count;
+      get_info_data->get.subtype = g_strdup ("web_application_vt");
     }
   else
     {
@@ -14928,6 +14948,39 @@ handle_get_info (gmp_parser_t *gmp_parser, GError **error)
                             ? dfn_cert_adv_info_iterator_severity(&info)
                             : "",
                            dfn_cert_adv_info_iterator_cve_refs (&info));
+      else if (g_strcmp0 ("web_application_vt", get_info_data->type) == 0)
+        {
+          iterator_t refs;
+
+          xml_string_append (
+              result,
+              "<web_application_vt>"
+              "<type>%s</type>"
+              "<description>%s</description>"
+              "<solution>%s</solution>"
+              "<severity>%s</severity>"
+              "<type_metadata>%s</type_metadata>"
+              "<refs>",
+              web_application_vt_info_iterator_type (&info),
+              web_application_vt_info_iterator_description (&info),
+              web_application_vt_info_iterator_solution (&info),
+              web_application_vt_info_iterator_severity (&info),
+              web_application_vt_info_iterator_type_metadata (&info));
+
+          init_web_application_vt_ref_iterator (&refs,
+                                                get_iterator_uuid (&info));
+          while (next (&refs))
+            {
+              xml_string_append (
+                  result,
+                  "<ref type=\"%s\" id=\"%s\"/>",
+                  web_application_vt_ref_iterator_type (&refs),
+                  web_application_vt_ref_iterator_ref_id (&refs));
+            }
+          cleanup_iterator (&refs);
+
+          xml_string_append (result, "</refs>");
+        }
       else if (g_strcmp0 ("nvt", get_info_data->type) == 0)
         {
           if (send_nvt (&info, 1, 1, -1, NULL, 0, 0, 0, 0,

--- a/src/manage.h
+++ b/src/manage.h
@@ -2675,6 +2675,44 @@ init_nvt_dfn_cert_adv_iterator (iterator_t*, const char*);
 const char*
 nvt_dfn_cert_adv_iterator_name (iterator_t*);
 
+
+/* Web Application VT data */
+
+int
+init_web_application_vt_info_iterator (iterator_t*, get_data_t *,
+                                       const char *);
+
+int
+init_web_application_vt_info_iterator_all (iterator_t*, get_data_t *);
+
+int
+web_application_vt_info_count (const get_data_t *);
+
+const char *
+web_application_vt_info_iterator_type (iterator_t *);
+
+const char *
+web_application_vt_info_iterator_description (iterator_t *);
+
+const char *
+web_application_vt_info_iterator_solution (iterator_t *);
+
+const char *
+web_application_vt_info_iterator_severity (iterator_t *);
+
+const char *
+web_application_vt_info_iterator_type_metadata (iterator_t *);
+
+void
+init_web_application_vt_ref_iterator (iterator_t *, const char *);
+
+const char *
+web_application_vt_ref_iterator_type (iterator_t *);
+
+const char *
+web_application_vt_ref_iterator_ref_id (iterator_t *);
+
+
 /* All SecInfo Data */
 
 int

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -3847,6 +3847,11 @@ manage_attach_databases ()
     sql ("SELECT set_config ('search_path',"
          "                   current_setting ('search_path') || ',cert',"
          "                   false);");
+
+  if (manage_web_application_vts_loaded ())
+    sql ("SELECT set_config ('search_path',"
+         "                   current_setting ('search_path') || ',vts',"
+         "                   false);");
 }
 
 /**

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -1397,6 +1397,217 @@ init_nvt_dfn_cert_adv_iterator (iterator_t *iterator, const char *oid)
 DEF_ACCESS (nvt_dfn_cert_adv_iterator_name, 0);
 
 
+/* Web Application VT data. */
+
+/**
+ * @brief Gets the SELECT columns for Web Application VT iterators and counts.
+ *
+ * @return The SELECT columns.
+ */
+static const column_t*
+web_application_vt_info_select_columns ()
+{
+  static column_t columns[] = WEB_APPLICATION_VT_INFO_ITERATOR_COLUMNS;
+  return columns;
+}
+
+/**
+ * @brief Gets the filter columns for Web Application VT iterators and counts.
+ *
+ * @return The filter columns.
+ */
+static const char **
+web_application_vt_info_filter_columns ()
+{
+  static const char *filter_columns[]
+    = WEB_APPLICATION_VT_INFO_ITERATOR_FILTER_COLUMNS;
+  return filter_columns;
+}
+
+/**
+ * @brief Initialise an Web Application VT info iterator.
+ *
+ * @param[in]  iterator        Iterator.
+ * @param[in]  get             GET data.
+ * @param[in]  name            Name of the info
+ *
+ * @return 0 success, 1 failed to find VT, 2 failed to find filter,
+ *         -1 error.
+ */
+int
+init_web_application_vt_info_iterator (iterator_t* iterator, get_data_t *get,
+                                       const char *name)
+{
+  static const char *filter_columns[] =
+      WEB_APPLICATION_VT_INFO_ITERATOR_FILTER_COLUMNS;
+  static column_t columns[] = WEB_APPLICATION_VT_INFO_ITERATOR_COLUMNS;
+  gchar *clause = NULL;
+  int ret;
+
+  if (get->id)
+    {
+      gchar *quoted = sql_quote (get->id);
+      clause = g_strdup_printf (" AND uuid = '%s'", quoted);
+      g_free (quoted);
+      /* The entry is specified by ID, so filtering just gets in the way. */
+      g_free (get->filter);
+      get->filter = NULL;
+    }
+  else if (name)
+    {
+      gchar *quoted = sql_quote (name);
+      clause = g_strdup_printf (" AND name = '%s'", quoted);
+      g_free (quoted);
+      /* The entry is specified by name, so filtering just gets in the way. */
+      g_free (get->filter);
+      get->filter = NULL;
+    }
+  ret = init_get_iterator (iterator,
+                           "web_application_vt",
+                           get,
+                           columns,
+                           NULL,
+                           filter_columns,
+                           0,
+                           NULL,
+                           clause,
+                           FALSE);
+  g_free (clause);
+  return ret;
+}
+
+/**
+ * @brief Initialise a Web Application VT info iterator not limited to a name.
+ *
+ * @param[in]  iterator        Iterator.
+ * @param[in]  get             GET data.
+ *
+ * @return 0 success, 1 failed to find target, 2 failed to find filter,
+ *         -1 error.
+ */
+int
+init_web_application_vt_info_iterator_all (iterator_t* iterator, get_data_t *get)
+{
+  return init_web_application_vt_info_iterator (iterator, get, NULL);
+}
+
+/**
+ * @brief Count number of Web Application VTs.
+ *
+ * @param[in]  get  GET params.
+ *
+ * @return Total number of Web Application VTs in filtered set.
+ */
+int
+web_application_vt_info_count (const get_data_t *get)
+{
+  static const char *filter_columns[] =
+                      WEB_APPLICATION_VT_INFO_ITERATOR_FILTER_COLUMNS;
+  static column_t columns[] = WEB_APPLICATION_VT_INFO_ITERATOR_COLUMNS;
+  return count ("web_application_vt", get, columns, NULL, filter_columns,
+                0, 0, 0, FALSE);
+}
+
+/**
+ * @brief Get the type from an WEB_APPLICATION_VT iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The type of the Web Application VT,
+ *         or NULL if iteration is complete.
+ *         Freed by cleanup_iterator.
+ */
+DEF_ACCESS (web_application_vt_info_iterator_type,
+            GET_ITERATOR_COLUMN_COUNT);
+
+/**
+ * @brief Get the description from an WEB_APPLICATION_VT iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The description of the Web Application VT,
+ *         or NULL if iteration is complete.
+ *         Freed by cleanup_iterator.
+ */
+DEF_ACCESS (web_application_vt_info_iterator_description,
+            GET_ITERATOR_COLUMN_COUNT + 1);
+
+/**
+ * @brief Get the solution from an WEB_APPLICATION_VT iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The solution of the Web Application VT,
+ *         or NULL if iteration is complete.
+ *         Freed by cleanup_iterator.
+ */
+DEF_ACCESS (web_application_vt_info_iterator_solution,
+            GET_ITERATOR_COLUMN_COUNT + 2);
+
+/**
+ * @brief Get the severity from an WEB_APPLICATION_VT iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The severity of the Web Application VT,
+ *         or NULL if iteration is complete.
+ *         Freed by cleanup_iterator.
+ */
+DEF_ACCESS (web_application_vt_info_iterator_severity,
+            GET_ITERATOR_COLUMN_COUNT + 3);
+
+/**
+ * @brief Get the type-specific metadata from an WEB_APPLICATION_VT iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The type-specific metadata of the Web Application VT,
+ *         or NULL if iteration is complete.
+ *         Freed by cleanup_iterator.
+ */
+DEF_ACCESS (web_application_vt_info_iterator_type_metadata,
+            GET_ITERATOR_COLUMN_COUNT + 4);
+
+/**
+ * @brief Initialize a Web Application VT reference iterator.
+ *
+ * @param[in]  iter   The iterator to initialize.
+ * @param[in]  vt_id  The ID of the VT to get the references of.
+ */
+void
+init_web_application_vt_ref_iterator (iterator_t *iter, const char *vt_id)
+{
+  init_ps_iterator (iter,
+                    "SELECT type, ref_id"
+                    " FROM web_application_vt_refs"
+                    " WHERE vt_id = $1",
+                    SQL_STR_PARAM (vt_id),
+                    NULL);
+}
+
+/**
+ * @brief Get the type from an WEB_APPLICATION_VT refs iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The type of the Web Application VT reference,
+ *         or NULL if iteration is complete.
+ *         Freed by cleanup_iterator.
+ */
+DEF_ACCESS (web_application_vt_ref_iterator_type, 0);
+
+/**
+ * @brief Get the type from an WEB_APPLICATION_VT refs iterator.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return The reference id of the Web Application VT reference,
+ *         or NULL if iteration is complete.
+ *         Freed by cleanup_iterator.
+ */
+DEF_ACCESS (web_application_vt_ref_iterator_ref_id, 1);
+
+
 /* All SecInfo data. */
 
 /**
@@ -1439,6 +1650,11 @@ secinfo_count_after (const get_data_t *get,
     {
       columns = dfn_cert_adv_info_select_columns ();
       filter_columns = dfn_cert_adv_info_filter_columns ();
+    }
+  else if (strcmp (type, "web_application_vt") == 0)
+    {
+      columns = web_application_vt_info_select_columns ();
+      filter_columns = web_application_vt_info_filter_columns ();
     }
   else
     {

--- a/src/manage_sql_secinfo.h
+++ b/src/manage_sql_secinfo.h
@@ -165,6 +165,29 @@ typedef enum {
  }
 
 /**
+ * @brief Filter columns for WEB_APPLICATION_VT iterator.
+ */
+#define WEB_APPLICATION_VT_INFO_ITERATOR_FILTER_COLUMNS          \
+ { GET_ITERATOR_FILTER_COLUMNS, "type", "description",           \
+   "solution", "severity", NULL }
+
+/**
+ * @brief WEB_APPLICATION_VT iterator columns.
+ */
+#define WEB_APPLICATION_VT_INFO_ITERATOR_COLUMNS                 \
+ {                                                               \
+   GET_ITERATOR_COLUMNS_PREFIX (""),                             \
+   { "''", "_owner", KEYWORD_TYPE_STRING },                      \
+   { "0", NULL, KEYWORD_TYPE_INTEGER },                          \
+   { "type", NULL, KEYWORD_TYPE_STRING },                        \
+   { "description", NULL, KEYWORD_TYPE_STRING },                 \
+   { "solution", NULL, KEYWORD_TYPE_INTEGER },                   \
+   { "severity", NULL, KEYWORD_TYPE_DOUBLE },                    \
+   { "type_metadata", NULL, KEYWORD_TYPE_STRING },               \
+   { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                          \
+ }
+
+/**
  * @brief Default for secinfo_update_strategy.
  */
 #define SECINFO_UPDATE_STRATEGY_DEFAULT SECINFO_UPDATE_STRATEGY_KEEP_SCHEMA

--- a/src/manage_sql_settings.c
+++ b/src/manage_sql_settings.c
@@ -861,6 +861,8 @@ modify_setting (const gchar *uuid, const gchar *name,
         setting_name = g_strdup ("CERT-Bund Filter");
       else if (strcmp (uuid, "312350ed-bc06-44f3-8b3f-ab9eb828b80b") == 0)
         setting_name = g_strdup ("DFN-CERT Filter");
+      else if (strcmp (uuid, "dbce4fcf-679f-4692-b925-a41617bb4851") == 0)
+        setting_name = g_strdup ("Web Application VT Filter");
       else if (strcmp (uuid, "32b3d606-461b-4770-b3e1-b9ea3cf0f84c") == 0)
         setting_name = g_strdup ("Notes Filter");
       else if (strcmp (uuid, "956d13bd-3baa-4404-a138-5e7eb8f9630e") == 0)

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -15495,6 +15495,24 @@ END:VCALENDAR
             <summary>Number of CVEs referenced by the CERT advisory</summary>
           </column>
         </filter_keywords>
+        <filter_keywords>
+          <condition>type is "web_application_vt"</condition>
+          <column>
+            <name>description</name>
+            <type>text</type>
+            <summary>Description text of the Web Application VT</summary>
+          </column>
+          <column>
+            <name>type</name>
+            <type>text</type>
+            <summary>Type of the Web Application VT</summary>
+          </column>
+          <column>
+            <name>solution</name>
+            <type>text</type>
+            <summary>Solution text of the Web Application VT</summary>
+          </column>
+        </filter_keywords>
       </attrib>
       <attrib>
         <name>filt_id</name>
@@ -15547,6 +15565,7 @@ END:VCALENDAR
             <e>cve</e>
             <e>dfn_cert_adv</e>
             <e>nvt</e>
+            <e>web_application_vt</e>
           </or>
         </pattern>
         <ele>
@@ -16152,6 +16171,78 @@ END:VCALENDAR
             <summary>Source representation of the information. Only when details were requested</summary>
             <pattern>
               text
+            </pattern>
+          </ele>
+        </ele>
+        <ele>
+          <name>web_application_vt</name>
+          <pattern>
+            <e>type</e>
+            <e>description</e>
+            <e>solution</e>
+            <e>severity</e>
+            <e>type_metadata</e>
+            <e>refs</e>
+          </pattern>
+          <summary>A Web Application VT info element</summary>
+          <ele>
+            <name>type</name>
+            <summary>Type of the vulnerability test</summary>
+            <pattern>
+              text
+            </pattern>
+          </ele>
+          <ele>
+            <name>description</name>
+            <summary>Description of the vulnerability test</summary>
+            <pattern>
+              text
+            </pattern>
+          </ele>
+          <ele>
+            <name>solution</name>
+            <summary>A suggested solution for mitigating the vulnerability</summary>
+            <pattern>
+              text
+            </pattern>
+          </ele>
+          <ele>
+            <name>severity</name>
+            <summary>Highest CVSS severity score of CVEs referenced by VT or an approximation based type-specific ratings</summary>
+            <pattern>
+              <t>severity</t>
+            </pattern>
+          </ele>
+          <ele>
+            <name>type_metadata</name>
+            <summary>Type-specific metadata as a JSON object</summary>
+            <pattern>
+              text
+            </pattern>
+          </ele>
+          <ele>
+            <name>refs</name>
+            <summary>References of the Web Application VT</summary>
+            <pattern>
+              <any><e>ref</e></any>
+            </pattern>
+            <ele>
+              <name>ref</name>
+              <summary>A reference of the Web Application VT</summary>
+            </ele>
+            <pattern>
+              <attrib>
+                <name>type</name>
+                <summary>The type of the reference</summary>
+                <type>text</type>
+                <required>1</required>
+              </attrib>
+              <attrib>
+                <name>ref_id</name>
+                <summary>The identifier of the reference</summary>
+                <type>text</type>
+                <required>1</required>
+              </attrib>
             </pattern>
           </ele>
         </ele>


### PR DESCRIPTION
## What
The Web Application VTs are now available as a subtype of the GMP command `get_info`.

## References
GEA-1884