### PR TITLE
fix: update permission {resource,subject}_id queries

### DIFF
--- a/src/manage_sql_permissions.c
+++ b/src/manage_sql_permissions.c
@@ -113,7 +113,22 @@ permission_subject (permission_t permission)
 static char *
 permission_subject_id (permission_t permission)
 {
-  return sql_string ("SELECT subject_id FROM permissions WHERE id = %llu;",
+  return sql_string ("SELECT"
+                     " (CASE"
+                     "  WHEN subject_type = 'user'"
+                     "  THEN (SELECT uuid FROM users WHERE users.id = subject)"
+                     "  WHEN subject_type = 'group'"
+                     "       AND subject_location = " G_STRINGIFY (LOCATION_TRASH)
+                     "  THEN (SELECT uuid FROM groups_trash"
+                     "        WHERE groups_trash.id = subject)"
+                     "  WHEN subject_type = 'group'"
+                     "  THEN (SELECT uuid FROM groups WHERE groups.id = subject)"
+                     "  WHEN subject_location = " G_STRINGIFY (LOCATION_TRASH)
+                     "  THEN (SELECT uuid FROM roles_trash"
+                     "        WHERE roles_trash.id = subject)"
+                     "  ELSE (SELECT uuid FROM roles WHERE roles.id = subject)"
+                     "  END)"
+                     " FROM permissions WHERE id = %llu;",
                      permission);
 }
 
@@ -141,7 +156,7 @@ permission_resource_type (permission_t permission)
 static char *
 permission_resource_id (permission_t permission)
 {
-  return sql_string ("SELECT resource_id FROM permissions WHERE id = %llu;",
+  return sql_string ("SELECT resource_uuid FROM permissions WHERE id = %llu;",
                      permission);
 }
 


### PR DESCRIPTION
## What

The two helpers queried columns that don't exist on permissions:

- permission_resource_id() queried resource_id → the real column is resource_uuid.

- permission_subject_id() queried subject_id → that column doesn't exist at all. The permissions table only stores the subject as an integer subject id plus subject_type/subject_location; the UUID has to be

looked up in users/groups/groups_trash/roles/roles_trash depending on those fields (mirroring the existing `subject_uuid `case logic already used by `PERMISSION_ITERATOR_COLUMNS`).

I rewrote `permission_subject_id()` to use that same CASE-based lookup, and fixed `permission_resource_id()` to select resource_uuid.

## Why

`src/manage_sql_permissions.c` — `modify_permission()` crashed gvmd whenever it needed to fall back to the existing resource/subject (when `<resource>`/`<subject>` weren't supplied)

## References

fixes #3091 




