### PR TITLE
Add/get audit report

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -193,6 +193,7 @@ set(
   manage_acl.c
   manage_alerts.c
   manage_asset_keys.c
+  manage_audit_report.c
   manage_configs.c
   manage_events.c
   manage_filter_utils.c
@@ -281,6 +282,7 @@ set(
   manage_sql_copy.c
   manage_sql_alerts.c
   manage_sql_assets.c
+  manage_sql_audit_report.c
   manage_sql_events.c
   manage_sql_filters.c
   manage_sql_groups.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -344,6 +344,7 @@ set(
   gmp_configs.c
   gmp_delete.c
   gmp_get.c
+  gmp_audit_report.c
   gmp_integration_configs.c
   gmp_license.c
   gmp_logout.c

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -85,6 +85,7 @@
 #include "gmp_delete.h"
 #include "gmp_get.h"
 #include "gmp_configs.h"
+#include "gmp_audit_report.h"
 #include "gmp_integration_configs.h"
 #include "gmp_license.h"
 #include "gmp_logout.h"
@@ -4603,6 +4604,7 @@ typedef enum
   CLIENT_GET_AGGREGATES_TEXT_COLUMN,
   CLIENT_GET_ALERTS,
   CLIENT_GET_ASSETS,
+  CLIENT_GET_AUDIT_REPORT,
   CLIENT_GET_CONFIGS,
   CLIENT_GET_CREDENTIALS,
 #if ENABLE_CREDENTIAL_STORES
@@ -5607,6 +5609,9 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
               get_assets_data->type = g_ascii_strdown (typebuf, -1);
             set_client_state (CLIENT_GET_ASSETS);
           }
+
+        ELSE_GET_START (audit_report, AUDIT_REPORT)
+
         else if (strcasecmp ("GET_CONFIGS", element_name) == 0)
           {
             const gchar* attribute;
@@ -22477,6 +22482,8 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
       case CLIENT_GET_ASSETS:
         handle_get_assets (gmp_parser, error);
         break;
+
+      CASE_GET_END (AUDIT_REPORT, audit_report)
 
       case CLIENT_GET_CONFIGS:
         handle_get_configs (gmp_parser, error);

--- a/src/gmp_audit_report.c
+++ b/src/gmp_audit_report.c
@@ -1,0 +1,337 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file
+ * @brief GVM GMP layer: Structured audit report retrieval.
+ *
+ * Implements GMP handling for the get_audit_report command.
+ */
+
+#include "gmp_audit_report.h"
+
+#include "gmp_get.h"
+#include "gmp_report_common.h"
+#include "manage_audit_report.h"
+
+#undef G_LOG_DOMAIN
+
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md    gmp"
+
+/**
+ * @brief Command data for the get_audit_report command.
+ */
+typedef struct
+{
+  get_data_t get;
+} get_audit_report_data_t;
+
+/**
+ * @brief Parser callback data.
+ */
+static get_audit_report_data_t get_audit_report_data;
+
+/**
+ * @brief Reset the internal state of the get_audit_report command.
+ */
+static void
+get_audit_report_reset (void)
+{
+  get_data_reset (&get_audit_report_data.get);
+
+  memset (&get_audit_report_data,
+          0,
+          sizeof (get_audit_report_data));
+}
+
+/**
+ * @brief Send audit report compliance counts.
+ *
+ * @param[in] gmp_parser  GMP parser handling the current session.
+ * @param[in] summary     Audit report summary.
+ *
+ * @return FALSE on success, TRUE on failure.
+ */
+static gboolean
+send_audit_report_compliance_count (
+  gmp_parser_t *gmp_parser,
+  audit_report_summary_t summary)
+{
+  const audit_report_result_summary_t *results;
+
+  if (gmp_parser == NULL || summary == NULL)
+    return TRUE;
+
+  results = &summary->results;
+
+  if (send_report_xml (
+        gmp_parser,
+        "<compliance_count>%d",
+        results->total.full))
+    return TRUE;
+
+  if (send_report_xml (
+        gmp_parser,
+        "<full>%d</full>"
+        "<filtered>%d</filtered>",
+        results->total.full,
+        results->total.filtered))
+    return TRUE;
+
+  if (send_report_xml (
+        gmp_parser,
+        "<yes>"
+        "<full>%d</full>"
+        "<filtered>%d</filtered>"
+        "</yes>",
+        results->yes.full,
+        results->yes.filtered))
+    return TRUE;
+
+  if (send_report_xml (
+        gmp_parser,
+        "<no>"
+        "<full>%d</full>"
+        "<filtered>%d</filtered>"
+        "</no>",
+        results->no.full,
+        results->no.filtered))
+    return TRUE;
+
+  if (send_report_xml (
+        gmp_parser,
+        "<incomplete>"
+        "<full>%d</full>"
+        "<filtered>%d</filtered>"
+        "</incomplete>",
+        results->incomplete.full,
+        results->incomplete.filtered))
+    return TRUE;
+
+  if (send_report_xml (
+        gmp_parser,
+        "<undefined>"
+        "<full>%d</full>"
+        "<filtered>%d</filtered>"
+        "</undefined>",
+        results->undefined.full,
+        results->undefined.filtered))
+    return TRUE;
+
+  return send_report_xml (gmp_parser, "</compliance_count>");
+}
+
+/**
+ * @brief Send full and filtered audit compliance values.
+ *
+ * @param[in] gmp_parser  GMP parser handling the current session.
+ * @param[in] summary     Audit report summary.
+ *
+ * @return FALSE on success, TRUE on failure.
+ */
+static gboolean
+send_audit_report_compliance (
+  gmp_parser_t *gmp_parser,
+  audit_report_summary_t summary)
+{
+  const audit_report_compliance_t *compliance;
+
+  if (gmp_parser == NULL || summary == NULL)
+    return TRUE;
+
+  compliance = &summary->results.compliance;
+
+  return send_report_xml (
+    gmp_parser,
+    "<compliance>"
+    "<full>%s</full>"
+    "<filtered>%s</filtered>"
+    "</compliance>",
+    compliance->full ? compliance->full : "",
+    compliance->filtered ? compliance->filtered : "");
+}
+
+/**
+ * @brief Send the complete structured audit report.
+ *
+ * @param[in] gmp_parser  GMP parser handling the current session.
+ * @param[in] summary     Audit report summary.
+ *
+ * @return FALSE on success, TRUE on failure.
+ */
+static gboolean
+send_audit_report_summary (gmp_parser_t *gmp_parser,
+                           audit_report_summary_t summary)
+{
+  if (gmp_parser == NULL
+      || summary == NULL
+      || summary->base == NULL)
+    return TRUE;
+
+  if (send_report_base_start (gmp_parser, summary->base))
+    return TRUE;
+
+  if (send_report_resource_counts (gmp_parser, summary->resources))
+    return TRUE;
+
+  if (send_report_task (gmp_parser, summary->task))
+    return TRUE;
+
+  if (send_report_scan_information (gmp_parser, summary->base))
+    return TRUE;
+
+  if (send_audit_report_compliance_count (gmp_parser, summary))
+    return TRUE;
+
+  if (send_audit_report_compliance (gmp_parser, summary))
+    return TRUE;
+
+  if (send_report_base_end (gmp_parser, summary->base))
+    return TRUE;
+
+  return FALSE;
+}
+
+/**
+ * @brief Initialize the get_audit_report command by parsing attributes.
+ *
+ * @param[in] attribute_names   Null-terminated attribute names.
+ * @param[in] attribute_values  Null-terminated attribute values.
+ */
+void
+get_audit_report_start (const gchar **attribute_names,
+                        const gchar **attribute_values)
+{
+  get_data_parse_attributes (&get_audit_report_data.get,
+                             "audit_report",
+                             attribute_names,
+                             attribute_values);
+}
+
+/**
+ * @brief Execute the get_audit_report GMP command.
+ *
+ * @param[in] gmp_parser  GMP parser handling the current session.
+ * @param[in] error       Location for error information.
+ */
+void
+get_audit_report_run (gmp_parser_t *gmp_parser,
+                      GError **error)
+{
+  manage_get_audit_report_response_t response;
+  audit_report_summary_t summary = NULL;
+  int ret;
+
+  if (get_audit_report_data.get.id == NULL)
+    {
+      SEND_TO_CLIENT_OR_FAIL (
+        XML_ERROR_SYNTAX (
+          "get_audit_report",
+          "Missing audit_report_id attribute"));
+
+      get_audit_report_reset ();
+      return;
+    }
+
+  ret = init_get ("get_audit_report",
+                  &get_audit_report_data.get,
+                  "Audit Reports",
+                  NULL);
+
+  if (ret)
+    {
+      switch (ret)
+        {
+        case 99:
+          SEND_TO_CLIENT_OR_FAIL (
+            XML_ERROR_SYNTAX (
+              "get_audit_report",
+              "Permission denied"));
+          break;
+
+        default:
+          internal_error_send_to_client (error);
+          break;
+        }
+
+      get_audit_report_reset ();
+      return;
+    }
+
+  /*
+   * Use the underlying report resource type in the management and SQL
+   * layers.
+   */
+  g_free (get_audit_report_data.get.subtype);
+  get_audit_report_data.get.subtype = g_strdup ("report");
+
+  response = manage_get_audit_report_summary (
+    &get_audit_report_data.get,
+    &summary);
+
+  switch (response)
+    {
+    case MANAGE_GET_AUDIT_REPORT_SUCCESS:
+      break;
+
+    case MANAGE_GET_AUDIT_REPORT_NOT_FOUND:
+      if (send_find_error_to_client (
+            "get_audit_report",
+            "report",
+            get_audit_report_data.get.id,
+            gmp_parser))
+        error_send_to_client (error);
+
+      get_audit_report_reset ();
+      return;
+
+    case MANAGE_GET_AUDIT_REPORT_FILTER_NOT_FOUND:
+      SEND_TO_CLIENT_OR_FAIL (
+        XML_ERROR_SYNTAX (
+          "get_audit_report",
+          "Failed to find filter"));
+
+      get_audit_report_reset ();
+      return;
+
+    case MANAGE_GET_AUDIT_REPORT_UNSUPPORTED_TYPE:
+      SEND_TO_CLIENT_OR_FAIL (
+        XML_ERROR_SYNTAX (
+          "get_audit_report",
+          "Report type is not supported"));
+
+      get_audit_report_reset ();
+      return;
+
+    case MANAGE_GET_AUDIT_REPORT_ERROR:
+    default:
+      internal_error_send_to_client (error);
+      get_audit_report_reset ();
+      return;
+    }
+
+  SEND_GET_START_SINGULAR ("audit_report");
+
+  if (send_audit_report_summary (gmp_parser, summary))
+    goto send_error;
+
+  SEND_GET_END_SINGULAR ("audit_report",
+                         &get_audit_report_data.get,
+                         1,
+                         1);
+
+  audit_report_summary_free (summary);
+  get_audit_report_reset ();
+
+  return;
+
+send_error:
+  error_send_to_client (error);
+  audit_report_summary_free (summary);
+  get_audit_report_reset ();
+}

--- a/src/gmp_audit_report.h
+++ b/src/gmp_audit_report.h
@@ -1,0 +1,26 @@
+/* Copyright (C) 2026 Greenbone AG
+*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file
+ * @brief GVM GMP layer: Audit report summary command headers.
+ */
+
+#ifndef _GVM_GMP_AUDIT_REPORT_H
+#define _GVM_GMP_AUDIT_REPORT_H
+
+#include "gmp_base.h"
+
+/* GET_AUDIT_REPORT. */
+
+void
+get_audit_report_start (const gchar **attribute_names,
+                        const gchar **attribute_values);
+
+void
+get_audit_report_run (gmp_parser_t *gmp_parser,
+                      GError **error);
+
+#endif /* _GVM_GMP_AUDIT_REPORT_H */

--- a/src/gmp_get.c
+++ b/src/gmp_get.c
@@ -632,7 +632,8 @@ send_get_end_internal (const char *type, get_data_t *get, int get_counts,
       new_filter = manage_clean_filter (filter ? filter : get->filter,
                                         get->ignore_max_rows_per_page);
       g_free (filter);
-      if ((strcmp (type, "task") == 0)
+      if ((strcmp (type, "audit_report") == 0)
+          || (strcmp (type, "task") == 0)
           || (strcmp (type, "report") == 0)
           || (strcmp (type, "report_application") == 0)
           || (strcmp (type, "report_closed_cve") == 0)
@@ -660,7 +661,8 @@ send_get_end_internal (const char *type, get_data_t *get, int get_counts,
             }
           g_free (value);
 
-          if ((strcmp (type, "task") == 0)
+          if ((strcmp (type, "audit_report") == 0)
+              || (strcmp (type, "task") == 0)
               || (strcmp (type, "report") == 0)
               || (strcmp (type, "report_application") == 0)
               || (strcmp (type, "report_closed_cve") == 0)
@@ -691,7 +693,8 @@ send_get_end_internal (const char *type, get_data_t *get, int get_counts,
     }
   else
     {
-      if ((strcmp (type, "task") == 0)
+      if ((strcmp (type, "audit_report") == 0)
+          || (strcmp (type, "task") == 0)
           || (strcmp (type, "report") == 0)
           || (strcmp (type, "report_application") == 0)
           || (strcmp (type, "report_closed_cve") == 0)

--- a/src/gmp_report_common.c
+++ b/src/gmp_report_common.c
@@ -304,3 +304,75 @@ send_report_base_end (gmp_parser_t *gmp_parser,
 
   return send_report_xml (gmp_parser, "</report>");
 }
+
+/**
+ * @brief Send common report resource count elements.
+ *
+ * @param[in] gmp_parser  GMP parser handling the current session.
+ * @param[in] resources   Report resource summary.
+ *
+ * @return FALSE on success, TRUE on failure.
+ */
+gboolean
+send_report_resource_counts (gmp_parser_t *gmp_parser,
+                             report_resource_summary_t resources)
+{
+  if (gmp_parser == NULL || resources == NULL)
+    return TRUE;
+
+  if (send_report_xml (
+        gmp_parser,
+        "<hosts><count>%d</count></hosts>",
+        resources->hosts))
+    return TRUE;
+
+  if (send_report_xml (
+        gmp_parser,
+        "<closed_cves><count>%d</count></closed_cves>",
+        resources->closed_cves))
+    return TRUE;
+
+  if (send_report_xml (
+        gmp_parser,
+        "<cves><count>%d</count></cves>",
+        resources->cves))
+    return TRUE;
+
+  if (send_report_xml (
+        gmp_parser,
+        "<vulns><count>%d</count></vulns>",
+        resources->vulnerabilities))
+    return TRUE;
+
+  if (send_report_xml (
+        gmp_parser,
+        "<os><count>%d</count></os>",
+        resources->operating_systems))
+    return TRUE;
+
+  if (send_report_xml (
+        gmp_parser,
+        "<apps><count>%d</count></apps>",
+        resources->applications))
+    return TRUE;
+
+  if (send_report_xml (
+        gmp_parser,
+        "<ssl_certs><count>%d</count></ssl_certs>",
+        resources->tls_certificates))
+    return TRUE;
+
+  if (send_report_xml (
+        gmp_parser,
+        "<ports><count>%d</count></ports>",
+        resources->ports))
+    return TRUE;
+
+  if (send_report_xml (
+        gmp_parser,
+        "<errors><count>%d</count></errors>",
+        resources->errors))
+    return TRUE;
+
+  return FALSE;
+}

--- a/src/gmp_report_common.h
+++ b/src/gmp_report_common.h
@@ -29,4 +29,8 @@ send_report_scan_information (gmp_parser_t *, report_summary_base_t);
 gboolean
 send_report_base_end (gmp_parser_t *, report_summary_base_t);
 
+gboolean
+send_report_resource_counts (gmp_parser_t *,
+                             report_resource_summary_t);
+
 #endif /* _GVM_GMP_REPORT_COMMON_H */

--- a/src/gmp_scan_report.c
+++ b/src/gmp_scan_report.c
@@ -48,82 +48,6 @@ get_scan_report_reset (void)
 }
 
 /**
- * @brief Send scan report resource count elements.
- *
- * @param[in] gmp_parser  GMP parser handling the current session.
- * @param[in] summary     Scan report summary.
- *
- * @return FALSE on success, TRUE on failure.
- */
-static gboolean
-send_scan_report_resource_counts (gmp_parser_t *gmp_parser,
-                                  scan_report_summary_t summary)
-{
-  report_resource_summary_t resources;
-
-  if (summary == NULL || summary->resources == NULL)
-    return TRUE;
-
-  resources = summary->resources;
-
-  if (send_report_xml (
-    gmp_parser,
-    "<hosts><count>%d</count></hosts>",
-    resources->hosts))
-    return TRUE;
-
-  if (send_report_xml (
-    gmp_parser,
-    "<closed_cves><count>%d</count></closed_cves>",
-    resources->closed_cves))
-    return TRUE;
-
-  if (send_report_xml (
-    gmp_parser,
-    "<cves><count>%d</count></cves>",
-    resources->cves))
-    return TRUE;
-
-  if (send_report_xml (
-    gmp_parser,
-    "<vulns><count>%d</count></vulns>",
-    resources->vulnerabilities))
-    return TRUE;
-
-  if (send_report_xml (
-    gmp_parser,
-    "<os><count>%d</count></os>",
-    resources->operating_systems))
-    return TRUE;
-
-  if (send_report_xml (
-    gmp_parser,
-    "<apps><count>%d</count></apps>",
-    resources->applications))
-    return TRUE;
-
-  if (send_report_xml (
-    gmp_parser,
-    "<ssl_certs><count>%d</count></ssl_certs>",
-    resources->tls_certificates))
-    return TRUE;
-
-  if (send_report_xml (
-    gmp_parser,
-    "<ports><count>%d</count></ports>",
-    resources->ports))
-    return TRUE;
-
-  if (send_report_xml (
-    gmp_parser,
-    "<errors><count>%d</count></errors>",
-    resources->errors))
-    return TRUE;
-
-  return FALSE;
-}
-
-/**
  * @brief Send the result count summary.
  *
  * @param[in] gmp_parser  GMP parser handling the current session.
@@ -282,7 +206,7 @@ send_scan_report_summary (gmp_parser_t *gmp_parser,
   if (send_report_base_start (gmp_parser, summary->base))
     return TRUE;
 
-  if (send_scan_report_resource_counts (gmp_parser, summary))
+  if (send_report_resource_counts (gmp_parser, summary->resources))
     return TRUE;
 
   if (send_report_task (gmp_parser, summary->task))

--- a/src/manage_audit_report.c
+++ b/src/manage_audit_report.c
@@ -21,7 +21,6 @@
  */
 #define G_LOG_DOMAIN "md manage"
 
-
 /**
  * @brief Allocate and initialize an audit report summary.
  *
@@ -60,6 +59,9 @@ audit_report_summary_free (audit_report_summary_t summary)
   report_summary_base_free (summary->base);
   report_task_reference_free (summary->task);
   report_resource_summary_free (summary->resources);
+
+  g_free (summary->results.compliance.full);
+  g_free (summary->results.compliance.filtered);
 
   g_free (summary);
 }

--- a/src/manage_audit_report.c
+++ b/src/manage_audit_report.c
@@ -123,6 +123,8 @@ manage_get_audit_report_summary (const get_data_t *get,
 
   if (ret)
     {
+      g_warning ("%s: Failed to load audit report summary for report %lld",
+                 __func__, report);
       audit_report_summary_free (loaded_summary);
       return MANAGE_GET_AUDIT_REPORT_ERROR;
     }

--- a/src/manage_audit_report.c
+++ b/src/manage_audit_report.c
@@ -1,0 +1,133 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file
+ * @brief GVM management layer: Audit Report summary and operations.
+ */
+
+#include "manage_audit_report.h"
+
+#include "manage_settings.h"
+#include "manage_sql_audit_report.h"
+#include "manage_sql_scan_report.h"
+
+#undef G_LOG_DOMAIN
+
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md manage"
+
+
+/**
+ * @brief Allocate and initialize an audit report summary.
+ *
+ * Allocates the scan report summary and initializes its shared base,
+ * task reference, target reference, and resource summary structures.
+ *
+ * @return Newly allocated audit report summary.
+ */
+audit_report_summary_t
+audit_report_summary_new (void)
+{
+  audit_report_summary_t summary;
+
+  summary = g_malloc0 (sizeof (struct audit_report_summary));
+
+  summary->base = report_summary_base_new ();
+
+  summary->task = report_task_reference_new ();
+
+  summary->resources = report_resource_summary_new ();
+
+  return summary;
+}
+
+/**
+ * @brief Free an audit report summary.
+ *
+ * @param[in] summary  Audit report summary to free.
+ */
+void
+audit_report_summary_free (audit_report_summary_t summary)
+{
+  if (summary == NULL)
+    return;
+
+  report_summary_base_free (summary->base);
+  report_task_reference_free (summary->task);
+  report_resource_summary_free (summary->resources);
+
+  g_free (summary);
+}
+
+/**
+ * @brief Load a structured audit report summary.
+ *
+ * @param[in]  get          GET command data.
+ * @param[out] summary      Loaded report summary.
+ *
+ * @return Status describing the result of the operation.
+ */
+manage_get_audit_report_response_t
+manage_get_audit_report_summary (const get_data_t *get,
+                                 audit_report_summary_t *summary)
+{
+  get_report_controls_t controls = {0};
+  audit_report_summary_t loaded_summary = NULL;
+  report_t report = 0;
+  int ret;
+
+  if (get == NULL
+      || summary == NULL
+      || get->id == NULL)
+    return MANAGE_GET_AUDIT_REPORT_ERROR;
+
+  *summary = NULL;
+
+  ret = find_report_with_permission (get->id,
+                                     &report,
+                                     "get_reports");
+  if (ret)
+    return MANAGE_GET_AUDIT_REPORT_ERROR;
+
+  if (report == 0)
+    return MANAGE_GET_AUDIT_REPORT_NOT_FOUND;
+
+  ret = validate_get_report_usage_type (report,
+                                        REPORT_USAGE_TYPE_AUDIT);
+  if (ret < 0)
+    return MANAGE_GET_AUDIT_REPORT_ERROR;
+
+  if (ret > 0)
+    return MANAGE_GET_AUDIT_REPORT_UNSUPPORTED_TYPE;
+
+  ret = resolve_get_report_controls (get, &controls);
+  if (ret < 0)
+    return MANAGE_GET_AUDIT_REPORT_ERROR;
+
+  if (ret > 0)
+    return MANAGE_GET_AUDIT_REPORT_FILTER_NOT_FOUND;
+
+  loaded_summary = audit_report_summary_new ();
+
+  ret = manage_sql_fill_audit_report_summary (report,
+                                              get,
+                                              controls.zone,
+                                              loaded_summary);
+
+  get_report_controls_cleanup (&controls);
+
+  if (ret)
+    {
+      audit_report_summary_free (loaded_summary);
+      return MANAGE_GET_AUDIT_REPORT_ERROR;
+    }
+
+  *summary = loaded_summary;
+
+  return MANAGE_GET_AUDIT_REPORT_SUCCESS;
+}

--- a/src/manage_audit_report.h
+++ b/src/manage_audit_report.h
@@ -1,0 +1,75 @@
+/* Copyright (C) 2026 Greenbone AG
+*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file
+ * @brief GVM management layer: Audit report summary and operations.
+ */
+
+#ifndef _GVMD_MANAGE_AUDIT_REPORT_H
+#define _GVMD_MANAGE_AUDIT_REPORT_H
+
+#include "manage_report_common.h"
+
+/**
+ * @brief Full and filtered compliance values for an audit report.
+ */
+typedef struct
+{
+  gchar *full;
+  gchar *filtered;
+} audit_report_compliance_t;
+
+/**
+ * @brief Result summary for an audit report.
+ */
+typedef struct
+{
+  report_count_t total;
+  report_count_t yes;
+  report_count_t no;
+  report_count_t incomplete;
+  report_count_t undefined;
+
+  audit_report_compliance_t compliance;
+} audit_report_result_summary_t;
+
+/**
+ * @brief Structured summary of an audit report.
+ */
+struct audit_report_summary
+{
+  report_summary_base_t base;
+  report_task_reference_t task;
+  report_resource_summary_t resources;
+
+  audit_report_result_summary_t results;
+};
+
+typedef struct audit_report_summary *audit_report_summary_t;
+
+/**
+ * @brief Result of loading an audit report summary.
+ */
+typedef enum
+{
+  MANAGE_GET_AUDIT_REPORT_ERROR = -1,
+  MANAGE_GET_AUDIT_REPORT_SUCCESS = 0,
+  MANAGE_GET_AUDIT_REPORT_NOT_FOUND = 1,
+  MANAGE_GET_AUDIT_REPORT_FILTER_NOT_FOUND = 2,
+  MANAGE_GET_AUDIT_REPORT_UNSUPPORTED_TYPE = 3
+} manage_get_audit_report_response_t;
+
+audit_report_summary_t
+audit_report_summary_new (void);
+
+void
+audit_report_summary_free (audit_report_summary_t);
+
+manage_get_audit_report_response_t
+manage_get_audit_report_summary (const get_data_t *,
+                                 audit_report_summary_t *);
+
+#endif /* _GVMD_MANAGE_AUDIT_REPORT_H */

--- a/src/manage_commands.c
+++ b/src/manage_commands.c
@@ -104,6 +104,7 @@ command_t gmp_commands[]
     {"GET_AGGREGATES", "Get aggregates of resources."},
     {"GET_ALERTS", "Get all alerts."},
     {"GET_ASSETS", "Get all assets."},
+    {"GET_AUDIT_REPORT", "Get specific audit report summary."},
     {"GET_CONFIGS", "Get all configs."},
     {"GET_CREDENTIALS", "Get all credentials."},
 #if ENABLE_CREDENTIAL_STORES

--- a/src/manage_report_common.c
+++ b/src/manage_report_common.c
@@ -10,6 +10,8 @@
 
 #include "manage_report_common.h"
 
+#include "manage_filters.h"
+
 #undef G_LOG_DOMAIN
 
 /**
@@ -194,4 +196,155 @@ report_target_type_to_string (report_target_type_t type)
     default:
       return "unknown";
     }
+}
+
+/**
+ * @brief Check whether a report is supported by GET_%s_REPORT.
+ *
+ * @param[in] report  Report resource.
+ * @param [in] expected_usage_type  Expected usage type of the report.
+ *
+ * @return 0 if supported, 1 if unsupported, or -1 on error.
+ */
+static int
+validate_report_usage_type (report_t report,
+                             const gchar *expected_usage_type)
+{
+  task_t task = 0;
+  gchar *usage_type = NULL;
+  int ret;
+
+  if (report == 0)
+    return -1;
+
+  ret = report_task (report, &task);
+  if (ret)
+    return -1;
+
+  /*
+   * A report without an associated task has no usage type to validate.
+   */
+  if (task == 0)
+    return 0;
+
+  ret = task_usage_type (task, &usage_type);
+  if (ret)
+    return -1;
+
+  if (usage_type && !strcmp (usage_type, expected_usage_type) == 0)
+    {
+      g_free (usage_type);
+      return 1;
+    }
+
+  g_free (usage_type);
+
+  return 0;
+}
+
+/**
+ * @brief Get the expected usage type string for a report.
+ *
+ * @param[in] usage_type  Expected usage type of the report.
+ *
+ * @return String representation of the expected usage type, or NULL if
+ *         unsupported.
+ */
+static const gchar *
+get_report_expected_usage_type (report_usage_type_t usage_type)
+{
+  switch (usage_type)
+    {
+    case REPORT_USAGE_TYPE_SCAN:
+      return "scan";
+
+    case REPORT_USAGE_TYPE_AUDIT:
+      return "audit";
+
+    default:
+      return NULL;
+    }
+}
+
+/**
+ * @brief Check whether a report is supported by GET_%s_REPORT.
+ *
+ * @param[in] report      Report resource.
+ * @param[in] usage_type  Expected usage type of the report.
+ *
+ * @return 0 if supported, 1 if unsupported, or -1 on error.
+ */
+int
+validate_get_report_usage_type (report_t report, report_usage_type_t usage_type)
+{
+  const gchar *expected_usage_type = get_report_expected_usage_type (usage_type);
+  if (expected_usage_type == NULL)
+    return -1;
+
+  return validate_report_usage_type (report, expected_usage_type);
+}
+
+/**
+ * @brief Validate and resolve controls needed by GET_%s_REPORT.
+ *
+ * @param[in]  get       GET command data.
+ * @param[out] controls  Resolved controls required by the report summary.
+ *
+ * @return 0 on success, 2 if the filter cannot be resolved, or -1 on error.
+ */
+int
+resolve_get_report_controls (const get_data_t *get,
+                             get_report_controls_t *controls)
+{
+  gchar *term = NULL;
+  gchar *sort_field = NULL;
+  gchar *min_qod = NULL;
+  gchar *levels = NULL;
+  gchar *compliance_levels = NULL;
+  gchar *delta_states = NULL;
+  gchar *search_phrase = NULL;
+  int first_result = 0;
+  int max_results = 0;
+  int sort_order = 0;
+  int result_hosts_only = 0;
+  int search_phrase_exact = 0;
+  int notes = 0;
+  int overrides = 0;
+  int apply_overrides = 0;
+  int ret;
+
+  if (get == NULL || controls == NULL)
+    return -1;
+
+  controls->zone = NULL;
+
+  ret = manage_report_filter_controls_from_get (
+    get,
+    &term,
+    &first_result,
+    &max_results,
+    &sort_field,
+    &sort_order,
+    &result_hosts_only,
+    NULL,
+    &min_qod,
+    &levels,
+    &compliance_levels,
+    &delta_states,
+    &search_phrase,
+    &search_phrase_exact,
+    &notes,
+    &overrides,
+    &apply_overrides,
+    &controls->zone);
+
+  g_free (term);
+  g_free (sort_field);
+  g_free (min_qod);
+  g_free (levels);
+  g_free (compliance_levels);
+  g_free (delta_states);
+  g_free (search_phrase);
+
+  return ret;
 }

--- a/src/manage_report_common.h
+++ b/src/manage_report_common.h
@@ -132,6 +132,16 @@ struct report_summary_base
  gchar *timezone_abbrev;
 };
 
+/**
+* @brief Usage type of a report,
+*        used to validate the report type for GET_%s_REPORT.
+*/
+typedef enum
+{
+ REPORT_USAGE_TYPE_SCAN = 0,
+ REPORT_USAGE_TYPE_AUDIT = 1
+} report_usage_type_t;
+
 typedef struct report_summary_base *report_summary_base_t;
 
 report_summary_base_t
@@ -157,5 +167,12 @@ get_report_controls_cleanup (get_report_controls_t *);
 
 const gchar *
 report_target_type_to_string (report_target_type_t);
+
+int
+validate_get_report_usage_type (report_t, report_usage_type_t);
+
+int
+resolve_get_report_controls (const get_data_t *,
+                             get_report_controls_t *);
 
 #endif //_GVM_MANAGE_REPORT_COMMON_H

--- a/src/manage_resources.c
+++ b/src/manage_resources.c
@@ -41,6 +41,7 @@ valid_type (const char* type)
 
   return (strcasecmp (type, "alert") == 0)
          || (strcasecmp (type, "asset") == 0)
+         || (strcasecmp (type, "audit_report") == 0)
          || (strcasecmp (type, "config") == 0)
          || (strcasecmp (type, "credential") == 0)
          || (strcasecmp (type, "filter") == 0)

--- a/src/manage_scan_report.c
+++ b/src/manage_scan_report.c
@@ -10,7 +10,6 @@
 
 #include "manage_scan_report.h"
 
-#include "manage_filters.h"
 #include "manage_settings.h"
 #include "manage_sql_scan_report.h"
 
@@ -64,117 +63,6 @@ scan_report_summary_free (scan_report_summary_t summary)
 }
 
 /**
- * @brief Check whether a report is supported by GET_REPORT.
- *
- * GET_REPORT currently supports vulnerability reports only.
- * Audit reports are handled by a separate command.
- *
- * @param[in] report  Report resource.
- *
- * @return 0 if supported, 1 if unsupported, or -1 on error.
- */
-static int
-validate_get_report_usage_type (report_t report)
-{
-  task_t task = 0;
-  gchar *usage_type = NULL;
-  int ret;
-
-  if (report == 0)
-    return -1;
-
-  ret = report_task (report, &task);
-  if (ret)
-    return -1;
-
-  /*
-   * A report without an associated task has no usage type to validate.
-   */
-  if (task == 0)
-    return 0;
-
-  ret = task_usage_type (task, &usage_type);
-  if (ret)
-    return -1;
-
-  if (usage_type && strcmp (usage_type, "audit") == 0)
-    {
-      g_free (usage_type);
-      return 1;
-    }
-
-  g_free (usage_type);
-
-  return 0;
-}
-
-
-/**
- * @brief Validate and resolve controls needed by GET_REPORT.
- *
- * @param[in]  get       GET command data.
- * @param[out] controls  Resolved controls required by the report summary.
- *
- * @return 0 on success, 2 if the filter cannot be resolved, or -1 on error.
- */
-static int
-resolve_get_report_controls (const get_data_t *get,
-                             get_report_controls_t *controls)
-{
-  gchar *term = NULL;
-  gchar *sort_field = NULL;
-  gchar *min_qod = NULL;
-  gchar *levels = NULL;
-  gchar *compliance_levels = NULL;
-  gchar *delta_states = NULL;
-  gchar *search_phrase = NULL;
-  int first_result = 0;
-  int max_results = 0;
-  int sort_order = 0;
-  int result_hosts_only = 0;
-  int search_phrase_exact = 0;
-  int notes = 0;
-  int overrides = 0;
-  int apply_overrides = 0;
-  int ret;
-
-  if (get == NULL || controls == NULL)
-    return -1;
-
-  controls->zone = NULL;
-
-  ret = manage_report_filter_controls_from_get (
-    get,
-    &term,
-    &first_result,
-    &max_results,
-    &sort_field,
-    &sort_order,
-    &result_hosts_only,
-    NULL,
-    &min_qod,
-    &levels,
-    &compliance_levels,
-    &delta_states,
-    &search_phrase,
-    &search_phrase_exact,
-    &notes,
-    &overrides,
-    &apply_overrides,
-    &controls->zone);
-
-  g_free (term);
-  g_free (sort_field);
-  g_free (min_qod);
-  g_free (levels);
-  g_free (compliance_levels);
-  g_free (delta_states);
-  g_free (search_phrase);
-
-  return ret;
-}
-
-/**
  * @brief Load a structured vulnerability report summary.
  *
  * @param[in]  get          GET command data.
@@ -208,7 +96,7 @@ manage_get_scan_report_summary (const get_data_t *get,
   if (report == 0)
     return MANAGE_GET_SCAN_REPORT_NOT_FOUND;
 
-  ret = validate_get_report_usage_type (report);
+  ret = validate_get_report_usage_type (report, REPORT_USAGE_TYPE_SCAN);
   if (ret < 0)
     return MANAGE_GET_SCAN_REPORT_ERROR;
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -11625,7 +11625,10 @@ results_extra_where (int trash, report_t report, const gchar* host,
                                 compliance_levels_clause ?: "");
 
   g_free (min_qod_clause);
-  g_string_free (levels_clause, TRUE);
+
+  if (levels_clause)
+    g_string_free (levels_clause, TRUE);
+
   g_free (report_clause);
   g_free (host_clause);
   g_free (compliance_levels_clause);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -14197,7 +14197,7 @@ report_compliance_from_counts (const int* yes_count,
  *
  * @return 0 on success, -1 on error.
  */
-static int
+int
 report_compliance_f_counts (report_t report,
                             const get_data_t* get,
                             int* f_compliance_yes,

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -14274,7 +14274,7 @@ report_compliance_f_counts (report_t report,
  *
  * @return 0 on success, -1 on error.
  */
-static int
+int
 report_compliance_counts (report_t report,
                           const get_data_t* get,
                           int* compliance_yes,

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -605,6 +605,10 @@ int
 report_compliance_f_counts (report_t, const get_data_t*, int*, int*, int*,
                             int*);
 
+int
+report_compliance_counts (report_t, const get_data_t*, int* , int*, int* ,
+                          int*);
+
 gboolean
 nvt_exists (const char *);
 

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -601,6 +601,10 @@ report_counts_id_full (report_t, int *, int *, int *, int *, int *, int *,
                        double *, const get_data_t*, const char* ,
                        int *, int *, int *, int *, int *, int *, double *);
 
+int
+report_compliance_f_counts (report_t, const get_data_t*, int*, int*, int*,
+                            int*);
+
 gboolean
 nvt_exists (const char *);
 

--- a/src/manage_sql_audit_report.c
+++ b/src/manage_sql_audit_report.c
@@ -1,0 +1,204 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file
+ * @brief GVM SQL layer: Structured audit report summary loading.
+ *
+ * SQL-backed functions for filling a structured audit report summary.
+ */
+
+#include "manage_sql_audit_report.h"
+
+#include "manage_sql_report_common.h"
+#include "manage_sql_report_ports.h"
+#include "manage_sql_settings.h"
+#include "manage_sql_targets.h"
+#include "manage_targets.h"
+
+#undef G_LOG_DOMAIN
+
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md manage"
+
+/**
+ * @brief Fill full and filtered compliance counts.
+ *
+ * Compliance states are mapped directly to the legacy GMP response:
+ *
+ * - yes
+ * - no
+ * - incomplete
+ * - undefined
+ *
+ * @param[in]     report             Report to inspect.
+ * @param[in]     get                Result filtering information.
+ * @param[in,out] summary            Audit report summary to fill.
+ *
+ * @return 0 on success, -1 on Error.
+ */
+static int
+fill_audit_report_result_summary (
+  report_t report,
+  const get_data_t *get,
+  audit_report_summary_t summary)
+{
+  int yes;
+  int no;
+  int incomplete;
+  int undefined;
+
+  int filtered_yes;
+  int filtered_no;
+  int filtered_incomplete;
+  int filtered_undefined;
+  int res;
+
+  const gchar *levels;
+
+  if (report == 0 || get == NULL || summary == NULL)
+    return -1;
+
+  levels = "yniu";
+
+  yes = 0;
+  no = 0;
+  incomplete = 0;
+  undefined = 0;
+
+  filtered_yes = 0;
+  filtered_no = 0;
+  filtered_incomplete = 0;
+  filtered_undefined = 0;
+  res = -1;
+
+  res = report_compliance_f_counts (
+    report,
+    get,
+    &filtered_yes,
+    &filtered_no,
+    &filtered_incomplete,
+    &filtered_undefined);
+
+  if (res != 0)
+    return res;
+
+  summary->results.yes.full = yes;
+  summary->results.yes.filtered =
+    strchr (levels, 'y') ? filtered_yes : 0;
+
+  summary->results.no.full = no;
+  summary->results.no.filtered =
+    strchr (levels, 'n') ? filtered_no : 0;
+
+  summary->results.incomplete.full = incomplete;
+  summary->results.incomplete.filtered =
+    strchr (levels, 'i') ? filtered_incomplete : 0;
+
+  summary->results.undefined.full = undefined;
+  summary->results.undefined.filtered =
+    strchr (levels, 'u') ? filtered_undefined : 0;
+
+  summary->results.total.full =
+    summary->results.yes.full
+    + summary->results.no.full
+    + summary->results.incomplete.full
+    + summary->results.undefined.full;
+
+  summary->results.total.filtered =
+    summary->results.yes.filtered
+    + summary->results.no.filtered
+    + summary->results.incomplete.filtered
+    + summary->results.undefined.filtered;
+
+  g_free (summary->results.compliance.full);
+  g_free (summary->results.compliance.filtered);
+
+  summary->results.compliance.full =
+    g_strdup (
+      report_compliance_from_counts (
+        &yes,
+        &no,
+        &incomplete,
+        &undefined));
+
+  summary->results.compliance.filtered =
+    g_strdup (
+      report_compliance_from_counts (
+        &summary->results.yes.filtered,
+        &summary->results.no.filtered,
+        &summary->results.incomplete.filtered,
+        &summary->results.undefined.filtered));
+
+  return 0;
+}
+
+/**
+ * @brief Fill a structured audit report summary.
+ *
+ * Loads report metadata, scan status, task information, target information,
+ * resource counts, compliance counts and timezone data.
+ *
+ * @param[in]     report             Internal report resource.
+ * @param[in]     get                Result filtering controls.
+ * @param[in]     zone               Resolved request timezone, or NULL.
+ * @param[in,out] summary            Allocated audit report summary to populate.
+ *
+ * @return 0 on success, or -1 on error.
+ */
+int
+manage_sql_fill_audit_report_summary (
+  report_t report,
+  const get_data_t *get,
+  const gchar *zone,
+  audit_report_summary_t summary)
+{
+  int ret;
+
+  if (report == 0 || get == NULL || summary == NULL)
+    return -1;
+
+  ret = fill_report_base (report, summary->base);
+  if (ret)
+    return ret;
+
+  ret = fill_report_scan_information (report, summary->base);
+  if (ret)
+    return ret;
+
+  ret = fill_report_task (report, summary->task);
+  if (ret)
+    return ret;
+
+  ret = fill_report_target (
+    summary->task ? summary->task->id : 0,
+    summary->task ? summary->task->target : NULL);
+  if (ret)
+    return ret;
+
+  ret = fill_report_resource_summary (
+    report,
+    get,
+    summary->resources);
+  if (ret)
+    return ret;
+
+  ret = fill_audit_report_result_summary (
+    report,
+    get,
+    summary);
+  if (ret)
+    return ret;
+
+  ret = fill_report_timezone (
+    summary->base,
+    zone);
+  if (ret)
+    return ret;
+
+  return 0;
+}

--- a/src/manage_sql_audit_report.c
+++ b/src/manage_sql_audit_report.c
@@ -76,6 +76,21 @@ fill_audit_report_result_summary (
   filtered_undefined = 0;
   res = -1;
 
+  res = report_compliance_counts (
+    report,
+    get,
+    &yes,
+    &no,
+    &incomplete,
+    &undefined);
+
+  if (res != 0)
+    {
+      g_warning ("%s: Failed to get compliance counts for report %lld",
+                 __func__, report);
+      return res;
+    }
+
   res = report_compliance_f_counts (
     report,
     get,
@@ -85,7 +100,11 @@ fill_audit_report_result_summary (
     &filtered_undefined);
 
   if (res != 0)
-    return res;
+    {
+      g_warning ("%s: Failed to get filtered compliance counts for report %lld",
+                 __func__, report);
+      return res;
+    }
 
   summary->results.yes.full = yes;
   summary->results.yes.filtered =

--- a/src/manage_sql_audit_report.h
+++ b/src/manage_sql_audit_report.h
@@ -1,0 +1,22 @@
+/* Copyright (C) 2026 Greenbone AG
+*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file
+ * @brief GVM SQL layer: Structured scan report summary loading.
+ */
+
+#ifndef _GVMD_MANAGE_SQL_AUDIT_REPORT_H
+#define _GVMD_MANAGE_SQL_AUDIT_REPORT_H
+
+#include "manage_audit_report.h"
+
+int
+manage_sql_fill_audit_report_summary (report_t,
+                                      const get_data_t *,
+                                      const gchar *,
+                                      audit_report_summary_t);
+
+#endif /* _GVMD_MANAGE_SQL_AUDIT_REPORT_H */

--- a/src/manage_sql_resources.c
+++ b/src/manage_sql_resources.c
@@ -64,7 +64,22 @@ resource_name (const char *type, const char *uuid, int location, char **name)
 
   GString *query = g_string_new ("");
 
-  if (strcasecmp (type, "note") == 0)
+  if (strcasecmp (type, "audit_report") == 0)
+    {
+      *name = sql_string_ps ("SELECT (SELECT name FROM tasks WHERE id = task)"
+                             " || ' - '"
+                             " || (SELECT"
+                             "       CASE (SELECT end_time FROM tasks"
+                             "             WHERE id = task)"
+                             "       WHEN 0 THEN 'N/A'"
+                             "       ELSE (SELECT iso_time (end_time)"
+                             "             FROM tasks WHERE id = task)"
+                             "    END)"
+                             " FROM reports"
+                             " WHERE uuid = $1;",
+                             SQL_STR_PARAM (uuid), NULL);
+    }
+  else if (strcasecmp (type, "note") == 0)
     {
       g_string_printf (query,
                        "SELECT 'Note for: '"

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -11915,6 +11915,807 @@ END:VCALENDAR
     </example>
   </command>
   <command>
+    <name>get_audit_report</name>
+    <summary>Get a structured audit report</summary>
+    <description>
+      <p>
+          The client uses the get_audit_report command to retrieve a single
+          structured audit report.
+      </p>
+      <p>
+          The response includes report metadata, task and target information, scan
+          status, scan times, resource counts, compliance counts, compliance values
+          and task progress.
+      </p>
+      <p>
+          Result filters affect the filtered compliance counts and filtered
+          compliance value returned by the command. Full compliance counts remain
+          unchanged.
+      </p>
+      <p>
+          Normal vulnerability reports are not supported by this command and must
+          be retrieved using the get_scan_report command.
+      </p>
+    </description>
+    <pattern>
+      <attrib>
+        <name>audit_report_id</name>
+        <summary>ID of the audit report to retrieve</summary>
+        <type>uuid</type>
+        <required>1</required>
+      </attrib>
+      <attrib>
+        <name>filter</name>
+        <summary>Filter term to apply to the audit report summary</summary>
+        <type>text</type>
+        <filter_keywords>
+          <option>
+            <name>first</name>
+            <type>integer</type>
+            <summary>
+                Index of the first result, starting at 1
+              </summary>
+          </option>
+          <option>
+            <name>rows</name>
+            <type>integer</type>
+            <summary>Maximum number of results</summary>
+          </option>
+          <option>
+            <name>sort</name>
+            <type>text</type>
+            <summary>Result column to sort by in ascending order</summary>
+          </option>
+          <option>
+            <name>sort-reverse</name>
+            <type>text</type>
+            <summary>Result column to sort by in descending order</summary>
+          </option>
+          <option>
+            <name>compliance_levels</name>
+            <type>text</type>
+            <summary>
+                Compliance levels included in the filtered compliance summary
+              </summary>
+          </option>
+          <option>
+            <name>min_qod</name>
+            <type>integer</type>
+            <summary>Minimum quality of detection</summary>
+          </option>
+          <option>
+            <name>apply_overrides</name>
+            <type>boolean</type>
+            <summary>Whether result overrides are applied</summary>
+          </option>
+          <option>
+            <name>result_hosts_only</name>
+            <type>boolean</type>
+            <summary>
+                Whether only hosts containing matching results are considered
+              </summary>
+          </option>
+        </filter_keywords>
+      </attrib>
+      <attrib>
+        <name>filt_id</name>
+        <summary>ID of a saved filter to apply</summary>
+        <type>uuid</type>
+      </attrib>
+    </pattern>
+    <response>
+      <pattern>
+        <attrib>
+          <name>status</name>
+          <type>status</type>
+          <required>1</required>
+        </attrib>
+        <attrib>
+          <name>status_text</name>
+          <type>text</type>
+          <required>1</required>
+        </attrib>
+        <o>
+          <e>report</e>
+        </o>
+        <o>
+          <e>filters</e>
+        </o>
+        <o>
+          <e>sort</e>
+        </o>
+        <o>
+          <e>audit_report</e>
+        </o>
+        <o>
+          <e>audit_report_count</e>
+        </o>
+      </pattern>
+      <ele>
+        <name>report</name>
+        <summary>Structured audit report</summary>
+        <pattern>
+          <attrib>
+            <name>id</name>
+            <summary>UUID of the report</summary>
+            <type>uuid</type>
+            <required>1</required>
+          </attrib>
+          <e>owner</e>
+          <e>name</e>
+          <e>comment</e>
+          <e>creation_time</e>
+          <e>modification_time</e>
+          <e>writable</e>
+          <e>in_use</e>
+          <e>scan_run_status</e>
+          <e>hosts</e>
+          <e>closed_cves</e>
+          <e>cves</e>
+          <e>vulns</e>
+          <e>os</e>
+          <e>apps</e>
+          <e>ssl_certs</e>
+          <e>ports</e>
+          <e>errors</e>
+          <e>task</e>
+          <e>timestamp</e>
+          <e>scan_start</e>
+          <e>timezone</e>
+          <e>timezone_abbrev</e>
+          <e>compliance_count</e>
+          <e>compliance</e>
+          <e>scan_end</e>
+        </pattern>
+        <ele>
+          <name>owner</name>
+          <summary>Owner of the report</summary>
+          <pattern>
+            <e>name</e>
+          </pattern>
+          <ele>
+            <name>name</name>
+            <summary>Name of the report owner</summary>
+            <pattern>text</pattern>
+          </ele>
+        </ele>
+        <ele>
+          <name>name</name>
+          <summary>Name of the report</summary>
+          <pattern>text</pattern>
+        </ele>
+        <ele>
+          <name>comment</name>
+          <summary>Comment associated with the report</summary>
+          <pattern>text</pattern>
+        </ele>
+        <ele>
+          <name>creation_time</name>
+          <summary>Creation time of the report</summary>
+          <pattern>ctime</pattern>
+        </ele>
+        <ele>
+          <name>modification_time</name>
+          <summary>Last modification time of the report</summary>
+          <pattern>ctime</pattern>
+        </ele>
+        <ele>
+          <name>writable</name>
+          <summary>Whether the report is writable by the current user</summary>
+          <pattern>
+            <t>boolean</t>
+          </pattern>
+        </ele>
+        <ele>
+          <name>in_use</name>
+          <summary>Whether the report is currently in use</summary>
+          <pattern>
+            <t>boolean</t>
+          </pattern>
+        </ele>
+        <ele>
+          <name>scan_run_status</name>
+          <summary>Run status of the audit scan associated with the report</summary>
+          <pattern>text</pattern>
+        </ele>
+        <ele>
+          <name>hosts</name>
+          <summary>Host count information</summary>
+          <pattern>
+            <e>count</e>
+          </pattern>
+          <ele>
+            <name>count</name>
+            <summary>Number of hosts in the report</summary>
+            <pattern>
+              <t>integer</t>
+            </pattern>
+          </ele>
+        </ele>
+        <ele>
+          <name>closed_cves</name>
+          <summary>Closed CVE count information</summary>
+          <pattern>
+            <e>count</e>
+          </pattern>
+          <ele>
+            <name>count</name>
+            <summary>Number of closed CVEs in the report</summary>
+            <pattern>
+              <t>integer</t>
+            </pattern>
+          </ele>
+        </ele>
+        <ele>
+          <name>cves</name>
+          <summary>CVE count information</summary>
+          <pattern>
+            <e>count</e>
+          </pattern>
+          <ele>
+            <name>count</name>
+            <summary>Number of CVEs in the report</summary>
+            <pattern>
+              <t>integer</t>
+            </pattern>
+          </ele>
+        </ele>
+        <ele>
+          <name>vulns</name>
+          <summary>Vulnerability count information</summary>
+          <pattern>
+            <e>count</e>
+          </pattern>
+          <ele>
+            <name>count</name>
+            <summary>Number of vulnerabilities in the report</summary>
+            <pattern>
+              <t>integer</t>
+            </pattern>
+          </ele>
+        </ele>
+        <ele>
+          <name>os</name>
+          <summary>Operating system count information</summary>
+          <pattern>
+            <e>count</e>
+          </pattern>
+          <ele>
+            <name>count</name>
+            <summary>Number of operating systems in the report</summary>
+            <pattern>
+              <t>integer</t>
+            </pattern>
+          </ele>
+        </ele>
+        <ele>
+          <name>apps</name>
+          <summary>Application count information</summary>
+          <pattern>
+            <e>count</e>
+          </pattern>
+          <ele>
+            <name>count</name>
+            <summary>Number of applications in the report</summary>
+            <pattern>
+              <t>integer</t>
+            </pattern>
+          </ele>
+        </ele>
+        <ele>
+          <name>ssl_certs</name>
+          <summary>TLS certificate count information</summary>
+          <pattern>
+            <e>count</e>
+          </pattern>
+          <ele>
+            <name>count</name>
+            <summary>Number of TLS certificates in the report</summary>
+            <pattern>
+              <t>integer</t>
+            </pattern>
+          </ele>
+        </ele>
+        <ele>
+          <name>ports</name>
+          <summary>Port count information</summary>
+          <pattern>
+            <e>count</e>
+          </pattern>
+          <ele>
+            <name>count</name>
+            <summary>Number of ports in the report</summary>
+            <pattern>
+              <t>integer</t>
+            </pattern>
+          </ele>
+        </ele>
+        <ele>
+          <name>errors</name>
+          <summary>Scan error count information</summary>
+          <pattern>
+            <e>count</e>
+          </pattern>
+          <ele>
+            <name>count</name>
+            <summary>Number of scan errors in the report</summary>
+            <pattern>
+              <t>integer</t>
+            </pattern>
+          </ele>
+        </ele>
+        <ele>
+          <name>task</name>
+          <summary>Audit task associated with the report</summary>
+          <pattern>
+            <attrib>
+              <name>id</name>
+              <summary>UUID of the task</summary>
+              <type>uuid</type>
+            </attrib>
+            <e>name</e>
+            <e>comment</e>
+            <o>
+              <e>target</e>
+            </o>
+            <e>progress</e>
+          </pattern>
+          <ele>
+            <name>name</name>
+            <summary>Name of the task</summary>
+            <pattern>text</pattern>
+          </ele>
+          <ele>
+            <name>comment</name>
+            <summary>Comment associated with the task</summary>
+            <pattern>text</pattern>
+          </ele>
+          <ele>
+            <name>target</name>
+            <summary>Target associated with the task</summary>
+            <pattern>
+              <attrib>
+                <name>id</name>
+                <summary>UUID of the target</summary>
+                <type>uuid</type>
+              </attrib>
+              <e>trash</e>
+              <e>name</e>
+              <e>comment</e>
+              <e>target_type</e>
+            </pattern>
+            <ele>
+              <name>trash</name>
+              <summary>Whether the target is in the trash</summary>
+              <pattern>
+                <t>boolean</t>
+              </pattern>
+            </ele>
+            <ele>
+              <name>name</name>
+              <summary>Name of the target</summary>
+              <pattern>text</pattern>
+            </ele>
+            <ele>
+              <name>comment</name>
+              <summary>Comment associated with the target</summary>
+              <pattern>text</pattern>
+            </ele>
+            <ele>
+              <name>target_type</name>
+              <summary>Type of the target associated with the task</summary>
+              <pattern>text</pattern>
+            </ele>
+          </ele>
+          <ele>
+            <name>progress</name>
+            <summary>Progress of the task associated with the report</summary>
+            <pattern>
+              <t>integer</t>
+            </pattern>
+          </ele>
+        </ele>
+        <ele>
+          <name>timestamp</name>
+          <summary>Timestamp identifying the report</summary>
+          <pattern>ctime</pattern>
+        </ele>
+        <ele>
+          <name>scan_start</name>
+          <summary>Start time of the audit scan</summary>
+          <pattern>ctime</pattern>
+        </ele>
+        <ele>
+          <name>timezone</name>
+          <summary>Timezone used for report timestamps</summary>
+          <pattern>text</pattern>
+        </ele>
+        <ele>
+          <name>timezone_abbrev</name>
+          <summary>Abbreviation of the report timezone</summary>
+          <pattern>text</pattern>
+        </ele>
+        <ele>
+          <name>compliance_count</name>
+          <summary>Full and filtered result counts by compliance status</summary>
+          <pattern>
+                text
+            <e>full</e>
+            <e>filtered</e>
+            <e>yes</e>
+            <e>no</e>
+            <e>incomplete</e>
+            <e>undefined</e>
+          </pattern>
+          <ele>
+            <name>full</name>
+            <summary>Total number of unfiltered compliance results</summary>
+            <pattern>
+              <t>integer</t>
+            </pattern>
+          </ele>
+          <ele>
+            <name>filtered</name>
+            <summary>Total number of filtered compliance results</summary>
+            <pattern>
+              <t>integer</t>
+            </pattern>
+          </ele>
+          <ele>
+            <name>yes</name>
+            <summary>Compliant result counts</summary>
+            <pattern>
+              <e>full</e>
+              <e>filtered</e>
+            </pattern>
+            <ele>
+              <name>full</name>
+              <summary>Number of unfiltered compliant results</summary>
+              <pattern>
+                <t>integer</t>
+              </pattern>
+            </ele>
+            <ele>
+              <name>filtered</name>
+              <summary>Number of filtered compliant results</summary>
+              <pattern>
+                <t>integer</t>
+              </pattern>
+            </ele>
+          </ele>
+          <ele>
+            <name>no</name>
+            <summary>Non-compliant result counts</summary>
+            <pattern>
+              <e>full</e>
+              <e>filtered</e>
+            </pattern>
+            <ele>
+              <name>full</name>
+              <summary>Number of unfiltered non-compliant results</summary>
+              <pattern>
+                <t>integer</t>
+              </pattern>
+            </ele>
+            <ele>
+              <name>filtered</name>
+              <summary>Number of filtered non-compliant results</summary>
+              <pattern>
+                <t>integer</t>
+              </pattern>
+            </ele>
+          </ele>
+          <ele>
+            <name>incomplete</name>
+            <summary>Incomplete compliance result counts</summary>
+            <pattern>
+              <e>full</e>
+              <e>filtered</e>
+            </pattern>
+            <ele>
+              <name>full</name>
+              <summary>Number of unfiltered incomplete results</summary>
+              <pattern>
+                <t>integer</t>
+              </pattern>
+            </ele>
+            <ele>
+              <name>filtered</name>
+              <summary>Number of filtered incomplete results</summary>
+              <pattern>
+                <t>integer</t>
+              </pattern>
+            </ele>
+          </ele>
+          <ele>
+            <name>undefined</name>
+            <summary>Undefined compliance result counts</summary>
+            <pattern>
+              <e>full</e>
+              <e>filtered</e>
+            </pattern>
+            <ele>
+              <name>full</name>
+              <summary>Number of unfiltered undefined results</summary>
+              <pattern>
+                <t>integer</t>
+              </pattern>
+            </ele>
+            <ele>
+              <name>filtered</name>
+              <summary>Number of filtered undefined results</summary>
+              <pattern>
+                <t>integer</t>
+              </pattern>
+            </ele>
+          </ele>
+        </ele>
+        <ele>
+          <name>compliance</name>
+          <summary>Full and filtered overall compliance values</summary>
+          <pattern>
+            <e>full</e>
+            <e>filtered</e>
+          </pattern>
+          <ele>
+            <name>full</name>
+            <summary>Overall compliance without result filtering</summary>
+            <pattern>text</pattern>
+          </ele>
+          <ele>
+            <name>filtered</name>
+            <summary>Overall compliance after applying the result filter</summary>
+            <pattern>text</pattern>
+          </ele>
+        </ele>
+        <ele>
+          <name>scan_end</name>
+          <summary>End time of the audit scan</summary>
+          <pattern>ctime</pattern>
+        </ele>
+      </ele>
+      <ele>
+        <name>filters</name>
+        <pattern>
+          <attrib>
+            <name>id</name>
+            <summary>UUID of the filter, or empty if no saved filter was used</summary>
+            <type>uuid</type>
+          </attrib>
+          <e>term</e>
+          <e>keywords</e>
+        </pattern>
+        <ele>
+          <name>term</name>
+          <summary>Resolved filter term</summary>
+          <pattern>text</pattern>
+        </ele>
+        <ele>
+          <name>keywords</name>
+          <summary>Filter broken down into keywords</summary>
+          <pattern>
+            <any>
+              <e>keyword</e>
+            </any>
+          </pattern>
+          <ele>
+            <name>keyword</name>
+            <pattern>
+              <e>column</e>
+              <e>relation</e>
+              <e>value</e>
+            </pattern>
+            <ele>
+              <name>column</name>
+              <summary>Filter column</summary>
+              <pattern>text</pattern>
+            </ele>
+            <ele>
+              <name>relation</name>
+              <summary>Filter relation</summary>
+              <pattern>
+                <alts>
+                  <alt>=</alt>
+                  <alt>:</alt>
+                  <alt>~</alt>
+                  <alt>&gt;</alt>
+                  <alt>&lt;</alt>
+                </alts>
+              </pattern>
+            </ele>
+            <ele>
+              <name>value</name>
+              <summary>Filter value</summary>
+              <pattern>text</pattern>
+            </ele>
+          </ele>
+        </ele>
+      </ele>
+      <ele>
+        <name>sort</name>
+        <pattern>
+              text
+          <e>field</e>
+        </pattern>
+        <ele>
+          <name>field</name>
+          <pattern>
+                text
+            <e>order</e>
+          </pattern>
+          <ele>
+            <name>order</name>
+            <pattern>
+              <alts>
+                <alt>ascending</alt>
+                <alt>descending</alt>
+              </alts>
+            </pattern>
+          </ele>
+        </ele>
+      </ele>
+      <ele>
+        <name>audit_report</name>
+        <pattern>
+          <attrib>
+            <name>start</name>
+            <summary>First returned audit report</summary>
+            <type>integer</type>
+            <required>1</required>
+          </attrib>
+          <attrib>
+            <name>max</name>
+            <summary>Maximum number of audit reports</summary>
+            <type>integer</type>
+            <required>1</required>
+          </attrib>
+        </pattern>
+      </ele>
+      <ele>
+        <name>audit_report_count</name>
+        <pattern>
+              text
+          <e>filtered</e>
+          <e>page</e>
+        </pattern>
+        <ele>
+          <name>filtered</name>
+          <summary>Number of matching audit reports</summary>
+          <pattern>
+            <t>integer</t>
+          </pattern>
+        </ele>
+        <ele>
+          <name>page</name>
+          <summary>
+                Number of additional audit reports on the current page
+              </summary>
+          <pattern>
+            <t>integer</t>
+          </pattern>
+        </ele>
+      </ele>
+    </response>
+    <example>
+      <summary>Get a structured audit report</summary>
+      <request>
+        <get_audit_report audit_report_id="c00e2b2b-6b3a-4be9-a6df-337f76262fe0" filter="compliance_levels=yniu min_qod=70">
+            </get_audit_report>
+      </request>
+      <response>
+        <get_audit_report_response status="200" status_text="OK">
+          <report id="c00e2b2b-6b3a-4be9-a6df-337f76262fe0">
+            <owner>
+              <name>moezgen</name>
+            </owner>
+            <name>2026-06-15T11:24:38Z</name>
+            <comment/>
+            <creation_time>2026-06-15T11:24:38Z</creation_time>
+            <modification_time>2026-06-15T12:30:23Z</modification_time>
+            <writable>0</writable>
+            <in_use>0</in_use>
+            <scan_run_status>Done</scan_run_status>
+            <hosts>
+              <count>1</count>
+            </hosts>
+            <closed_cves>
+              <count>0</count>
+            </closed_cves>
+            <cves>
+              <count>0</count>
+            </cves>
+            <vulns>
+              <count>10</count>
+            </vulns>
+            <os>
+              <count>1</count>
+            </os>
+            <apps>
+              <count>4</count>
+            </apps>
+            <ssl_certs>
+              <count>1</count>
+            </ssl_certs>
+            <ports>
+              <count>6</count>
+            </ports>
+            <errors>
+              <count>0</count>
+            </errors>
+            <task id="7cda9ee9-63d5-4802-9a31-5dacc8f19b5b">
+              <name>test-audit</name>
+              <comment/>
+              <target id="4809d998-2d2d-4a65-9148-f99f04799b09">
+                <trash>0</trash>
+                <name>test-target</name>
+                <comment/>
+                <target_type>target</target_type>
+              </target>
+              <progress>100</progress>
+            </task>
+            <timestamp>2026-06-15T11:24:38Z</timestamp>
+            <scan_start>2026-06-15T11:24:41Z</scan_start>
+            <timezone>UTC</timezone>
+            <timezone_abbrev>UTC</timezone_abbrev>
+            <compliance_count>
+              10
+              <full>10</full>
+              <filtered>8</filtered>
+              <yes>
+                <full>5</full>
+                <filtered>5</filtered>
+              </yes>
+              <no>
+                <full>3</full>
+                <filtered>3</filtered>
+              </no>
+              <incomplete>
+                <full>1</full>
+                <filtered>0</filtered>
+              </incomplete>
+              <undefined>
+                <full>1</full>
+                <filtered>0</filtered>
+              </undefined>
+            </compliance_count>
+            <compliance>
+              <full>No</full>
+              <filtered>No</filtered>
+            </compliance>
+            <scan_end>2026-06-15T12:30:23Z</scan_end>
+          </report>
+          <filters id="">
+            <term>compliance_levels=yniu min_qod=70</term>
+            <keywords>
+              <keyword>
+                <column>compliance_levels</column>
+                <relation>=</relation>
+                <value>yniu</value>
+              </keyword>
+              <keyword>
+                <column>min_qod</column>
+                <relation>=</relation>
+                <value>70</value>
+              </keyword>
+            </keywords>
+          </filters>
+          <sort>
+            <field>
+              type
+              <order>descending</order>
+            </field>
+          </sort>
+          <audit_report start="1" max="1"/>
+          <audit_report_count>
+                1
+            <filtered>1</filtered>
+            <page>0</page>
+          </audit_report_count>
+        </get_audit_report_response>
+      </response>
+    </example>
+  </command>
+  <command>
     <name>get_configs</name>
     <summary>Get one or many configs</summary>
     <description>


### PR DESCRIPTION
## What

- Add audit report summary loading
- Add the `get_audit_report` GMP command
- Add command documentation

## Why

- Support structured audit report retrieval
- Separate audit reports from `get_reports`


## References

GEA-1958

