### PR TITLE
Fix: respond with error in CLIENT_STOP_TASK end handler

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -29924,8 +29924,9 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                   assert (0);
                 case -1:
                   /* Some other error occurred. */
-                  /** @todo Should respond with internal error. */
-                  abort ();
+                  SEND_TO_CLIENT_OR_FAIL
+                   (XML_ERROR_SYNTAX ("stop_task",
+                                      "Internal error stopping task"));
               }
           }
         else


### PR DESCRIPTION
## What

Respond with error in CLIENT_STOP_TASK end handler, instead of aborting.

## Why

The abort was getting in the way during memory testing.

The "internal error" response is also more useful, and consistent with other cases.

## Testing

I ran GMP commands on main to start and stop a task, then looked for the abort in the Asan logs.
I ran the same commands with the patch and the abort was gone.

