### PR TITLE
Fix: do not compute severity for tasks without a report

### DIFF
--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -1452,11 +1452,16 @@ manage_create_sql_functions ()
                "               FROM tasks WHERE id = $1)"
                "         THEN CAST (NULL AS double precision)"
                "         ELSE"
-               "         (SELECT report_severity ((SELECT id FROM reports"
-               "                                   WHERE task = $1"
-               "                                   AND scan_run_status = %u"
-               "                                   ORDER BY creation_time DESC"
-               "                                   LIMIT 1 OFFSET 0), $2, $3))"
+               /* Only look up the severity when the task has a report.  Calling
+                * report_severity with NULL returns NULL as well, but it costs a
+                * full evaluation of the severity query for every task that never
+                * ran, which dominates aggregates over many tasks. */
+               "         (SELECT report_severity (last_report.id, $2, $3)"
+               "          FROM (SELECT id FROM reports"
+               "                WHERE task = $1"
+               "                AND scan_run_status = %u"
+               "                ORDER BY creation_time DESC"
+               "                LIMIT 1 OFFSET 0) AS last_report)"
                "         END;"
                "$$ LANGUAGE SQL;",
                TASK_STATUS_DONE);
@@ -1477,11 +1482,16 @@ manage_create_sql_functions ()
                "               FROM tasks WHERE id = $1)"
                "         THEN CAST (NULL AS double precision)"
                "         ELSE"
-               "         (SELECT report_severity ((SELECT id FROM reports"
-               "                                   WHERE task = $1"
-               "                                   AND scan_run_status = %u"
-               "                                   ORDER BY creation_time DESC"
-               "                                   LIMIT 1 OFFSET 0), $2, $3))"
+               /* Only look up the severity when the task has a report.  Calling
+                * report_severity with NULL returns NULL as well, but it costs a
+                * full evaluation of the severity query for every task that never
+                * ran, which dominates aggregates over many tasks. */
+               "         (SELECT report_severity (last_report.id, $2, $3)"
+               "          FROM (SELECT id FROM reports"
+               "                WHERE task = $1"
+               "                AND scan_run_status = %u"
+               "                ORDER BY creation_time DESC"
+               "                LIMIT 1 OFFSET 0) AS last_report)"
                "         END;"
                "$$ LANGUAGE SQL;",
                TASK_STATUS_DONE);
@@ -1499,11 +1509,16 @@ manage_create_sql_functions ()
                "               FROM tasks WHERE id = $1)"
                "         THEN CAST (NULL AS double precision)"
                "         ELSE"
-               "         (SELECT report_severity ((SELECT id FROM reports"
-               "                                   WHERE task = $1"
-               "                                   AND scan_run_status = %u"
-               "                                   ORDER BY creation_time DESC"
-               "                                   LIMIT 1 OFFSET 0), $2, $3))"
+               /* Only look up the severity when the task has a report.  Calling
+                * report_severity with NULL returns NULL as well, but it costs a
+                * full evaluation of the severity query for every task that never
+                * ran, which dominates aggregates over many tasks. */
+               "         (SELECT report_severity (last_report.id, $2, $3)"
+               "          FROM (SELECT id FROM reports"
+               "                WHERE task = $1"
+               "                AND scan_run_status = %u"
+               "                ORDER BY creation_time DESC"
+               "                LIMIT 1 OFFSET 0) AS last_report)"
                "         END;"
                "$$ LANGUAGE SQL;",
                TASK_STATUS_DONE);
@@ -1521,11 +1536,16 @@ manage_create_sql_functions ()
                "               FROM tasks WHERE id = $1)"
                "         THEN CAST (NULL AS double precision)"
                "         ELSE"
-               "         (SELECT report_severity ((SELECT id FROM reports"
-               "                                   WHERE task = $1"
-               "                                   AND scan_run_status = %u"
-               "                                   ORDER BY date DESC"
-               "                                   LIMIT 1 OFFSET 0), $2, $3))"
+               /* Only look up the severity when the task has a report.  Calling
+                * report_severity with NULL returns NULL as well, but it costs a
+                * full evaluation of the severity query for every task that never
+                * ran, which dominates aggregates over many tasks. */
+               "         (SELECT report_severity (last_report.id, $2, $3)"
+               "          FROM (SELECT id FROM reports"
+               "                WHERE task = $1"
+               "                AND scan_run_status = %u"
+               "                ORDER BY date DESC"
+               "                LIMIT 1 OFFSET 0) AS last_report)"
                "         END;"
                "$$ LANGUAGE SQL;",
                TASK_STATUS_DONE);


### PR DESCRIPTION
## What

Look up the last report in a FROM subquery and pass its id to `report_severity`

## Why

`task_severity` passed the report lookup straight to `report_severity`, so a task that never produced a report called `report_severity(NULL, ...)`. That returns NULL, but only after the whole severity query has been evaluated, including the `report_counts` lookup and the dynamic severity check. The cost is per task, so it shows up wherever severity is aggregated over many tasks.

With the subquery there are no rows when the task has no report, so `report_severity` is never called and the result is unchanged.

On an installation with 4507 tasks the aggregate goes from 2782 ms to 376 ms. The saving is proportional to the number of tasks that never ran; where almost none of them have a report it was 2774 ms to 9 ms.

## Checklist

- [x] Tests: severity distribution over all tasks identical before and after