### PR TITLE
Added the option "-i" to the "sendmail" command of alerts.

### DIFF
--- a/src/manage_alerts.c
+++ b/src/manage_alerts.c
@@ -986,7 +986,7 @@ email (const char *to_address, const char *from_address, const char *subject,
     }
 
   command = g_strdup_printf ("read FROM TO < %s;"
-                             " /usr/sbin/sendmail -f \"$FROM\" \"$TO\" < %s"
+                             " /usr/sbin/sendmail -f \"$FROM\" \"$TO\" -i < %s"
                              " > /dev/null 2>&1",
                              args_file_name,
                              content_file_name);

--- a/src/manage_alerts.c
+++ b/src/manage_alerts.c
@@ -986,7 +986,7 @@ email (const char *to_address, const char *from_address, const char *subject,
     }
 
   command = g_strdup_printf ("read FROM TO < %s;"
-                             " /usr/sbin/sendmail -f \"$FROM\" \"$TO\" -i < %s"
+                             " /usr/sbin/sendmail -f \"$FROM\" -i \"$TO\" < %s"
                              " > /dev/null 2>&1",
                              args_file_name,
                              content_file_name);


### PR DESCRIPTION
## What
Added the option "-i" to the "sendmail" command of alerts.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
Without this option TXT-reports included in mails from alerts may end prematurely (see GEA-2032).
<!-- Describe why are these changes necessary? -->

## References
GEA-2032
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist
I could not reproduce the problem but according to the documentation in e. g. https://www.ibm.com/docs/en/aix/7.2.0?topic=s-sendmail-command and https://linux.die.net/man/8/sendmail.sendmail the "-i" option should be set and solve the Problem described in GEA-2032.
