### PR TITLE
add: sync agents after agent controller scanner changes

### DIFF
--- a/src/manage_agents.c
+++ b/src/manage_agents.c
@@ -18,6 +18,7 @@
 #include "manage_sql_agents.h"
 #include "manage_sql_resources.h"
 #include "manage_sql_settings.h"
+#include "manage_runtime_flags.h"
 
 #include <assert.h>
 
@@ -1065,6 +1066,55 @@ out_unlock:
              __func__, AGENT_SYNC_LOCK_NAME);
 
   return ret;
+}
+
+/**
+ * @brief Synchronize agents from a specific agent controller scanner.
+ *
+ * @param[in] scanner  The scanner ID of the agent controller to sync from.
+ */
+void
+manage_agents_sync_from_scanner (scanner_t scanner)
+{
+  if (scanner == 0)
+    {
+      g_warning ("%s: Invalid scanner provided", __func__);
+      return;
+    }
+
+  if (!feature_enabled (FEATURE_ID_AGENTS))
+    {
+      g_debug ("%s: Agents feature is disabled, skipping sync", __func__);
+      return;
+    }
+
+  int type = scanner_type (scanner);
+  if (type != SCANNER_TYPE_AGENT_CONTROLLER &&
+      type != SCANNER_TYPE_AGENT_CONTROLLER_SENSOR)
+    {
+      g_debug ("%s: Scanner is not an agent controller type", __func__);
+      return;
+    }
+
+  gvmd_agent_connector_t connector =
+    gvmd_agent_connector_new_from_scanner (scanner);
+
+  if (!connector || !connector->base)
+    {
+      g_warning ("%s: Failed to create agent connector for scanner", __func__);
+      gvmd_agent_connector_free (connector);
+      return;
+    }
+
+  agent_response_t response = sync_agents_from_agent_controller (connector);
+
+  if (response != AGENT_RESPONSE_SUCCESS)
+    {
+      g_warning ("%s: Synchronizing agent data failed: %s",
+                 __func__, agent_response_to_string (response));
+    }
+
+  gvmd_agent_connector_free (connector);
 }
 
 /**

--- a/src/manage_agents.h
+++ b/src/manage_agents.h
@@ -130,6 +130,9 @@ agent_data_list_free (agent_data_list_t);
 agent_response_t
 sync_agents_from_agent_controller (gvmd_agent_connector_t);
 
+void
+manage_agents_sync_from_scanner (scanner_t scanner);
+
 agent_response_t
 get_agents_by_scanner_and_uuids (scanner_t, agent_uuid_list_t,
                                  agent_data_list_t);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -23620,6 +23620,11 @@ create_scanner (const char* name, const char *comment, const char *host,
     }
 
   sql_commit ();
+
+#if ENABLE_AGENTS
+  manage_agents_sync_from_scanner (*new_scanner);
+#endif
+
   return CREATE_SCANNER_SUCCESS;
 }
 
@@ -23977,6 +23982,11 @@ modify_scanner (const char *scanner_id, const char *name, const char *comment,
     }
 
   sql_commit ();
+
+#if ENABLE_AGENTS
+  manage_agents_sync_from_scanner (scanner);
+#endif
+
   return MODIFY_SCANNER_SUCCESS;
 }
 
@@ -26018,6 +26028,10 @@ manage_restore (const char *id)
 
       sql ("DELETE FROM scanners_trash WHERE id = %llu;", resource);
       sql_commit ();
+
+#if ENABLE_AGENTS
+      manage_agents_sync_from_scanner (scanner);
+#endif
       return 0;
     }
 


### PR DESCRIPTION
## What

Sync agents after an Agent Controller scanner is created, modified, or restored.

## Why

To make sure gvmd has the latest agents from the Agent Controller.

## References

GEA-2009

