### PR TITLE
Fix: Validate get_settings sort field

### DIFF
--- a/src/manage_sql_settings.c
+++ b/src/manage_sql_settings.c
@@ -7,6 +7,7 @@
 #include "manage_acl.h"
 #include "manage_runtime_flags.h"
 #include "manage_sql_configs.h"
+#include "manage_sql_filters.h"
 #include "manage_sql_port_lists.h"
 #include "manage_sql_report_formats.h"
 #include "manage_sql_users.h"
@@ -267,7 +268,7 @@ init_setting_iterator (iterator_t *iterator, const char *uuid,
 {
   static const char *filter_columns[] = SETTING_ITERATOR_FILTER_COLUMNS;
   static column_t select_columns[] = SETTING_ITERATOR_COLUMNS;
-  gchar *clause, *columns, *quoted_uuid;
+  gchar *clause, *columns, *quoted_uuid, *sort_column;
 
   assert (current_credentials.uuid);
 
@@ -281,6 +282,11 @@ init_setting_iterator (iterator_t *iterator, const char *uuid,
 
   quoted_uuid = uuid ? sql_quote (uuid) : NULL;
   columns = columns_build_select (select_columns);
+
+  if (sort_field && vector_find_filter (filter_columns, sort_field))
+    sort_column = columns_select_column (select_columns, NULL, sort_field);
+  else
+    sort_column = NULL;
 
   if (quoted_uuid)
     init_iterator (iterator,
@@ -316,7 +322,7 @@ init_setting_iterator (iterator_t *iterator, const char *uuid,
                    current_credentials.uuid,
                    clause ? " AND " : "",
                    clause ? clause : "",
-                   sort_field ? sort_field : "id",
+                   sort_column ? sort_column : "id",
                    ascending ? "ASC" : "DESC",
                    sql_select_limit (max),
                    first);


### PR DESCRIPTION
## What
The sort field of the GET_SETTINGS GMP command is now validated against the list of filter columns and looked up in the select columns.

## Why
This ensures only valid columns are allowed when initializing the settings iterator.

## References
GEA-2035