### PR TITLE
Fix: get_reports aborts because SEVERITY_ERROR is not defined

### DIFF
--- a/src/manage_sql_report_common.c
+++ b/src/manage_sql_report_common.c
@@ -11,6 +11,7 @@
 
 #include "manage_sql_settings.h"
 #include "manage_sql_targets.h"
+#include "manage_utils.h" // for SEVERITY_ERROR
 
 #undef G_LOG_DOMAIN
 


### PR DESCRIPTION
## What

Include `manage_utils.h` in `manage_sql_report_common.c`

## Why

`report_vuln_count` builds its statement with `G_STRINGIFY (SEVERITY_ERROR)`, and without the include the macro is undefined, so the name itself goes to the server. PostgreSQL reads it as a column reference, `sql_int` aborts, and the process serving the client dies. Every `get_reports` therefore ends with no response, which leaves the reports page of the web interface broken.

The function came to this file with 4acc77f8 without its include. It is the only place that still carries the macro name; the other eight uses expand to -3.0 as intended.

## Checklist

- [x] Tests: built main with and without the include, `get_reports` returns 200 with it and aborts without it