### PR TITLE
Change release workflow to not bypass branch protection rules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,7 @@ jobs:
         id: release
         uses: greenbone/actions/release@v3
         with:
+          admin-bypass: "false"
           github-user: ${{ secrets.GREENBONE_BOT }}
           github-user-mail: ${{ secrets.GREENBONE_BOT_MAIL }}
           github-user-token: ${{ secrets.GREENBONE_BOT_TOKEN }}


### PR DESCRIPTION


## What
Change release workflow to not bypass branch protection rules

## Why

Branch protection rules will be replaced with rulesets which allow specific users to bypass rules.

