### PR TITLE
Fix: prevent segv when creating report host

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -24827,7 +24827,7 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
 
               result = g_malloc (sizeof (create_report_result_t));
               result->description = create_report_data->host_start;
-              result->host = strdup (create_report_data->ip);
+              result->host = g_strdup (create_report_data->ip);
 
               array_add (create_report_data->host_starts, result);
 
@@ -24840,7 +24840,7 @@ gmp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
 
               result = g_malloc (sizeof (create_report_result_t));
               result->description = create_report_data->host_end;
-              result->host = strdup (create_report_data->ip);
+              result->host = g_strdup (create_report_data->ip);
 
               array_add (create_report_data->host_ends, result);
 


### PR DESCRIPTION
## What

Use `g_strdup` instead of `strdup` to copy `create_report_data->ip`.

## Why

CREATE_REPORT may be called with a HOST that has an END/START that is missing an IP.

This was leading to `strdup` of NULL, causing a segfault.

Using `g_strdup` instead of `strdup` is safe, because `g_strdup` allows NULL as arg.

## Testing

On main I ran CREATE_REPORT with a HOST/END that was missing an IP, and saw the segv in the asan logs.
I did the same with the patch and the segv was gone.