### PR TITLE
Fix: Handle HTTP status 409 when deleting scans

### DIFF
--- a/src/manage_http_scanner.c
+++ b/src/manage_http_scanner.c
@@ -445,13 +445,13 @@ delete_http_scanner_scan_with_retry (http_scanner_connector_t connector,
         {
           break;
         }
-      else if (response->code == 406)
+      else if (response->code == 409 || response->code == 406)
         {
           if (delete_retry > 0)
             {
-              g_warning ("%s: Scan %s is still running and cannot be deleted yet,"
-                         " retrying stop and delete.",
-                         __func__, scan_id);
+              g_info ("%s: Scan %s is still running and cannot be deleted yet,"
+                      " retrying stop and delete.",
+                      __func__, scan_id);
 
               http_scanner_resp_t stop_response = http_scanner_stop_scan (connector);
               if (stop_response->code != 204)


### PR DESCRIPTION
## What
When trying to delete a scan, gvmd will now also try to stop the scan again retry the delete on HTTP status 409 in addition to 406. Also, the log level of the retry message is reduced from warning to info.

## Why
This is an adjustment to changes of the status code in recent openvasd versions while delays of a few seconds before scans being stopped are also expected.

## References
GEA-1963