### PR TITLE
add: support optional encryption for agent support bundles

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,7 +14,7 @@ Prerequisites:
 * glib-2.0 >= 2.42
 * gnutls >= 3.2.15
 * gpgme
-* [gvm-libs](https://github.com/greenbone/gvm-libs/) >= 23.9
+* [gvm-libs](https://github.com/greenbone/gvm-libs/) >= 23.9 (or 23.10 if ENABLE_AGENTS)
 * [gvm-auth-lib](https://github.com/greenbone/gvm-auth-lib/) >= 0.3 (if ENABLE_SECURITY_INTELLIGENCE_EXPORT or ENABLE_JWT_AUTH is enabled)
 * libical >= 1.0.0
 * libbsd

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,7 +32,7 @@ if(ENABLE_AGENTS)
   pkg_check_modules(
     LIBGVM_AGENT_CONTROLLER
     REQUIRED
-    libgvm_agent_controller>=23.6
+    libgvm_agent_controller>=23.10
   )
 else(ENABLE_AGENTS)
   message(STATUS "ENABLE_AGENTS flag is not enabled")

--- a/src/gmp_agent_support_bundle.c
+++ b/src/gmp_agent_support_bundle.c
@@ -31,6 +31,7 @@ typedef struct
 {
   gchar *agent_uuid; ///< UUID of the agent.
   gchar *days;       ///< Optional number of days to include.
+  gchar *encryption; ///< Whether to get encrypted the support bundle (0 or 1).
 } get_agent_support_bundle_t;
 
 /**
@@ -73,6 +74,10 @@ get_agent_support_bundle_start (const gchar **attribute_names,
   if (find_attribute (attribute_names, attribute_values,
                       "days", &attribute))
     get_agent_support_bundle_data.days = g_strdup (attribute);
+
+  if (find_attribute (attribute_names, attribute_values,
+                      "encryption", &attribute))
+    get_agent_support_bundle_data.encryption = g_strdup (attribute);
 }
 
 /**
@@ -105,6 +110,40 @@ get_agent_support_bundle_parse_days (int *days)
     return FALSE;
 
   *days = (int) parsed;
+  return TRUE;
+}
+
+/**
+ * @brief Parse the optional encryption attribute.
+ *
+ * @param[out] encryption Whether the support bundle should be encrypted.
+ *
+ * @return TRUE if valid, FALSE otherwise.
+ */
+static gboolean
+get_agent_support_bundle_parse_encryption (int *encryption)
+{
+  gchar *end = NULL;
+  gint64 parsed;
+
+  if (!encryption)
+    return FALSE;
+
+  *encryption = 1;
+
+  if (!get_agent_support_bundle_data.encryption)
+    return TRUE;
+
+  parsed =
+    g_ascii_strtoll (get_agent_support_bundle_data.encryption, &end, 10);
+
+  if (end == get_agent_support_bundle_data.encryption
+      || *end != '\0'
+      || parsed < 0
+      || parsed > 1)
+    return FALSE;
+
+  *encryption = (int) parsed;
   return TRUE;
 }
 
@@ -195,6 +234,7 @@ get_agent_support_bundle_run (gmp_parser_t *gmp_parser, GError **error)
   agent_response_t result;
   gchar *escaped_filename = NULL;
   int days;
+  int encryption;
   int ret;
 
   if (!acl_user_may ("get_agents"))
@@ -226,9 +266,19 @@ get_agent_support_bundle_run (gmp_parser_t *gmp_parser, GError **error)
       return;
     }
 
+  if (!get_agent_support_bundle_parse_encryption (&encryption))
+    {
+      SEND_TO_CLIENT_OR_FAIL
+      (XML_ERROR_SYNTAX ("get_agent_support_bundle",
+        "Invalid encryption value"));
+      get_agent_support_bundle_reset ();
+      return;
+    }
+
   result =
     get_agent_support_bundle (get_agent_support_bundle_data.agent_uuid,
                               days,
+                              encryption,
                               &bundle);
 
   switch (result)

--- a/src/gmp_agent_support_bundle.c
+++ b/src/gmp_agent_support_bundle.c
@@ -49,6 +49,7 @@ get_agent_support_bundle_reset (void)
 {
   g_free (get_agent_support_bundle_data.agent_uuid);
   g_free (get_agent_support_bundle_data.days);
+  g_free (get_agent_support_bundle_data.encryption);
 
   memset (&get_agent_support_bundle_data,
           0,

--- a/src/manage_agents.c
+++ b/src/manage_agents.c
@@ -1123,6 +1123,7 @@ manage_agents_sync_from_scanner (scanner_t scanner)
  * @param[in]  agent_uuid UUID of the agent.
  * @param[in]  days Number of days of data to include. A value of 0 uses the
  *                  Agent Controller default.
+ * @param[in] encryption Encryption for the support bundle (0, 1).
  * @param[out] out_bundle Receives the newly allocated support bundle.
  *
  * @return AGENT_RESPONSE_SUCCESS on success, or a specific AGENT_RESPONSE_*
@@ -1132,6 +1133,7 @@ agent_response_t
 get_agent_support_bundle (
   const gchar *agent_uuid,
   int days,
+  int encryption,
   agent_controller_support_bundle_t *out_bundle)
 {
   gvmd_agent_connector_t connector = NULL;
@@ -1169,9 +1171,18 @@ get_agent_support_bundle (
       return AGENT_RESPONSE_CONNECTOR_CREATION_FAILED;
     }
 
-  *out_bundle =
-    agent_controller_download_support_bundle (
-      connector->base, agent_id, days);
+  if (encryption)
+    {
+      *out_bundle =
+        agent_controller_download_support_bundle (
+          connector->base, agent_id, days);
+    }
+  else
+    {
+      *out_bundle =
+        agent_controller_download_support_bundle_plain (
+          connector->base, agent_id, days);
+    }
 
   gvmd_agent_connector_free (connector);
   g_free (agent_id);

--- a/src/manage_agents.h
+++ b/src/manage_agents.h
@@ -158,7 +158,7 @@ int
 manage_agents_sync_from_agent_controllers (gboolean *);
 
 agent_response_t
-get_agent_support_bundle (const gchar *, int,
+get_agent_support_bundle (const gchar *, int, int,
                           agent_controller_support_bundle_t *);
 
 int

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -9185,6 +9185,12 @@ END:VCALENDAR
         <type>integer</type>
         <required>0</required>
       </attrib>
+      <attrib>
+        <name>encryption</name>
+        <summary>Whether agent support bundle is encrypted (1) or not (0) (Default 1)</summary>
+        <type>integer</type>
+        <required>0</required>
+      </attrib>
     </pattern>
     <response>
       <pattern>
@@ -9243,7 +9249,8 @@ END:VCALENDAR
       <request>
         <get_agent_support_bundle
           agent_uuid="31acafd6-5f48-43c5-bac0-dbeeccc526dd"
-          days="7"/>
+          days="7"
+          encryption="1"/>
       </request>
       <response>
         <get_agent_support_bundle_response status="200" status_text="OK">


### PR DESCRIPTION
## What

- Add an optional `encryption` attribute to `get_agent_support_bundle`.
- Keep encrypted support bundles as the default behavior.
- Use the plain support bundle endpoint when `encryption="0"`.
- Update the required `gvm-libs` version when agent support is enabled.
- Update the GMP schema documentation and example.

## Why

- Allow clients to request decrypted agent support bundles through GMP.
- Keep the existing behavior backward compatible.


## References

GEA-2040

