### PR TITLE
Change: allow editing targets and port lists that are in use

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -24523,11 +24523,6 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                                     "Port range TYPE must be TCP or UDP"));
                 log_event_fail ("port_range", "Port Range", NULL, "created");
                 break;
-              case 5:
-                SEND_TO_CLIENT_OR_FAIL
-                 (XML_ERROR_SYNTAX ("create_port_range",
-                                    "Port list is in use"));
-                break;
               case 6:
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("create_port_range",

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -28467,14 +28467,6 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                                 modify_target_data->target_id,
                                 "modified");
                 break;
-              case 15:
-                SEND_TO_CLIENT_OR_FAIL
-                 (XML_ERROR_SYNTAX ("modify_target",
-                                    "Target is in use"));
-                log_event_fail ("target", "Target",
-                                modify_target_data->target_id,
-                                "modified");
-                break;
               case 16:
                 log_event_fail ("target", "Target",
                                 modify_target_data->target_id,

--- a/src/manage_sql_port_lists.c
+++ b/src/manage_sql_port_lists.c
@@ -1498,7 +1498,7 @@ modify_port_list (const char *port_list_id, const char *name,
  * @param[out]  port_range_return  Created port range.
  *
  * @return 0 success, 1 syntax error in start, 2 syntax error in end, 3 failed
- *         to find port list, 4 syntax error in type, 5 port list in use,
+ *         to find port list, 4 syntax error in type,
  *         6 new range overlaps an existing range, 99 permission denied,
  *         -1 error.
  */
@@ -1555,12 +1555,6 @@ create_port_range (const char *port_list_id, const char *type,
     {
       sql_rollback ();
       return 3;
-    }
-
-  if (port_list_in_use (port_list))
-    {
-      sql_rollback ();
-      return 5;
     }
 
   if (sql_int ("SELECT count (*) FROM port_ranges"
@@ -2093,7 +2087,7 @@ trash_port_list_in_use (port_list_t port_list)
 int
 port_list_writable (port_list_t port_list)
 {
-  return port_list_in_use (port_list) == 0;
+  return 1;
 }
 
 /**

--- a/src/manage_sql_targets.c
+++ b/src/manage_sql_targets.c
@@ -1136,7 +1136,7 @@ create_target (const char* name, const char* asset_hosts_filter,
  *         find SMB cred, 9 failed to find target, 10 error in alive tests,
  *         11 zero length name, 12 exclude hosts requires hosts
  *         13 hosts requires exclude hosts,
- *         14 hosts must be at least one character, 15 target is in use,
+ *         14 hosts must be at least one character,
  *         16 failed to find ESXi cred, 17 failed to find SNMP cred,
  *         18 invalid SSH credential type, 19 invalid SMB credential type,
  *         20 invalid ESXi credential type, 21 invalid SNMP credential type,
@@ -1241,12 +1241,6 @@ modify_target (const char *target_id, const char *name, const char *hosts,
 
   if (allow_simultaneous_ips)
     {
-      if (target_in_use (target))
-        {
-          sql_rollback ();
-          return 15;
-        }
-
       sql ("UPDATE targets SET"
            " allow_simultaneous_ips = '%i',"
            " modification_time = m_now ()"
@@ -1297,12 +1291,6 @@ modify_target (const char *target_id, const char *name, const char *hosts,
     {
       port_list_t port_list;
 
-      if (target_in_use (target))
-        {
-          sql_rollback ();
-          return 15;
-        }
-
       port_list = 0;
       if (find_port_list_with_permission (port_list_id, &port_list,
                                           "get_port_lists"))
@@ -1327,12 +1315,6 @@ modify_target (const char *target_id, const char *name, const char *hosts,
 
   if (ssh_credential_id)
     {
-      if (target_in_use (target))
-        {
-          sql_rollback ();
-          return 15;
-        }
-
       ssh_credential = 0;
       if (strcmp (ssh_credential_id, "0"))
         {
@@ -1385,12 +1367,6 @@ modify_target (const char *target_id, const char *name, const char *hosts,
 
   if (ssh_elevate_credential_id)
     {
-      if (target_in_use (target))
-        {
-          sql_rollback ();
-          return 15;
-        }
-
       ssh_elevate_credential = 0;
       if (strcmp (ssh_elevate_credential_id, "0"))
         {
@@ -1429,12 +1405,6 @@ modify_target (const char *target_id, const char *name, const char *hosts,
 
   if (smb_credential_id)
     {
-      if (target_in_use (target))
-        {
-          sql_rollback ();
-          return 15;
-        }
-
       smb_credential = 0;
       if (strcmp (smb_credential_id, "0"))
         {
@@ -1477,12 +1447,6 @@ modify_target (const char *target_id, const char *name, const char *hosts,
     {
       credential_t esxi_credential;
 
-      if (target_in_use (target))
-        {
-          sql_rollback ();
-          return 15;
-        }
-
       esxi_credential = 0;
       if (strcmp (esxi_credential_id, "0"))
         {
@@ -1522,12 +1486,6 @@ modify_target (const char *target_id, const char *name, const char *hosts,
   if (snmp_credential_id)
     {
       credential_t snmp_credential;
-
-      if (target_in_use (target))
-        {
-          sql_rollback ();
-          return 15;
-        }
 
       snmp_credential = 0;
       if (strcmp (snmp_credential_id, "0"))
@@ -1586,12 +1544,6 @@ modify_target (const char *target_id, const char *name, const char *hosts,
 
   if (krb5_credential_id)
     {
-      if (target_in_use (target))
-        {
-          sql_rollback ();
-          return 15;
-        }
-
       krb5_credential = 0;
       if (strcmp (krb5_credential_id, "0"))
         {
@@ -1637,12 +1589,6 @@ modify_target (const char *target_id, const char *name, const char *hosts,
     {
       gchar *quoted_exclude_hosts, *quoted_hosts, *clean, *clean_exclude;
       int max;
-
-      if (target_in_use (target))
-        {
-          sql_rollback ();
-          return 15;
-        }
 
       if (hosts == NULL)
         {
@@ -1695,12 +1641,6 @@ modify_target (const char *target_id, const char *name, const char *hosts,
 
   if (reverse_lookup_only)
     {
-      if (target_in_use (target))
-        {
-          sql_rollback ();
-          return 15;
-        }
-
       sql ("UPDATE targets SET"
            " reverse_lookup_only = '%i',"
            " modification_time = m_now ()"
@@ -1711,12 +1651,6 @@ modify_target (const char *target_id, const char *name, const char *hosts,
 
   if (reverse_lookup_unify)
     {
-      if (target_in_use (target))
-        {
-          sql_rollback ();
-          return 15;
-        }
-
       sql ("UPDATE targets SET"
            " reverse_lookup_unify = '%i',"
            " modification_time = m_now ()"


### PR DESCRIPTION
## What

- `modify_target`: drop the "Target is in use" checks
- `create_port_range`: drop the "Port list is in use" check
- `port_list_writable`: report a port list as writable regardless of use, like target, schedule and credential already do

## Why

A target and its port list are frozen as soon as the first task refers to them, for the lifetime of that task. Correcting a wrong host in a scan target means creating a replacement target and repointing the task. For a port list it is worse: `port_list_writable` returns 0, so the web interface disables the edit icon altogether.

Nothing reads the target once a scan has started. `launch_osp_openvas_task` and `launch_openvasd_openvas_task` read hosts, port range, exclude hosts, alive test, reverse lookup settings and the credentials once, when they hand the scan to the scanner, and a report keeps the hosts it recorded. A later change therefore cannot reach a scan that is under way, nor make an earlier report unreadable.

Deleting is unchanged. `delete_target` and `delete_port_list` still refuse while a task refers to the resource.

## Testing

24.10 container stack, two tasks with their own targets sharing one port list. With the second task in state Requested: changed its target hosts, switched its port list, and added and removed a port range on the port list in use. All accepted, and the scan carried on. Deleting the target and the port list is still refused.
