### PR TITLE
[GEA-1810] Task scheduler changes

### DIFF
--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -309,9 +309,19 @@ static int feed_version_check_in_progress = 0;
 static pid_t periodic_job_runner_pid = -1;
 
 /**
+ * @brief PID of the dedicated scheduler, or -1.
+ */
+static pid_t scheduler_pid = -1;
+
+/**
  * @brief Set when the periodic worker terminates.
  */
 static volatile sig_atomic_t periodic_job_runner_terminated = 0;
+
+/**
+ * @brief Set when the scheduler terminates.
+ */
+static volatile sig_atomic_t scheduler_terminated = 0;
 
 /**
  * @brief Logging parameters, as passed to setup_log_handlers.
@@ -1084,6 +1094,11 @@ handle_sigchld (/* unused */ int given_signal, siginfo_t *info, void *ucontext)
           periodic_job_runner_pid = -1;
           periodic_job_runner_terminated = 1;
         }
+      else if (scheduler_pid == pid)
+        {
+          scheduler_pid = -1;
+          scheduler_terminated = 1;
+        }
     }
 }
 
@@ -1797,7 +1812,6 @@ fork_asset_snapshot_delete_stale ()
  */
 typedef struct
 {
-  time_t last_schedule;    ///< Last time the scheduler management was executed.
   time_t last_feed_sync;   ///< Last time the feed sync was executed.
   time_t last_queue;       ///< Last time queued task actions were executed.
   time_t last_report_export; ///< Last time report export was executed
@@ -1838,24 +1852,24 @@ set_last_run_time (time_t *last, time_t now)
  *
  * On fatal error this exits the process.
  *
- * @param[in,out] t   Periodic timestamps; updates t->last_schedule on success.
+ * @param[in,out] last_schedule   Periodic timestamp; updates on success.
+ * @param[in]     sigmask_current Current signal mask.
  */
 static void
-run_schedule (periodic_times_t *t)
+run_schedule (time_t* last_schedule, sigset_t* sigmask_current)
 {
   time_t start = time (NULL);
-  if (!time_to_run (t->last_schedule, SCHEDULE_PERIOD, start))
+  if (!time_to_run (*last_schedule, SCHEDULE_PERIOD, start))
     return;
 
-  int rc = manage_schedule (scheduling_enabled,
-                            sigmask_normal);
+  int rc = manage_schedule (scheduling_enabled, sigmask_current);
   switch (rc)
     {
     case 0:
       {
         time_t end = time (NULL);
-        set_last_run_time (&t->last_schedule, end);
-        g_debug ("%s: last_schedule_time: %li", __func__, t->last_schedule);
+        set_last_run_time (last_schedule, end);
+        g_debug ("%s: last_schedule_time: %li", __func__, *last_schedule);
         break;
       }
     case 1:
@@ -1965,7 +1979,6 @@ run_asset_snapshot_delete_stale (periodic_times_t *t)
 static void
 run_periodic_block (periodic_times_t *t)
 {
-  run_schedule (t);
   run_feed_sync (t);
   run_agents_sync (t);
   run_queue (t);
@@ -1985,7 +1998,7 @@ run_periodic_job_runner_loop (sigset_t *sigmask_current)
 
   init_sentry ();
   is_parent = 0;
-  setproctitle ("Periodic scheduler");
+  setproctitle ("Periodic jobs");
 
   if (sigmask_normal)
     pthread_sigmask (SIG_SETMASK, sigmask_normal, NULL);
@@ -2025,6 +2038,94 @@ run_periodic_job_runner_loop (sigset_t *sigmask_current)
   exit (EXIT_SUCCESS);
 }
 
+/**
+ * @brief Run the schedule in a loop.
+ *
+ * @param[in] sigmask_current  Signal mask to use in the loop.
+ */
+static void
+run_scheduler_loop (sigset_t *sigmask_current)
+{
+  init_sentry ();
+  setproctitle ("Scheduler");
+
+  /* Reset SIGCHLD to default so manage_schedule can reap its own children. */
+  setup_signal_handler (SIGCHLD, SIG_DFL, 0);
+
+  if (sigmask_normal)
+    pthread_sigmask (SIG_SETMASK, sigmask_normal, NULL);
+  else
+    pthread_sigmask (SIG_SETMASK, sigmask_current, NULL);
+
+  cleanup_manage_process (FALSE);
+  init_manage_process (&database);
+
+  /* This worker does not serve client sockets. */
+  if (manager_socket > -1)
+    {
+      close (manager_socket);
+      manager_socket = -1;
+    }
+  if (manager_socket_2 > -1)
+    {
+      close (manager_socket_2);
+      manager_socket_2 = -1;
+    }
+
+  time_t last_schedule = 0;
+  while (1)
+    {
+      gvm_sleep (1);
+      run_schedule (&last_schedule, sigmask_current);
+
+      if (termination_signal)
+        {
+          g_debug ("%s, Received %s signal",
+                   __func__, strsignal (termination_signal));
+          break;
+        }
+    }
+
+  cleanup_manage_process (FALSE);
+  gvm_close_sentry ();
+  exit (EXIT_SUCCESS);
+}
+
+/**
+ * @brief Start the scheduler in a child process.
+ *
+ * @param[in] sigmask_current  Signal mask to use in the child process.
+ *
+ * @return 0 on success, -1 on error.
+ */
+static int
+start_scheduler (sigset_t *sigmask_current)
+{
+  pid_t pid;
+
+  /* fork() is used instead of fork_with_handlers() for graceful shutdown */
+  pid = fork ();
+  switch (pid)
+    {
+      case 0:
+        run_scheduler_loop (sigmask_current);
+        exit (EXIT_FAILURE); /* should never be reached */
+
+      case -1:
+        g_warning ("%s: failed to fork scheduler: %s",
+                   __func__, strerror (errno));
+        return -1;
+
+      default:
+        scheduler_pid = pid;
+        scheduler_terminated = 0;
+        g_debug ("%s: started scheduler %d", __func__, pid);
+        return 0;
+    }
+
+  return -1;
+}
+
 /*
  * @brief Start the periodic job runner loop in a child process.
  *
@@ -2061,23 +2162,27 @@ start_periodic_job_runner (sigset_t *sigmask_current)
 }
 
 /**
- * @brief Terminate the periodic job runner process.
+ * @brief Terminate a child process gracefully.
+ *
+ * @param[in,out] pid_ptr     Pointer to the PID of the process to terminate.
+ * @param[in,out] term_ptr    Pointer to the termination flag.
+ * @param[in]     name        Name of the process for logging.
  */
 static void
-terminate_periodic_job_runner (void)
+terminate_child_process (pid_t *pid_ptr, volatile sig_atomic_t *term_ptr, const char *name)
 {
   int status;
   pid_t pid;
   int reaped = 0;
 
-  if (periodic_job_runner_pid <= 0)
+  if (pid_ptr == NULL || *pid_ptr <= 0)
     return;
 
-  pid = periodic_job_runner_pid;
+  pid = *pid_ptr;
 
   if (kill (pid, SIGTERM) == -1 && errno != ESRCH)
-    g_warning ("%s: failed to send SIGTERM to periodic job runner %d: %s",
-               __func__, pid, strerror (errno));
+    g_warning ("%s: failed to send SIGTERM to %s %d: %s",
+               __func__, name, pid, strerror (errno));
 
   for (int i = 0; i < 5; i++)
     {
@@ -2102,8 +2207,8 @@ terminate_periodic_job_runner (void)
   if (!reaped)
     {
       if (kill (pid, SIGKILL) == -1 && errno != ESRCH)
-        g_warning ("%s: failed to send SIGKILL to periodic job runner %d: %s",
-                   __func__, pid, strerror (errno));
+        g_warning ("%s: failed to send SIGKILL to %s %d: %s",
+                   __func__, name, pid, strerror (errno));
 
       while (waitpid (pid, &status, 0) == -1)
         {
@@ -2111,14 +2216,29 @@ terminate_periodic_job_runner (void)
             continue;
           if (errno == ECHILD)
             break;
-          g_warning ("%s: failed to wait for periodic job runner %d: %s",
-                     __func__, pid, strerror (errno));
+          g_warning ("%s: failed to wait for %s %d: %s",
+                     __func__, name, pid, strerror (errno));
           break;
         }
     }
 
-  periodic_job_runner_pid = -1;
-  periodic_job_runner_terminated = 0;
+  *pid_ptr = -1;
+  if (term_ptr)
+    *term_ptr = 0;
+}
+
+/**
+ * @brief Terminate the periodic job runner and scheduler processes.
+ */
+static void
+terminate_processes (void)
+{
+  terminate_child_process (&periodic_job_runner_pid,
+                           &periodic_job_runner_terminated,
+                           "periodic job runner");
+  terminate_child_process (&scheduler_pid,
+                           &scheduler_terminated,
+                           "scheduler");
 }
 
 /**
@@ -2155,6 +2275,13 @@ serve_and_schedule ()
       gvm_close_sentry ();
       exit (EXIT_FAILURE);
     }
+  if (start_scheduler (&sigmask_current))
+    {
+      g_critical ("%s: Failed to start scheduler", __func__);
+      terminate_processes ();
+      gvm_close_sentry ();
+      exit (EXIT_FAILURE);
+    }
 
   g_info ("gvmd is ready to accept GMP connections");
 
@@ -2171,6 +2298,19 @@ serve_and_schedule ()
           if (start_periodic_job_runner (&sigmask_current))
             {
               g_critical ("%s: Failed to restart periodic job runner", __func__);
+              cleanup ();
+              gvm_close_sentry ();
+              exit (EXIT_FAILURE);
+            }
+        }
+
+      if (scheduler_terminated && !termination_signal)
+        {
+          g_warning ("%s: scheduler exited; restarting", __func__);
+          scheduler_terminated = 0;
+          if (start_scheduler (&sigmask_current))
+            {
+              g_critical ("%s: Failed to restart scheduler", __func__);
               cleanup ();
               gvm_close_sentry ();
               exit (EXIT_FAILURE);
@@ -2195,7 +2335,7 @@ serve_and_schedule ()
         {
           g_debug ("Received %s signal",
                    strsignal (termination_signal));
-          terminate_periodic_job_runner ();
+          terminate_processes ();
           cleanup ();
           /* Raise signal again, to exit with the correct return value. */
           setup_signal_handler (termination_signal, SIG_DFL, 0);
@@ -2245,7 +2385,7 @@ serve_and_schedule ()
         {
           g_debug ("Received %s signal",
                    strsignal (termination_signal));
-          terminate_periodic_job_runner ();
+          terminate_processes ();
           cleanup ();
           /* Raise signal again, to exit with the correct return value. */
           setup_signal_handler (termination_signal, SIG_DFL, 0);

--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -303,6 +303,17 @@ static int update_in_progress = 0;
 static int feed_version_check_in_progress = 0;
 
 /**
+ * @brief PID of the dedicated periodic worker, or -1.
+ */
+
+static pid_t periodic_job_runner_pid = -1;
+
+/**
+ * @brief Set when the periodic worker terminates.
+ */
+static volatile sig_atomic_t periodic_job_runner_terminated = 0;
+
+/**
  * @brief Logging parameters, as passed to setup_log_handlers.
  */
 GSList *log_config = NULL;
@@ -1067,10 +1078,14 @@ handle_sigchld (/* unused */ int given_signal, siginfo_t *info, void *ucontext)
       if (feed_version_check_in_progress == pid)
         /* This was a version check child, so allow version checks again */
         feed_version_check_in_progress = 0;
+
+      if (periodic_job_runner_pid == pid)
+        {
+          periodic_job_runner_pid = -1;
+          periodic_job_runner_terminated = 1;
+        }
     }
 }
-
-
 
 /**
  * @brief Handle a SIGABRT signal.
@@ -1959,6 +1974,154 @@ run_periodic_block (periodic_times_t *t)
 }
 
 /**
+ * @brief Run periodic jobs in a loop, sleeping 1 second between runs.
+ *
+ * @param[in] sigmask_current  Signal mask to use in the child process.
+ */
+static void
+run_periodic_job_runner_loop (sigset_t *sigmask_current)
+{
+  periodic_times_t times = {0};
+
+  init_sentry ();
+  is_parent = 0;
+  setproctitle ("Periodic scheduler");
+
+  if (sigmask_normal)
+    pthread_sigmask (SIG_SETMASK, sigmask_normal, NULL);
+  else
+    pthread_sigmask (SIG_SETMASK, sigmask_current, NULL);
+
+  cleanup_manage_process (FALSE);
+  // might not be needed if manage_schedule() is called from a forked process.
+  init_manage_process (&database);
+
+  /* This worker does not serve client sockets. */
+  if (manager_socket > -1)
+    {
+      close (manager_socket);
+      manager_socket = -1;
+    }
+  if (manager_socket_2 > -1)
+    {
+      close (manager_socket_2);
+      manager_socket_2 = -1;
+    }
+
+  while (1)
+    {
+      run_periodic_block (&times);
+      gvm_sleep (1);
+      if (termination_signal)
+        {
+          g_debug ("%s, Received %s signal",
+                   __func__, strsignal (termination_signal));
+          break;
+        }
+    }
+
+  cleanup_manage_process (FALSE);
+  gvm_close_sentry ();
+  exit (EXIT_SUCCESS);
+}
+
+/*
+ * @brief Start the periodic job runner loop in a child process.
+ *
+ * @param[in] sigmask_current  Signal mask to use in the child process.
+ *
+ * @return 0 on success, -1 on error.
+*/
+static int
+start_periodic_job_runner (sigset_t *sigmask_current)
+{
+  pid_t pid;
+
+  /* fork() is used instead of fork_with_handlers() for graceful shutdown */
+  pid = fork ();
+  switch (pid)
+    {
+      case 0:
+        run_periodic_job_runner_loop (sigmask_current);
+        exit (EXIT_FAILURE); /* should never be reached */
+
+      case -1:
+        g_warning ("%s: failed to fork periodic job runner: %s",
+                   __func__, strerror (errno));
+        return -1;
+
+      default:
+        periodic_job_runner_pid = pid;
+        periodic_job_runner_terminated = 0;
+        g_debug ("%s: started periodic job runner %d", __func__, pid);
+        return 0;
+    }
+
+  return -1;
+}
+
+/**
+ * @brief Terminate the periodic job runner process.
+ */
+static void
+terminate_periodic_job_runner (void)
+{
+  int status;
+  pid_t pid;
+  int reaped = 0;
+
+  if (periodic_job_runner_pid <= 0)
+    return;
+
+  pid = periodic_job_runner_pid;
+
+  if (kill (pid, SIGTERM) == -1 && errno != ESRCH)
+    g_warning ("%s: failed to send SIGTERM to periodic job runner %d: %s",
+               __func__, pid, strerror (errno));
+
+  for (int i = 0; i < 5; i++)
+    {
+      pid_t ret = waitpid (pid, &status, WNOHANG);
+      if (ret == pid)
+        {
+          reaped = 1;
+          break;
+        }
+      if (ret == -1)
+        {
+          if (errno == EINTR)
+            continue;
+          if (errno == ECHILD)
+            reaped = 1;
+          break;
+        }
+      if (ret == 0)
+        gvm_sleep (1);
+    }
+
+  if (!reaped)
+    {
+      if (kill (pid, SIGKILL) == -1 && errno != ESRCH)
+        g_warning ("%s: failed to send SIGKILL to periodic job runner %d: %s",
+                   __func__, pid, strerror (errno));
+
+      while (waitpid (pid, &status, 0) == -1)
+        {
+          if (errno == EINTR)
+            continue;
+          if (errno == ECHILD)
+            break;
+          g_warning ("%s: failed to wait for periodic job runner %d: %s",
+                     __func__, pid, strerror (errno));
+          break;
+        }
+    }
+
+  periodic_job_runner_pid = -1;
+  periodic_job_runner_terminated = 0;
+}
+
+/**
  * @brief Serve incoming connections, scheduling periodically.
  *
  * Enter an infinite loop, waiting for connections and passing the work to
@@ -1969,13 +2132,6 @@ run_periodic_block (periodic_times_t *t)
 static void
 serve_and_schedule ()
 {
-  periodic_times_t times = {
-    .last_schedule = 0,
-    .last_feed_sync = 0,
-    .last_queue = 0,
-    .last_agents_sync = 0,
-  };
-
   sigset_t sigmask_all;
   static sigset_t sigmask_current;
 
@@ -1993,6 +2149,13 @@ serve_and_schedule ()
     }
   sigmask_normal = &sigmask_current;
 
+  if (start_periodic_job_runner (&sigmask_current))
+    {
+      g_critical ("%s: Failed to start periodic job runner", __func__);
+      gvm_close_sentry ();
+      exit (EXIT_FAILURE);
+    }
+
   g_info ("gvmd is ready to accept GMP connections");
 
   while (1)
@@ -2001,7 +2164,18 @@ serve_and_schedule ()
       fd_set readfds, exceptfds;
       struct timespec timeout;
 
-      run_periodic_block (&times);
+      if (periodic_job_runner_terminated && !termination_signal)
+        {
+          g_warning ("%s: periodic job runner exited; restarting", __func__);
+          periodic_job_runner_terminated = 0;
+          if (start_periodic_job_runner (&sigmask_current))
+            {
+              g_critical ("%s: Failed to restart periodic job runner", __func__);
+              cleanup ();
+              gvm_close_sentry ();
+              exit (EXIT_FAILURE);
+            }
+        }
 
       FD_ZERO (&readfds);
       FD_SET (manager_socket, &readfds);
@@ -2021,6 +2195,7 @@ serve_and_schedule ()
         {
           g_debug ("Received %s signal",
                    strsignal (termination_signal));
+          terminate_periodic_job_runner ();
           cleanup ();
           /* Raise signal again, to exit with the correct return value. */
           setup_signal_handler (termination_signal, SIG_DFL, 0);
@@ -2066,12 +2241,11 @@ serve_and_schedule ()
             accept_and_maybe_fork (manager_socket_2, sigmask_normal);
         }
 
-      run_periodic_block (&times);
-
       if (termination_signal)
         {
           g_debug ("Received %s signal",
                    strsignal (termination_signal));
+          terminate_periodic_job_runner ();
           cleanup ();
           /* Raise signal again, to exit with the correct return value. */
           setup_signal_handler (termination_signal, SIG_DFL, 0);

--- a/src/manage.c
+++ b/src/manage.c
@@ -170,6 +170,26 @@
 #define MAX_REPORTS_PER_TICK 10
 
 /**
+ * @brief Scheduled task actions.
+ */
+typedef enum
+{
+  SCHEDULED_TASK_ACTION_START = 0,
+  SCHEDULED_TASK_ACTION_STOP = 1,
+} scheduled_task_action_t;
+
+/**
+ * @brief Scheduled task startup status.
+ */
+typedef enum
+{
+  SCHEDULED_TASK_STATUS_PENDING = 0,
+  SCHEDULED_TASK_STATUS_DB_OK = 1,
+  SCHEDULED_TASK_STATUS_DB_FAILED = 2,
+  SCHEDULED_TASK_STATUS_UNKNOWN = 3,
+} scheduled_task_startup_status_t;
+
+/**
  * @brief Number of minutes until the authentication cache is deleted
  *        if the session is idle.
  */
@@ -235,6 +255,23 @@ static int schedule_timeout = SCHEDULE_TIMEOUT_DEFAULT;
  *        lost in a running task.
  */
 static int scanner_connection_retry = SCANNER_CONNECTION_RETRY_DEFAULT;
+
+/**
+ * @brief Keep track of scheduled tasks that are currently being processed.
+ *        key format: "<action>:<task_uuid>"
+ */
+static GHashTable *scheduled_task_set = NULL;
+
+/**
+ * @brief Queue of scheduled tasks to be processed.
+ *        Values are of type scheduled_task_item_t*.
+ */
+static GQueue *scheduled_task_queue = NULL;
+
+/**
+ * @brief List of scheduled task runners.
+ */
+static GSList *scheduled_task_runners = NULL;
 
 
 /* Certificate and key management. */
@@ -3381,6 +3418,203 @@ scheduled_task_free (scheduled_task_t *scheduled_task)
 }
 
 /**
+ * @brief Scheduled task queue item.
+ *        Used for deduplicating scheduled tasks in the queue.
+ */
+typedef struct
+{
+  scheduled_task_t *task;                 ///< Pointer to the scheduled task.
+  scheduled_task_action_t action;          ///< Action to be performed.
+} scheduled_task_item_t;
+
+/**
+ * @brief Scheduled task runner.
+ */
+typedef struct
+{
+  pid_t pid;  ///< Process ID of the scheduled task runner.
+  int fd;      //< File descriptor for communication with the scheduled runner.
+  scheduled_task_t *scheduled_task;         ///< Pointer to the scheduled task.
+  scheduled_task_startup_status_t status;   ///< Startup status of the runner.
+  scheduled_task_action_t action;           ///< Action to be performed.
+} scheduled_task_runner_t;
+
+/**
+ * @brief Create a scheduled task runner structure.
+ *
+ * @param[in] pid             Process ID of the runner.
+ * @param[in] pipe_fd         Pipe file descriptor for communication.
+ * @param[in] scheduled_task  Scheduled task.
+ * @param[in] action          Action to be performed by the runner.
+ *
+ * @return Scheduled task runner structure.
+ */
+static scheduled_task_runner_t *
+scheduled_task_runner_new (pid_t pid,
+                           int pipe_fd,
+                           scheduled_task_t *scheduled_task,
+                           scheduled_task_action_t action)
+{
+  if (!scheduled_task)
+    return NULL;
+
+  scheduled_task_runner_t *runner;
+
+  runner = g_malloc (sizeof (*runner));
+  runner->pid = pid;
+  runner->fd = pipe_fd;
+  runner->scheduled_task = scheduled_task;
+  runner->action = action;
+  runner->status = SCHEDULED_TASK_STATUS_PENDING;
+
+  return runner;
+}
+
+/**
+ * @brief Free a scheduled task runner structure.
+ *
+ * @param[in] scheduled_task  Scheduled task.
+ */
+static void
+scheduled_task_runner_free (scheduled_task_runner_t *runner)
+{
+  if (!runner)
+    return;
+
+  if (runner->fd >= 0)
+    {
+      close (runner->fd);
+      runner->fd = -1;
+    }
+  if (runner->scheduled_task)
+    scheduled_task_free (runner->scheduled_task);
+
+  g_free (runner);
+}
+
+/**
+ * @brief Create a key for a scheduled task.
+ */
+static gchar *
+scheduled_task_key_new (scheduled_task_action_t action, const gchar *task_uuid)
+{
+  if (!task_uuid)
+    return NULL;
+  return g_strdup_printf ("%d:%s", action, task_uuid);
+}
+
+/**
+ * @brief Initialise the scheduled task queue and set.
+ */
+static void
+scheduled_task_queue_init_once (void)
+{
+  if (scheduled_task_set == NULL)
+    scheduled_task_set = g_hash_table_new_full (g_str_hash,
+                                                g_str_equal,
+                                                g_free,
+                                                NULL);
+ if (scheduled_task_queue == NULL)
+    scheduled_task_queue = g_queue_new ();
+}
+
+/**
+ * @brief Add a scheduled task to the queue.
+ *
+ * @param[in] task    Scheduled task.
+ * @param[in] action  Action to be performed.
+ *
+ * @return 0 on success, -1 on failure (task already in queue or invalid task).
+ */
+static int
+scheduled_task_queue_add (scheduled_task_t *task, scheduled_task_action_t action)
+{
+  gchar *key;
+  scheduled_task_item_t *item;
+
+  if (!task || !task->task_uuid)
+    return -1;
+
+  scheduled_task_queue_init_once ();
+  key = scheduled_task_key_new (action, task->task_uuid);
+  if (!key)
+    return -1;
+
+  if (g_hash_table_contains (scheduled_task_set, key))
+    {
+      g_free (key);
+      return -1;
+    }
+
+  g_hash_table_insert (scheduled_task_set, key,
+                       GINT_TO_POINTER (1));
+
+  item = g_malloc (sizeof (*item));
+  item->task = task;
+  item->action = action;
+  g_queue_push_tail (scheduled_task_queue, item);
+
+  return 0;
+}
+
+/**
+ * @brief Requeue an existing scheduled task in the queue.
+ *
+ * @param[in] task    Scheduled task.
+ * @param[in] action  Action to be performed.
+ */
+static void
+scheduled_task_requeue_existing (scheduled_task_t *task,
+                                 scheduled_task_action_t action)
+{
+  gchar *key;
+  scheduled_task_item_t *item;
+
+  if (!task || !task->task_uuid)
+    return;
+
+  key = scheduled_task_key_new (action, task->task_uuid);
+  if (!key)
+    return;
+
+  if (!g_hash_table_contains (scheduled_task_set, key))
+    {
+      g_free (key);
+      return;
+    }
+
+  item = g_malloc (sizeof (*item));
+  item->task = task;
+  item->action = action;
+  g_queue_push_tail (scheduled_task_queue, item);
+
+  g_free (key);
+}
+
+/**
+ * @brief Finalize a scheduled task and remove it from the set.
+ *
+ * @param[in] task    Scheduled task.
+ * @param[in] action  Action to be performed.
+ */
+static void
+scheduled_task_finalize (scheduled_task_t *task, scheduled_task_action_t action)
+{
+  gchar *key;
+
+  if (!task || !task->task_uuid)
+    return;
+
+  key = scheduled_task_key_new (action, task->task_uuid);
+  if (!key)
+    return;
+
+  g_hash_table_remove (scheduled_task_set, key);
+  g_free (key);
+  scheduled_task_free (task);
+}
+
+/**
  * @brief Setup owner session for a scheduled task.
  *
  * @param[in] scheduled_task  Scheduled task.
@@ -3447,134 +3681,273 @@ scheduled_task_handle_start_success (scheduled_task_t *scheduled_task)
 }
 
 /**
- * @brief Start a task, for the scheduler.
+ * @brief Fork a runner process for a scheduled task.
  *
- * @param[in]  scheduled_task   Scheduled task.
- * @param[in]  sigmask_current  Sigmask to restore in child.
+ * @param[in] scheduled_task  Scheduled task.
+ * @param[in] action          Action to be performed by the runner.
+ * @param[in] sigmask_current Current signal mask.
  *
- * @return 0 success, -1 error.  Child does not return.
+ * @return 0 on success, or -1 on failure.
  */
 static int
-scheduled_task_start (scheduled_task_t *scheduled_task,
-                      sigset_t *sigmask_current)
+scheduled_task_fork_runner (scheduled_task_t *scheduled_task,
+                            scheduled_task_action_t action,
+                            sigset_t *sigmask_current)
 {
-  int pid, task_ret;
+  int pipe_fds[2];
+  int flags, task_ret;
+  pid_t pid;
+  scheduled_task_runner_t *runner;
 
-  /* Fork a child to start the task so parent can continue scheduler loop. */
+  if (!scheduled_task)
+    {
+      g_warning ("%s: scheduled_task is NULL", __func__);
+      return -1;
+    }
+  if (!sigmask_current)
+    {
+      g_warning ("%s: sigmask_current is NULL", __func__);
+      return -1;
+    }
+
+  if (pipe (pipe_fds))
+    {
+      g_warning ("%s: Failed to create pipe: %s",
+                 __func__, strerror (errno));
+      return -1;
+    }
+
   pid = fork ();
   switch (pid)
     {
       case 0:
-        /* Child.  Carry on to start the task, reopen the database (required
-         * after fork). */
+       {
+         /* Child */
+         scheduled_task_startup_status_t status;
+         close (pipe_fds[0]);
 
-        /* Restore the sigmask that was blanked for pselect. */
-        pthread_sigmask (SIG_SETMASK, sigmask_current, NULL);
+         pthread_sigmask (SIG_SETMASK, sigmask_current, NULL);
+         init_sentry ();
 
-        init_sentry ();
-        reinit_manage_process ();
-        scheduled_task_setup_owner_session (scheduled_task);
-        break;
+         if (reinit_manage_process_no_abort ())
+           {
+             status = SCHEDULED_TASK_STATUS_DB_FAILED;
+             if (write (pipe_fds[1], &status, sizeof (status)) != sizeof (status))
+               g_warning ("%s: Failed to write to pipe: %s",
+                          __func__, strerror (errno));
+              close (pipe_fds[1]);
+              gvm_close_sentry ();
+              exit (EXIT_FAILURE);
+           }
 
+          scheduled_task_setup_owner_session (scheduled_task);
+
+          status = SCHEDULED_TASK_STATUS_DB_OK;
+          if (write (pipe_fds[1], &status, sizeof (status)) != sizeof (status))
+            g_warning ("%s: Failed to write to pipe: %s",
+                       __func__, strerror (errno));
+          close (pipe_fds[1]);
+
+          switch (action)
+            {
+              case SCHEDULED_TASK_ACTION_START:
+                {
+                  setproctitle ("scheduler: starting %s", scheduled_task->task_uuid);
+
+                  task_ret = resume_task (scheduled_task->task_uuid, NULL);
+                  if (task_ret)
+                    task_ret = start_task (scheduled_task->task_uuid, NULL);
+
+                  if (task_ret == 0 || task_ret == 99)
+                    {
+                      gvm_close_sentry ();
+                      if (task_ret == 0)
+                        exit (EXIT_SUCCESS);
+                      g_warning ("%s: user denied permission to start task", __func__);
+                      /* Permission denied. No need to reschedule. */
+                      exit (EXIT_SUCCESS);
+                    }
+
+                  g_warning ("%s: start/resume failed for task %s (ret=%d)",
+                            __func__, scheduled_task->task_uuid, task_ret);
+                  gvm_close_sentry ();
+                  exit (EXIT_FAILURE);
+                }
+              case SCHEDULED_TASK_ACTION_STOP:
+                {
+                  task_ret = stop_task (scheduled_task->task_uuid);
+
+                  if (task_ret == 0 || task_ret == 99)
+                    {
+                      gvm_close_sentry ();
+                      if (task_ret == 0)
+                        exit (EXIT_SUCCESS);
+                      g_warning ("%s: user denied permission to stop task", __func__);
+                      /* Permission denied. No need to reschedule. */
+                      exit (EXIT_SUCCESS);
+                    }
+
+                  g_warning ("%s: stop failed for task %s (ret=%d)",
+                            __func__, scheduled_task->task_uuid, task_ret);
+                  gvm_close_sentry ();
+                  exit (EXIT_FAILURE);
+                }
+              default:
+                g_warning ("%s: Unknown action %d", __func__, action);
+                gvm_close_sentry ();
+                exit (EXIT_FAILURE);
+            }
+       }
       case -1:
-        /* Parent on error. */
+        close (pipe_fds[0]);
+        close (pipe_fds[1]);
         g_warning ("%s: fork failed", __func__);
         return -1;
 
       default:
-        /* Parent.  Continue to next task. */
-        g_debug ("%s: %i forked %i", __func__, getpid (), pid);
+        /* Parent */
+        close (pipe_fds[1]);
+        flags = fcntl (pipe_fds[0], F_GETFL, 0);
+        if (flags == -1)
+          {
+            g_warning ("%s: fcntl failed: %s", __func__, strerror (errno));
+            close (pipe_fds[0]);
+            return -1;
+          }
+        if (fcntl (pipe_fds[0], F_SETFL, flags | O_NONBLOCK) == -1)
+          {
+            g_warning ("%s: fcntl failed: %s", __func__, strerror (errno));
+            close (pipe_fds[0]);
+            return -1;
+          }
+
+        runner = scheduled_task_runner_new (pid, pipe_fds[0],
+                                            scheduled_task,
+                                            action);
+        if (!runner)
+          {
+            g_warning ("%s: Failed to create scheduled task runner", __func__);
+            close (pipe_fds[0]);
+            return -1;
+          }
+
+        scheduled_task_runners = g_slist_prepend (scheduled_task_runners, runner);
+
+        g_debug ("%s: forked runner %i for task %s",
+                 __func__, pid, scheduled_task->task_uuid);
+
         return 0;
     }
-
-  /* Start the task. */
-  setproctitle ("scheduler: starting %s", scheduled_task->task_uuid);
-
-  task_ret = resume_task (scheduled_task->task_uuid, NULL);
-  if (task_ret)
-    task_ret = start_task (scheduled_task->task_uuid, NULL);
-
-  if (task_ret == 0)
-    {
-      scheduled_task_handle_start_success (scheduled_task);
-      scheduled_task_free (scheduled_task);
-      gvm_close_sentry ();
-      exit (EXIT_SUCCESS);
-    }
-
-  if (task_ret == 99)
-    {
-      /* Permission denied. No need to reschedule. */
-      g_warning ("%s: user denied permission to start task", __func__);
-      scheduled_task_free (scheduled_task);
-      gvm_close_sentry ();
-      exit (EXIT_SUCCESS);
-    }
-
-  g_warning ("%s: start/resume failed for task %s (ret=%d)",
-             __func__, scheduled_task->task_uuid, task_ret);
-  reschedule_task (scheduled_task->task_uuid);
-  scheduled_task_free (scheduled_task);
-  gvm_close_sentry ();
-  exit (EXIT_FAILURE);
 }
 
 /**
- * @brief Stop a task, for the scheduler.
- *
- * @param[in]  scheduled_task   Scheduled task.
- * @param[in]  sigmask_current  Sigmask to restore in child.
- *
- * @return 0 success, -1 error.  Child does not return.
+ * @brief Process forked task runners.
+ *        Append tasks failed to start due to database errors
+ *        to the queue for retrying.
  */
-static int
-scheduled_task_stop (scheduled_task_t *scheduled_task,
-                     sigset_t *sigmask_current)
+static void
+scheduled_task_check_runners_startup_status (void)
 {
-  int pid, task_ret;
-
-  pid = fork ();
-  switch (pid)
+  GSList *iter, *next;
+  for (iter = scheduled_task_runners; iter != NULL; iter = next)
     {
-      case 0:
-        /* Child. */
+      scheduled_task_runner_t *runner;
+      scheduled_task_startup_status_t status;
+      ssize_t bytes_read;
+      pid_t wait_ret;
+      int wait_status;
 
-        /* Restore the sigmask that was blanked for pselect. */
-        pthread_sigmask (SIG_SETMASK, sigmask_current, NULL);
+      next = iter->next;
+      runner = (scheduled_task_runner_t *) iter->data;
 
-        init_sentry ();
-        reinit_manage_process ();
-        scheduled_task_setup_owner_session (scheduled_task);
-        break;
+      if (runner->fd >= 0 && runner->status == SCHEDULED_TASK_STATUS_PENDING)
+        {
+          bytes_read = read (runner->fd, &status, sizeof (status));
 
-      case -1:
-        /* Parent on error. */
-        g_warning ("%s: fork failed", __func__);
-        return -1;
+          if (bytes_read == (ssize_t) sizeof (status))
+            {
+              runner->status = status;
+              close (runner->fd);
+              runner->fd = -1;
+            }
+          else if (bytes_read == 0)
+            {
+              g_warning ("%s: runner %i for task %s closed pipe without sending status",
+                         __func__, runner->pid, runner->scheduled_task->task_uuid);
+              runner->status = SCHEDULED_TASK_STATUS_UNKNOWN;
+              close (runner->fd);
+              runner->fd = -1;
+            }
+          else if (bytes_read < 0 && errno != EAGAIN && errno != EINTR)
+            {
+              g_warning ("%s: failed to read startup status from runner %i"
+                         " for task %s: %s", __func__, runner->pid,
+                         runner->scheduled_task->task_uuid, strerror(errno));
+              runner->status = SCHEDULED_TASK_STATUS_UNKNOWN;
+              close (runner->fd);
+              runner->fd = -1;
+            }
+        }
 
-      default:
-        /* Parent.  Continue to next task. */
-        g_debug ("%s: %i forked %i", __func__, getpid (), pid);
-        return 0;
+      wait_ret = waitpid (runner->pid, &wait_status, WNOHANG);
+      if (wait_ret == 0)
+        continue;
+
+      if (wait_ret < 0)
+        {
+          if (errno == EINTR)
+            continue;
+
+          g_warning ("%s: waitpid failed for runner %i for task %s: %s",
+                     __func__, runner->pid, runner->scheduled_task->task_uuid,
+                     strerror(errno));
+          // reschedule the task, the status is unknown
+          if (runner->action == SCHEDULED_TASK_ACTION_START)
+            reschedule_task (runner->scheduled_task->task_uuid);
+
+          scheduled_task_finalize (runner->scheduled_task, runner->action);
+          runner->scheduled_task = NULL;
+        }
+      else if (runner->status == SCHEDULED_TASK_STATUS_DB_FAILED)
+        {
+          g_warning ("%s: runner %i for task %s failed to start due to DB error",
+                   __func__, runner->pid, runner->scheduled_task->task_uuid);
+
+          scheduled_task_requeue_existing (runner->scheduled_task, runner->action);
+          // This avoids freeing the scheduled_task, it will be retried later
+          runner->scheduled_task = NULL;
+        }
+      else
+        {
+          if (runner->status == SCHEDULED_TASK_STATUS_UNKNOWN)
+            {
+              g_warning ("%s: runner %i for task %s exited with unknown status",
+                         __func__, runner->pid, runner->scheduled_task->task_uuid);
+              if (runner->action == SCHEDULED_TASK_ACTION_START)
+                reschedule_task (runner->scheduled_task->task_uuid);
+            }
+          else if (WIFEXITED (wait_status) && WEXITSTATUS (wait_status) == EXIT_SUCCESS)
+            {
+              if (runner->action == SCHEDULED_TASK_ACTION_START)
+                scheduled_task_handle_start_success (runner->scheduled_task);
+            }
+          else
+            {
+              if (runner->action == SCHEDULED_TASK_ACTION_START)
+                {
+                  g_warning ("%s: runner %i for task %s failed to start",
+                             __func__, runner->pid,
+                             runner->scheduled_task->task_uuid);
+                  reschedule_task (runner->scheduled_task->task_uuid);
+                }
+            }
+          scheduled_task_finalize (runner->scheduled_task, runner->action);
+          runner->scheduled_task = NULL;
+        }
+
+      scheduled_task_runner_free (runner);
+      scheduled_task_runners = g_slist_delete_link (scheduled_task_runners, iter);
     }
-
-  /* Stop the task. */
-  setproctitle ("scheduler: stopping %s", scheduled_task->task_uuid);
-
-  task_ret = stop_task (scheduled_task->task_uuid);
-
-  if (task_ret == 0)
-    {
-      scheduled_task_free (scheduled_task);
-      gvm_close_sentry ();
-      exit (EXIT_SUCCESS);
-    }
-
-  g_warning ("%s: stop failed for task %s (ret=%d)",
-             __func__, scheduled_task->task_uuid, task_ret);
-  scheduled_task_free (scheduled_task);
-  gvm_close_sentry ();
-  exit (EXIT_FAILURE);
 }
 
 /**
@@ -4110,12 +4483,12 @@ manage_schedule (gboolean run_tasks,
                  sigset_t *sigmask_current)
 {
   iterator_t schedules;
-  GSList *starts, *stops;
   int ret;
   task_t previous_start_task, previous_stop_task;
 
-  starts = NULL;
-  stops = NULL;
+  scheduled_task_queue_init_once ();
+  scheduled_task_check_runners_startup_status ();
+
   previous_start_task = 0;
   previous_stop_task = 0;
 
@@ -4139,150 +4512,169 @@ manage_schedule (gboolean run_tasks,
   if (run_tasks == 0)
     return 0;
 
-  /* Assemble "starts" and "stops" list containing task uuid, owner name and
-   * owner UUID for each (scheduled) task to start or stop. */
+  if (sigmask_current == NULL)
+    {
+      g_warning ("%s: sigmask_current is NULL", __func__);
+      return -1;
+    }
 
   ret = init_task_schedule_iterator (&schedules);
   if (ret)
-    {
-      if (ret == -1)
-        {
-          g_warning ("%s: iterator init error"
-                     " (Perhaps the db went down?)",
-                     __func__);
-          /* Just ignore, in case the db went down temporarily. */
-          return 0;
-        }
+    return (ret == -1) ? 0 : ret;
 
-      return ret;
-    }
   /* This iterator runs in a transaction. */
   while (next (&schedules))
-    if (task_schedule_iterator_start_due (&schedules))
-      {
-        const char *icalendar, *zone;
-        int timed_out;
+   {
+     if (task_schedule_iterator_start_due (&schedules))
+       {
+         const char *icalendar, *zone;
+         int timed_out;
+         scheduled_task_t *scheduled_task;
+         task_t task_id;
 
-        /* Check if task schedule is timed out before updating next due time */
-        timed_out = task_schedule_iterator_timed_out (&schedules);
+         task_id = task_schedule_iterator_task (&schedules);
 
-        /* Update the task schedule info to prevent multiple schedules. */
+         /* Skip duplicates for same task withing the iterator loop to
+          * avoid conflicts between multiple users with permissions. */
+         if (previous_start_task == task_id)
+           continue;
+         previous_start_task = task_id;
 
-        icalendar = task_schedule_iterator_icalendar (&schedules);
-        zone = task_schedule_iterator_timezone (&schedules);
+         /* Check if task schedule is timed out before updating next due time */
+         timed_out = task_schedule_iterator_timed_out (&schedules);
 
-        g_debug ("%s: start due for %llu, setting next_time",
-                 __func__,
-                 task_schedule_iterator_task (&schedules));
-        set_task_schedule_next_time
-         (task_schedule_iterator_task (&schedules),
-          icalendar_next_time_from_string (icalendar, time(NULL), zone, 0));
+         /* Update the task schedule info to prevent multiple schedules. */
 
-        /* Skip this task if it was already added to the starts list
-         * to avoid conflicts between multiple users with permissions. */
+         icalendar = task_schedule_iterator_icalendar (&schedules);
+         zone = task_schedule_iterator_timezone (&schedules);
 
-        if (previous_start_task == task_schedule_iterator_task (&schedules))
-          continue;
+         g_debug ("%s: start due for %llu, setting next_time",
+                  __func__,
+                  task_id);
 
-        if (scans_blocked_by_maintenance_window (
-              task_schedule_iterator_owner_uuid (&schedules))
-            )
-          {
-            g_warning ("%s: task %s cannot be started or resumed"
-                       " in maintenance window", __func__,
-                       task_schedule_iterator_task_uuid (&schedules));
-            continue;
-          }
+         set_task_schedule_next_time (
+           task_id,
+           icalendar_next_time_from_string (icalendar, time(NULL), zone, 0));
 
-        if (timed_out)
-          {
-            g_message (" %s: Task timed out: %s",
-                       __func__,
-                       task_schedule_iterator_task_uuid (&schedules));
-            continue;
-          }
+         if (scans_blocked_by_maintenance_window (
+               task_schedule_iterator_owner_uuid (&schedules))
+             )
+           {
+             g_warning ("%s: task %s cannot be started or resumed"
+                        " in maintenance window", __func__,
+                        task_schedule_iterator_task_uuid (&schedules));
+             continue;
+           }
 
-        previous_start_task = task_schedule_iterator_task (&schedules);
+         if (timed_out)
+           {
+             g_message (" %s: Task timed out: %s",
+                        __func__,
+                        task_schedule_iterator_task_uuid (&schedules));
+             continue;
+           }
 
-        /* Add task UUID and owner name and UUID to the list. */
+         scheduled_task = scheduled_task_new
+                          (task_schedule_iterator_task_uuid (&schedules),
+                           task_schedule_iterator_owner_uuid (&schedules),
+                           task_schedule_iterator_owner_name (&schedules));
 
-        starts = g_slist_prepend
-                  (starts,
-                   scheduled_task_new
-                    (task_schedule_iterator_task_uuid (&schedules),
-                     task_schedule_iterator_owner_uuid (&schedules),
-                     task_schedule_iterator_owner_name (&schedules)));
-      }
-    else if (task_schedule_iterator_stop_due (&schedules))
-      {
-        /* Skip this task if it was already added to the stops list
-         * to avoid conflicts between multiple users with permissions. */
+         if (scheduled_task_queue_add (scheduled_task,
+                                       SCHEDULED_TASK_ACTION_START))
+           {
+             g_warning ("%s: Failed to add task %s to scheduled task queue",
+                        __func__,
+                        task_schedule_iterator_task_uuid (&schedules));
+             scheduled_task_free (scheduled_task);
+           }
+       }
+     else if (task_schedule_iterator_stop_due (&schedules))
+       {
+         task_t task_id;
+         scheduled_task_t *scheduled_task;
 
-        if (previous_stop_task == task_schedule_iterator_task (&schedules))
-          continue;
-        previous_stop_task = task_schedule_iterator_task (&schedules);
+         task_id = task_schedule_iterator_task (&schedules);
+         if (previous_stop_task == task_id)
+           continue;
+         previous_stop_task = task_id;
 
-        /* Add task UUID and owner name and UUID to the list. */
+         scheduled_task = scheduled_task_new
+                          (task_schedule_iterator_task_uuid (&schedules),
+                           task_schedule_iterator_owner_uuid (&schedules),
+                           task_schedule_iterator_owner_name (&schedules));
 
-        stops = g_slist_prepend
-                 (stops,
-                  scheduled_task_new
-                   (task_schedule_iterator_task_uuid (&schedules),
-                    task_schedule_iterator_owner_uuid (&schedules),
-                    task_schedule_iterator_owner_name (&schedules)));
-      }
+         if (scheduled_task_queue_add (scheduled_task,
+                                       SCHEDULED_TASK_ACTION_STOP))
+           {
+             g_warning ("%s: Failed to add task %s to scheduled task queue",
+                        __func__,
+                        task_schedule_iterator_task_uuid (&schedules));
+             scheduled_task_free (scheduled_task);
+           }
+       }
+   }
   cleanup_task_schedule_iterator (&schedules);
 
-  /* Start tasks in forked processes, now that the SQL statement is closed. */
-
-  while (starts)
+  while (!g_queue_is_empty (scheduled_task_queue))
     {
-      scheduled_task_t *scheduled_task;
-      GSList *head;
+      scheduled_task_item_t *item;
 
-      scheduled_task = starts->data;
+      item = g_queue_pop_head (scheduled_task_queue);
 
-      head = starts;
-      starts = starts->next;
-      g_slist_free_1 (head);
-
-      if (scheduled_task_start (scheduled_task,
-                                sigmask_current))
-        /* Error.  Reschedule and continue to next task. */
-        reschedule_task (scheduled_task->task_uuid);
-      scheduled_task_free (scheduled_task);
-    }
-
-  /* Stop tasks in forked processes, now that the SQL statement is closed. */
-
-  while (stops)
-    {
-      scheduled_task_t *scheduled_task;
-      GSList *head;
-
-      scheduled_task = stops->data;
-      head = stops;
-      stops = stops->next;
-      g_slist_free_1 (head);
-
-      if (scheduled_task_stop (scheduled_task,
-                               sigmask_current))
+      if (!item || !item->task || !item->task->task_uuid || !item->task->owner_uuid)
         {
-          /* Error.  Exit. */
-          scheduled_task_free (scheduled_task);
-          while (stops)
+          g_warning ("%s: Invalid scheduled task item", __func__);
+          if (item)
             {
-              scheduled_task_free (stops->data);
-              stops = g_slist_delete_link (stops, stops);
+              if (item->task)
+                {
+                  if (item->task->task_uuid)
+                    scheduled_task_finalize (item->task, item->action);
+                  else
+                    scheduled_task_free (item->task);
+                }
+              g_free (item);
             }
-          return -1;
+          continue;
         }
-      scheduled_task_free (scheduled_task);
+
+      if (item->action == SCHEDULED_TASK_ACTION_START)
+       {
+         if (task_schedule_timed_out_uuid (item->task->task_uuid))
+           {
+             g_message (" %s: Skipping timed out scheduled task: %s",
+                        __func__, item->task->task_uuid);
+             scheduled_task_finalize (item->task, item->action);
+             g_free (item);
+             continue;
+           }
+
+         if (scans_blocked_by_maintenance_window (item->task->owner_uuid))
+           {
+             g_message (" %s: Skipping scheduled task in maintenance window: %s",
+                        __func__, item->task->task_uuid);
+             scheduled_task_finalize (item->task, item->action);
+             g_free (item);
+             continue;
+           }
+       }
+
+      ret = scheduled_task_fork_runner (item->task, item->action,
+                                        sigmask_current);
+      if (ret)
+        {
+          g_warning ("%s: Failed to fork runner for task %s",
+                     __func__,
+                     item->task->task_uuid);
+          if (item->action == SCHEDULED_TASK_ACTION_START)
+            reschedule_task (item->task->task_uuid);
+          scheduled_task_finalize (item->task, item->action);
+        }
+      g_free (item);
     }
 
   clear_duration_schedules (0);
   update_duration_schedule_periods (0);
-
   return 0;
 }
 

--- a/src/manage.h
+++ b/src/manage.h
@@ -187,6 +187,9 @@ init_manage_process (const db_conn_info_t*);
 void
 reinit_manage_process ();
 
+int
+reinit_manage_process_no_abort ();
+
 void
 cleanup_manage_process (gboolean);
 

--- a/src/manage_schedules.h
+++ b/src/manage_schedules.h
@@ -116,6 +116,9 @@ gboolean
 task_schedule_iterator_timed_out (iterator_t *);
 
 gboolean
+task_schedule_timed_out_uuid (const gchar *);
+
+gboolean
 task_schedule_iterator_start_due (iterator_t *);
 
 gboolean

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -3243,10 +3243,10 @@ task_average_scan_duration (task_t task)
  *
  * @param[in]  database          Location of manage database.
  *
- * @return 1 if open already, else 0.
+ * @return 0 on success, 1 if open already, -1 on error.
  */
 static int
-init_manage_open_db (const db_conn_info_t *database)
+init_manage_open_db_no_abort (const db_conn_info_t *database)
 {
   if (sql_is_open ())
     return 1;
@@ -3255,7 +3255,7 @@ init_manage_open_db (const db_conn_info_t *database)
   if (sql_open (database))
     {
       g_warning ("%s: sql_open failed", __func__);
-      abort ();
+      return -1;
     }
 
   /* Ensure the user session variables always exists. */
@@ -3266,6 +3266,24 @@ init_manage_open_db (const db_conn_info_t *database)
   manage_attach_databases ();
 
   return 0;
+}
+
+/**
+ * @brief Initialize the manage library: open db.
+ *
+ * @param[in] database  Location of manage database.
+ *
+ * @return 0 on success, 1 if open already, aborts on error.
+ */
+static int
+init_manage_open_db (const db_conn_info_t *database)
+{
+  int ret;
+
+  ret = init_manage_open_db_no_abort (database);
+  if (ret < 0)
+    abort ();
+  return ret;
 }
 
 /**
@@ -3317,6 +3335,29 @@ reinit_manage_process ()
 {
   cleanup_manage_process (FALSE);
   init_manage_process (&gvmd_db_conn_info);
+}
+
+/**
+ * @brief Reinitialize the manage library for a process.
+ *
+ * This is mandatory after a fork, to not carry open databases around (refer
+ * to database documentation).
+ *
+ * @return 0 on success, -1 on error.
+ */
+int
+reinit_manage_process_no_abort ()
+{
+  cleanup_manage_process (FALSE);
+
+  if (reinit_semaphore_set())
+    return -1;
+
+  if (init_manage_open_db_no_abort (&gvmd_db_conn_info) < 0)
+    return -1;
+
+  init_manage_create_functions ();
+  return 0;
 }
 
 /**

--- a/src/manage_sql_schedules.c
+++ b/src/manage_sql_schedules.c
@@ -947,36 +947,29 @@ task_schedule_iterator_stop_due (iterator_t* iterator)
 }
 
 /**
- * @brief Get if schedule of task in iterator is timed out.
+ * @brief Check if a task schedule is timed out given
+ *        its run status, start time, and duration.
  *
- * @param[in]  iterator  Iterator.
- *
- * @return Whether task schedule is timed out.
+ * @param[in]  run_status  The current run status of the task.
+ * @param[in]  start_time  The start time of the task schedule.
+ * @param[in]  duration    The duration of the task schedule.
  */
-gboolean
-task_schedule_iterator_timed_out (iterator_t* iterator)
+static gboolean
+task_schedule_is_timed_out_common (task_status_t run_status,
+                                   time_t start_time,
+                                   time_t duration)
 {
-  time_t schedule_timeout_secs;
-  int duration;
-  task_status_t run_status;
-  time_t start_time, timeout_time;
+  time_t schedule_timeout_secs, timeout_time;
 
   if (get_schedule_timeout () < 0)
     return FALSE;
 
-  if (iterator->done) return FALSE;
-
-  start_time = task_schedule_iterator_next_time (iterator);
-
-  if (start_time == 0)
+  if (start_time == 0 || duration < 0)
     return FALSE;
 
   schedule_timeout_secs = get_schedule_timeout () * 60;
   if (schedule_timeout_secs < SCHEDULE_TIMEOUT_MIN_SECS)
     schedule_timeout_secs = SCHEDULE_TIMEOUT_MIN_SECS;
-
-  run_status = task_run_status (task_schedule_iterator_task (iterator));
-  duration = task_schedule_iterator_duration (iterator);
 
   if (duration && (duration < schedule_timeout_secs))
     timeout_time = start_time + duration;
@@ -993,6 +986,76 @@ task_schedule_iterator_timed_out (iterator_t* iterator)
   return FALSE;
 }
 
+/**
+ * @brief Get if schedule of task in iterator is timed out.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return Whether task schedule is timed out.
+ */
+gboolean
+task_schedule_iterator_timed_out (iterator_t* iterator)
+{
+  task_status_t run_status;
+  time_t start_time, duration;
+
+  if (get_schedule_timeout () < 0)
+    return FALSE;
+
+  if (iterator->done) return FALSE;
+
+  start_time = task_schedule_iterator_next_time (iterator);
+
+  if (start_time == 0)
+    return FALSE;
+
+  run_status = task_run_status (task_schedule_iterator_task (iterator));
+  duration = task_schedule_iterator_duration (iterator);
+
+  return task_schedule_is_timed_out_common (run_status, start_time, duration);
+}
+
+/**
+ * @brief Get if schedule of task is timed out given its UUID.
+ *
+ * @param[in]  task_uuid  Task UUID.
+ *
+ * @return Whether task schedule is timed out.
+ */
+gboolean
+task_schedule_timed_out_uuid (const gchar *task_uuid)
+{
+  task_t task = 0;
+  long long int start_time_int, duration_int;
+  task_status_t run_status;
+
+  if (task_uuid == NULL || strcmp (task_uuid, "") == 0)
+    return FALSE;
+
+  sql_int64_ps (&task,
+                "SELECT id FROM tasks WHERE uuid = $1 AND hidden != 2;",
+                SQL_STR_PARAM(task_uuid), NULL);
+  if (task == 0)
+    return FALSE;
+
+  sql_int64_ps (&start_time_int,
+                "SELECT schedule_next_time FROM tasks WHERE id = $1;",
+                SQL_RESOURCE_PARAM(task), NULL);
+
+  if (start_time_int == 0)
+    return FALSE;
+
+  sql_int64_ps (&duration_int,
+                "SELECT duration FROM schedules"
+                " WHERE id = (SELECT schedule FROM tasks WHERE id = $1);",
+                SQL_RESOURCE_PARAM(task), NULL);
+
+  run_status = task_run_status (task);
+
+  return task_schedule_is_timed_out_common (run_status,
+                                            (time_t) start_time_int,
+                                            (time_t) duration_int);
+}
 /**
  * @brief Initialise a schedule task iterator.
  *


### PR DESCRIPTION
## What

- Move periodic jobs and scheduler to their own separate processes forked from `serve_and_schedule`
- Scheduler now processes previously forked runners each tick (`scheduled_task_check_runners_startup_status`).
If child startup reports DB connection failure, task is re-queued for retry.
- Runner status is checked in a nonblocking way (nonblocking pipe read + `waitpid(..., WNOHANG)`) to keep the scheduler loop responsive.
- Replace start/stop list handling with a queue and hash set for deduplication.

## Why

Scheduled tasks were sporadically skipped.
This re-work of the scheduler should fix that.

## References

GEA-1810

## Checklist

- [x] Tests (Regression test locally)


