### PR TITLE
Fix: NULL handling in buffer_aggregate_xml

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -11428,7 +11428,7 @@ buffer_aggregate_xml (GString *xml, iterator_t* aggregate, const gchar* type,
                       GArray *text_columns, GArray *text_column_types,
                       GArray *c_sums)
 {
-  int index;
+  int index, first_group;
   long c_count, previous_c_count;
   gchar *previous_group_value;
   long int aggregate_group_count;
@@ -11471,6 +11471,7 @@ buffer_aggregate_xml (GString *xml, iterator_t* aggregate, const gchar* type,
                             subgroup_column);
 
   previous_group_value = NULL;
+  first_group = 1;
   aggregate_group_count = 0L;
   c_count = 0L;
   previous_c_count = 0L;
@@ -11576,7 +11577,7 @@ buffer_aggregate_xml (GString *xml, iterator_t* aggregate, const gchar* type,
               *subgroup_c_count += aggregate_iterator_count (aggregate);
 
               // Output of group elements
-              if (previous_group_value == NULL)
+              if (first_group)
                 {
                   // Output start of first group
                   g_string_append_printf (xml,
@@ -11657,7 +11658,7 @@ buffer_aggregate_xml (GString *xml, iterator_t* aggregate, const gchar* type,
                 }
 
               // Update group statistics using current subgroup after output
-              if (previous_group_value == NULL
+              if (first_group
                   || g_strcmp0 (previous_group_value, value))
                 {
                   // First subgroup of any group:
@@ -11700,6 +11701,7 @@ buffer_aggregate_xml (GString *xml, iterator_t* aggregate, const gchar* type,
 
               g_free (previous_group_value);
               previous_group_value = g_strdup (value);
+              first_group = 0;
 
               // Add subgroup values
               g_string_append_printf (xml,

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -11584,7 +11584,7 @@ buffer_aggregate_xml (GString *xml, iterator_t* aggregate, const gchar* type,
                                           "<value>%s</value>",
                                           value_escaped);
                 }
-              else if (strcmp (previous_group_value, value))
+              else if (g_strcmp0 (previous_group_value, value))
                 {
                   // First subgroup of a new group:
                   //  output collected data of previous group and close it, ...
@@ -11658,7 +11658,7 @@ buffer_aggregate_xml (GString *xml, iterator_t* aggregate, const gchar* type,
 
               // Update group statistics using current subgroup after output
               if (previous_group_value == NULL
-                  || strcmp (previous_group_value, value))
+                  || g_strcmp0 (previous_group_value, value))
                 {
                   // First subgroup of any group:
                   //  Reset group statistics using current subgroup data

--- a/src/gmp.c
+++ b/src/gmp.c
@@ -11583,7 +11583,7 @@ buffer_aggregate_xml (GString *xml, iterator_t* aggregate, const gchar* type,
                   g_string_append_printf (xml,
                                           "<group>"
                                           "<value>%s</value>",
-                                          value_escaped);
+                                          value_escaped ? value_escaped : "");
                 }
               else if (g_strcmp0 (previous_group_value, value))
                 {
@@ -11654,7 +11654,7 @@ buffer_aggregate_xml (GString *xml, iterator_t* aggregate, const gchar* type,
                   g_string_append_printf (xml,
                                           "<group>"
                                           "<value>%s</value>",
-                                          value_escaped);
+                                          value_escaped ? value_escaped : "");
                 }
 
               // Update group statistics using current subgroup after output


### PR DESCRIPTION
## What

For GET_AGGREGATES, in particular `buffer_aggregates_xml`:

1. Check NULL in `strcmp` of group values
2. Use dedicated var to track first subgroup
3. Check `value_escaped` before trying to print it.

## Why

Otherwise when the group value is NULL:

1. it segfaults
2. the XML is broken (parsing the response fails)
3. "(null)' appears in the response.

## Testing

I ran GMP commands on main that ran a scan, imported a report, then got the aggregates (with `group_column="path"`). I noted the problem in the response and Asan logs.
I ran the same GMP with the PR and the problems were gone. 