### PR TITLE
fix: restore delta report results

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -15427,8 +15427,8 @@ init_delta_iterator (report_t report, iterator_t *results, report_t delta,
                                   "                           result2_id)"
                                   " LEFT OUTER JOIN result_vt_epss"
                                   " ON results.nvt = result_vt_epss.vt_id"
-                                  " LEFT OUTER JOIN nvts"
-                                  " ON results.nvt = nvts.oid %s,"
+                                  " LEFT OUTER JOIN all_vts"
+                                  " ON results.nvt = all_vts.oid %s,"
                                   " LATERAL %s AS lateral_new_severity",
                                   opts_tables,
                                   lateral_clause);

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -162,7 +162,7 @@
 /**
  * @brief Delta results columns offset for result iterator.
  */
-#define RESULT_ITERATOR_DELTA_COLUMN_OFFSET GET_ITERATOR_COLUMN_COUNT + 51
+#define RESULT_ITERATOR_DELTA_COLUMN_OFFSET GET_ITERATOR_COLUMN_COUNT + 53
 
 /**
  * @brief Struct to be sent as user data to the GFunc for adding results


### PR DESCRIPTION
## What

Fix delta report generation by using the correct `all_vts` join and updating the delta result column offset.

The offset is adjusted to account for the two CERT-related columns added before the delta result columns.

## Why

Delta reports failed because the query referenced `all_vts` without joining it.

After fixing the query, delta results were still filtered out because the delta state was read from the wrong column due to the outdated offset.


## References

Fixes #3106


