### PR TITLE
Update dependabot config and pin actions to commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "actions/*"
+    ignore:
+      - dependency-name: "greenbone/actions"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+    commit-message:
+      prefix: "Deps"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out gvmd
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Check Source Format
         run: |
           clang-format -i -style=file src/gmp_{base,delete,get,tickets}.h \
@@ -35,7 +35,7 @@ jobs:
     container: ghcr.io/greenbone/gvm-libs:stable
     steps:
       - name: Check out gvmd
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install clang tools
         run: |
           apt update
@@ -48,7 +48,7 @@ jobs:
           scan-build -o ~/scan-build-report cmake --build build
       - name: Upload scan-build report
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: scan-build-report
           path: ~/scan-build-report/
@@ -80,7 +80,7 @@ jobs:
               flags: "-DENABLE_OPENVASD=1 -DENABLE_CONTAINER_SCANNING=1"
     container: ghcr.io/greenbone/gvm-libs:${{ matrix.build.container }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install build dependencies
         run: sh .github/install-dependencies.sh .github/build-dependencies.list
       - name: Configure and compile gvmd
@@ -95,7 +95,7 @@ jobs:
     container: ghcr.io/greenbone/gvm-libs:stable
     steps:
       - name: Check out gvmd
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install git for Codecov uploader
         run: |
           apt update
@@ -124,7 +124,7 @@ jobs:
     name: Check CMake Formatting
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: greenbone/actions/uv@v3
         with:
           install: gersemi

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -25,7 +25,7 @@ jobs:
     container: ghcr.io/greenbone/gvm-libs:stable
     steps:
       - name: Check out gvmd
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Generate GMP documentation (HTML)
         run: |
           mkdir build
@@ -33,7 +33,7 @@ jobs:
           cmake -DSKIP_SRC=1 ..
           make doc-gmp
       - name: Upload GMP documentation artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gmp.html
           path: build/doc/gmp.html

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,10 +6,10 @@ on:
 jobs:
   changelog:
     name: Show changelog since last release
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # for conventional commits and getting all git tags
           persist-credentials: false

--- a/.github/workflows/codeql-analysis-c.yml
+++ b/.github/workflows/codeql-analysis-c.yml
@@ -32,11 +32,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install build dependencies
         run: sh .github/install-dependencies.sh .github/build-dependencies.list
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: ${{ matrix.language }}
       # build between init and analyze ...
@@ -47,4 +47,4 @@ jobs:
           cmake -DCMAKE_BUILD_TYPE=Debug ..
           make install
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           release-type-input: ${{ inputs.release-type }}
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # for conventional commits and getting all git tags
           persist-credentials: false


### PR DESCRIPTION


## What

Update dependabot config and pin actions to commits

## Why

Only update greenbone actions for major updates because we trust these tags and don't want to get PRs for each bugfix or minor releases.

Also group updates for github's native actions in one PR to allow for less required reviews.

Pin actions to commits for improved security. Git tags can be overridden easily. Hashes not.