### PR TITLE
Fix: use right reset fn in modify_agent_group_run

### DIFF
--- a/src/gmp_agent_groups.c
+++ b/src/gmp_agent_groups.c
@@ -666,7 +666,7 @@ modify_agent_group_run (gmp_parser_t *gmp_parser, GError **error)
     {
       SEND_TO_CLIENT_OR_FAIL (XML_ERROR_SYNTAX ("modify_agent_group",
                               "Permission denied"));
-      create_agent_group_reset ();
+      modify_agent_group_reset ();
       return;
     }
 
@@ -714,7 +714,7 @@ modify_agent_group_run (gmp_parser_t *gmp_parser, GError **error)
       SEND_TO_CLIENT_OR_FAIL (
         XML_ERROR_SYNTAX ("modify_agent_group",
           "Missing or empty <scheduler_cron_time>"));
-      create_agent_group_reset ();
+      modify_agent_group_reset ();
       return;
     }
 


### PR DESCRIPTION
## What

In `modify_agent_group_run` call the right reset functions.

## Why

Use the wrong reset function can result in crashes.

## Testing

On main I ran an empty MODIFY_AGENT_GROUP with a user with guest permissions, and noted the Asan crash in the logs.
Then I ran the same with the patch and the log was gone.
