### PR TITLE
Add index on targets_login_data

### DIFF
--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -3643,6 +3643,12 @@ create_tables ()
   sql ("SELECT create_index ('reports_by_task',"
        "                     'reports', 'task');");
 
+  /* The target iterator looks up the credential of every login type with its
+   * own subquery, so listing targets scans this table once per target and
+   * login type without an index. */
+  sql ("SELECT create_index ('targets_login_data_by_target',"
+       "                     'targets_login_data', 'target, type');");
+
   sql ("SELECT create_index ('tag_resources_by_resource',"
        "                     'tag_resources',"
        "                     'resource_type, resource, resource_location');");


### PR DESCRIPTION
## What

Add an index on `targets_login_data (target, type)`

## Why

The target iterator looks up the credential of every login type with its own subquery, so listing targets scans this table once per target and login type. The table only had its primary key on `id`.

`create_index` is idempotent and runs from `create_tables`, so existing databases pick the index up on the next start without a migration.