### PR TITLE
explicitly include assert.h in locations where used

### DIFF
--- a/src/manage_alerts.c
+++ b/src/manage_alerts.c
@@ -24,6 +24,7 @@
 #include "manage_tickets.h"
 #include "manage_users.h"
 
+#include <assert.h>
 #include <bsd/unistd.h>
 #include <glib/gstdio.h>
 #include <grp.h>

--- a/src/manage_cve_scan.c
+++ b/src/manage_cve_scan.c
@@ -14,6 +14,8 @@
 #include "manage_sql.h"
 #include "manage_sql_assets.h"
 
+#include <assert.h>
+
 #include <util/cpeutils.h>
 #include <util/versionutils.h>
 

--- a/src/manage_osp.c
+++ b/src/manage_osp.c
@@ -19,6 +19,8 @@
 #include "manage_sql_nvts.h"
 #include "manage_sql_targets.h"
 
+#include <assert.h>
+
 #undef G_LOG_DOMAIN
 /**
  * @brief GLib log domain.

--- a/src/manage_sql_alerts.c
+++ b/src/manage_sql_alerts.c
@@ -12,6 +12,7 @@
 #include "manage_sql_resources.h"
 #include "manage_sql_tags.h"
 
+#include <assert.h>
 #include <ctype.h>
 
 #include <gvm/base/hosts.h>

--- a/src/manage_sql_assets.c
+++ b/src/manage_sql_assets.c
@@ -22,6 +22,8 @@
 #include "manage_sql_tls_certificates.h"
 #include "sql.h"
 
+#include <assert.h>
+
 #include <gvm/base/array.h>
 #include <gvm/base/hosts.h>
 #include <gvm/util/xmlutils.h>

--- a/src/manage_sql_filters.c
+++ b/src/manage_sql_filters.c
@@ -12,6 +12,7 @@
 #include "manage_sql_resources.h"
 #include "manage_sql_tags.h"
 
+#include <assert.h>
 #include <ctype.h>
 
 #undef G_LOG_DOMAIN

--- a/src/manage_sql_groups.c
+++ b/src/manage_sql_groups.c
@@ -13,6 +13,8 @@
 #include "manage_sql_tags.h"
 #include "sql.h"
 
+#include <assert.h>
+
 #undef G_LOG_DOMAIN
 /**
  * @brief GLib log domain.

--- a/src/manage_sql_notes.c
+++ b/src/manage_sql_notes.c
@@ -12,6 +12,7 @@
 #include "manage_sql_tags.h"
 #include "sql.h"
 
+#include <assert.h>
 #include <ctype.h>
 
 #undef G_LOG_DOMAIN

--- a/src/manage_sql_nvts_common.c
+++ b/src/manage_sql_nvts_common.c
@@ -16,6 +16,8 @@
 #include "manage_sql_nvts_common.h"
 #include "sql.h"
 
+#include <assert.h>
+
 #undef G_LOG_DOMAIN
 /**
  * @brief GLib log domain.

--- a/src/manage_sql_nvts_osp.c
+++ b/src/manage_sql_nvts_osp.c
@@ -17,6 +17,8 @@
 #include "manage_sql_configs.h"
 #include "sql.h"
 
+#include <assert.h>
+
 #include <gvm/base/cvss.h>
 #include <gvm/osp/osp.h>
 

--- a/src/manage_sql_overrides.c
+++ b/src/manage_sql_overrides.c
@@ -11,6 +11,7 @@
 #include "manage_sql_settings.h"
 #include "manage_sql_tags.h"
 
+#include <assert.h>
 #include <ctype.h>
 
 #undef G_LOG_DOMAIN

--- a/src/manage_sql_permissions.c
+++ b/src/manage_sql_permissions.c
@@ -14,6 +14,8 @@
 #include "manage_sql_tags.h"
 #include "sql.h"
 
+#include <assert.h>
+
 #undef G_LOG_DOMAIN
 /**
  * @brief GLib log domain.

--- a/src/manage_sql_port_lists.c
+++ b/src/manage_sql_port_lists.c
@@ -18,6 +18,7 @@
 #include "manage_sql_tags.h"
 #include "sql.h"
 
+#include <assert.h>
 #include <errno.h>
 #include <glib.h>
 #include <glib/gstdio.h>

--- a/src/manage_sql_report_configs.c
+++ b/src/manage_sql_report_configs.c
@@ -19,6 +19,8 @@
 #include "manage_sql_tags.h"
 #include "sql.h"
 #include "utils.h"
+
+#include <assert.h>
 #include <glib.h>
 
 #undef G_LOG_DOMAIN

--- a/src/manage_sql_report_formats.c
+++ b/src/manage_sql_report_formats.c
@@ -22,6 +22,7 @@
 #include "sql.h"
 #include "utils.h"
 
+#include <assert.h>
 #include <cjson/cJSON.h>
 #include <errno.h>
 #include <glib.h>

--- a/src/manage_sql_roles.c
+++ b/src/manage_sql_roles.c
@@ -13,6 +13,8 @@
 #include "manage_sql_tags.h"
 #include "sql.h"
 
+#include <assert.h>
+
 #undef G_LOG_DOMAIN
 /**
  * @brief GLib log domain.

--- a/src/manage_sql_schedules.c
+++ b/src/manage_sql_schedules.c
@@ -10,6 +10,7 @@
 #include "manage_sql_resources.h"
 #include "manage_sql_tags.h"
 
+#include <assert.h>
 #include <libical/ical.h>
 
 #undef G_LOG_DOMAIN

--- a/src/manage_sql_settings.c
+++ b/src/manage_sql_settings.c
@@ -12,6 +12,7 @@
 #include "manage_sql_users.h"
 #include "sql.h"
 
+#include <assert.h>
 #include <ctype.h>
 
 #undef G_LOG_DOMAIN

--- a/src/manage_sql_tags.c
+++ b/src/manage_sql_tags.c
@@ -12,6 +12,8 @@
 #include "manage_sql_tickets.h"
 #include "sql.h"
 
+#include <assert.h>
+
 /**
  * @file
  * @brief GVM management layer: Tags SQL

--- a/src/manage_sql_tickets.c
+++ b/src/manage_sql_tickets.c
@@ -18,6 +18,7 @@
 #include "manage_sql_tags.h"
 #include "sql.h"
 
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/manage_sql_tls_certificates.c
+++ b/src/manage_sql_tls_certificates.c
@@ -19,6 +19,7 @@
 #include "utils.h"
 #include "sql.h"
 
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/manage_sql_users.c
+++ b/src/manage_sql_users.c
@@ -23,6 +23,8 @@
 #include "manage_sql_tls_certificates.h"
 #include "sql.h"
 
+#include <assert.h>
+
 #include <gvm/base/pwpolicy.h>
 #include <gvm/util/uuidutils.h>
 


### PR DESCRIPTION
## What

Without those explicit imports the compilation errored out in the changed locations. Reason being `implicit-function-declaration` errors. Happens since `gvmd 26.26.0` (up until now which is as of writing  `26.36.1`).

Example log:
```
gvmd-26.26.0/src/manage_sql_alerts.c: In function ‘copy_alert’: gvmd-26.26.0/src/manage_sql_alerts.c:67:3: error: implicit declaration of function ‘assert’ [-Wimplicit-function-declaration]
   67 |   assert (current_credentials.uuid);
      |   ^~~~~~
gvmd-26.26.0/src/manage_sql_alerts.c:18:1: note: ‘assert’ is defined in header ‘<assert.h>’; this is probably fixable by adding ‘#include <assert.h>’
   17 | #include <gvm/base/hosts.h>
  +++ |+#include <assert.h>
   18 |
```

With those changes the compilation doesn't error out anymore in regards to missing inclusion of `assert.h`.

## Why

It triggers `-Wimplicit-function-declaration`.
Odd is only that it appeared. IIRC the changelogs for GCC 15 and GCC 16 don't mention a change in that regard and my distribution `CFLAGS` weren't adjusted either.

## References

Got reported in gh-2920.