### PR TITLE
Fix agent resource permission checks

### DIFF
--- a/src/gmp_agent_groups.c
+++ b/src/gmp_agent_groups.c
@@ -660,6 +660,7 @@ modify_agent_group_run (gmp_parser_t *gmp_parser, GError **error)
   entity_t root, name, comment, scheduler_cron_time, agents_elem;
   const char *agent_group_uuid, *name_text, *scheduler_cron_time_text;
   GPtrArray *errs = NULL;
+  agent_group_t agent_group;
 
   if (!acl_user_may ("modify_agent_group"))
     {
@@ -681,8 +682,9 @@ modify_agent_group_run (gmp_parser_t *gmp_parser, GError **error)
       return;
     }
 
-  agent_group_t agent_group = agent_group_id_by_uuid (agent_group_uuid);
-  if (!agent_group)
+  if (find_agent_group_with_permission (agent_group_uuid, &agent_group,
+                                        "modify_agent_group")
+      || !agent_group)
     {
       if (send_find_error_to_client ("modify_agent_group",
                                      "agent_group",

--- a/src/gmp_agent_support_bundle.c
+++ b/src/gmp_agent_support_bundle.c
@@ -207,7 +207,8 @@ get_agent_support_bundle_run (gmp_parser_t *gmp_parser, GError **error)
     }
 
   if (!get_agent_support_bundle_data.agent_uuid
-      || *get_agent_support_bundle_data.agent_uuid == '\0')
+      || *get_agent_support_bundle_data.agent_uuid == '\0'
+      || !is_uuid (get_agent_support_bundle_data.agent_uuid))
     {
       SEND_TO_CLIENT_OR_FAIL
       (XML_ERROR_SYNTAX ("get_agent_support_bundle",

--- a/src/manage_agent_common.h
+++ b/src/manage_agent_common.h
@@ -61,5 +61,9 @@ agent_uuid_list_free (agent_uuid_list_t uuid_list);
 agent_uuid_list_t
 agent_uuid_list_from_group (agent_group_t group);
 
+gboolean
+find_agent_with_permission (const char* uuid, agent_t*,
+                                  const char *);
+
 #endif // not _GVMD_MANAGE_AGENT_COMMON_H
 #endif // ENABLE_AGENTS

--- a/src/manage_agents.c
+++ b/src/manage_agents.c
@@ -1087,11 +1087,15 @@ get_agent_support_bundle (
   gvmd_agent_connector_t connector = NULL;
   scanner_t scanner;
   gchar *agent_id;
+  agent_t agent;
 
   if (!agent_uuid || !out_bundle || days < 0)
     return AGENT_RESPONSE_INVALID_ARGUMENT;
 
   *out_bundle = NULL;
+
+  if(find_agent_with_permission (agent_uuid, &agent, "get_agents") != 0 || !agent)
+    return AGENT_RESPONSE_AGENT_NOT_FOUND;
 
   agent_id = agent_id_by_uuid (agent_uuid);
   if (!agent_id)

--- a/src/manage_sql_agent_groups.c
+++ b/src/manage_sql_agent_groups.c
@@ -1017,7 +1017,6 @@ find_agent_group_with_permission (const char *uuid, agent_group_t *agent_group,
                                         permission, 0);
 }
 
-
 /**
  * @brief Return whether a agent_group is in use.
  *

--- a/src/manage_sql_agents.c
+++ b/src/manage_sql_agents.c
@@ -14,11 +14,13 @@
  * for iterating agent data and handling agent IP address relationships.
  */
 
+
 #if ENABLE_AGENTS
 
 #include "manage_sql_agents.h"
 
 #include "manage_sql_copy.h"
+#include "manage_sql_resources.h"
 
 #include <util/uuidutils.h>
 
@@ -887,8 +889,25 @@ agent_id_by_uuid (const gchar *agent_uuid)
 {
   g_return_val_if_fail (agent_uuid != NULL, NULL);
 
-  return sql_string ("SELECT agent_id FROM agents WHERE uuid = '%s';",
-                     agent_uuid);
+  return sql_string_ps ("SELECT agent_id FROM agents WHERE uuid = $1;",
+                     SQL_STR_PARAM (agent_uuid), NULL);
+}
+
+/**
+ * @brief Find an agent for a specific permission, given a UUID.
+ *
+ * @param[in]   uuid        UUID of agent group.
+ * @param[out]  agent       Agent id return.
+ * @param[in]   permission  Permission.
+ *
+ * @return FALSE on success (including if failed to find agent), TRUE on error.
+ */
+gboolean
+find_agent_with_permission (const char *uuid, agent_t *agent,
+                                  const char *permission)
+{
+  return find_resource_with_permission ("agent", uuid, agent,
+                                        permission, 0);
 }
 
 /**

--- a/src/manage_sql_agents.c
+++ b/src/manage_sql_agents.c
@@ -14,7 +14,6 @@
  * for iterating agent data and handling agent IP address relationships.
  */
 
-
 #if ENABLE_AGENTS
 
 #include "manage_sql_agents.h"


### PR DESCRIPTION
## What

- Validate agent UUIDs for support bundle requests.
- Check user permissions before accessing agents or modifying agent groups.
- Use a parameterized query when looking up an agent ID.

## Why

To prevent invalid or unauthorized access to agent resources and make the database query safer.




