### PR TITLE
Fix: add missing resets in handle_get_aggregates

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -11959,6 +11959,8 @@ handle_get_aggregates (gmp_parser_t *gmp_parser, GError **error)
       SEND_TO_CLIENT_OR_FAIL
           (XML_ERROR_SYNTAX ("get_aggregates",
                              "A 'type' attribute is required"));
+      get_aggregates_data_reset (get_aggregates_data);
+      set_client_state (CLIENT_AUTHENTIC);
       return;
     }
 
@@ -12105,6 +12107,8 @@ handle_get_aggregates (gmp_parser_t *gmp_parser, GError **error)
         sort_data_free (g_array_index (sort_data, sort_data_t*, index));
       g_array_free (sort_data, TRUE);
       g_array_free (c_sums, TRUE);
+      get_aggregates_data_reset (get_aggregates_data);
+      set_client_state (CLIENT_AUTHENTIC);
       return;
     }
 


### PR DESCRIPTION
## What

In `handle_get_aggregates` add missing resets of client state and GET data.

## Why

When these error cases happened gvmd would stop handling any following commands.

## Testing

Before PR, the GET_VERSION_RESPONSE is missing, for both error cases:
```
$ printf '<authenticate>...</authenticate><get_aggregates type="nvt"><data_column>no_such_column</data_column></get_aggregates><get_version/>' | socat -t5 GOPEN:$HOME/alts/main/run/gvmd/gvmd.sock -
<authenticate_response status="200" status_text="OK">...</authenticate_response><get_aggregates_response status="400" status_text="Invalid data_column"/>

$ printf '<authenticate>...</authenticate><get_aggregates><data_column>no_such_column</data_column></get_aggregates><get_version/>' | socat -t5 GOPEN:$HOME/alts/main/run/gvmd/gvmd.sock -
<authenticate_response status="200" status_text="OK">...</authenticate_response><get_aggregates_response status="400" status_text="A 'type' attribute is required"/>
```

After PR, the GET_VERSION response is there:
```
$ printf '<authenticate>...</authenticate><get_aggregates type="nvt"><data_column>no_such_column</data_column></get_aggregates><get_version/>' | socat -t5 GOPEN:$HOME/alts/main/run/gvmd/gvmd.sock -
<authenticate_response status="200" status_text="OK">...</authenticate_response><get_aggregates_response status="400" status_text="Invalid data_column"/><get_version_response status="200" status_text="OK"><version>22.8</version></get_version_response>

$ printf '<authenticate>...</authenticate><get_aggregates><data_column>no_such_column</data_column></get_aggregates><get_version/>' | socat -t5 GOPEN:$HOME/alts/main/run/gvmd/gvmd.sock -
<authenticate_response status="200" status_text="OK">...</authenticate_response><get_aggregates_response status="400" status_text="A 'type' attribute is required"/><get_version_response status="200" status_text="OK"><version>22.8</version></get_version_response>
```