### PR TITLE
Fix: resume of a task with a schedule with duration

### DIFF
--- a/src/manage_osp.c
+++ b/src/manage_osp.c
@@ -820,6 +820,18 @@ run_osp_scan_get_report (task_t task, int from, char **report_id)
       /* Ensure the report is marked as requested. */
       set_report_scan_run_status (resume_report, TASK_STATUS_REQUESTED);
 
+      /* Update the scheduled flag for this run, like create_current_report
+       * does for a new report.  The flag says whether the run that is now
+       * starting was triggered by the scheduler, so it has to follow the
+       * current session and must not be inherited from the earlier run of
+       * this report.  Otherwise a report that the scheduler once started
+       * keeps the flag forever, and task_schedule_iterator_stop_due () stops
+       * the task again right after a manual resume, because the duration of
+       * its schedule is long over.  The scheduler itself sets the flag again
+       * in scheduled_task_handle_start_success () when it is the one
+       * resuming. */
+      set_report_scheduled (resume_report);
+
       /* Clear the end times of the task and partial report. */
       set_task_start_time_epoch (task,
                                  scan_start_time_epoch (resume_report));


### PR DESCRIPTION
## What

Update the report's scheduled flag when a report is resumed, the same way `create_current_report()` does when a report is created.

## Why

A resumed scan keeps the report of the stopped run, and with it `reports.flags`, the flag that says whether the run was started by the scheduler. `run_osp_scan_get_report()` reuses the report and updates its status and times, but never touches that flag. If the stopped run had been started by the scheduler, the flag stays set, so for the scheduler the resumed run still looks like a scheduled one.

`task_schedule_iterator_stop_due()` then compares the start of the last occurrence of the schedule plus its duration with the current time:

```c
report = task_running_report (task_schedule_iterator_task (iterator));
if (report && (report_scheduled (report) == 0))
  return FALSE;
...
start = icalendar_next_time_from_string (icalendar, time (NULL), zone, -1);
if ((start + duration) < now)
  return TRUE;
```

After a manual resume that window is long over, so `manage_schedule()` stops the task again within one scheduler tick. A task in Stopped or Interrupted state whose schedule has a duration cannot be resumed at all — and a schedule with a duration is a very common way for a task to end up stopped in the first place, because the scheduler stops it at the end of the window.

## How to reproduce

Task with a recurring schedule that has a duration, started by the scheduler, stopped at the end of the window. Then resume it:

```
<resume_task_response status="202" status_text="OK, request submitted">
  +8s  Requested
  +16s Stop Requested      <- the scheduler
  +24s Stopped
  +40s Stopped
```

With the change, the same task, the same report and the same schedule:

```
  +8s  Requested
  +16s Queued
  +24s Running
  ...  Done
```

The flag is what differs, `1` = started by the scheduler:

```
                 uuid                 | flags | scan_run_status
 d29f5831-…  (resumed, unpatched)     |     1 |  13 (Interrupted)
 ed977710-…  (resumed, patched)       |     0 |   4 (Running)
```

## Notes

Both directions stay correct. A resume through GMP runs in a client session, so `set_report_scheduled()` clears the flag and the scheduler leaves the run alone. When the scheduler itself resumes a task, `scheduled_task_handle_start_success()` sets the flag again right after the start, so duration based stopping keeps working for scheduled runs.

All scanner types go through `run_osp_scan_get_report()`, so OSP/OpenVAS, openvasd, container image and web application scans are covered by the single change.

## Testing

Verified against the Greenbone Community Edition container stack with two gvmd images built from the same source, one with and one without this commit, resuming the identical task: without it the task returns to Stopped after ~16 s, with it the task runs to Done. No automated test — the code path needs a scanner, a schedule and the scheduler loop.
