### PR TITLE
Add/get audit report hosts

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -194,6 +194,7 @@ set(
   manage_alerts.c
   manage_asset_keys.c
   manage_audit_report.c
+  manage_audit_report_hosts.c
   manage_configs.c
   manage_events.c
   manage_filter_utils.c
@@ -283,6 +284,7 @@ set(
   manage_sql_alerts.c
   manage_sql_assets.c
   manage_sql_audit_report.c
+  manage_sql_audit_report_hosts.c
   manage_sql_events.c
   manage_sql_filters.c
   manage_sql_groups.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -347,6 +347,7 @@ set(
   gmp_delete.c
   gmp_get.c
   gmp_audit_report.c
+  gmp_audit_report_hosts.c
   gmp_integration_configs.c
   gmp_license.c
   gmp_logout.c

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -86,6 +86,7 @@
 #include "gmp_get.h"
 #include "gmp_configs.h"
 #include "gmp_audit_report.h"
+#include "gmp_audit_report_hosts.h"
 #include "gmp_integration_configs.h"
 #include "gmp_license.h"
 #include "gmp_logout.h"
@@ -4605,6 +4606,7 @@ typedef enum
   CLIENT_GET_ALERTS,
   CLIENT_GET_ASSETS,
   CLIENT_GET_AUDIT_REPORT,
+  CLIENT_GET_AUDIT_REPORT_HOSTS,
   CLIENT_GET_CONFIGS,
   CLIENT_GET_CREDENTIALS,
 #if ENABLE_CREDENTIAL_STORES
@@ -5611,6 +5613,8 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
           }
 
         ELSE_GET_START (audit_report, AUDIT_REPORT)
+
+        ELSE_GET_START (audit_report_hosts, AUDIT_REPORT_HOSTS)
 
         else if (strcasecmp ("GET_CONFIGS", element_name) == 0)
           {
@@ -22484,6 +22488,8 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
         break;
 
       CASE_GET_END (AUDIT_REPORT, audit_report)
+
+      CASE_GET_END (AUDIT_REPORT_HOSTS, audit_report_hosts)
 
       case CLIENT_GET_CONFIGS:
         handle_get_configs (gmp_parser, error);

--- a/src/gmp_audit_report_hosts.c
+++ b/src/gmp_audit_report_hosts.c
@@ -1,0 +1,223 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file
+ * @brief GMP handlers for audit report hosts.
+ */
+
+#include "gmp_audit_report_hosts.h"
+
+#include "gmp_get.h"
+#include "manage.h"
+#include "manage_audit_report_hosts.h"
+
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md    gmp"
+
+/**
+ * @brief Command data for the get_audit_report_hosts command.
+ */
+typedef struct
+{
+  get_data_t get;   ///< GET arguments with host/result filtering.
+  gchar *report_id; ///< ID of the audit report.
+  int lean;         ///< Whether to return lean host data.
+} get_audit_report_hosts_data_t;
+
+/**
+ * @brief Parser callback data.
+ *
+ * This is initially zero because it is a global variable.
+ */
+static get_audit_report_hosts_data_t get_audit_report_hosts_data;
+
+/**
+ * @brief Reset the internal state of the get_audit_report_hosts command.
+ */
+static void
+get_audit_report_hosts_reset (void)
+{
+  get_data_reset (&get_audit_report_hosts_data.get);
+  g_free (get_audit_report_hosts_data.report_id);
+
+  memset (&get_audit_report_hosts_data,
+          0,
+          sizeof (get_audit_report_hosts_data));
+}
+
+/**
+ * @brief Initialize the get_audit_report_hosts GMP command.
+ *
+ * @param[in] attribute_names   Null-terminated array of attribute names.
+ * @param[in] attribute_values  Null-terminated array of attribute values.
+ */
+void
+get_audit_report_hosts_start (const gchar **attribute_names,
+                              const gchar **attribute_values)
+{
+  const gchar *attribute;
+
+  get_data_parse_attributes (&get_audit_report_hosts_data.get,
+                             "audit_report_host",
+                             attribute_names,
+                             attribute_values);
+
+  if (find_attribute (attribute_names,
+                      attribute_values,
+                      "report_id",
+                      &attribute))
+    {
+      get_audit_report_hosts_data.report_id = g_strdup (attribute);
+
+      get_data_set_extra (&get_audit_report_hosts_data.get,
+                          "report_id",
+                          attribute);
+    }
+
+  if (find_attribute (attribute_names,
+                      attribute_values,
+                      "lean",
+                      &attribute))
+    get_audit_report_hosts_data.lean = strcmp (attribute, "0");
+  else
+    get_audit_report_hosts_data.lean = 0;
+}
+
+/**
+ * @brief Execute the get_audit_report_hosts GMP command.
+ *
+ * @param[in] gmp_parser  GMP parser handling the current session.
+ * @param[in] error       Location to store error information.
+ */
+void
+get_audit_report_hosts_run (gmp_parser_t *gmp_parser, GError **error)
+{
+  report_t report;
+  int ret;
+  int filtered;
+  int count;
+
+  count = 0;
+
+  if (get_audit_report_hosts_data.report_id == NULL)
+    {
+      SEND_TO_CLIENT_OR_FAIL (
+        XML_ERROR_SYNTAX (
+          "get_audit_report_hosts",
+          "Missing report_id attribute"));
+
+      get_audit_report_hosts_reset ();
+      return;
+    }
+
+  ret = init_get ("get_audit_report_hosts",
+                  &get_audit_report_hosts_data.get,
+                  "Audit Report Hosts",
+                  NULL);
+  if (ret)
+    {
+      switch (ret)
+        {
+        case 99:
+          SEND_TO_CLIENT_OR_FAIL (
+            XML_ERROR_SYNTAX (
+              "get_audit_report_hosts",
+              "Permission denied"));
+          break;
+
+        default:
+          internal_error_send_to_client (error);
+          get_audit_report_hosts_reset ();
+          return;
+        }
+
+      get_audit_report_hosts_reset ();
+      return;
+    }
+
+  if (find_report_with_permission (
+    get_audit_report_hosts_data.report_id,
+    &report,
+    "get_reports"))
+    {
+      internal_error_send_to_client (error);
+      get_audit_report_hosts_reset ();
+      return;
+    }
+
+  if (report == 0)
+    {
+      if (send_find_error_to_client (
+        "get_audit_report_hosts",
+        "report",
+        get_audit_report_hosts_data.report_id,
+        gmp_parser))
+        error_send_to_client (error);
+
+      get_audit_report_hosts_reset ();
+      return;
+    }
+
+  SEND_GET_START ("audit_report_host");
+
+  /*
+   * Use the underlying report resource type in the management and SQL
+   * layers.
+   */
+  g_free (get_audit_report_hosts_data.get.subtype);
+  get_audit_report_hosts_data.get.subtype = g_strdup ("report_host");
+
+  ret = manage_send_audit_report_hosts (
+    report,
+    &get_audit_report_hosts_data.get,
+    get_audit_report_hosts_data.lean,
+    send_to_client,
+    gmp_parser->client_writer,
+    gmp_parser->client_writer_data);
+
+  if (ret)
+    {
+      switch (ret)
+        {
+        case 2:
+          if (send_find_error_to_client (
+            "get_audit_report_hosts",
+            "filter",
+            get_audit_report_hosts_data.get.filt_id,
+            gmp_parser))
+            error_send_to_client (error);
+          break;
+
+        case 3:
+          SEND_TO_CLIENT_OR_FAIL (
+            XML_ERROR_SYNTAX (
+              "get_audit_report_hosts",
+              "Report is not an audit report"));
+          break;
+
+        default:
+          internal_error_send_to_client (error);
+          break;
+        }
+
+      get_audit_report_hosts_reset ();
+      return;
+    }
+
+  filtered = get_audit_report_hosts_data.get.id
+               ? 1
+               : report_host_count (report);
+
+  SEND_GET_END ("audit_report_host",
+                &get_audit_report_hosts_data.get,
+                count,
+                filtered);
+
+  get_audit_report_hosts_reset ();
+}

--- a/src/gmp_audit_report_hosts.h
+++ b/src/gmp_audit_report_hosts.h
@@ -1,0 +1,19 @@
+/* Copyright (C) 2026 Greenbone AG
+*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef _GVM_GMP_AUDIT_REPORT_HOSTS_H
+#define _GVM_GMP_AUDIT_REPORT_HOSTS_H
+
+#include "gmp_base.h"
+
+/* GET_AUDIT_REPORT_HOSTS. */
+
+void
+get_audit_report_hosts_start (const gchar **, const gchar **);
+
+void
+get_audit_report_hosts_run (gmp_parser_t *, GError **);
+
+#endif /* _GVM_GMP_AUDIT_REPORT_HOSTS_H */

--- a/src/gmp_get.c
+++ b/src/gmp_get.c
@@ -633,6 +633,7 @@ send_get_end_internal (const char *type, get_data_t *get, int get_counts,
                                         get->ignore_max_rows_per_page);
       g_free (filter);
       if ((strcmp (type, "audit_report") == 0)
+          || (strcmp (type, "audit_report_host") == 0)
           || (strcmp (type, "task") == 0)
           || (strcmp (type, "report") == 0)
           || (strcmp (type, "report_application") == 0)
@@ -662,6 +663,7 @@ send_get_end_internal (const char *type, get_data_t *get, int get_counts,
           g_free (value);
 
           if ((strcmp (type, "audit_report") == 0)
+              || (strcmp (type, "audit_report_host") == 0)
               || (strcmp (type, "task") == 0)
               || (strcmp (type, "report") == 0)
               || (strcmp (type, "report_application") == 0)
@@ -694,6 +696,7 @@ send_get_end_internal (const char *type, get_data_t *get, int get_counts,
   else
     {
       if ((strcmp (type, "audit_report") == 0)
+          || (strcmp (type, "audit_report_host") == 0)
           || (strcmp (type, "task") == 0)
           || (strcmp (type, "report") == 0)
           || (strcmp (type, "report_application") == 0)

--- a/src/manage_audit_report_hosts.c
+++ b/src/manage_audit_report_hosts.c
@@ -1,0 +1,281 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file
+ * @brief GVM management layer: Audit report hosts.
+ *
+ * Non-SQL audit report hosts code for the GVM management layer.
+ */
+
+#include "manage_audit_report_hosts.h"
+
+#include "manage_filters.h"
+#include "manage_report_common.h"
+#include "manage_sql_audit_report_hosts.h"
+#include "manage_sql_report_hosts.h"
+
+#include <gvm/util/fileutils.h>
+
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md manage"
+
+/**
+ * @brief Send audit report hosts XML to the client.
+ *
+ * @param[in]  report       Audit report.
+ * @param[in]  get          GET command data.
+ * @param[in]  lean         Whether to send lean host data.
+ * @param[in]  send         Function to write to client.
+ * @param[in]  send_data_1  Second argument to @p send.
+ * @param[in]  send_data_2  Third argument to @p send.
+ *
+ * @return 0 on success, -1 on error, 2 if the filter was not found,
+ *         or 3 if the report usage type is not audit.
+ */
+int
+manage_send_audit_report_hosts (
+  report_t report,
+  const get_data_t *get,
+  int lean,
+  gboolean (*send) (const char *,
+                    int (*) (const char *, void *),
+                    void *),
+  int (*send_data_1) (const char *, void *),
+  void *send_data_2)
+{
+  print_report_context_t ctx;
+  get_data_t get_ignore_pagination;
+  gchar *xml_file;
+  gchar *term;
+  gchar *host_filter;
+  char xml_dir[] = "/tmp/gvmd_XXXXXX";
+  gboolean xml_dir_created;
+  char chunk[MANAGE_SEND_REPORT_CHUNK_SIZE + 1];
+  FILE *stream;
+  int ret;
+  int result_hosts_only;
+  array_t *result_hosts;
+  iterator_t results;
+  int results_initialized;
+
+  memset (&ctx, 0, sizeof (ctx));
+
+  xml_file = NULL;
+  term = NULL;
+  host_filter = NULL;
+  stream = NULL;
+  result_hosts = NULL;
+  xml_dir_created = FALSE;
+  results_initialized = 0;
+  result_hosts_only = 0;
+
+  if (report == 0 || get == NULL || send == NULL)
+    {
+      g_warning ("%s: Invalid argument", __func__);
+      return -1;
+    }
+
+  if (report == 0 || get == NULL || send == NULL)
+    {
+      g_warning ("%s: Invalid argument", __func__);
+      return -1;
+    }
+
+  ret = validate_get_report_usage_type (report,
+                                        REPORT_USAGE_TYPE_AUDIT);
+  if (ret < 0)
+    {
+      g_warning ("%s: Failed to validate report usage type", __func__);
+      return -1;
+    }
+
+  if (ret > 0)
+    return 3;
+
+  ctx.get = get;
+  ctx.report = report;
+  ctx.tsk_usage_type = g_strdup ("audit");
+
+  get_ignore_pagination = *get;
+  get_ignore_pagination.ignore_pagination = 1;
+  get_ignore_pagination.ignore_max_rows_per_page = 1;
+
+  /*
+   * Resolve the report filters, including result_hosts_only and the
+   * optional exact host filter.
+   */
+  ret = manage_report_filter_controls_from_get (
+    &get_ignore_pagination,
+    &term,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    &result_hosts_only,
+    &host_filter,
+    NULL,
+    NULL,
+    NULL,
+    &ctx.compliance_levels,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL);
+
+  if (ret)
+    goto cleanup;
+
+  print_report_init_f_hosts (&ctx);
+
+  ctx.f_host_ports = g_hash_table_new_full (g_str_hash,
+                                            g_str_equal,
+                                            g_free,
+                                            NULL);
+
+  if (mkdtemp (xml_dir) == NULL)
+    {
+      g_warning ("%s: mkdtemp failed: %s",
+                 __func__,
+                 strerror (errno));
+      ret = -1;
+      goto cleanup;
+    }
+
+  xml_dir_created = TRUE;
+
+  if (get_ignore_pagination.details)
+    {
+      /*
+       * Populate the per-host compliance hash tables used by
+       * print_report_hosts_xml().
+       */
+      ret = fill_filtered_audit_report_hosts (
+        &result_hosts,
+        &get_ignore_pagination,
+        report,
+        &results,
+        &ctx,
+        host_filter);
+
+      if (ret)
+        goto cleanup;
+
+      results_initialized = 1;
+    }
+
+  xml_file = g_strdup_printf ("%s/audit-report-hosts.xml", xml_dir);
+
+  stream = fopen (xml_file, "w");
+  if (stream == NULL)
+    {
+      g_warning ("%s: Failed to open XML file: %s",
+                 __func__,
+                 strerror (errno));
+      ret = -1;
+      goto cleanup;
+    }
+
+  ret = print_report_hosts_xml (&ctx,
+                                stream,
+                                report,
+                                &get_ignore_pagination,
+                                "audit",
+                                lean,
+                                FALSE,
+                                result_hosts_only,
+                                host_filter,
+                                result_hosts,
+                                NULL,
+                                TRUE);
+
+  if (fclose (stream))
+    {
+      stream = NULL;
+      g_warning ("%s: Failed to close XML file: %s",
+                 __func__,
+                 strerror (errno));
+      ret = -1;
+      goto cleanup;
+    }
+
+  stream = NULL;
+
+  if (ret)
+    {
+      ret = -1;
+      goto cleanup;
+    }
+
+  stream = fopen (xml_file, "r");
+  if (stream == NULL)
+    {
+      g_warning ("%s: Failed to reopen XML file: %s",
+                 __func__,
+                 strerror (errno));
+      ret = -1;
+      goto cleanup;
+    }
+
+  while (1)
+    {
+      size_t bytes_read;
+
+      bytes_read = fread (chunk,
+                          1,
+                          MANAGE_SEND_REPORT_CHUNK_SIZE,
+                          stream);
+
+      if (ferror (stream))
+        {
+          g_warning ("%s: Error reading XML file", __func__);
+          ret = -1;
+          goto cleanup;
+        }
+
+      if (bytes_read > 0)
+        {
+          chunk[bytes_read] = '\0';
+
+          if (send (chunk, send_data_1, send_data_2))
+            {
+              g_warning ("%s: Send error", __func__);
+              ret = -1;
+              goto cleanup;
+            }
+        }
+
+      if (feof (stream))
+        break;
+    }
+
+  ret = 0;
+
+cleanup:
+  if (stream)
+    fclose (stream);
+
+  if (results_initialized)
+    cleanup_iterator (&results);
+
+  if (result_hosts)
+    array_free (result_hosts);
+
+  g_free (xml_file);
+  g_free (term);
+  g_free (host_filter);
+
+  print_report_context_cleanup (&ctx);
+
+  if (xml_dir_created)
+    gvm_file_remove_recurse (xml_dir);
+
+  return ret;
+}

--- a/src/manage_audit_report_hosts.c
+++ b/src/manage_audit_report_hosts.c
@@ -81,12 +81,6 @@ manage_send_audit_report_hosts (
       return -1;
     }
 
-  if (report == 0 || get == NULL || send == NULL)
-    {
-      g_warning ("%s: Invalid argument", __func__);
-      return -1;
-    }
-
   ret = validate_get_report_usage_type (report,
                                         REPORT_USAGE_TYPE_AUDIT);
   if (ret < 0)

--- a/src/manage_audit_report_hosts.h
+++ b/src/manage_audit_report_hosts.h
@@ -1,0 +1,28 @@
+/* Copyright (C) 2026 Greenbone AG
+*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file
+ * @brief GVM management layer: Audit report hosts.
+ *
+ * Headers for non-SQL audit report hosts code.
+ */
+
+#ifndef _GVM_MANAGE_AUDIT_REPORT_HOSTS_H
+#define _GVM_MANAGE_AUDIT_REPORT_HOSTS_H
+
+#include "manage.h"
+
+int
+manage_send_audit_report_hosts (report_t,
+                                const get_data_t *,
+                                int,
+                                gboolean (*)(const char*,
+                                             int (*)(const char*, void*),
+                                             void*),
+                                int (*) (const char *, void *),
+                                void *);
+
+#endif /* _GVM_MANAGE_AUDIT_REPORT_HOSTS_H */

--- a/src/manage_commands.c
+++ b/src/manage_commands.c
@@ -105,6 +105,7 @@ command_t gmp_commands[]
     {"GET_ALERTS", "Get all alerts."},
     {"GET_ASSETS", "Get all assets."},
     {"GET_AUDIT_REPORT", "Get specific audit report summary."},
+    {"GET_AUDIT_REPORT_HOSTS", "Get specific audit report host details."},
     {"GET_CONFIGS", "Get all configs."},
     {"GET_CREDENTIALS", "Get all credentials."},
 #if ENABLE_CREDENTIAL_STORES

--- a/src/manage_resources.c
+++ b/src/manage_resources.c
@@ -317,6 +317,7 @@ type_owned (const char* type)
 {
   return strcasecmp (type, "info")
          && type_is_info_subtype (type) == 0
+         && strcasecmp (type, "audit_report_host")
          && strcasecmp (type, "vuln")
          && strcasecmp (type, "report_application")
          && strcasecmp (type, "report_closed_cve")

--- a/src/manage_sql_audit_report_hosts.c
+++ b/src/manage_sql_audit_report_hosts.c
@@ -106,19 +106,16 @@ fill_filtered_audit_report_hosts (array_t **result_hosts,
   while (next (results))
     {
       const gchar *host;
-      gchar *host_key;
 
       host = result_iterator_host (results);
       if (host == NULL)
         continue;
 
-      host_key = g_strdup (host);
-
-      array_add_new_string (*result_hosts, host_key);
+      array_add_new_string (*result_hosts, host);
 
       update_filtered_host_compliance_counts (ctx,
                                               results,
-                                              host_key);
+                                              host);
     }
 
   return 0;

--- a/src/manage_sql_audit_report_hosts.c
+++ b/src/manage_sql_audit_report_hosts.c
@@ -1,0 +1,125 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file
+ * @brief GVM SQL layer: Audit report hosts.
+ *
+ * SQL handlers for audit report host summaries.
+ */
+
+#include "manage_sql_audit_report_hosts.h"
+
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "md manage"
+
+/**
+ * @brief Update filtered per-host compliance counts.
+ *
+ * @param[in,out] ctx       Report print context.
+ * @param[in]     results   Result iterator positioned at the current result.
+ * @param[in]     host_key  Host key used for aggregation.
+ */
+static void
+update_filtered_host_compliance_counts (print_report_context_t *ctx,
+                                        iterator_t *results,
+                                        const gchar *host_key)
+{
+  GHashTable *host_counts;
+  const gchar *compliance;
+  int count;
+
+  if (ctx == NULL || results == NULL || host_key == NULL)
+    return;
+
+  compliance = result_iterator_compliance (results);
+  if (compliance == NULL)
+    return;
+
+  if (strcasecmp (compliance, "yes") == 0)
+    host_counts = ctx->f_host_compliant;
+  else if (strcasecmp (compliance, "no") == 0)
+    host_counts = ctx->f_host_notcompliant;
+  else if (strcasecmp (compliance, "incomplete") == 0)
+    host_counts = ctx->f_host_incomplete;
+  else if (strcasecmp (compliance, "undefined") == 0)
+    host_counts = ctx->f_host_undefined;
+  else
+    host_counts = NULL;
+
+  if (host_counts == NULL)
+    return;
+
+  count = GPOINTER_TO_INT (
+    g_hash_table_lookup (host_counts, host_key));
+
+  g_hash_table_replace (host_counts,
+                        g_strdup (host_key),
+                        GINT_TO_POINTER (count + 1));
+}
+
+/**
+ * @brief Initialize the result iterator and collect filtered audit hosts.
+ *
+ * Populates per-host compliance counts in the report print context.
+ *
+ * @param[in,out] result_hosts  Array to fill with result host keys.
+ * @param[in]     get           Request filter information.
+ * @param[in]     report        Audit report.
+ * @param[in,out] results       Result iterator.
+ * @param[in,out] ctx           Report print context.
+ * @param[in]     host_filter   Exact host filter, or NULL.
+ *
+ * @return 0 on success, non-zero on failure.
+ */
+int
+fill_filtered_audit_report_hosts (array_t **result_hosts,
+                                  const get_data_t *get,
+                                  report_t report,
+                                  iterator_t *results,
+                                  print_report_context_t *ctx,
+                                  const gchar *host_filter)
+{
+  int ret;
+
+  if (result_hosts == NULL
+      || get == NULL
+      || results == NULL
+      || ctx == NULL)
+    return -1;
+
+  *result_hosts = make_array ();
+
+  ret = init_result_get_iterator (results,
+                                  get,
+                                  report,
+                                  host_filter,
+                                  NULL);
+  if (ret)
+    return ret;
+
+  while (next (results))
+    {
+      const gchar *host;
+      gchar *host_key;
+
+      host = result_iterator_host (results);
+      if (host == NULL)
+        continue;
+
+      host_key = g_strdup (host);
+
+      array_add_new_string (*result_hosts, host_key);
+
+      update_filtered_host_compliance_counts (ctx,
+                                              results,
+                                              host_key);
+    }
+
+  return 0;
+}

--- a/src/manage_sql_audit_report_hosts.h
+++ b/src/manage_sql_audit_report_hosts.h
@@ -1,0 +1,26 @@
+/* Copyright (C) 2026 Greenbone AG
+*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file
+ * @brief GVM SQL layer: Audit report hosts.
+ *
+ * Headers for SQL handlers for audit report hosts.
+ */
+
+#ifndef _GVM_MANAGE_SQL_AUDIT_REPORT_HOSTS_H
+#define _GVM_MANAGE_SQL_AUDIT_REPORT_HOSTS_H
+
+#include "manage_sql_report_hosts.h"
+
+int
+fill_filtered_audit_report_hosts (array_t **,
+                                  const get_data_t *,
+                                  report_t,
+                                  iterator_t *,
+                                  print_report_context_t *,
+                                  const gchar *);
+
+#endif /* _GVM_MANAGE_SQL_AUDIT_REPORT_HOSTS_H */

--- a/src/manage_sql_resources.c
+++ b/src/manage_sql_resources.c
@@ -861,7 +861,8 @@ resource_count (const char *type, const get_data_t *get)
         }
       return 0;
     }
-  else if (strcmp (type, "report_host") == 0)
+  else if (strcmp (type, "report_host") == 0 ||
+           strcmp (type, "audit_report_host") == 0)
     {
       const gchar *report_uuid = get_data_get_extra (get, "report_id");
       if (!str_blank (report_uuid))

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -12716,6 +12716,549 @@ END:VCALENDAR
     </example>
   </command>
   <command>
+    <name>get_audit_report_hosts</name>
+    <summary>Get hosts from an audit report</summary>
+    <description>
+      <p>
+        The client uses the get_audit_report_hosts command to get host information
+        from a single audit report.
+      </p>
+      <p>
+        If the "details" attribute is set, the response includes host entries.
+        Otherwise only filter, sort and count information is returned.
+      </p>
+      <p>
+        Host entries include compliance information derived from matching audit
+        results, including counts for compliant, non-compliant, incomplete and
+        undefined results, as well as the overall compliance status of each host.
+      </p>
+      <p>
+        Currently "lean" omits selected optional or redundant XML elements from the
+        audit report hosts output to reduce response size.
+      </p>
+      <p>
+        The filter affects the selection of matching audit results and the derived
+        host information returned by the command. When "result_hosts_only" is set,
+        only hosts with matching results are included.
+      </p>
+    </description>
+    <pattern>
+      <attrib>
+        <name>report_id</name>
+        <summary>ID of the audit report to get hosts from</summary>
+        <type>uuid</type>
+        <required>1</required>
+      </attrib>
+      <attrib>
+        <name>filter</name>
+        <summary>Filter term to use for audit report host retrieval</summary>
+        <type>text</type>
+        <filter_keywords>
+          <option>
+            <name>first</name>
+            <type>integer</type>
+            <summary>
+              Index of the first item returned, starting at 1 (e.g. first=5
+              starts at the 5th item)
+            </summary>
+          </option>
+          <option>
+            <name>sort</name>
+            <type>text</type>
+            <summary>Column to sort by in ascending order</summary>
+          </option>
+          <option>
+            <name>sort-reverse</name>
+            <type>text</type>
+            <summary>Column to sort by in descending order</summary>
+          </option>
+          <option>
+            <name>levels</name>
+            <type>levels</type>
+            <summary>Compliance levels to select</summary>
+          </option>
+          <option>
+            <name>result_hosts_only</name>
+            <type>boolean</type>
+            <summary>
+              Whether to limit the response to hosts having audit results matching
+              the filter
+            </summary>
+          </option>
+          <column>
+            <name>uuid</name>
+            <type>uuid</type>
+            <summary>Unique ID</summary>
+          </column>
+          <column>
+            <name>ip</name>
+            <type>text</type>
+            <summary>IP address of the host</summary>
+          </column>
+          <column>
+            <name>asset_id</name>
+            <type>uuid</type>
+            <summary>UUID of the associated asset</summary>
+          </column>
+          <column>
+            <name>start</name>
+            <type>iso_time</type>
+            <summary>Host scan start time</summary>
+          </column>
+          <column>
+            <name>end</name>
+            <type>iso_time</type>
+            <summary>Host scan end time</summary>
+          </column>
+          <column>
+            <name>severity</name>
+            <type>severity</type>
+            <summary>Highest severity of matching audit results for the host</summary>
+          </column>
+        </filter_keywords>
+      </attrib>
+      <attrib>
+        <name>filt_id</name>
+        <summary>ID of filter to use to filter audit report hosts</summary>
+        <type>uuid</type>
+      </attrib>
+      <attrib>
+        <name>lean</name>
+        <summary>Whether to return a streamlined response</summary>
+        <type>boolean</type>
+      </attrib>
+      <attrib>
+        <name>details</name>
+        <summary>Whether to include host details</summary>
+        <type>boolean</type>
+      </attrib>
+    </pattern>
+    <response>
+      <pattern>
+        <attrib>
+          <name>status</name>
+          <type>status</type>
+          <required>1</required>
+        </attrib>
+        <attrib>
+          <name>status_text</name>
+          <type>text</type>
+          <required>1</required>
+        </attrib>
+        <any><e>host</e></any>
+        <o><e>filters</e></o>
+        <o><e>sort</e></o>
+        <o><e>audit_report_hosts</e></o>
+        <o><e>audit_report_host_count</e></o>
+      </pattern>
+      <ele>
+        <name>host</name>
+        <summary>A host from the selected audit report</summary>
+        <pattern>
+          <e>ip</e>
+          <o><e>asset</e></o>
+          <o><e>asset_snapshot</e></o>
+          <o><e>start</e></o>
+          <o><e>end</e></o>
+          <o><e>port_count</e></o>
+          <o><e>compliance_count</e></o>
+          <o><e>host_compliance</e></o>
+          <o><e>app_count</e></o>
+          <o><e>hostname</e></o>
+          <any><e>detail</e></any>
+        </pattern>
+        <ele>
+          <name>ip</name>
+          <summary>IP address of the host</summary>
+          <pattern>text</pattern>
+        </ele>
+        <ele>
+          <name>asset</name>
+          <summary>Asset associated with the host</summary>
+          <pattern>
+            <attrib>
+              <name>asset_id</name>
+              <type>uuid</type>
+              <required>1</required>
+            </attrib>
+          </pattern>
+        </ele>
+        <ele>
+          <name>asset_snapshot</name>
+          <summary>Asset snapshot associated with the host</summary>
+          <pattern>
+            <attrib>
+              <name>asset_key</name>
+              <type>uuid</type>
+              <required>1</required>
+            </attrib>
+          </pattern>
+        </ele>
+        <ele>
+          <name>start</name>
+          <summary>Host scan start time</summary>
+          <pattern>iso_time</pattern>
+        </ele>
+        <ele>
+          <name>end</name>
+          <summary>Host scan end time</summary>
+          <pattern>iso_time</pattern>
+        </ele>
+        <ele>
+          <name>port_count</name>
+          <summary>Count of ports on the current page</summary>
+          <pattern>
+            <e>page</e>
+          </pattern>
+          <ele>
+            <name>page</name>
+            <summary>Number of ports on the current page</summary>
+            <pattern><t>integer</t></pattern>
+          </ele>
+        </ele>
+        <ele>
+          <name>compliance_count</name>
+          <summary>Counts of audit results for the host by compliance status</summary>
+          <pattern>
+            <e>page</e>
+            <e>yes</e>
+            <e>no</e>
+            <e>incomplete</e>
+            <e>undefined</e>
+          </pattern>
+          <ele>
+            <name>page</name>
+            <summary>Number of audit results on the current page</summary>
+            <pattern><t>integer</t></pattern>
+          </ele>
+          <ele>
+            <name>yes</name>
+            <summary>Count of compliant audit results</summary>
+            <pattern>
+              <e>page</e>
+            </pattern>
+            <ele>
+              <name>page</name>
+              <pattern><t>integer</t></pattern>
+            </ele>
+          </ele>
+          <ele>
+            <name>no</name>
+            <summary>Count of non-compliant audit results</summary>
+            <pattern>
+              <e>page</e>
+            </pattern>
+            <ele>
+              <name>page</name>
+              <pattern><t>integer</t></pattern>
+            </ele>
+          </ele>
+          <ele>
+            <name>incomplete</name>
+            <summary>Count of incomplete audit results</summary>
+            <pattern>
+              <e>page</e>
+            </pattern>
+            <ele>
+              <name>page</name>
+              <pattern><t>integer</t></pattern>
+            </ele>
+          </ele>
+          <ele>
+            <name>undefined</name>
+            <summary>Count of audit results with undefined compliance</summary>
+            <pattern>
+              <e>page</e>
+            </pattern>
+            <ele>
+              <name>page</name>
+              <pattern><t>integer</t></pattern>
+            </ele>
+          </ele>
+        </ele>
+        <ele>
+          <name>host_compliance</name>
+          <summary>Overall compliance status of the host</summary>
+          <pattern>
+            <alts>
+              <alt>yes</alt>
+              <alt>no</alt>
+              <alt>incomplete</alt>
+              <alt>undefined</alt>
+            </alts>
+          </pattern>
+        </ele>
+        <ele>
+          <name>app_count</name>
+          <summary>Count of applications for the host on the current page</summary>
+          <pattern>
+            <e>page</e>
+          </pattern>
+          <ele>
+            <name>page</name>
+            <summary>Number of applications on the current page</summary>
+            <pattern><t>integer</t></pattern>
+          </ele>
+        </ele>
+        <ele>
+          <name>hostname</name>
+          <summary>Hostname of the host</summary>
+          <pattern>text</pattern>
+        </ele>
+        <ele>
+          <name>detail</name>
+          <summary>A detail of the host</summary>
+          <pattern>
+            <e>name</e>
+            <e>value</e>
+            <o><e>source</e></o>
+            <o><e>extra</e></o>
+          </pattern>
+          <ele>
+            <name>name</name>
+            <summary>Name of the host detail</summary>
+            <pattern>text</pattern>
+          </ele>
+          <ele>
+            <name>value</name>
+            <summary>Value of the host detail</summary>
+            <pattern>text</pattern>
+          </ele>
+          <ele>
+            <name>source</name>
+            <summary>Source of the host detail</summary>
+            <pattern>
+              <o><e>type</e></o>
+              <e>name</e>
+              <o><e>description</e></o>
+            </pattern>
+            <ele>
+              <name>type</name>
+              <summary>Type of source</summary>
+              <pattern>text</pattern>
+            </ele>
+            <ele>
+              <name>name</name>
+              <summary>Name of source</summary>
+              <pattern>text</pattern>
+            </ele>
+            <ele>
+              <name>description</name>
+              <summary>Description of source</summary>
+              <pattern>text</pattern>
+            </ele>
+          </ele>
+          <ele>
+            <name>extra</name>
+            <summary>Extra information for the detail</summary>
+            <pattern>text</pattern>
+          </ele>
+        </ele>
+      </ele>
+      <ele>
+        <name>filters</name>
+        <pattern>
+          <attrib>
+            <name>id</name>
+            <summary>UUID of filter if any, else empty or 0</summary>
+            <type>uuid</type>
+          </attrib>
+          <e>term</e>
+          <e>keywords</e>
+        </pattern>
+        <ele>
+          <name>term</name>
+          <summary>Filter term</summary>
+          <pattern>text</pattern>
+        </ele>
+        <ele>
+          <name>keywords</name>
+          <summary>Filter broken down into keywords</summary>
+          <pattern><any><e>keyword</e></any></pattern>
+          <ele>
+            <name>keyword</name>
+            <pattern>
+              <e>column</e>
+              <e>relation</e>
+              <e>value</e>
+            </pattern>
+            <ele>
+              <name>column</name>
+              <summary>Column prefix</summary>
+              <pattern>text</pattern>
+            </ele>
+            <ele>
+              <name>relation</name>
+              <summary>Relation operator</summary>
+              <pattern>
+                <alts>
+                  <alt>=</alt>
+                  <alt>:</alt>
+                  <alt>~</alt>
+                  <alt>&gt;</alt>
+                  <alt>&lt;</alt>
+                </alts>
+              </pattern>
+            </ele>
+            <ele>
+              <name>value</name>
+              <summary>The filter text</summary>
+              <pattern>text</pattern>
+            </ele>
+          </ele>
+        </ele>
+      </ele>
+      <ele>
+        <name>sort</name>
+        <pattern>
+          text
+          <e>field</e>
+        </pattern>
+        <ele>
+          <name>field</name>
+          <pattern>
+            text
+            <e>order</e>
+          </pattern>
+          <ele>
+            <name>order</name>
+            <pattern>
+              <alts>
+                <alt>ascending</alt>
+                <alt>descending</alt>
+              </alts>
+            </pattern>
+          </ele>
+        </ele>
+      </ele>
+      <ele>
+        <name>audit_report_hosts</name>
+        <pattern>
+          <attrib>
+            <name>start</name>
+            <summary>First audit report host</summary>
+            <type>integer</type>
+            <required>1</required>
+          </attrib>
+          <attrib>
+            <name>max</name>
+            <summary>Maximum number of audit report hosts</summary>
+            <type>integer</type>
+            <required>1</required>
+          </attrib>
+        </pattern>
+      </ele>
+      <ele>
+        <name>audit_report_host_count</name>
+        <pattern>
+          text
+          <e>filtered</e>
+          <e>page</e>
+        </pattern>
+        <ele>
+          <name>filtered</name>
+          <summary>Number of audit report hosts after filtering</summary>
+          <pattern><t>integer</t></pattern>
+        </ele>
+        <ele>
+          <name>page</name>
+          <summary>Number of audit report hosts on current page</summary>
+          <pattern><t>integer</t></pattern>
+        </ele>
+      </ele>
+    </response>
+    <example>
+      <summary>Get hosts of an audit report with details</summary>
+      <request>
+        <get_audit_report_hosts report_id="6587438c-4787-41e6-a0a7-765193dcd44f"
+                                details="1"
+                                filter="levels=yniu rows=10 min_qod=70 first=1 sort-reverse=severity">
+        </get_audit_report_hosts>
+      </request>
+      <response>
+        <get_audit_report_hosts_response status="200" status_text="OK">
+          <host>
+            <ip>127.0.0.1</ip>
+            <asset asset_id="9fd3aff1-4550-42cb-8339-1b6776f555d0"/>
+            <asset_snapshot asset_key="3ee92e06-cead-4a77-af12-4df8bb60871b"/>
+            <start>2026-05-29T08:40:24Z</start>
+            <end>2026-05-29T08:51:01Z</end>
+            <port_count>
+              <page>0</page>
+            </port_count>
+            <compliance_count>
+              <page>183</page>
+              <yes>
+                <page>5</page>
+              </yes>
+              <no>
+                <page>2</page>
+              </no>
+              <incomplete>
+                <page>145</page>
+              </incomplete>
+              <undefined>
+                <page>31</page>
+              </undefined>
+            </compliance_count>
+            <host_compliance>no</host_compliance>
+            <app_count>
+              <page>5</page>
+            </app_count>
+            <hostname>localhost</hostname>
+            <detail>
+              <name>App</name>
+              <value>cpe:/a:postgresql:postgresql</value>
+              <source>
+                <name>1.3.6.1.4.1.25623.1.0.128025</name>
+              </source>
+            </detail>
+          </host>
+          <filters id="">
+            <term>apply_overrides=0 levels=yniu rows=10 min_qod=70 first=1 sort-reverse=severity</term>
+            <keywords>
+              <keyword>
+                <column>apply_overrides</column>
+                <relation>=</relation>
+                <value>0</value>
+              </keyword>
+              <keyword>
+                <column>levels</column>
+                <relation>=</relation>
+                <value>yniu</value>
+              </keyword>
+              <keyword>
+                <column>rows</column>
+                <relation>=</relation>
+                <value>10</value>
+              </keyword>
+              <keyword>
+                <column>min_qod</column>
+                <relation>=</relation>
+                <value>70</value>
+              </keyword>
+              <keyword>
+                <column>first</column>
+                <relation>=</relation>
+                <value>1</value>
+              </keyword>
+              <keyword>
+                <column>sort-reverse</column>
+                <relation>=</relation>
+                <value>severity</value>
+              </keyword>
+            </keywords>
+          </filters>
+          <sort>
+            <field>severity<order>descending</order></field>
+          </sort>
+          <audit_report_hosts start="1" max="10"/>
+          <audit_report_host_count>1<filtered>1</filtered><page>0</page></audit_report_host_count>
+        </get_audit_report_hosts_response>
+      </response>
+    </example>
+  </command>
+  <command>
     <name>get_configs</name>
     <summary>Get one or many configs</summary>
     <description>


### PR DESCRIPTION
## What

- add dedicated management and SQL support for audit report hosts
- add the `get_audit_report_hosts` GMP command
- return per-host compliance counts and audit host details
- document the new GMP command and response format
- verify the command with an audit report response

## Why

- separate audit report host retrieval from the regular report host flow
- provide audit-specific compliance information through a dedicated GMP command
- support smaller, paginated host-focused responses for audit reports


## References

GEA-1967


