### PR TITLE
Fix: free hashtable on empty return in launch_osp_openvas_task

### DIFF
--- a/src/manage_osp.c
+++ b/src/manage_osp.c
@@ -656,6 +656,7 @@ launch_osp_openvas_task (task_t task, target_t target, const char *scan_id,
     g_slist_free_full (osp_targets, (GDestroyNotify) osp_target_free);
     // Credentials are freed with target
     g_slist_free_full (vts, (GDestroyNotify) osp_vt_single_free);
+    g_hash_table_destroy (vts_hash_table);
     return -1;
   }
 


### PR DESCRIPTION
## What

Add missing  `g_hash_table_destroy` in `launch_osp_openvas_task`.

## Why

Was leaking.

## Testing

I ran GMP commands on main that showed the leak in the Asan logs.
I ran the same commands with the patch and the logs were gone.
