### PR TITLE
Fix: do not query the run status of every scheduled task in the schedule loop

### DIFF
--- a/src/manage_sql_schedules.c
+++ b/src/manage_sql_schedules.c
@@ -703,7 +703,8 @@ init_task_schedule_iterator (iterator_t* iterator)
                  " schedules.id, tasks.schedule_next_time,"
                  " schedules.icalendar, schedules.timezone,"
                  " schedules.duration,"
-                 " users.uuid, users.name"
+                 " users.uuid, users.name,"
+                 " tasks.run_status"
                  " FROM tasks, schedules, users"
                  " WHERE tasks.schedule = schedules.id"
                  " AND tasks.hidden = 0"
@@ -820,6 +821,23 @@ DEF_ACCESS (task_schedule_iterator_owner_uuid, 7);
 DEF_ACCESS (task_schedule_iterator_owner_name, 8);
 
 /**
+ * @brief Get the run status from a task schedule iterator.
+ *
+ * Comes with the row.  The three due checks each used to ask the database for
+ * it separately, once per row and once per pass of the schedule loop.
+ *
+ * @param[in]  iterator  Iterator.
+ *
+ * @return Task run status.
+ */
+static task_status_t
+task_schedule_iterator_run_status (iterator_t* iterator)
+{
+  if (iterator->done) return TASK_STATUS_DONE;
+  return (task_status_t) iterator_int (iterator, 9);
+}
+
+/**
  * @brief Get the start due state from a task schedule iterator.
  *
  * @param[in]  iterator  Iterator.
@@ -837,7 +855,7 @@ task_schedule_iterator_start_due (iterator_t* iterator)
   if (task_schedule_iterator_next_time (iterator) == 0)
     return FALSE;
 
-  run_status = task_run_status (task_schedule_iterator_task (iterator));
+  run_status = task_schedule_iterator_run_status (iterator);
   start_time = task_schedule_iterator_next_time (iterator);
 
   if ((run_status == TASK_STATUS_DONE
@@ -922,17 +940,20 @@ task_schedule_iterator_stop_due (iterator_t* iterator)
       report_t report;
       task_status_t run_status;
 
-      report = task_running_report (task_schedule_iterator_task (iterator));
-      if (report && (report_scheduled (report) == 0))
-        return FALSE;
-
-      run_status = task_run_status (task_schedule_iterator_task (iterator));
+      run_status = task_schedule_iterator_run_status (iterator);
 
       if (run_status == TASK_STATUS_RUNNING
           || run_status == TASK_STATUS_REQUESTED
           || run_status == TASK_STATUS_QUEUED)
         {
           time_t now, start;
+
+          /* Only a task that is on its way can have a running report, so the
+           * lookup - and the run status query inside it - is not needed for
+           * any of the others. */
+          report = task_running_report (task_schedule_iterator_task (iterator));
+          if (report && (report_scheduled (report) == 0))
+            return FALSE;
 
           now = time (NULL);
 
@@ -1009,7 +1030,7 @@ task_schedule_iterator_timed_out (iterator_t* iterator)
   if (start_time == 0)
     return FALSE;
 
-  run_status = task_run_status (task_schedule_iterator_task (iterator));
+  run_status = task_schedule_iterator_run_status (iterator);
   duration = task_schedule_iterator_duration (iterator);
 
   return task_schedule_is_timed_out_common (run_status, start_time, duration);


### PR DESCRIPTION
## What

- Select `tasks.run_status` in `init_task_schedule_iterator` and read it from the row
- In `task_schedule_iterator_stop_due`, check the run status before looking for a running report

## Why

The three due checks each asked the database for the run status separately, once per row and once per pass of the schedule loop, and `task_running_report` asks for it again - three identical queries per scheduled task and pass. They all run inside the transaction that the iterator opens with `sql_begin_immediate_giveup`, so the loop holds that transaction while issuing them.

Only a task that is requested, queued or running can have a running report, so that lookup is not needed for any of the others.

Idle with 7 scheduled tasks the `SELECT run_status FROM tasks` statements go from 108 to 0 per minute. The count is three per scheduled task and pass, so it grows with the number of scheduled tasks: with 4503 of them it was 40527 statements per 30 s and the loop held its transaction for about 850 ms every 10 seconds.

The run status column is appended to the select list, so the existing column indices are untouched, and the accessor is static because nothing outside the file needs it.

## Checklist

- [x] Tests: schedules still evaluated, nothing new in the log